### PR TITLE
server: don't path information to the same AS number peer

### DIFF
--- a/server/peer.go
+++ b/server/peer.go
@@ -167,6 +167,10 @@ func (peer *Peer) sendPathsToSiblings(pathList []table.Path) {
 		msgData: pathList,
 	}
 	for _, s := range peer.siblings {
+		if peer.peerConfig.RouteServer.RouteServerClient && peer.peerConfig.PeerAs == s.As {
+			// don't send to a peer having the same AS number.
+			continue
+		}
 		s.peerMsgCh <- pm
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -43,6 +43,7 @@ type serverMsg struct {
 type serverMsgDataPeer struct {
 	peerMsgCh chan *peerMsg
 	address   net.IP
+	As        uint32
 }
 
 type peerMapInfo struct {
@@ -176,6 +177,7 @@ func (server *BgpServer) Serve() {
 			d := &serverMsgDataPeer{
 				address:   peer.NeighborAddress,
 				peerMsgCh: pch,
+				As:        peer.PeerAs,
 			}
 			msg := &serverMsg{
 				msgType: SRV_MSG_PEER_ADDED,


### PR DESCRIPTION
fix the above issue with route server use case.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>