### PR TITLE
gobgp: fix showing neighbor info twice

### DIFF
--- a/gobgp/main.go
+++ b/gobgp/main.go
@@ -506,10 +506,6 @@ func (x *ShowNeighborsCommand) Execute(args []string) error {
 		fmt.Printf(format, p.Conf.RemoteIp, fmt.Sprint(p.Conf.RemoteAs), timedelta[i], format_fsm(p.Info.AdminState, p.Info.BgpState), fmt.Sprint(p.Info.Advertized), fmt.Sprint(p.Info.Received), fmt.Sprint(p.Info.Accepted))
 	}
 
-	for i, p := range m {
-		fmt.Printf(format, p.Conf.RemoteIp, fmt.Sprint(p.Conf.RemoteAs), timedelta[i], format_fsm(p.Info.AdminState, p.Info.BgpState), fmt.Sprint(p.Info.Advertized), fmt.Sprint(p.Info.Received), fmt.Sprint(p.Info.Accepted))
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>