### PR TITLE
server: pull paths from rib instead of adj-rib-out when peer get esta…

### DIFF
--- a/table/destination.go
+++ b/table/destination.go
@@ -56,7 +56,7 @@ type Destination interface {
 	setNlri(nlri bgp.AddrPrefixInterface)
 	getBestPathReason() string
 	setBestPathReason(string)
-	getBestPath() Path
+	GetBestPath() Path
 	setBestPath(path Path)
 	getKnownPathList() []Path
 	setKnownPathList([]Path)
@@ -102,7 +102,7 @@ func (dd *DestinationDefault) ToApiStruct() *api.Destination {
 
 	idx := func() int {
 		for i, p := range dd.knownPathList {
-			if p == dd.getBestPath() {
+			if p == dd.GetBestPath() {
 				return i
 			}
 		}
@@ -152,7 +152,7 @@ func (dd *DestinationDefault) setBestPathReason(reason string) {
 	dd.bestPathReason = reason
 }
 
-func (dd *DestinationDefault) getBestPath() Path {
+func (dd *DestinationDefault) GetBestPath() Path {
 	return dd.bestPath
 }
 
@@ -917,7 +917,7 @@ func (ipv6d *IPv6Destination) MarshalJSON() ([]byte, error) {
 	prefix := ipv6d.getNlri().(*bgp.IPv6AddrPrefix).Prefix
 	idx := func() int {
 		for i, p := range ipv6d.DestinationDefault.knownPathList {
-			if p == ipv6d.DestinationDefault.getBestPath() {
+			if p == ipv6d.DestinationDefault.GetBestPath() {
 				return i
 			}
 		}
@@ -973,7 +973,7 @@ func (ipv4vpnd *IPv4VPNDestination) MarshalJSON() ([]byte, error) {
 	prefix := ipv4vpnd.getNlri().(*bgp.LabelledVPNIPAddrPrefix).Prefix
 	idx := func() int {
 		for i, p := range ipv4vpnd.DestinationDefault.knownPathList {
-			if p == ipv4vpnd.DestinationDefault.getBestPath() {
+			if p == ipv4vpnd.DestinationDefault.GetBestPath() {
 				return i
 			}
 		}
@@ -1011,7 +1011,7 @@ func (evpnd *EVPNDestination) MarshalJSON() ([]byte, error) {
 	nlri := evpnd.getNlri().(*bgp.EVPNNLRI)
 	idx := func() int {
 		for i, p := range evpnd.DestinationDefault.knownPathList {
-			if p == evpnd.DestinationDefault.getBestPath() {
+			if p == evpnd.DestinationDefault.GetBestPath() {
 				return i
 			}
 		}

--- a/table/destination_test.go
+++ b/table/destination_test.go
@@ -82,7 +82,7 @@ func TestDestinationSetBestPath(t *testing.T) {
 	pathD := DestCreatePath(peerD)
 	ipv4d := NewIPv4Destination(pathD[0].GetNlri())
 	ipv4d.setBestPath(pathD[0])
-	r_pathD := ipv4d.getBestPath()
+	r_pathD := ipv4d.GetBestPath()
 	assert.Equal(t, r_pathD, pathD[0])
 }
 func TestDestinationGetBestPath(t *testing.T) {
@@ -90,7 +90,7 @@ func TestDestinationGetBestPath(t *testing.T) {
 	pathD := DestCreatePath(peerD)
 	ipv4d := NewIPv4Destination(pathD[0].GetNlri())
 	ipv4d.setBestPath(pathD[0])
-	r_pathD := ipv4d.getBestPath()
+	r_pathD := ipv4d.GetBestPath()
 	assert.Equal(t, r_pathD, pathD[0])
 }
 func TestDestinationCalculate(t *testing.T) {

--- a/table/table_manager.go
+++ b/table/table_manager.go
@@ -159,7 +159,7 @@ func (manager *TableManager) calculate(destinationList []Destination) ([]Path, e
 		}
 
 		destination.setBestPathReason(reason)
-		currentBestPath := destination.getBestPath()
+		currentBestPath := destination.GetBestPath()
 
 		if newBestPath != nil && currentBestPath == newBestPath {
 			// best path is not changed
@@ -192,7 +192,7 @@ func (manager *TableManager) calculate(destinationList []Destination) ([]Path, e
 						"next_hop": currentBestPath.GetNexthop().String(),
 					}).Debug("best path is lost")
 
-					p := destination.getBestPath()
+					p := destination.GetBestPath()
 					newPaths = append(newPaths, p.Clone(true))
 				}
 				destination.setBestPath(nil)
@@ -221,7 +221,7 @@ func (manager *TableManager) calculate(destinationList []Destination) ([]Path, e
 			destination.setBestPath(newBestPath)
 		}
 
-		if len(destination.getKnownPathList()) == 0 && destination.getBestPath() == nil {
+		if len(destination.getKnownPathList()) == 0 && destination.GetBestPath() == nil {
 			rf := destination.getRouteFamily()
 			t := manager.Tables[rf]
 			deleteDest(t, destination)
@@ -262,7 +262,7 @@ func (manager *TableManager) GetPathList(rf bgp.RouteFamily) []Path {
 	}
 	var paths []Path
 	for _, dest := range manager.Tables[rf].GetDestinations() {
-		paths = append(paths, dest.getBestPath())
+		paths = append(paths, dest.GetBestPath())
 	}
 	return paths
 }
@@ -361,13 +361,6 @@ func (adj *AdjRib) GetOutCount(rf bgp.RouteFamily) int {
 		return 0
 	}
 	return len(adj.adjRibOut[rf])
-}
-
-func (adj *AdjRib) DropAllIn(rf bgp.RouteFamily) {
-	if _, ok := adj.adjRibIn[rf]; ok {
-		// replace old one
-		adj.adjRibIn[rf] = make(map[string]*ReceivedRoute)
-	}
 }
 
 type ReceivedRoute struct {


### PR DESCRIPTION
…blished

Current implmentation pull paths from adj-rib-out when peer get
established. This is fine for route-server-client which doesn't
modify paths' path attributes, but problematic for normal bgp.

Let some paths are added before a peer get established.
In current implementation, these paths are stored in adj-rib-out and
path attributes are not modified.
If the peer get established, we have to modify paths' path attributes,
and send them. But current implmentation has a BUG and doesn't modify
them.

This patch fix this bug by pulling paths from rib instead of
adj-rib-out, and not storing paths to adj-rib-out when peer is not
established.

To implement path pulling, new path message PEER_MSG_RESEND is defined.

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>