### PR TITLE
scenario_test: add wait after state changed

### DIFF
--- a/test/scenario_test/bgp_router_test.py
+++ b/test/scenario_test/bgp_router_test.py
@@ -58,6 +58,8 @@ class GoBGPTest(GoBGPTestBase):
             remote_ip = neighbor['conf']['remote_ip']
             self.assertEqual(address, remote_ip)
             self.assertEqual(state, "BGP_FSM_ESTABLISHED")
+        print "please wait " + str(self.wait_after_state_changed) + " second after established"
+        time.sleep(self.wait_after_state_changed)
 
     # Test of advertised route gobgp from each quagga
     def test_02_received_route(self):
@@ -135,6 +137,8 @@ class GoBGPTest(GoBGPTestBase):
         remote_ip = neighbor['conf']['remote_ip']
         self.assertEqual(append_quagga_address, remote_ip)
         self.assertEqual(state, "BGP_FSM_ESTABLISHED")
+        print "please wait " + str(self.wait_after_state_changed) + " second after established"
+        time.sleep(self.wait_after_state_changed)
 
     # Test of advertised route gobgp from each quagga when append quagga container
     def test_05_received_route_when_appended_quagga(self):
@@ -205,6 +209,8 @@ class GoBGPTest(GoBGPTestBase):
         remote_ip = neighbor['conf']['remote_ip']
         self.assertEqual(removed_quagga_address, remote_ip)
         self.assertEqual(state, "BGP_FSM_ACTIVE")
+        print "please wait " + str(self.wait_after_state_changed) + " second after removed"
+        time.sleep(self.wait_after_state_changed)
 
     def test_08_received_route_when_quagga_removed(self):
         print "test_received_route_when_removed_quagga"

--- a/test/scenario_test/gobgp_test.py
+++ b/test/scenario_test/gobgp_test.py
@@ -34,6 +34,7 @@ class GoBGPTestBase(unittest.TestCase):
     gobgp_config = None
     initial_wait_time = 10
     wait_per_retry = 5
+    wait_after_state_changed = 5
     retry_limit = (60 - initial_wait_time) / wait_per_retry
 
     def __init__(self, *args, **kwargs):

--- a/test/scenario_test/route_server_test.py
+++ b/test/scenario_test/route_server_test.py
@@ -58,6 +58,8 @@ class GoBGPTest(GoBGPTestBase):
             remote_ip = neighbor['conf']['remote_ip']
             self.assertEqual(address, remote_ip)
             self.assertEqual(state, "BGP_FSM_ESTABLISHED")
+        print "please wait " + str(self.wait_after_state_changed) + " second after established"
+        time.sleep(self.wait_after_state_changed)
 
     # Test of advertised route gobgp from each quagga
     def test_02_received_route(self):
@@ -137,6 +139,8 @@ class GoBGPTest(GoBGPTestBase):
         remote_ip = neighbor['conf']['remote_ip']
         self.assertEqual(append_quagga_address, remote_ip)
         self.assertEqual(state, "BGP_FSM_ESTABLISHED")
+        print "please wait " + str(self.wait_after_state_changed) + " second after established"
+        time.sleep(self.wait_after_state_changed)
 
     # Test of advertised route gobgp from each quagga when append quagga container
     def test_05_received_route_when_appended_quagga(self):
@@ -222,6 +226,8 @@ class GoBGPTest(GoBGPTestBase):
         remote_ip = neighbor['conf']['remote_ip']
         self.assertEqual(removed_quagga_address, remote_ip)
         self.assertEqual(state, "BGP_FSM_ACTIVE")
+        print "please wait " + str(self.wait_after_state_changed) + " second after removed"
+        time.sleep(self.wait_after_state_changed)
 
     def test_08_received_route_when_quagga_removed(self):
         print "test_received_route_when_removed_quagga"


### PR DESCRIPTION
add 5-second wait after the establishment of peer connection and the removal of quagga in the test cases to avoid timing issue.