### PR TITLE
cli: fix AS_PATH string format

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -26,6 +26,7 @@ It has these top-level messages:
 	TunnelEncapSubTLV
 	TunnelEncapTLV
 	PathAttr
+	AsPath
 	Path
 	Destination
 	PeerConf
@@ -767,7 +768,7 @@ type PathAttr struct {
 	Type        BGP_ATTR_TYPE     `protobuf:"varint,1,opt,name=type,enum=api.BGP_ATTR_TYPE" json:"type,omitempty"`
 	Value       []string          `protobuf:"bytes,2,rep,name=value" json:"value,omitempty"`
 	Origin      Origin            `protobuf:"varint,3,opt,name=origin,enum=api.Origin" json:"origin,omitempty"`
-	AsPath      []uint32          `protobuf:"varint,4,rep,name=as_path" json:"as_path,omitempty"`
+	AsPaths     []*AsPath         `protobuf:"bytes,4,rep,name=as_paths" json:"as_paths,omitempty"`
 	Nexthop     string            `protobuf:"bytes,5,opt,name=nexthop" json:"nexthop,omitempty"`
 	Metric      uint32            `protobuf:"varint,6,opt,name=metric" json:"metric,omitempty"`
 	Pref        uint32            `protobuf:"varint,7,opt,name=pref" json:"pref,omitempty"`
@@ -782,6 +783,13 @@ type PathAttr struct {
 func (m *PathAttr) Reset()         { *m = PathAttr{} }
 func (m *PathAttr) String() string { return proto.CompactTextString(m) }
 func (*PathAttr) ProtoMessage()    {}
+
+func (m *PathAttr) GetAsPaths() []*AsPath {
+	if m != nil {
+		return m.AsPaths
+	}
+	return nil
+}
 
 func (m *PathAttr) GetAggregator() *Aggregator {
 	if m != nil {
@@ -803,6 +811,15 @@ func (m *PathAttr) GetTunnelEncap() []*TunnelEncapTLV {
 	}
 	return nil
 }
+
+type AsPath struct {
+	SegmentType uint32   `protobuf:"varint,1,opt,name=segment_type" json:"segment_type,omitempty"`
+	Asns        []uint32 `protobuf:"varint,2,rep,name=asns" json:"asns,omitempty"`
+}
+
+func (m *AsPath) Reset()         { *m = AsPath{} }
+func (m *AsPath) String() string { return proto.CompactTextString(m) }
+func (*AsPath) ProtoMessage()    {}
 
 type Path struct {
 	Nlri       *Nlri       `protobuf:"bytes,1,opt,name=nlri" json:"nlri,omitempty"`

--- a/api/gobgp.proto
+++ b/api/gobgp.proto
@@ -277,7 +277,7 @@ message PathAttr {
     BGP_ATTR_TYPE type = 1;
     repeated string value = 2;
     Origin origin = 3;
-    repeated uint32 as_path = 4;
+    repeated AsPath as_paths = 4;
     string nexthop = 5;
     uint32 metric = 6;
     uint32 pref = 7;
@@ -287,6 +287,11 @@ message PathAttr {
     repeated string cluster = 11;
     repeated Nlri nlri = 12;
     repeated TunnelEncapTLV tunnel_encap = 13;
+}
+
+message AsPath {
+    uint32 segment_type = 1;
+    repeated uint32 asns = 2;
 }
 
 message Path {

--- a/gobgp/neighbor.go
+++ b/gobgp/neighbor.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/jessevdk/go-flags"
 	"github.com/osrg/gobgp/api"
+	"github.com/osrg/gobgp/packet"
 	"github.com/osrg/gobgp/policy"
 	"golang.org/x/net/context"
 	"io"
@@ -262,6 +263,12 @@ func NewNeighborRibCommand(addr string, resource api.Resource, cmd string) *Neig
 	}
 }
 
+type AsPathFormat struct {
+	start string
+	end string
+	separator string
+}
+
 func showRoute(pathList []*api.Path, showAge bool, showBest bool) {
 
 	var pathStrs [][]interface{}
@@ -271,19 +278,35 @@ func showRoute(pathList []*api.Path, showAge bool, showBest bool) {
 
 	for _, p := range pathList {
 		aspath := func(attrs []*api.PathAttr) string {
-			s := bytes.NewBuffer(make([]byte, 0, 64))
-			s.WriteString("[")
+
+			delimiter := make(map[int]*AsPathFormat)
+			delimiter[bgp.BGP_ASPATH_ATTR_TYPE_SET] = &AsPathFormat{"{", "}", ","}
+			delimiter[bgp.BGP_ASPATH_ATTR_TYPE_SEQ] = &AsPathFormat{"", "", " "}
+			delimiter[bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ] = &AsPathFormat{"(", ")", " "}
+			delimiter[bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET] = &AsPathFormat{"[", "]", ","}
+
+			var segments []string = make([]string, 0)
 			for _, a := range attrs {
 				if a.Type == api.BGP_ATTR_TYPE_AS_PATH {
-					var ss []string
-					for _, as := range a.AsPath {
-						ss = append(ss, fmt.Sprintf("%d", as))
+					aspaths := a.AsPaths
+					for _, aspath := range aspaths {
+						s := bytes.NewBuffer(make([]byte, 0, 64))
+						t := int(aspath.SegmentType)
+						start := delimiter[t].start
+						end := delimiter[t].end
+						separator := delimiter[t].separator
+						s.WriteString(start)
+						var asnsStr []string
+						for _, asn := range aspath.Asns {
+							asnsStr = append(asnsStr, fmt.Sprintf("%d", asn))
+						}
+						s.WriteString(strings.Join(asnsStr, separator))
+						s.WriteString(end)
+						segments = append(segments, s.String())
 					}
-					s.WriteString(strings.Join(ss, " "))
 				}
 			}
-			s.WriteString("]")
-			return s.String()
+			return strings.Join(segments, " ")
 		}
 		formatAttrs := func(attrs []*api.PathAttr) string {
 			s := []string{}


### PR DESCRIPTION
changed AS_PATH string format based on AS_PATH segment type as follows.
- AS_SEQ
```
   Network          Next Hop   AS_PATH          Age        Attrs
*> 192.168.100.0/24 10.0.0.100 1 2 3            00:00:00   [{Origin: IGP}]
# 1 2 3 : AS_SEQ
```
- AS_SET
```
   Network          Next Hop   AS_PATH       Age        Attrs
*> 192.168.100.0/24 10.0.0.100 1 2 3 {4,5,6} 00:00:05   [{Origin: IGP}]
# 4,5,6 : AS_SET
```
- AS_CONFED_SEQ
```
     Network        Next Hop   AS_PATH       Age        Attrs
*> 192.168.100.0/24 10.0.0.100 1 2 3 (4 5 6) 00:06:55   [{Origin: IGP}]
# 4,5,6 : AS_CONFED_SEQ
```
- AS_CONFED_SET
```
     Network        Next Hop   AS_PATH      Age        Attrs
*> 192.168.100.0/24 10.0.0.100 1 2 3 [4,5,6] 00:00:01   [{Origin: IGP}]
# 4,5,6 : AS_CONFED_SET
```
