### PR TITLE
gobgp: remove verbose variable

### DIFF
--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -167,7 +167,7 @@ func main() {
 				policyConfig = &newConfig.Policy
 				bgpServer.SetPolicy(newConfig.Policy)
 			} else {
-				if res := config.CheckPolicyDifference(policyConfig, &newConfig.Policy); res {
+				if config.CheckPolicyDifference(policyConfig, &newConfig.Policy) {
 					log.Info("Policy config is updated")
 					bgpServer.UpdatePolicy(newConfig.Policy)
 				}


### PR DESCRIPTION
Use  straightforward function