### PR TITLE
server: keepalive interval should be honor a negotiated hold time

### DIFF
--- a/server/fsm.go
+++ b/server/fsm.go
@@ -510,12 +510,12 @@ func (h *FSMHandler) openconfirm() bgp.FSMState {
 		fsm.keepaliveTicker = &time.Ticker{}
 		h.holdTimer = &time.Timer{}
 	} else {
-		sec := time.Second * time.Duration(fsm.peerConfig.Timers.KeepaliveInterval)
-		fsm.keepaliveTicker = time.NewTicker(sec)
-
 		// RFC 4271 P.65
 		// sets the HoldTimer according to the negotiated value
-		h.holdTimer = time.NewTimer(time.Second * time.Duration(fsm.negotiatedHoldTime))
+		holdtime := time.Second * time.Duration(fsm.negotiatedHoldTime)
+		fsm.keepaliveTicker = time.NewTicker(holdtime / 3)
+
+		h.holdTimer = time.NewTimer(holdtime)
 	}
 
 	for {


### PR DESCRIPTION
configured keepalive interval is ignored. Probably, we should use the
keepalive interval if an operator explicitly configures.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>