### PR TITLE
cli: set wisely address family if not specified

### DIFF
--- a/gobgp/main.go
+++ b/gobgp/main.go
@@ -60,13 +60,12 @@ func formatTimedelta(d int64) string {
 	u /= 60
 	mins := u % 60
 	u /= 60
-	hours := u % 60
+	hours := u % 24
 	days := u / 24
 
 	if days == 0 {
 		return fmt.Sprintf("%02d:%02d:%02d", hours, mins, secs)
 	} else {
-		hours -= days * 24
 		return fmt.Sprintf("%dd ", days) + fmt.Sprintf("%02d:%02d:%02d", hours, mins, secs)
 	}
 }

--- a/gobgp/main.go
+++ b/gobgp/main.go
@@ -225,7 +225,7 @@ func extractArgs(head string) []string {
 	return eArgs
 }
 
-func checkAddressFamily() (*api.AddressFamily, error) {
+func checkAddressFamily(ip net.IP) (*api.AddressFamily, error) {
 	var rf *api.AddressFamily
 	var e error
 	switch subOpts.AddressFamily {
@@ -240,7 +240,12 @@ func checkAddressFamily() (*api.AddressFamily, error) {
 	case "rtc":
 		rf = api.AF_RTC
 	case "":
-		e = fmt.Errorf("address family is not specified")
+		fmt.Println("hello", ip.To16())
+		if len(ip) == 0 || ip.To4() != nil {
+			rf = api.AF_IPV4_UC
+		} else {
+			rf = api.AF_IPV6_UC
+		}
 	default:
 		e = fmt.Errorf("unsupported address family: %s", subOpts.AddressFamily)
 	}
@@ -273,7 +278,7 @@ func NewGlobalRibCommand(resource api.Resource) *GlobalRibCommand {
 	}
 }
 func showGlobalRib() error {
-	rt, err := checkAddressFamily()
+	rt, err := checkAddressFamily(net.IP{})
 	if err != nil {
 		return err
 	}
@@ -351,7 +356,7 @@ func NewGlobalRibAddCommand(resource api.Resource) *GlobalRibAddCommand {
 }
 
 func modPath(modtype string, eArgs []string) error {
-	rf, err := checkAddressFamily()
+	rf, err := checkAddressFamily(net.IP{})
 	if err != nil {
 		return err
 	}
@@ -906,7 +911,7 @@ func showRoute(pathList []*api.Path, showAge bool, showBest bool) {
 }
 
 func showNeighborRib(resource api.Resource, remoteIP net.IP) error {
-	rt, err := checkAddressFamily()
+	rt, err := checkAddressFamily(remoteIP)
 	if err != nil {
 		return err
 	}
@@ -1008,7 +1013,7 @@ func NewNeighborResetCommand(addr string, cmd string) *NeighborResetCommand {
 }
 
 func resetNeighbor(cmd string, remoteIP net.IP) error {
-	rt, err := checkAddressFamily()
+	rt, err := checkAddressFamily(remoteIP)
 	if err != nil {
 		return err
 	}
@@ -1087,7 +1092,7 @@ var globalOpts struct {
 }
 
 var subOpts struct {
-	AddressFamily string `short:"a" long:"address-family" description:"specifying an address family" default:"ipv4"`
+	AddressFamily string `short:"a" long:"address-family" description:"specifying an address family"`
 }
 
 var neighborsOpts struct {


### PR DESCRIPTION
Use transport address (ipv4 or v6) as a hint.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>