### PR TITLE
cli: show configured and negotiated holdtime and keepalive interval

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -670,6 +670,8 @@ type PeerConf struct {
 	CapEnhancedRefresh bool    `protobuf:"varint,5,opt,name=cap_enhanced_refresh" json:"cap_enhanced_refresh,omitempty"`
 	RemoteCap          []int32 `protobuf:"varint,6,rep,name=remote_cap" json:"remote_cap,omitempty"`
 	LocalCap           []int32 `protobuf:"varint,7,rep,name=local_cap" json:"local_cap,omitempty"`
+	Holdtime           uint32  `protobuf:"varint,8,opt,name=holdtime" json:"holdtime,omitempty"`
+	KeepaliveInterval  uint32  `protobuf:"varint,9,opt,name=keepalive_interval" json:"keepalive_interval,omitempty"`
 }
 
 func (m *PeerConf) Reset()         { *m = PeerConf{} }
@@ -702,6 +704,8 @@ type PeerInfo struct {
 	Advertized                uint32 `protobuf:"varint,23,opt,name=advertized" json:"advertized,omitempty"`
 	OutQ                      uint32 `protobuf:"varint,24,opt,name=out_q" json:"out_q,omitempty"`
 	Flops                     uint32 `protobuf:"varint,25,opt,name=flops" json:"flops,omitempty"`
+	NegotiatedHoldtime        uint32 `protobuf:"varint,26,opt,name=negotiated_holdtime" json:"negotiated_holdtime,omitempty"`
+	KeepaliveInterval         uint32 `protobuf:"varint,27,opt,name=keepalive_interval" json:"keepalive_interval,omitempty"`
 }
 
 func (m *PeerInfo) Reset()         { *m = PeerInfo{} }

--- a/api/gobgp.proto
+++ b/api/gobgp.proto
@@ -252,6 +252,8 @@ message PeerConf {
     bool cap_enhanced_refresh = 5;
     repeated int32 remote_cap = 6;
     repeated int32 local_cap = 7;
+    uint32 holdtime = 8;
+    uint32 keepalive_interval = 9;
 }
 
 message PeerInfo {
@@ -280,6 +282,8 @@ message PeerInfo {
     uint32 advertized = 23;
     uint32 out_q = 24;
     uint32 flops = 25;
+    uint32 negotiated_holdtime = 26;
+    uint32 keepalive_interval = 27;
 }
 
 message Peer {

--- a/gobgp/main.go
+++ b/gobgp/main.go
@@ -630,6 +630,9 @@ func showNeighbor(args []string) error {
 	fmt.Printf("  BGP version 4, remote router ID %s\n", p.Conf.Id)
 	fmt.Printf("  BGP state = %s, up for %s\n", p.Info.BgpState, formatTimedelta(p.Info.Uptime))
 	fmt.Printf("  BGP OutQ = %d, Flops = %d\n", p.Info.OutQ, p.Info.Flops)
+	fmt.Printf("  Hold time is %d, keepalive interval is %d seconds\n", p.Conf.Holdtime, p.Conf.KeepaliveInterval)
+	fmt.Printf("  Configured hold time is %d, keepalive interval is %d seconds\n", p.Info.NegotiatedHoldtime, p.Info.KeepaliveInterval)
+
 	fmt.Printf("  Neighbor capabilities:\n")
 	caps := []int32{}
 	lookup := func(val int32, l []int32) bool {


### PR DESCRIPTION
fujita@ubuntu:~/git/gobgp/gobgp$ go run main.go neighbor 10.0.255.1
BGP neighbor is 10.0.255.1, remote AS 65001
  BGP version 4, remote router ID 192.168.0.1
  BGP state = BGP_FSM_ESTABLISHED, up for 00:02:52
  BGP OutQ = 0, Flops = 0
  Hold time is 90, keepalive interval is 30 seconds
  Configured hold time is 30, keepalive interval is 10 seconds
  Neighbor capabilities:
    MULTIPROTOCOL: advertised and received
    ROUTE_REFRESH: advertised and received
    FOUR_OCTET_AS_NUMBER: advertised and received
    ROUTE_REFRESH_CISCO: received
  Message statistics:
                         Sent       Rcvd
    Opens:                  1          1
    Notifications:          0          0
    Updates:                1          1
    Keepalives:            18         19
    Route Refesh:           0          0
    Discarded:              0          0
    Total:                 20         21

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>