### PR TITLE
server: bug fix of REQ_LOCAL_RIB handling

### DIFF
--- a/server/peer.go
+++ b/server/peer.go
@@ -400,9 +400,9 @@ func (peer *Peer) handleGrpc(grpcReq *GrpcRequest) {
 				result.Data = dst.ToApiStruct()
 				grpcReq.ResponseCh <- result
 			}
-			close(grpcReq.ResponseCh)
-			return
 		}
+		close(grpcReq.ResponseCh)
+		return
 	case REQ_NEIGHBOR_SHUTDOWN:
 		peer.outgoing <- bgp.NewBGPNotificationMessage(bgp.BGP_ERROR_CEASE, bgp.BGP_ERROR_SUB_ADMINISTRATIVE_SHUTDOWN, nil)
 	case REQ_NEIGHBOR_RESET:


### PR DESCRIPTION
When route family is not supported for a peer's local rib,
gobgpd dies with following message.

$ gobgp show neighbor 10.0.0.1 local evpn

> panic: interface conversion: interface is nil, not *api.Destination

this patch fix this.

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>