### PR TITLE
table: fix nexthop path attribute updating for normal BGP

### DIFF
--- a/server/peer.go
+++ b/server/peer.go
@@ -627,7 +627,7 @@ func (peer *Peer) loop() error {
 				peer.peerConfig.LocalAddress = peer.fsm.LocalAddr()
 				for rf, _ := range peer.rfMap {
 					pathList := peer.adjRib.GetOutPathList(rf)
-					peer.sendMessages(table.CreateUpdateMsgFromPaths(pathList))
+					peer.sendUpdateMsgFromPaths(pathList)
 				}
 				peer.fsm.peerConfig.BgpNeighborCommonState.Uptime = time.Now().Unix()
 				peer.fsm.peerConfig.BgpNeighborCommonState.EstablishedCount++


### PR DESCRIPTION
Paths whose route family are other than ipv4 have nexthop information in
a mp_reach_nlri path attribute instead of a nexthop path attribute.

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>