### PR TITLE
Aspath count

### DIFF
--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -1997,7 +1997,15 @@ func (a *AsPathParam) Len() int {
 }
 
 func (a *AsPathParam) ASLen() int {
-	return len(a.AS)
+	switch a.Type {
+		case BGP_ASPATH_ATTR_TYPE_SEQ:
+		return len(a.AS)
+		case BGP_ASPATH_ATTR_TYPE_SET:
+		return 1
+		case BGP_ASPATH_ATTR_TYPE_CONFED_SET,BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
+		return 0
+	}
+	return 0
 }
 
 func NewAsPathParam(segType uint8, as []uint16) *AsPathParam {
@@ -2048,7 +2056,15 @@ func (a *As4PathParam) Len() int {
 }
 
 func (a *As4PathParam) ASLen() int {
-	return len(a.AS)
+	switch a.Type {
+		case BGP_ASPATH_ATTR_TYPE_SEQ:
+		return len(a.AS)
+		case BGP_ASPATH_ATTR_TYPE_SET:
+		return 1
+		case BGP_ASPATH_ATTR_TYPE_CONFED_SET,BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
+		return 0
+	}
+	return 0
 }
 
 func NewAs4PathParam(segType uint8, as []uint32) *As4PathParam {

--- a/packet/bgp_test.go
+++ b/packet/bgp_test.go
@@ -323,3 +323,42 @@ func Test_RFC5512(t *testing.T) {
 	assert.Equal(nil, err)
 	assert.Equal("2001::1", n2.String())
 }
+
+func Test_ASLen(t *testing.T) {
+	assert := assert.New(t)
+
+	aspath := AsPathParam{
+		Num: 2,
+		AS: []uint16{65000, 65001},
+	}
+	aspath.Type = BGP_ASPATH_ATTR_TYPE_SEQ
+	assert.Equal(2, aspath.ASLen())
+
+	aspath.Type = BGP_ASPATH_ATTR_TYPE_SET
+	assert.Equal(1, aspath.ASLen())
+
+	aspath.Type = BGP_ASPATH_ATTR_TYPE_CONFED_SEQ
+	assert.Equal(0, aspath.ASLen())
+
+	aspath.Type = BGP_ASPATH_ATTR_TYPE_CONFED_SET
+	assert.Equal(0, aspath.ASLen())
+
+
+	as4path := As4PathParam{
+		Num: 2,
+		AS: []uint32{65000, 65001},
+	}
+	as4path.Type = BGP_ASPATH_ATTR_TYPE_SEQ
+	assert.Equal(2, as4path.ASLen())
+
+	as4path.Type = BGP_ASPATH_ATTR_TYPE_SET
+	assert.Equal(1, as4path.ASLen())
+
+	as4path.Type = BGP_ASPATH_ATTR_TYPE_CONFED_SEQ
+	assert.Equal(0, as4path.ASLen())
+
+	as4path.Type = BGP_ASPATH_ATTR_TYPE_CONFED_SET
+	assert.Equal(0, as4path.ASLen())
+
+}
+

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -527,7 +527,7 @@ func TestPolicyRejectOnlyNeighborSet(t *testing.T) {
 }
 
 func TestPolicyDifferentRoutefamilyOfPathAndPolicy(t *testing.T) {
-	// creatae path ipv4
+	// create path ipv4
 	peerIPv4 := &table.PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	originIPv4 := bgp.NewPathAttributeOrigin(0)
 	aspathParamIPv4 := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
@@ -539,7 +539,7 @@ func TestPolicyDifferentRoutefamilyOfPathAndPolicy(t *testing.T) {
 	withdrawnRoutesIPv4 := []bgp.WithdrawnRoute{}
 	updateMsgIPv4 := bgp.NewBGPUpdateMessage(withdrawnRoutesIPv4, pathAttributesIPv4, nlriIPv4)
 	pathIPv4 := table.ProcessMessage(updateMsgIPv4, peerIPv4)[0]
-	// creatae path ipv6
+	// create path ipv6
 	peerIPv6 := &table.PeerInfo{AS: 65001, Address: net.ParseIP("2001::192:168:50:1")}
 	originIPv6 := bgp.NewPathAttributeOrigin(0)
 	aspathParamIPv6 := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
@@ -651,7 +651,7 @@ func TestAsPathLengthConditionEvaluate(t *testing.T) {
 	// create match condition
 	asPathLength := config.AsPathLength{
 		Operator: "eq",
-		Value:    8,
+		Value:    5,
 	}
 	c := NewAsPathLengthCondition(asPathLength)
 

--- a/table/destination.go
+++ b/table/destination.go
@@ -622,30 +622,19 @@ func compareByASPath(path1, path2 Path) Path {
 	_, attribute1 := path1.getPathAttr(bgp.BGP_ATTR_TYPE_AS_PATH)
 	_, attribute2 := path2.getPathAttr(bgp.BGP_ATTR_TYPE_AS_PATH)
 
-	asPath1 := attribute1.(*bgp.PathAttributeAsPath)
-	asPath2 := attribute2.(*bgp.PathAttributeAsPath)
-
-	if asPath1 == nil || asPath2 == nil {
+	if attribute1 == nil || attribute2 == nil {
 		log.WithFields(log.Fields{
 			"Topic":   "Table",
 			"Key":     "compareByASPath",
-			"ASPath1": asPath1,
-			"ASPath2": asPath2,
+			"ASPath1": attribute1,
+			"ASPath2": attribute2,
 		}).Error("can't compare ASPath because it's not present")
 	}
 
-	var l1, l2 int
-	for _, pathParam := range asPath1.Value {
-		l1 += pathParam.ASLen()
-	}
-
-	for _, pathParam := range asPath2.Value {
-		l2 += pathParam.ASLen()
-	}
+	l1 := path1.GetAsPathLen()
+	l2 := path2.GetAsPathLen()
 
 	log.Debugf("compareByASPath -- l1: %d, l2: %d", l1, l2)
-	log.Debug(reflect.TypeOf(asPath1.Value))
-	log.Debug(asPath1.Value)
 	if l1 > l2 {
 		return path2
 	} else if l1 < l2 {

--- a/table/destination_test.go
+++ b/table/destination_test.go
@@ -146,7 +146,9 @@ func updateMsgD1() *bgp.BGPMessage {
 
 	nlri := []bgp.NLRInfo{*bgp.NewNLRInfo(24, "10.10.10.0")}
 	withdrawnRoutes := []bgp.WithdrawnRoute{}
-	return bgp.NewBGPUpdateMessage(withdrawnRoutes, pathAttributes, nlri)
+	updateMsg := bgp.NewBGPUpdateMessage(withdrawnRoutes, pathAttributes, nlri)
+	UpdatePathAttrs4ByteAs(updateMsg.Body.(*bgp.BGPUpdate))
+	return updateMsg
 }
 
 func updateMsgD2() *bgp.BGPMessage {
@@ -166,7 +168,9 @@ func updateMsgD2() *bgp.BGPMessage {
 
 	nlri := []bgp.NLRInfo{*bgp.NewNLRInfo(24, "20.20.20.0")}
 	withdrawnRoutes := []bgp.WithdrawnRoute{}
-	return bgp.NewBGPUpdateMessage(withdrawnRoutes, pathAttributes, nlri)
+	updateMsg := bgp.NewBGPUpdateMessage(withdrawnRoutes, pathAttributes, nlri)
+	UpdatePathAttrs4ByteAs(updateMsg.Body.(*bgp.BGPUpdate))
+	return updateMsg
 }
 func updateMsgD3() *bgp.BGPMessage {
 	origin := bgp.NewPathAttributeOrigin(0)
@@ -185,5 +189,7 @@ func updateMsgD3() *bgp.BGPMessage {
 	nlri := []bgp.NLRInfo{*bgp.NewNLRInfo(24, "30.30.30.0")}
 	w1 := bgp.WithdrawnRoute{*bgp.NewIPAddrPrefix(23, "40.40.40.0")}
 	withdrawnRoutes := []bgp.WithdrawnRoute{w1}
-	return bgp.NewBGPUpdateMessage(withdrawnRoutes, pathAttributes, nlri)
+	updateMsg := bgp.NewBGPUpdateMessage(withdrawnRoutes, pathAttributes, nlri)
+	UpdatePathAttrs4ByteAs(updateMsg.Body.(*bgp.BGPUpdate))
+	return updateMsg
 }

--- a/table/path.go
+++ b/table/path.go
@@ -349,13 +349,6 @@ func (pd *PathDefault) GetAsPathLen() int {
 			segment := paramIf.(*bgp.As4PathParam)
 			length += segment.ASLen()
 		}
-
-	} else {
-		_, attr := pd.getPathAttr(bgp.BGP_ATTR_TYPE_AS4_PATH)
-		aspath := attr.(*bgp.PathAttributeAs4Path)
-		for _, segment := range aspath.Value {
-			length += segment.ASLen()
-		}
 	}
 	return length
 }

--- a/table/path.go
+++ b/table/path.go
@@ -339,29 +339,22 @@ func (pi *PathDefault) getPrefix() string {
 	return pi.nlri.String()
 }
 
-// return total length of AS_PATH whose type is AS_SEQ or AS_SET
+// GetAsPathLen returns the number of AS_PATH
 func (pd *PathDefault) GetAsPathLen() int {
-
-	aslen := func(p *bgp.As4PathParam) int {
-		if p.Type == bgp.BGP_ASPATH_ATTR_TYPE_SEQ || p.Type == bgp.BGP_ASPATH_ATTR_TYPE_SET {
-			return p.ASLen()
-		}
-		return 0
-	}
 
 	var length int = 0
 	if _, attr := pd.getPathAttr(bgp.BGP_ATTR_TYPE_AS_PATH); attr != nil {
 		aspath := attr.(*bgp.PathAttributeAsPath)
 		for _, paramIf := range aspath.Value {
 			segment := paramIf.(*bgp.As4PathParam)
-			length += aslen(segment)
+			length += segment.ASLen()
 		}
 
 	} else {
 		_, attr := pd.getPathAttr(bgp.BGP_ATTR_TYPE_AS4_PATH)
 		aspath := attr.(*bgp.PathAttributeAs4Path)
 		for _, segment := range aspath.Value {
-			length += aslen(segment)
+			length += segment.ASLen()
 		}
 	}
 	return length


### PR DESCRIPTION
ASLen() in AsPathParam and As4PathParam returns the number of AS number based on the segment type.

segment type                   | length to be returned (based on RFC5065)
--------------------------------- | -------------
AS_SET                           | 1 
AS_SEQ                          | actual AS length 
AS_CONFED_SEQ         | 0
AS_CONFED_SET         | 0