### PR TITLE
rest: add stats api

### DIFF
--- a/api/rest.go
+++ b/api/rest.go
@@ -115,7 +115,7 @@ func (rs *RestServer) Serve() {
 	// r.HandleFunc(adjRibOut+"/{"+PARAM_REMOTE_PEER_ADDR+"}", rs.AdjRibOut).Methods("GET")
 	r.HandleFunc(neighbor+"/{"+PARAM_REMOTE_PEER_ADDR+"}/"+"local-rib", rs.NeighborLocalRib).Methods("GET")
 	// stats
-	r.HandleFunc(STATS, stats_api.Handler)
+	r.HandleFunc(STATS, stats_api.Handler).Methods("GET")
 
 	// Handler when not found url
 	r.NotFoundHandler = http.HandlerFunc(NotFoundHandler)

--- a/api/rest.go
+++ b/api/rest.go
@@ -17,6 +17,7 @@ package api
 
 import (
 	log "github.com/Sirupsen/logrus"
+	"github.com/fukata/golang-stats-api-handler"
 	"github.com/gorilla/mux"
 	"net/http"
 	"strconv"
@@ -41,6 +42,7 @@ const (
 	ADJ_RIB_LOCAL_BEST = "/bgp/adj-rib-local/best"
 
 	PARAM_REMOTE_PEER_ADDR = "remotePeerAddr"
+	STATS                  = "/stats"
 )
 
 const REST_PORT = 8080
@@ -112,6 +114,8 @@ func (rs *RestServer) Serve() {
 	// r.HandleFunc(adjRibIn+"/{"+PARAM_REMOTE_PEER_ADDR+"}", rs.AdjRibIn).Methods("GET")
 	// r.HandleFunc(adjRibOut+"/{"+PARAM_REMOTE_PEER_ADDR+"}", rs.AdjRibOut).Methods("GET")
 	r.HandleFunc(neighbor+"/{"+PARAM_REMOTE_PEER_ADDR+"}/"+"local-rib", rs.NeighborLocalRib).Methods("GET")
+	// stats
+	r.HandleFunc(STATS, stats_api.Handler)
 
 	// Handler when not found url
 	r.NotFoundHandler = http.HandlerFunc(NotFoundHandler)


### PR DESCRIPTION
added api to show golang statistics.

api response sample:
```
% curl -s "http://127.0.0.1:8080/stats" | jq '.'
{
  "time": 1420593644090014500,
  "go_version": "go1.3.3",
  "go_os": "darwin",
  "go_arch": "amd64",
  "cpu_num": 4,
  "goroutine_num": 11,
  "gomaxprocs": 4,
  "cgo_call_num": 0,
  "memory_alloc": 562056,
  "memory_total_alloc": 1222520,
  "memory_sys": 5703928,
  "memory_lookups": 103,
  "memory_mallocs": 3559,
  "memory_frees": 2508,
  "memory_stack": 360448,
  "heap_alloc": 562056,
  "heap_sys": 2097152,
  "heap_idle": 1097728,
  "heap_inuse": 999424,
  "heap_released": 0,
  "heap_objects": 1051,
  "gc_next": 972368,
  "gc_last": 1420593638961659600,
  "gc_num": 4,
  "gc_per_second": 0,
  "gc_pause_per_second": 0,
  "gc_pause": []
}
```
