### PR TITLE
table: remove unnecessary distinction of paths

### DIFF
--- a/cli/gobgpcli
+++ b/cli/gobgpcli
@@ -82,6 +82,31 @@ class Show(object):
                 return f[1]()
         return 1
 
+    def do_global(self):
+        if len(self.args) != 1 and len(self.args) != 2:
+            return 1
+
+        url = self.base_url + "/global/rib"
+        if len(self.args) == 2:
+            url += "/" + self.args[1]
+        else:
+            url += "/ipv4"
+
+        try:
+            r = requests.get(url)
+        except:
+            print "Failed to connect to gobgpd. It runs?"
+            sys.exit(1)
+
+        f = "{:2s} {:18s} {:15s} {:10s} {:10s} {:s}"
+        print(f.format("", "Network", "Next Hop", "AS_PATH", "Age", "Attrs"))
+
+        for d in r.json()["Destinations"]:
+            d["Paths"][d["BestPathIdx"]]["Best"] = True
+            self.show_routes(f, d["Paths"], True, True)
+
+        return 0
+
     def _neighbor(self, neighbor=None):
         capdict = {1: "MULTIPROTOCOL",
                    2: "ROUTE_REFRESH",

--- a/config/default.go
+++ b/config/default.go
@@ -75,6 +75,14 @@ func SetDefaultConfigValues(md toml.MetaData, bt *Bgp) error {
 				}
 			}
 		}
+
+		if _, ok := n.attributes["NeighborList.PeerType"]; !ok {
+			if bt.NeighborList[i].PeerAs != bt.Global.As {
+				bt.NeighborList[i].PeerType = PEER_TYPE_EXTERNAL
+			} else {
+				bt.NeighborList[i].PeerType = PEER_TYPE_INTERNAL
+			}
+		}
 	}
 	return nil
 }

