### PR TITLE
packet: add AS_PATH validator

### DIFF
--- a/packet/validate_test.go
+++ b/packet/validate_test.go
@@ -41,29 +41,29 @@ func bgpupdateV6() *BGPMessage {
 func Test_Validate_CapV4(t *testing.T) {
 	assert := assert.New(t)
 	message := bgpupdate().Body.(*BGPUpdate)
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv6_UC: true})
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv6_UC: true}, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 
-	res, err = ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true})
+	res, err = ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, false)
 	assert.Equal(true, res)
 }
 
 func Test_Validate_CapV6(t *testing.T) {
 	assert := assert.New(t)
 	message := bgpupdateV6().Body.(*BGPUpdate)
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv6_UC: true})
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv6_UC: true}, false)
 	assert.Equal(true, res)
 	assert.NoError(err)
 
-	res, err = ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true})
+	res, err = ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, false)
 	assert.Equal(false, res)
 }
 
 func Test_Validate_OK(t *testing.T) {
 	assert := assert.New(t)
 	message := bgpupdate().Body.(*BGPUpdate)
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true})
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, false)
 	assert.Equal(true, res)
 	assert.NoError(err)
 
@@ -151,7 +151,7 @@ func Test_Validate_duplicate_attribute(t *testing.T) {
 	origin.DecodeFromBytes(originBytes)
 	message.PathAttributes = append(message.PathAttributes, origin)
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true})
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -164,7 +164,7 @@ func Test_Validate_mandatory_missing(t *testing.T) {
 	assert := assert.New(t)
 	message := bgpupdate().Body.(*BGPUpdate)
 	message.PathAttributes = message.PathAttributes[1:]
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true})
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -180,7 +180,7 @@ func Test_Validate_mandatory_missing_nocheck(t *testing.T) {
 	message.PathAttributes = message.PathAttributes[1:]
 	message.NLRI = nil
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true})
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, false)
 	assert.Equal(true, res)
 	assert.NoError(err)
 }
@@ -194,7 +194,7 @@ func Test_Validate_invalid_origin(t *testing.T) {
 	origin.DecodeFromBytes(originBytes)
 	message.PathAttributes[0] = origin
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true})
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -215,7 +215,7 @@ func Test_Validate_invalid_nexthop_zero(t *testing.T) {
 	nexthop.DecodeFromBytes(nexthopBytes)
 	message.PathAttributes[2] = nexthop
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true})
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -236,7 +236,7 @@ func Test_Validate_invalid_nexthop_lo(t *testing.T) {
 	nexthop.DecodeFromBytes(nexthopBytes)
 	message.PathAttributes[2] = nexthop
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true})
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -257,7 +257,7 @@ func Test_Validate_invalid_nexthop_de(t *testing.T) {
 	nexthop.DecodeFromBytes(nexthopBytes)
 	message.PathAttributes[2] = nexthop
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true})
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -277,11 +277,67 @@ func Test_Validate_unrecognized_well_known(t *testing.T) {
 	unknown.DecodeFromBytes(unknownBytes)
 	message.PathAttributes = append(message.PathAttributes, unknown)
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true})
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
 	assert.Equal(uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR), e.TypeCode)
 	assert.Equal(uint8(BGP_ERROR_SUB_UNRECOGNIZED_WELL_KNOWN_ATTRIBUTE), e.SubTypeCode)
 	assert.Equal(unknownBytes, e.Data)
+}
+
+func Test_Validate_aspath(t *testing.T) {
+
+	assert := assert.New(t)
+	message := bgpupdate().Body.(*BGPUpdate)
+
+	// VALID AS_PATH
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, true)
+	assert.Equal(true, res)
+
+	// CONFED_SET
+	newAttrs := make([]PathAttributeInterface, 0)
+	attrs := message.PathAttributes
+	for _, attr := range attrs {
+		if _, y := attr.(*PathAttributeAsPath); y {
+			aspath := []AsPathParamInterface{
+				NewAsPathParam(BGP_ASPATH_ATTR_TYPE_CONFED_SET, []uint16{65001}),
+			}
+			newAttrs = append(newAttrs, NewPathAttributeAsPath(aspath))
+		} else {
+			newAttrs = append(newAttrs, attr)
+		}
+	}
+
+	message.PathAttributes = newAttrs
+	res, err = ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, true)
+	assert.Equal(false, res)
+	assert.Error(err)
+	e := err.(*MessageError)
+	assert.Equal(uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR), e.TypeCode)
+	assert.Equal(uint8(BGP_ERROR_SUB_MALFORMED_AS_PATH), e.SubTypeCode)
+	assert.Nil(e.Data)
+
+	// CONFED_SEQ
+	newAttrs = make([]PathAttributeInterface, 0)
+	attrs = message.PathAttributes
+	for _, attr := range attrs {
+		if _, y := attr.(*PathAttributeAsPath); y {
+			aspath := []AsPathParamInterface{
+				NewAsPathParam(BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint16{65001}),
+			}
+			newAttrs = append(newAttrs, NewPathAttributeAsPath(aspath))
+		} else {
+			newAttrs = append(newAttrs, attr)
+		}
+	}
+
+	message.PathAttributes = newAttrs
+	res, err = ValidateUpdateMsg(message, map[RouteFamily]bool{RF_IPv4_UC: true}, true)
+	assert.Equal(false, res)
+	assert.Error(err)
+	e = err.(*MessageError)
+	assert.Equal(uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR), e.TypeCode)
+	assert.Equal(uint8(BGP_ERROR_SUB_MALFORMED_AS_PATH), e.SubTypeCode)
+	assert.Nil(e.Data)
 }


### PR DESCRIPTION
added AS_PATH validator in validate.go.
This validation is implemented based on Section 5. Error handling in RFC 5065.