### PR TITLE
server: keepalive interval should be honor a negotiated hold time

### DIFF
--- a/server/fsm.go
+++ b/server/fsm.go
@@ -511,6 +511,9 @@ func (h *FSMHandler) openconfirm() bgp.FSMState {
 		h.holdTimer = &time.Timer{}
 	} else {
 		sec := time.Second * time.Duration(fsm.peerConfig.Timers.KeepaliveInterval)
+		if fsm.negotiatedHoldTime < fsm.peerConfig.Timers.HoldTime {
+			sec = time.Second * time.Duration(fsm.negotiatedHoldTime) / 3
+		}
 		fsm.keepaliveTicker = time.NewTicker(sec)
 
 		// RFC 4271 P.65


### PR DESCRIPTION
If a negotiated hold time is smaller than a configured hold time, we use
one third of the negotiated hold time for a keepalive interval.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>