### PR TITLE
cli: add support of route filtering in show commands

### DIFF
--- a/docs/sources/cli-command-syntax.md
+++ b/docs/sources/cli-command-syntax.md
@@ -26,6 +26,8 @@ Note: Currently gobgp supports only **global** and **neighbor** subcommand.
 % gobgp global rib del <prefix> [-a <address family>]
 # show all Route information
 % gobgp global rib [-a <address family>]
+# show a specific route information
+% gobgp global rib [<prefix>|<host>] [-a <address family>]
 ```
  - **Option**
   - \-a , \-\-address-family: specify the ipv4, ipv6, evpn, encap, or rtc
@@ -58,9 +60,10 @@ Note: Currently gobgp supports only **global** and **neighbor** subcommand.
 
 ### Show Rib - local-rib/adj-rib-in/adj-rib-out -
 ```shell
-% gobgp neighbor <neighbor address> local [-a <address family>]
-% gobgp neighbor <neighbor address> adj-in [-a <address family>]
-% gobgp neighbor <neighbor address> adj-out [-a <address family>]
+# show all routes in [local|adj-in|adj-out] table
+% gobgp neighbor <neighbor address> [local|adj-in|adj-out] [-a <address family>]
+# show a specific route in [local|adj-in|adj-out] table
+% gobgp neighbor <neighbor address> [local|adj-in|adj-out] [<prefix>|<host>] [-a <address family>]
 ```
  - **Option**
   - \-a , \-\-address-family: specify the ipv4 or ipv6

--- a/gobgp/global.go
+++ b/gobgp/global.go
@@ -16,62 +16,17 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/osrg/gobgp/api"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
-	"io"
 	"net"
-	"sort"
 	"strconv"
 )
 
-func showGlobalRib() error {
-	rt, err := checkAddressFamily(net.IP{})
-	if err != nil {
-		return err
-	}
-	arg := &api.Arguments{
-		Resource: api.Resource_GLOBAL,
-		Af:       rt,
-	}
-
-	stream, e := client.GetRib(context.Background(), arg)
-	if e != nil {
-		return e
-	}
-	ds := []*api.Destination{}
-	for {
-		d, e := stream.Recv()
-		if e == io.EOF {
-			break
-		} else if e != nil {
-			return e
-		}
-		ds = append(ds, d)
-	}
-
-	if globalOpts.Json {
-		j, _ := json.Marshal(ds)
-		fmt.Println(string(j))
-		return nil
-	}
-
-	ps := paths{}
-	for _, d := range ds {
-		for idx, p := range d.Paths {
-			if idx == int(d.BestPathIdx) {
-				p.Best = true
-			}
-			ps = append(ps, p)
-		}
-	}
-
-	sort.Sort(ps)
-
-	showRoute(ps, true, true, false)
-	return nil
+func showGlobalRib(args []string) error {
+	bogusIp := net.IP{}
+	return showNeighborRib(CMD_GLOBAL, bogusIp, args)
 }
 
 func modPath(modtype string, eArgs []string) error {
@@ -208,7 +163,7 @@ func NewGlobalCmd() *cobra.Command {
 	ribCmd := &cobra.Command{
 		Use: CMD_RIB,
 		Run: func(cmd *cobra.Command, args []string) {
-			showGlobalRib()
+			showGlobalRib(args)
 		},
 	}
 


### PR DESCRIPTION
$ gobgp global rib
   Network     Next Hop AS_PATH Age        Attrs
*> 10.0.0.0/24 0.0.0.0  65000   00:10:17   [{Origin: IGP}]
*> 10.0.0.0/25 0.0.0.0  65000   00:10:16   [{Origin: IGP}]
*> 10.0.0.0/26 0.0.0.0  65000   00:10:15   [{Origin: IGP}]
*> 10.0.1.0/24 0.0.0.0  65000   00:10:21   [{Origin: IGP}]
*> 10.0.2.0/24 0.0.0.0  65000   00:10:20   [{Origin: IGP}]

$ gobgp global rib 10.0.0.0/24
   Network     Next Hop AS_PATH Age        Attrs
*> 10.0.0.0/24 0.0.0.0  65000   00:10:54   [{Origin: IGP}]

$ gobgp global rib 10.0.0.10
   Network     Next Hop AS_PATH Age        Attrs
*> 10.0.0.0/26 0.0.0.0  65000   00:11:16   [{Origin: IGP}]

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>