### PR TITLE
Fix length parameters of BGP message structures

### DIFF
--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -473,7 +473,7 @@ func (o *OptionParameterCapability) DecodeFromBytes(data []byte) error {
 func (o *OptionParameterCapability) Serialize() ([]byte, error) {
 	buf := make([]byte, 2)
 	buf[0] = o.ParamType
-	//buf[1] = o.ParamLen
+	buf[1] = o.ParamLen
 	for _, p := range o.Capability {
 		pbuf, err := p.Serialize()
 		if err != nil {
@@ -481,13 +481,20 @@ func (o *OptionParameterCapability) Serialize() ([]byte, error) {
 		}
 		buf = append(buf, pbuf...)
 	}
-	buf[1] = uint8(len(buf) - 2)
 	return buf, nil
 }
 
 func NewOptionParameterCapability(capability []ParameterCapabilityInterface) *OptionParameterCapability {
+	length := 0
+
+	for _, p := range capability {
+		serialized, _ := p.Serialize()
+		length += len(serialized)
+	}
+
 	return &OptionParameterCapability{
 		ParamType:  BGP_OPT_CAPABILITY,
+	        ParamLen: uint8(length),
 		Capability: capability,
 	}
 }

--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -3850,9 +3850,21 @@ func (msg *BGPUpdate) Serialize() ([]byte, error) {
 }
 
 func NewBGPUpdateMessage(withdrawnRoutes []WithdrawnRoute, pathattrs []PathAttributeInterface, nlri []NLRInfo) *BGPMessage {
+	wlen := 0
+	for _, w := range withdrawnRoutes {
+		serialized, _ := w.Serialize()
+		wlen += len(serialized)
+	}
+
+	palen := 0
+	for _, pa := range pathattrs {
+		serialized, _ := pa.Serialize()
+		palen += len(serialized)
+	}
+	
 	return &BGPMessage{
 		Header: BGPHeader{Type: BGP_MSG_UPDATE},
-		Body:   &BGPUpdate{0, withdrawnRoutes, 0, pathattrs, nlri},
+		Body:   &BGPUpdate{uint16(wlen), withdrawnRoutes, uint16(palen), pathattrs, nlri},
 	}
 }
 


### PR DESCRIPTION
Length members of some structures are properly set in this fix.

These "hidden" bugs do not cause errors right now because these values are never accessed in the current gobgp (serialization methods calculate the lengths by themselves).

However they will be problematic for example in the following code:

    msg := NewBGPOpenMessage(...)
    l := msg.OptParamLen // Oops! msg.OptParamLen is 0 regardless of the contents of msg
    // do something using l