--- a/config/default.go
+++ b/config/default.go
@@ -17,6 +17,23 @@ type neighbor struct {
 
 func SetDefaultConfigValues(md toml.MetaData, bt *Bgp) error {
 	neighbors := []neighbor{}
+	global := make(map[string]bool)
+
+	for _, key := range md.Keys() {
+		if !strings.HasPrefix(key.String(), "Global") {
+			continue
+		}
+		if key.String() != "Global" {
+			global[key.String()] = true
+		}
+	}
+
+	if _, ok := global["Global.AfiSafiList"]; !ok {
+		bt.Global.AfiSafiList = []AfiSafi{
+			AfiSafi{AfiSafiName: "ipv4-unicast"},
+			AfiSafi{AfiSafiName: "ipv6-unicast"},
+		}
+	}
 
 	nidx := 0
 	for _, key := range md.Keys() {

--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -49,6 +49,11 @@ const (
 )
 
 const (
+	BGP_ASPATH_ATTR_TYPE_SET = 1
+	BGP_ASPATH_ATTR_TYPE_SEQ = 2
+)
+
+const (
 	_ = iota
 	BGP_MSG_OPEN
 	BGP_MSG_UPDATE

--- a/server/peer.go
+++ b/server/peer.go
@@ -56,15 +56,16 @@ type Peer struct {
 	adjRib         *table.AdjRib
 	// peer and rib are always not one-to-one so should not be
 	// here but it's the simplest and works our first target.
-	rib      *table.TableManager
-	rfMap    map[bgp.RouteFamily]bool
-	capMap   map[bgp.BGPCapabilityCode]bgp.ParameterCapabilityInterface
-	peerInfo *table.PeerInfo
-	siblings map[string]*serverMsgDataPeer
-	outgoing chan *bgp.BGPMessage
+	rib         *table.TableManager
+	isGlobalRib bool
+	rfMap       map[bgp.RouteFamily]bool
+	capMap      map[bgp.BGPCapabilityCode]bgp.ParameterCapabilityInterface
+	peerInfo    *table.PeerInfo
+	siblings    map[string]*serverMsgDataPeer
+	outgoing    chan *bgp.BGPMessage
 }
 
-func NewPeer(g config.Global, peer config.Neighbor, serverMsgCh chan *serverMsg, peerMsgCh chan *peerMsg, peerList []*serverMsgDataPeer) *Peer {
+func NewPeer(g config.Global, peer config.Neighbor, serverMsgCh chan *serverMsg, peerMsgCh chan *peerMsg, peerList []*serverMsgDataPeer, isGlobalRib bool) *Peer {
 	p := &Peer{
 		globalConfig:   g,
 		peerConfig:     peer,
@@ -73,6 +74,7 @@ func NewPeer(g config.Global, peer config.Neighbor, serverMsgCh chan *serverMsg,
 		peerMsgCh:      peerMsgCh,
 		rfMap:          make(map[bgp.RouteFamily]bool),
 		capMap:         make(map[bgp.BGPCapabilityCode]bgp.ParameterCapabilityInterface),
+		isGlobalRib:    isGlobalRib,
 	}
 	p.siblings = make(map[string]*serverMsgDataPeer)
 	for _, s := range peerList {
@@ -325,12 +327,25 @@ func (peer *Peer) sendUpdateMsgFromPaths(pList []table.Path) {
 func (peer *Peer) handlePeerMsg(m *peerMsg) {
 	switch m.msgType {
 	case PEER_MSG_PATH:
-		pList, _ := peer.rib.ProcessPaths(m.msgData.([]table.Path))
-		peer.sendUpdateMsgFromPaths(pList)
+		pList := m.msgData.([]table.Path)
+		if peer.peerConfig.RouteServer.RouteServerClient || peer.isGlobalRib {
+			pList, _ = peer.rib.ProcessPaths(pList)
+		}
+
+		if peer.isGlobalRib {
+			peer.sendPathsToSiblings(pList)
+		} else {
+			peer.sendUpdateMsgFromPaths(pList)
+		}
+
 	case PEER_MSG_PEER_DOWN:
 		for _, rf := range peer.configuredRFlist() {
 			pList, _ := peer.rib.DeletePathsforPeer(m.msgData.(*table.PeerInfo), rf)
-			peer.sendUpdateMsgFromPaths(pList)
+			if peer.peerConfig.RouteServer.RouteServerClient {
+				peer.sendUpdateMsgFromPaths(pList)
+			} else if peer.isGlobalRib {
+				peer.sendPathsToSiblings(pList)
+			}
 		}
 	}
 }
@@ -341,7 +356,11 @@ func (peer *Peer) handleServerMsg(m *serverMsg) {
 		d := m.msgData.(*serverMsgDataPeer)
 		peer.siblings[d.address.String()] = d
 		for _, rf := range peer.configuredRFlist() {
-			peer.sendPathsToSiblings(peer.adjRib.GetInPathList(rf))
+			if peer.peerConfig.RouteServer.RouteServerClient {
+				peer.sendPathsToSiblings(peer.adjRib.GetInPathList(rf))
+			} else if peer.isGlobalRib {
+				peer.sendPathsToSiblings(peer.rib.GetPathList(rf))
+			}
 		}
 	case SRV_MSG_PEER_DELETED:
 		d := m.msgData.(*table.PeerInfo)
@@ -349,7 +368,11 @@ func (peer *Peer) handleServerMsg(m *serverMsg) {
 			delete(peer.siblings, d.Address.String())
 			for _, rf := range peer.configuredRFlist() {
 				pList, _ := peer.rib.DeletePathsforPeer(d, rf)
-				peer.sendUpdateMsgFromPaths(pList)
+				if peer.peerConfig.RouteServer.RouteServerClient {
+					peer.sendUpdateMsgFromPaths(pList)
+				} else {
+					peer.sendPathsToSiblings(pList)
+				}
 			}
 		} else {
 			log.Warning("can not find peer: ", d.Address.String())

--- a/server/peer.go
+++ b/server/peer.go
@@ -320,7 +320,17 @@ func (peer *Peer) sendUpdateMsgFromPaths(pList []table.Path) {
 	peer.adjRib.UpdateOut(pList)
 	sendpathList := []table.Path{}
 	for _, p := range pList {
-		if _, ok := peer.rfMap[p.GetRouteFamily()]; ok {
+		_, ok := peer.rfMap[p.GetRouteFamily()]
+
+		if peer.peerConfig.NeighborAddress.Equal(p.GetNexthop()) {
+			log.WithFields(log.Fields{
+				"Topic": "Peer",
+				"Key":   peer.peerConfig.NeighborAddress,
+			}).Debugf("From me. Ignore: %s", p)
+			ok = false
+		}
+
+		if ok {
 			sendpathList = append(sendpathList, p)
 		}
 	}

--- a/server/peer.go
+++ b/server/peer.go
@@ -242,7 +242,7 @@ func (peer *Peer) sendMessages(msgs []*bgp.BGPMessage) {
 func (peer *Peer) handleREST(restReq *api.RestRequest) {
 	result := &api.RestResponse{}
 	switch restReq.RequestType {
-	case api.REQ_LOCAL_RIB:
+	case api.REQ_LOCAL_RIB, api.REQ_GLOBAL_RIB:
 		// just empty so we use ipv4 for any route family
 		j, _ := json.Marshal(table.NewIPv4Table(0))
 		if peer.fsm.adminState != ADMIN_STATE_DOWN {

--- a/server/peer_test.go
+++ b/server/peer_test.go
@@ -69,9 +69,9 @@ func TestProcessBGPUpdate_fourbyteAS(t *testing.T) {
 	msg := table.NewProcessMessage(m, peerInfo)
 	pathList := msg.ToPathList()
 
-	pList, wList, _ := rib1.ProcessPaths(pathList)
+	pList, _ := rib1.ProcessPaths(pathList)
 	assert.Equal(t, len(pList), 1)
-	assert.Equal(t, len(wList), 0)
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	fmt.Println(pList)
 	sendMsg := table.CreateUpdateMsgFromPaths(pList)
 	assert.Equal(t, len(sendMsg), 1)
@@ -87,9 +87,9 @@ func TestProcessBGPUpdate_fourbyteAS(t *testing.T) {
 	assert.Equal(t, attrAS.Value[0].(*bgp.AsPathParam).AS, []uint16{bgp.AS_TRANS, 4000, bgp.AS_TRANS})
 
 	rib2 := table.NewTableManager("peer_test", []bgp.RouteFamily{bgp.RF_IPv4_UC, bgp.RF_IPv6_UC})
-	pList2, wList2, _ := rib2.ProcessPaths(pathList)
+	pList2, _ := rib2.ProcessPaths(pathList)
 	assert.Equal(t, len(pList2), 1)
-	assert.Equal(t, len(wList2), 0)
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	sendMsg2 := table.CreateUpdateMsgFromPaths(pList2)
 	assert.Equal(t, len(sendMsg2), 1)
 	update2 := sendMsg2[0].Body.(*bgp.BGPUpdate)

--- a/server/server.go
+++ b/server/server.go
@@ -269,6 +269,12 @@ func (server *BgpServer) handleRest(restReq *api.RestRequest) {
 		}
 		restReq.ResponseCh <- result
 		close(restReq.ResponseCh)
+	case api.REQ_GLOBAL_RIB:
+		msg := &serverMsg{
+			msgType: SRV_MSG_API,
+			msgData: restReq,
+		}
+		server.globalRib.serverMsgCh <- msg
 	case api.REQ_LOCAL_RIB, api.REQ_NEIGHBOR_SHUTDOWN, api.REQ_NEIGHBOR_RESET,
 		api.REQ_NEIGHBOR_SOFT_RESET, api.REQ_NEIGHBOR_SOFT_RESET_IN, api.REQ_NEIGHBOR_SOFT_RESET_OUT,
 		api.REQ_ADJ_RIB_IN, api.REQ_ADJ_RIB_OUT,

--- a/table/message.go
+++ b/table/message.go
@@ -17,6 +17,7 @@ package table
 
 import (
 	"bytes"
+	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet"
 )
 
@@ -125,6 +126,16 @@ func cloneAttrSlice(attrs []bgp.PathAttributeInterface) []bgp.PathAttributeInter
 	clonedAttrs := make([]bgp.PathAttributeInterface, 0)
 	clonedAttrs = append(clonedAttrs, attrs...)
 	return clonedAttrs
+}
+
+func CloneAndUpdatePathAttrs(pathList []Path, global *config.Global, peer *config.Neighbor) []Path {
+	newPathList := make([]Path, 0, len(pathList))
+	for _, p := range pathList {
+		clone := p.clone(p.IsWithdraw())
+		clone.updatePathAttrs(global, peer)
+		newPathList = append(newPathList, clone)
+	}
+	return newPathList
 }
 
 func createUpdateMsgFromPath(path Path, msg *bgp.BGPMessage) *bgp.BGPMessage {

--- a/table/path.go
+++ b/table/path.go
@@ -35,7 +35,7 @@ type Path interface {
 	setSource(source *PeerInfo)
 	getSource() *PeerInfo
 	setNexthop(nexthop net.IP)
-	getNexthop() net.IP
+	GetNexthop() net.IP
 	setWithdraw(withdraw bool)
 	IsWithdraw() bool
 	getNlri() bgp.AddrPrefixInterface
@@ -225,7 +225,7 @@ func (pd *PathDefault) setNexthop(nexthop net.IP) {
 	pd.nexthop = nexthop
 }
 
-func (pd *PathDefault) getNexthop() net.IP {
+func (pd *PathDefault) GetNexthop() net.IP {
 	return pd.nexthop
 }
 
@@ -284,7 +284,7 @@ func (pd *PathDefault) getPathAttr(pattrType bgp.BGPAttrType) (int, bgp.PathAttr
 func (pi *PathDefault) String() string {
 	str := fmt.Sprintf("IPv4Path Source: %v, ", pi.getSource())
 	str = str + fmt.Sprintf(" NLRI: %s, ", pi.getPrefix())
-	str = str + fmt.Sprintf(" nexthop: %s, ", pi.getNexthop().String())
+	str = str + fmt.Sprintf(" nexthop: %s, ", pi.GetNexthop().String())
 	str = str + fmt.Sprintf(" withdraw: %s, ", pi.IsWithdraw())
 	//str = str + fmt.Sprintf(" path attributes: %s, ", pi.getPathAttributeMap())
 	return str
@@ -382,7 +382,7 @@ func (ipv6p *IPv6Path) getPrefix() string {
 func (ipv6p *IPv6Path) String() string {
 	str := fmt.Sprintf("IPv6Path Source: %v, ", ipv6p.getSource())
 	str = str + fmt.Sprintf(" NLRI: %s, ", ipv6p.getPrefix())
-	str = str + fmt.Sprintf(" nexthop: %s, ", ipv6p.getNexthop().String())
+	str = str + fmt.Sprintf(" nexthop: %s, ", ipv6p.GetNexthop().String())
 	str = str + fmt.Sprintf(" withdraw: %s, ", ipv6p.IsWithdraw())
 	//str = str + fmt.Sprintf(" path attributes: %s, ", ipv6p.getPathAttributeMap())
 	return str
@@ -447,7 +447,7 @@ func (ipv4vpnp *IPv4VPNPath) getPrefix() string {
 func (ipv4vpnp *IPv4VPNPath) String() string {
 	str := fmt.Sprintf("IPv4VPNPath Source: %v, ", ipv4vpnp.getSource())
 	str = str + fmt.Sprintf(" NLRI: %s, ", ipv4vpnp.getPrefix())
-	str = str + fmt.Sprintf(" nexthop: %s, ", ipv4vpnp.getNexthop().String())
+	str = str + fmt.Sprintf(" nexthop: %s, ", ipv4vpnp.GetNexthop().String())
 	str = str + fmt.Sprintf(" withdraw: %s, ", ipv4vpnp.IsWithdraw())
 	//str = str + fmt.Sprintf(" path attributes: %s, ", ipv4vpnp.getPathAttributeMap())
 	return str

--- a/table/path.go
+++ b/table/path.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
+	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet"
 	"net"
 	"reflect"
@@ -29,6 +30,7 @@ type Path interface {
 	String() string
 	getPathAttrs() []bgp.PathAttributeInterface
 	getPathAttr(bgp.BGPAttrType) (int, bgp.PathAttributeInterface)
+	updatePathAttrs(global *config.Global, peer *config.Neighbor)
 	GetRouteFamily() bgp.RouteFamily
 	setSource(source *PeerInfo)
 	getSource() *PeerInfo
@@ -80,6 +82,99 @@ func NewPathDefault(rf bgp.RouteFamily, source *PeerInfo, nlri bgp.AddrPrefixInt
 	return path
 }
 
+func cloneAsPath(asAttr *bgp.PathAttributeAsPath) *bgp.PathAttributeAsPath {
+	newASparams := make([]bgp.AsPathParamInterface, len(asAttr.Value))
+	for i, param := range asAttr.Value {
+		asParam := param.(*bgp.As4PathParam)
+		as := make([]uint32, len(asParam.AS))
+		copy(as, asParam.AS)
+		newASparams[i] = bgp.NewAs4PathParam(asParam.Type, as)
+	}
+	return bgp.NewPathAttributeAsPath(newASparams)
+}
+
+func (pd *PathDefault) updatePathAttrs(global *config.Global, peer *config.Neighbor) {
+	newPathAttrs := make([]bgp.PathAttributeInterface, len(pd.pathAttrs))
+	for i, v := range pd.pathAttrs {
+		newPathAttrs[i] = v
+	}
+	pd.pathAttrs = newPathAttrs
+
+	if peer.RouteServer.RouteServerClient {
+		return
+	}
+
+	if peer.PeerType == config.PEER_TYPE_EXTERNAL {
+		// NEXTHOP handling
+		idx, _ := pd.getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
+		if idx < 0 {
+			log.Fatal("missing NEXTHOP mandatory attribute")
+		}
+		newNexthop := bgp.NewPathAttributeNextHop(peer.LocalAddress.String())
+		newPathAttrs[idx] = newNexthop
+
+		// AS_PATH handling
+		//
+		//  When a given BGP speaker advertises the route to an external
+		//  peer, the advertising speaker updates the AS_PATH attribute
+		//  as follows:
+		//  1) if the first path segment of the AS_PATH is of type
+		//     AS_SEQUENCE, the local system prepends its own AS num as
+		//     the last element of the sequence (put it in the left-most
+		//     position with respect to the position of  octets in the
+		//     protocol message).  If the act of prepending will cause an
+		//     overflow in the AS_PATH segment (i.e.,  more than 255
+		//     ASes), it SHOULD prepend a new segment of type AS_SEQUENCE
+		//     and prepend its own AS number to this new segment.
+		//
+		//  2) if the first path segment of the AS_PATH is of type AS_SET
+		//     , the local system prepends a new path segment of type
+		//     AS_SEQUENCE to the AS_PATH, including its own AS number in
+		//     that segment.
+		//
+		//  3) if the AS_PATH is empty, the local system creates a path
+		//     segment of type AS_SEQUENCE, places its own AS into that
+		//     segment, and places that segment into the AS_PATH.
+		idx, originalAsPath := pd.getPathAttr(bgp.BGP_ATTR_TYPE_AS_PATH)
+		if idx < 0 {
+			log.Fatal("missing AS_PATH mandatory attribute")
+		}
+		asPath := cloneAsPath(originalAsPath.(*bgp.PathAttributeAsPath))
+		newPathAttrs[idx] = asPath
+		fst := asPath.Value[0].(*bgp.As4PathParam)
+		if len(asPath.Value) > 0 && fst.Type == bgp.BGP_ASPATH_ATTR_TYPE_SEQ &&
+			fst.ASLen() < 255 {
+			fst.AS = append([]uint32{global.As}, fst.AS...)
+			fst.Num += 1
+		} else {
+			p := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{global.As})
+			asPath.Value = append([]bgp.AsPathParamInterface{p}, asPath.Value...)
+		}
+
+		// MED Handling
+		idx, _ = pd.getPathAttr(bgp.BGP_ATTR_TYPE_MULTI_EXIT_DISC)
+		if idx >= 0 {
+			newPathAttrs = append(newPathAttrs[:idx], newPathAttrs[idx+1:]...)
+		}
+	} else if peer.PeerType == config.PEER_TYPE_INTERNAL {
+		// For iBGP peers we are required to send local-pref attribute
+		// for connected or local prefixes.
+		// We set default local-pref 100.
+		p := bgp.NewPathAttributeLocalPref(100)
+		idx, _ := pd.getPathAttr(bgp.BGP_ATTR_TYPE_LOCAL_PREF)
+		if idx < 0 {
+			newPathAttrs = append(newPathAttrs, p)
+		} else {
+			newPathAttrs[idx] = p
+		}
+	} else {
+		log.WithFields(log.Fields{
+			"Topic": "Peer",
+			"Key":   peer.NeighborAddress,
+		}).Warnf("invalid peer type: %d", peer.PeerType)
+	}
+}
+
 func (pd *PathDefault) getTimestamp() time.Time {
 	return pd.timestamp
 }
@@ -107,11 +202,7 @@ func (pd *PathDefault) clone(isWithdraw bool) Path {
 	nlri := pd.nlri
 	if isWithdraw {
 		if pd.IsWithdraw() {
-			log.WithFields(log.Fields{
-				"Topic": "Table",
-				"Key":   pd.getNlri().String(),
-				"Peer":  pd.getSource().Address.String(),
-			}).Fatal("Withdraw path is not supposed to be cloned")
+			nlri = pd.nlri
 		} else {
 			nlri = &bgp.WithdrawnRoute{pd.nlri.(*bgp.NLRInfo).IPAddrPrefix}
 		}
@@ -271,15 +362,6 @@ func NewIPv6Path(source *PeerInfo, nlri bgp.AddrPrefixInterface, isWithdraw bool
 
 func (ipv6p *IPv6Path) clone(isWithdraw bool) Path {
 	nlri := ipv6p.nlri
-	if isWithdraw {
-		if ipv6p.IsWithdraw() {
-			log.WithFields(log.Fields{
-				"Topic": "Table",
-				"Key":   ipv6p.getNlri().String(),
-				"Peer":  ipv6p.getSource().Address.String(),
-			}).Fatal("Withdraw path is not supposed to be cloned")
-		}
-	}
 	return CreatePath(ipv6p.source, nlri, ipv6p.pathAttrs, isWithdraw, ipv6p.PathDefault.timestamp)
 }
 

--- a/table/path_test.go
+++ b/table/path_test.go
@@ -83,7 +83,7 @@ func TestPathSetNexthop(t *testing.T) {
 	pd := &PathDefault{}
 	ip := net.ParseIP("192.168.0.1")
 	pd.setNexthop(ip)
-	nh := pd.getNexthop()
+	nh := pd.GetNexthop()
 	assert.Equal(t, nh, ip)
 }
 
@@ -91,7 +91,7 @@ func TestPathgetNexthop(t *testing.T) {
 	pd := &PathDefault{}
 	ip := net.ParseIP("192.168.0.2")
 	pd.setNexthop(ip)
-	nh := pd.getNexthop()
+	nh := pd.GetNexthop()
 	assert.Equal(t, nh, ip)
 }
 

--- a/table/table_manager.go
+++ b/table/table_manager.go
@@ -261,6 +261,17 @@ func (manager *TableManager) ProcessPaths(pathList []Path) ([]Path, error) {
 	return manager.calculate(destinationList)
 }
 
+func (manager *TableManager) GetPathList(rf bgp.RouteFamily) []Path {
+	if _, ok := manager.Tables[rf]; !ok {
+		return []Path{}
+	}
+	var paths []Path
+	for _, dest := range manager.Tables[rf].getDestinations() {
+		paths = append(paths, dest.getBestPath())
+	}
+	return paths
+}
+
 // process BGPUpdate message
 // this function processes only BGPUpdate
 func (manager *TableManager) ProcessUpdate(fromPeer *PeerInfo, message *bgp.BGPMessage) ([]Path, error) {

--- a/table/table_manager.go
+++ b/table/table_manager.go
@@ -175,7 +175,7 @@ func (manager *TableManager) calculate(destinationList []Destination) ([]Path, e
 				"Owner":    manager.owner,
 				"Key":      destination.getNlri().String(),
 				"peer":     newBestPath.getSource().Address,
-				"next_hop": newBestPath.getNexthop().String(),
+				"next_hop": newBestPath.GetNexthop().String(),
 				"reason":   reason,
 			}).Debug("best path is not changed")
 			continue
@@ -196,7 +196,7 @@ func (manager *TableManager) calculate(destinationList []Destination) ([]Path, e
 						"Owner":    manager.owner,
 						"Key":      destination.getNlri().String(),
 						"peer":     currentBestPath.getSource().Address,
-						"next_hop": currentBestPath.getNexthop().String(),
+						"next_hop": currentBestPath.GetNexthop().String(),
 					}).Debug("best path is lost")
 
 					p := destination.getBestPath()
@@ -218,7 +218,7 @@ func (manager *TableManager) calculate(destinationList []Destination) ([]Path, e
 				"Owner":    manager.owner,
 				"Key":      newBestPath.getNlri().String(),
 				"peer":     newBestPath.getSource().Address,
-				"next_hop": newBestPath.getNexthop(),
+				"next_hop": newBestPath.GetNexthop(),
 				"reason":   reason,
 			}).Debug("new best path")
 

--- a/table/table_manager_test.go
+++ b/table/table_manager_test.go
@@ -71,9 +71,9 @@ func TestProcessBGPUpdate_0_select_onlypath_ipv4(t *testing.T) {
 
 	bgpMessage := update_fromR1()
 	peer := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer, bgpMessage)
+	pList, err := tm.ProcessUpdate(peer, bgpMessage)
 	assert.Equal(t, len(pList), 1)
-	assert.Equal(t, len(wList), 0)
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -122,9 +122,9 @@ func TestProcessBGPUpdate_0_select_onlypath_ipv6(t *testing.T) {
 
 	bgpMessage := update_fromR1_ipv6()
 	peer := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer, bgpMessage)
+	pList, err := tm.ProcessUpdate(peer, bgpMessage)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -202,15 +202,15 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv4(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	peer2 := peerR2()
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -288,15 +288,15 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv6(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	peer2 := peerR2()
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -374,17 +374,17 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv4(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	var peer2 *PeerInfo = &PeerInfo{
 		Address: net.ParseIP("0.0.0.0"),
 	}
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -462,18 +462,18 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv6(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	var peer2 *PeerInfo = &PeerInfo{
 		Address: net.ParseIP("0.0.0.0"),
 	}
 
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -524,15 +524,15 @@ func TestProcessBGPUpdate_3_select_aspath_ipv4(t *testing.T) {
 
 	bgpMessage1 := update_fromR2viaR1()
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 	bgpMessage2 := update_fromR2()
 	peer2 := peerR2()
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -581,15 +581,15 @@ func TestProcessBGPUpdate_3_select_aspath_ipv6(t *testing.T) {
 
 	bgpMessage1 := update_fromR2viaR1_ipv6()
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 	bgpMessage2 := update_fromR2_ipv6()
 	peer2 := peerR2()
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -667,15 +667,15 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv4(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	peer2 := peerR2()
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -753,15 +753,15 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv6(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	peer2 := peerR2()
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -839,15 +839,15 @@ func TestProcessBGPUpdate_5_select_low_med_ipv4(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	peer2 := peerR2()
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -925,15 +925,15 @@ func TestProcessBGPUpdate_5_select_low_med_ipv6(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	peer2 := peerR2()
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -1013,15 +1013,15 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv4(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	peer2 := peerR2()
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -1100,15 +1100,15 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	peer2 := peerR2()
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -1190,15 +1190,15 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv4(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	peer3 := peerR3()
-	pList, wList, err = tm.ProcessUpdate(peer3, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer3, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -1277,15 +1277,15 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv6(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	peer3 := peerR3()
-	pList, wList, err = tm.ProcessUpdate(peer3, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer3, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -1364,15 +1364,15 @@ func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	peer2 := peerR2()
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -1419,9 +1419,9 @@ func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 	w := []bgp.WithdrawnRoute{w1}
 	bgpMessage3 := bgp.NewBGPUpdateMessage(w, []bgp.PathAttributeInterface{}, []bgp.NLRInfo{})
 
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage3)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage3)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	path = pList[0]
@@ -1474,15 +1474,15 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	peer2 := peerR2()
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -1554,9 +1554,9 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 	bgpMessage3 := bgp.NewBGPUpdateMessage([]bgp.WithdrawnRoute{},
 		[]bgp.PathAttributeInterface{mp_unreach}, []bgp.NLRInfo{})
 
-	pList, wList, err = tm.ProcessUpdate(peer2, bgpMessage3)
+	pList, err = tm.ProcessUpdate(peer2, bgpMessage3)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	path = pList[0]
@@ -1599,18 +1599,18 @@ func TestProcessBGPUpdate_bestpath_lost_ipv4(t *testing.T) {
 	bgpMessage1_w := bgp.NewBGPUpdateMessage(w, []bgp.PathAttributeInterface{}, []bgp.NLRInfo{})
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
-	pList, wList, err = tm.ProcessUpdate(peer1, bgpMessage1_w)
-	assert.Equal(t, 0, len(pList))
-	assert.Equal(t, 1, len(wList))
+	pList, err = tm.ProcessUpdate(peer1, bgpMessage1_w)
+	assert.Equal(t, 1, len(pList))
+	assert.Equal(t, pList[0].IsWithdraw(), true)
 	assert.NoError(t, err)
 
 	// check old best path
-	path := wList[0]
+	path := pList[0]
 	expectedType := "*table.IPv4Path"
 	assert.Equal(t, reflect.TypeOf(path).String(), expectedType)
 
@@ -1668,9 +1668,9 @@ func TestProcessBGPUpdate_bestpath_lost_ipv6(t *testing.T) {
 	bgpMessage1 := bgp.NewBGPUpdateMessage(withdrawnRoutes1, pathAttributes1, nlri1)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// path1 mpunreach
@@ -1678,13 +1678,13 @@ func TestProcessBGPUpdate_bestpath_lost_ipv6(t *testing.T) {
 	bgpMessage1_w := bgp.NewBGPUpdateMessage([]bgp.WithdrawnRoute{},
 		[]bgp.PathAttributeInterface{mp_unreach}, []bgp.NLRInfo{})
 
-	pList, wList, err = tm.ProcessUpdate(peer1, bgpMessage1_w)
-	assert.Equal(t, 0, len(pList))
-	assert.Equal(t, 1, len(wList))
+	pList, err = tm.ProcessUpdate(peer1, bgpMessage1_w)
+	assert.Equal(t, 1, len(pList))
+	assert.Equal(t, pList[0].IsWithdraw(), true)
 	assert.NoError(t, err)
 
 	// check old best path
-	path := wList[0]
+	path := pList[0]
 	expectedType := "*table.IPv6Path"
 	assert.Equal(t, reflect.TypeOf(path).String(), expectedType)
 
@@ -1758,14 +1758,14 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv4(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
-	pList, wList, err = tm.ProcessUpdate(peer1, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer1, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -1845,14 +1845,14 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv6(t *testing.T) {
 	bgpMessage2 := bgp.NewBGPUpdateMessage(withdrawnRoutes2, pathAttributes2, nlri2)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
-	pList, wList, err = tm.ProcessUpdate(peer1, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer1, bgpMessage2)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check type
@@ -2013,9 +2013,11 @@ func TestProcessBGPUpdate_multiple_nlri_ipv4(t *testing.T) {
 	bgpMessage4 := bgp.NewBGPUpdateMessage([]bgp.WithdrawnRoute{}, pathAttributes4, nlri4)
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 5, len(pList))
-	assert.Equal(t, 0, len(wList))
+	for _, p := range pList {
+		assert.Equal(t, p.IsWithdraw(), false)
+	}
 	assert.NoError(t, err)
 
 	checkBestPathResult("*table.IPv4Path", "10.10.10.0/24", "192.168.50.1", pList[0], bgpMessage1)
@@ -2024,9 +2026,11 @@ func TestProcessBGPUpdate_multiple_nlri_ipv4(t *testing.T) {
 	checkBestPathResult("*table.IPv4Path", "40.40.40.0/24", "192.168.50.1", pList[3], bgpMessage1)
 	checkBestPathResult("*table.IPv4Path", "50.50.50.0/24", "192.168.50.1", pList[4], bgpMessage1)
 
-	pList, wList, err = tm.ProcessUpdate(peer1, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer1, bgpMessage2)
 	assert.Equal(t, 5, len(pList))
-	assert.Equal(t, 0, len(wList))
+	for _, p := range pList {
+		assert.Equal(t, p.IsWithdraw(), false)
+	}
 	assert.NoError(t, err)
 
 	checkBestPathResult("*table.IPv4Path", "11.11.11.0/24", "192.168.50.1", pList[0], bgpMessage2)
@@ -2035,14 +2039,16 @@ func TestProcessBGPUpdate_multiple_nlri_ipv4(t *testing.T) {
 	checkBestPathResult("*table.IPv4Path", "44.44.44.0/24", "192.168.50.1", pList[3], bgpMessage2)
 	checkBestPathResult("*table.IPv4Path", "55.55.55.0/24", "192.168.50.1", pList[4], bgpMessage2)
 
-	pList, wList, err = tm.ProcessUpdate(peer1, bgpMessage3)
+	pList, err = tm.ProcessUpdate(peer1, bgpMessage3)
 	assert.Equal(t, 2, len(pList))
-	assert.Equal(t, 0, len(wList))
+	for _, p := range pList {
+		assert.Equal(t, p.IsWithdraw(), false)
+	}
 	assert.NoError(t, err)
 
-	pList, wList, err = tm.ProcessUpdate(peer1, bgpMessage4)
+	pList, err = tm.ProcessUpdate(peer1, bgpMessage4)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check table
@@ -2154,9 +2160,11 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 	bgpMessage4 := bgp.NewBGPUpdateMessage([]bgp.WithdrawnRoute{}, pathAttributes4, []bgp.NLRInfo{})
 
 	peer1 := peerR1()
-	pList, wList, err := tm.ProcessUpdate(peer1, bgpMessage1)
+	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
 	assert.Equal(t, 5, len(pList))
-	assert.Equal(t, 0, len(wList))
+	for _, p := range pList {
+		assert.Equal(t, p.IsWithdraw(), false)
+	}
 	assert.NoError(t, err)
 
 	checkBestPathResult("*table.IPv6Path", "2001:123:1210:11::/64", "2001::192:168:50:1", pList[0], bgpMessage1)
@@ -2165,9 +2173,11 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 	checkBestPathResult("*table.IPv6Path", "2001:123:1240:11::/64", "2001::192:168:50:1", pList[3], bgpMessage1)
 	checkBestPathResult("*table.IPv6Path", "2001:123:1250:11::/64", "2001::192:168:50:1", pList[4], bgpMessage1)
 
-	pList, wList, err = tm.ProcessUpdate(peer1, bgpMessage2)
+	pList, err = tm.ProcessUpdate(peer1, bgpMessage2)
 	assert.Equal(t, 5, len(pList))
-	assert.Equal(t, 0, len(wList))
+	for _, p := range pList {
+		assert.Equal(t, p.IsWithdraw(), false)
+	}
 	assert.NoError(t, err)
 
 	checkBestPathResult("*table.IPv6Path", "2001:123:1211:11::/64", "2001::192:168:50:1", pList[0], bgpMessage2)
@@ -2176,14 +2186,16 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 	checkBestPathResult("*table.IPv6Path", "2001:123:1244:11::/64", "2001::192:168:50:1", pList[3], bgpMessage2)
 	checkBestPathResult("*table.IPv6Path", "2001:123:1255:11::/64", "2001::192:168:50:1", pList[4], bgpMessage2)
 
-	pList, wList, err = tm.ProcessUpdate(peer1, bgpMessage3)
+	pList, err = tm.ProcessUpdate(peer1, bgpMessage3)
 	assert.Equal(t, 2, len(pList))
-	assert.Equal(t, 0, len(wList))
+	for _, p := range pList {
+		assert.Equal(t, p.IsWithdraw(), false)
+	}
 	assert.NoError(t, err)
 
-	pList, wList, err = tm.ProcessUpdate(peer1, bgpMessage4)
+	pList, err = tm.ProcessUpdate(peer1, bgpMessage4)
 	assert.Equal(t, 1, len(pList))
-	assert.Equal(t, 0, len(wList))
+	assert.Equal(t, pList[0].IsWithdraw(), false)
 	assert.NoError(t, err)
 
 	// check table

--- a/table/table_manager_test.go
+++ b/table/table_manager_test.go
@@ -111,7 +111,7 @@ func TestProcessBGPUpdate_0_select_onlypath_ipv4(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "192.168.50.1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -163,7 +163,7 @@ func TestProcessBGPUpdate_0_select_onlypath_ipv6(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "2001::192:168:50:1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -248,7 +248,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv4(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "192.168.50.1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -335,7 +335,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv6(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "2001::192:168:100:1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -422,7 +422,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv4(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "0.0.0.0"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -512,7 +512,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv6(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "::"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -570,7 +570,7 @@ func TestProcessBGPUpdate_3_select_aspath_ipv4(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "192.168.100.1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -628,7 +628,7 @@ func TestProcessBGPUpdate_3_select_aspath_ipv6(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "2001::192:168:100:1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -713,7 +713,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv4(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "192.168.100.1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -800,7 +800,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv6(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "2001::192:168:100:1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -885,7 +885,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv4(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "192.168.100.1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -972,7 +972,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv6(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "2001::192:168:100:1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -1059,7 +1059,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv4(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "192.168.100.1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -1147,7 +1147,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "2001::192:168:100:1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -1236,7 +1236,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv4(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "192.168.100.1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -1324,7 +1324,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv6(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "2001::192:168:100:1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -1412,7 +1412,7 @@ func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "192.168.100.1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 	//withdraw path
 	w1 := bgp.WithdrawnRoute{*bgp.NewIPAddrPrefix(24, "10.10.10.0")}
@@ -1434,7 +1434,7 @@ func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop = "192.168.50.1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 }
 
 // TODO MP_UNREACH
@@ -1547,7 +1547,7 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "2001::192:168:100:1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 	//mpunreach path
 	mp_unreach := createMpUNReach("2001:123:123:1::", 64)
@@ -1569,7 +1569,7 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop = "2001::192:168:50:1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -1805,7 +1805,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv4(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "192.168.50.1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -1917,7 +1917,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv6(t *testing.T) {
 	assert.Equal(t, expectedPrefix, path.getPrefix())
 	// check nexthop
 	expectedNexthop := "2001::192:168:50:1"
-	assert.Equal(t, expectedNexthop, path.getNexthop().String())
+	assert.Equal(t, expectedNexthop, path.GetNexthop().String())
 
 }
 
@@ -1974,7 +1974,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv4(t *testing.T) {
 		// check destination
 		assert.Equal(t, prefix, p.getPrefix())
 		// check nexthop
-		assert.Equal(t, nexthop, p.getNexthop().String())
+		assert.Equal(t, nexthop, p.GetNexthop().String())
 	}
 
 	// path1
@@ -2115,7 +2115,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 		// check destination
 		assert.Equal(t, prefix, p.getPrefix())
 		// check nexthop
-		assert.Equal(t, nexthop, p.getNexthop().String())
+		assert.Equal(t, nexthop, p.GetNexthop().String())
 	}
 
 	// path1


### PR DESCRIPTION
struct Path has a flag which can tell whether the path is withdrawal
path or not. so table.ProcessPaths() needs not to return withdrawal path
and non-withdrawal path separetly.

this removes such unnecessary distinction.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>