### PR TITLE
Fix a build issue, add an error handling on MPLS label serialization

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -920,9 +920,9 @@ func (x *grpcGetNeighborsServer) Send(m *Peer) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _Grpc_GetNeighbor_Handler(srv interface{}, ctx context.Context, buf []byte) (interface{}, error) {
+func _Grpc_GetNeighbor_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(Arguments)
-	if err := proto.Unmarshal(buf, in); err != nil {
+	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(GrpcServer).GetNeighbor(ctx, in)
@@ -974,9 +974,9 @@ func (x *grpcGetAdjRibServer) Send(m *Path) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _Grpc_Reset_Handler(srv interface{}, ctx context.Context, buf []byte) (interface{}, error) {
+func _Grpc_Reset_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(Arguments)
-	if err := proto.Unmarshal(buf, in); err != nil {
+	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(GrpcServer).Reset(ctx, in)
@@ -986,9 +986,9 @@ func _Grpc_Reset_Handler(srv interface{}, ctx context.Context, buf []byte) (inte
 	return out, nil
 }
 
-func _Grpc_SoftReset_Handler(srv interface{}, ctx context.Context, buf []byte) (interface{}, error) {
+func _Grpc_SoftReset_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(Arguments)
-	if err := proto.Unmarshal(buf, in); err != nil {
+	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(GrpcServer).SoftReset(ctx, in)
@@ -998,9 +998,9 @@ func _Grpc_SoftReset_Handler(srv interface{}, ctx context.Context, buf []byte) (
 	return out, nil
 }
 
-func _Grpc_SoftResetIn_Handler(srv interface{}, ctx context.Context, buf []byte) (interface{}, error) {
+func _Grpc_SoftResetIn_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(Arguments)
-	if err := proto.Unmarshal(buf, in); err != nil {
+	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(GrpcServer).SoftResetIn(ctx, in)
@@ -1010,9 +1010,9 @@ func _Grpc_SoftResetIn_Handler(srv interface{}, ctx context.Context, buf []byte)
 	return out, nil
 }
 
-func _Grpc_SoftResetOut_Handler(srv interface{}, ctx context.Context, buf []byte) (interface{}, error) {
+func _Grpc_SoftResetOut_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(Arguments)
-	if err := proto.Unmarshal(buf, in); err != nil {
+	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(GrpcServer).SoftResetOut(ctx, in)
@@ -1022,9 +1022,9 @@ func _Grpc_SoftResetOut_Handler(srv interface{}, ctx context.Context, buf []byte
 	return out, nil
 }
 
-func _Grpc_Shutdown_Handler(srv interface{}, ctx context.Context, buf []byte) (interface{}, error) {
+func _Grpc_Shutdown_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(Arguments)
-	if err := proto.Unmarshal(buf, in); err != nil {
+	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(GrpcServer).Shutdown(ctx, in)
@@ -1034,9 +1034,9 @@ func _Grpc_Shutdown_Handler(srv interface{}, ctx context.Context, buf []byte) (i
 	return out, nil
 }
 
-func _Grpc_Enable_Handler(srv interface{}, ctx context.Context, buf []byte) (interface{}, error) {
+func _Grpc_Enable_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(Arguments)
-	if err := proto.Unmarshal(buf, in); err != nil {
+	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(GrpcServer).Enable(ctx, in)
@@ -1046,9 +1046,9 @@ func _Grpc_Enable_Handler(srv interface{}, ctx context.Context, buf []byte) (int
 	return out, nil
 }
 
-func _Grpc_Disable_Handler(srv interface{}, ctx context.Context, buf []byte) (interface{}, error) {
+func _Grpc_Disable_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
 	in := new(Arguments)
-	if err := proto.Unmarshal(buf, in); err != nil {
+	if err := codec.Unmarshal(buf, in); err != nil {
 		return nil, err
 	}
 	out, err := srv.(GrpcServer).Disable(ctx, in)

--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -810,16 +810,18 @@ func labelDecode(data []byte) uint32 {
 	return uint32(data[0]<<16 | data[1]<<8 | data[2])
 }
 
-func labelSerialize(label uint32, buf []byte) error {
+func labelSerialize(label uint32) ([]byte, error) {
+	buf := make([]byte, 3)
+
 	if ((label >> 24) & 0xff) != 0 {
-		return fmt.Errorf("Label must not exceed 3 octets")
+		return nil, fmt.Errorf("Label must not exceed 3 octets")
 	}
 
 	buf[0] = byte((label >> 16) & 0xff)
 	buf[1] = byte((label >> 8) & 0xff)
 	buf[2] = byte(label & 0xff)
 
-	return nil
+	return buf, nil
 }
 
 type Label struct {
@@ -1194,8 +1196,7 @@ func (er *EVPNEthernetAutoDiscoveryRoute) Serialize() ([]byte, error) {
 	binary.BigEndian.PutUint32(tbuf, er.ETag)
 	buf = append(buf, tbuf...)
 
-	tbuf = make([]byte, 3)
-	err = labelSerialize(l, tbuf)
+	tbuf, err = labelSerialize(er.Label)
 	if err != nil {
 		return nil, err
 	}
@@ -1277,8 +1278,7 @@ func (er *EVPNMacIPAdvertisementRoute) Serialize() ([]byte, error) {
 	}
 
 	for _, l := range er.Labels {
-		tbuf = make([]byte, 3)
-		err = labelSerialize(l, tbuf)
+		tbuf, err := labelSerialize(l)
 		if err != nil {
 			return nil, err
 		}

--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -810,10 +810,16 @@ func labelDecode(data []byte) uint32 {
 	return uint32(data[0]<<16 | data[1]<<8 | data[2])
 }
 
-func labelSerialize(label uint32, buf []byte) {
+func labelSerialize(label uint32, buf []byte) error {
+	if ((label >> 24) & 0xff) != 0 {
+		return fmt.Errorf("Label must not exceed 3 octets")
+	}
+
 	buf[0] = byte((label >> 16) & 0xff)
 	buf[1] = byte((label >> 8) & 0xff)
 	buf[2] = byte(label & 0xff)
+
+	return nil
 }
 
 type Label struct {
@@ -1189,7 +1195,10 @@ func (er *EVPNEthernetAutoDiscoveryRoute) Serialize() ([]byte, error) {
 	buf = append(buf, tbuf...)
 
 	tbuf = make([]byte, 3)
-	labelSerialize(er.Label, tbuf)
+	err = labelSerialize(l, tbuf)
+	if err != nil {
+		return nil, err
+	}
 	buf = append(buf, tbuf...)
 
 	return buf, nil
@@ -1269,7 +1278,10 @@ func (er *EVPNMacIPAdvertisementRoute) Serialize() ([]byte, error) {
 
 	for _, l := range er.Labels {
 		tbuf = make([]byte, 3)
-		labelSerialize(l, tbuf)
+		err = labelSerialize(l, tbuf)
+		if err != nil {
+			return nil, err
+		}
 		buf = append(buf, tbuf...)
 	}
 	return buf, nil

--- a/packet/bgp_test.go
+++ b/packet/bgp_test.go
@@ -94,7 +94,7 @@ func update() *BGPMessage {
 			&EVPNMacIPAdvertisementRoute{NewRouteDistinguisherFourOctetAS(5, 6),
 				EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, 3, 48,
 				mac, 32, net.ParseIP("192.2.1.2"),
-				[]uint32{3, 4}}),
+				*NewLabel(3, 4)}),
 		NewEVPNNLRI(EVPN_INCLUSIVE_MULTICAST_ETHERNET_TAG, 0,
 			&EVPNMulticastEthernetTagRoute{NewRouteDistinguisherFourOctetAS(5, 6), 3, 32, net.ParseIP("192.2.1.2")}),
 		NewEVPNNLRI(EVPN_ETHERNET_SEGMENT_ROUTE, 0,

--- a/server/peer.go
+++ b/server/peer.go
@@ -369,7 +369,7 @@ func (peer *Peer) handleGrpc(grpcReq *GrpcRequest) {
 				MacAddress:       mac,
 				IPAddressLength:  uint8(iplen),
 				IPAddress:        ip,
-				Labels:           []uint32{0},
+				Labels:           *(bgp.NewLabel(0)),
 			}
 			nlri = bgp.NewEVPNNLRI(bgp.EVPN_ROUTE_TYPE_MAC_IP_ADVERTISEMENT, 0, macIpAdv)
 			pattr = append(pattr, bgp.NewPathAttributeMpReachNLRI("0.0.0.0", []bgp.AddrPrefixInterface{nlri}))


### PR DESCRIPTION
The current master does not compile with the latest grpc due to its api change,
thus gobgp.pb.go is re-generated with the latest protobuf.

Also add an error handling for MPLS label serialization
when a label exceeds 3 octets, which violates RFC 7432.