### PR TITLE
server: bug fix of extra as-path prepending

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -675,8 +675,6 @@ func handleGlobalRibRequest(grpcReq *GrpcRequest, peerInfo *table.PeerInfo) []*t
 
 	pattr := make([]bgp.PathAttributeInterface, 0)
 	pattr = append(pattr, bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP))
-	asparam := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{peerInfo.AS})
-	pattr = append(pattr, bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{asparam}))
 
 	rf := grpcReq.RouteFamily
 	path, ok := grpcReq.Data.(*api.Path)

--- a/table/path.go
+++ b/table/path.go
@@ -102,18 +102,21 @@ func (path *Path) UpdatePathAttrs(global *config.Global, peer *config.Neighbor) 
 		//     segment, and places that segment into the AS_PATH.
 		idx, originalAsPath := path.getPathAttr(bgp.BGP_ATTR_TYPE_AS_PATH)
 		if idx < 0 {
-			log.Fatal("missing AS_PATH mandatory attribute")
-		}
-		asPath := cloneAsPath(originalAsPath.(*bgp.PathAttributeAsPath))
-		path.pathAttrs[idx] = asPath
-		fst := asPath.Value[0].(*bgp.As4PathParam)
-		if len(asPath.Value) > 0 && fst.Type == bgp.BGP_ASPATH_ATTR_TYPE_SEQ &&
-			fst.ASLen() < 255 {
-			fst.AS = append([]uint32{global.As}, fst.AS...)
-			fst.Num += 1
-		} else {
 			p := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{global.As})
-			asPath.Value = append([]bgp.AsPathParamInterface{p}, asPath.Value...)
+			asPath := bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{p})
+			path.pathAttrs = append(path.pathAttrs, asPath)
+		} else {
+			asPath := cloneAsPath(originalAsPath.(*bgp.PathAttributeAsPath))
+			path.pathAttrs[idx] = asPath
+			fst := asPath.Value[0].(*bgp.As4PathParam)
+			if len(asPath.Value) > 0 && fst.Type == bgp.BGP_ASPATH_ATTR_TYPE_SEQ &&
+				fst.ASLen() < 255 {
+				fst.AS = append([]uint32{global.As}, fst.AS...)
+				fst.Num += 1
+			} else {
+				p := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{global.As})
+				asPath.Value = append([]bgp.AsPathParamInterface{p}, asPath.Value...)
+			}
 		}
 
 		// MED Handling

--- a/test/scenario_test/lib/base.py
+++ b/test/scenario_test/lib/base.py
@@ -35,6 +35,7 @@ BGP_ATTR_TYPE_NEXT_HOP = 3
 BGP_ATTR_TYPE_MULTI_EXIT_DISC = 4
 BGP_ATTR_TYPE_LOCAL_PREF = 5
 
+
 def get_bridges():
     return local("brctl show | awk 'NR > 1{print $1}'",
                  capture=True).split('\n')
@@ -196,9 +197,11 @@ class BGPContainer(Container):
                  policies=None, passive=False,
                  is_rr_client=False, cluster_id=''):
         neigh_addr = ''
+        local_addr = ''
         for me, you in itertools.product(self.ip_addrs, peer.ip_addrs):
             if me[2] == you[2]:
                 neigh_addr = you[1]
+                local_addr = me[1]
 
         if neigh_addr == '':
             raise Exception('peer {0} seems not ip reachable'.format(peer))
@@ -213,7 +216,8 @@ class BGPContainer(Container):
                             'is_rr_client': is_rr_client,
                             'cluster_id': cluster_id,
                             'policies': policies,
-                            'passive': passive}
+                            'passive': passive,
+                            'local_addr': local_addr}
         if self.is_running:
             self.create_config()
             self.reload_config()
@@ -224,8 +228,16 @@ class BGPContainer(Container):
             self.create_config()
             self.reload_config()
 
-    def add_route(self, route, attribute=''):
-        self.routes[route] = attribute
+    def disable_peer(self, peer):
+        raise Exception('implement disable_peer() method')
+
+    def enable_peer(self, peer):
+        raise Exception('implement enable_peer() method')
+
+    def add_route(self, route, rf='ipv4', attribute=''):
+        self.routes[route] = {'prefix': route,
+                              'rf': rf,
+                              'attr': attribute}
         if self.is_running:
             self.create_config()
             self.reload_config()


### PR DESCRIPTION
When gobgp originates a route, the generated route had incorrect
as-path. this patch fix this bug.

Scenario test is also added to check this.

[before]
$ gobgp neighbor global rib
   Network      Next Hop     AS_PATH     Age        Attrs
*> 10.0.1.0/24  192.168.10.3 65001       00:03:20   [{Origin: IGP} {Med: 0}]
*> 10.0.2.0/24  192.168.10.4 65002       00:03:36   [{Origin: IGP} {Med: 200}]
*> 10.10.0.0/24 0.0.0.0      65000       00:03:37   [{Origin: IGP}]

$ gobgp neighbor 192.168.10.5 adj-out
Network      Next Hop     AS_PATH     Attrs
10.0.1.0/24  192.168.10.2 65000 65001 [{Origin: IGP}]
10.0.2.0/24  192.168.10.2 65000 65002 [{Origin: IGP}]
10.10.0.0/24 192.168.10.2 65000 65000 [{Origin: IGP}]

[after]
$ gobgp neighbor global rib
   Network      Next Hop     AS_PATH     Age        Attrs
*> 10.0.1.0/24  192.168.10.3 65001       00:03:20   [{Origin: IGP} {Med: 0}]
*> 10.0.2.0/24  192.168.10.4 65002       00:03:36   [{Origin: IGP} {Med: 200}]
*> 10.10.0.0/24 0.0.0.0                  00:03:37   [{Origin: IGP}]

$ gobgp neighbor 192.168.10.5 adj-out
Network      Next Hop     AS_PATH     Attrs
10.0.1.0/24  192.168.10.2 65000 65001 [{Origin: IGP}]
10.0.2.0/24  192.168.10.2 65000 65002 [{Origin: IGP}]
10.10.0.0/24 192.168.10.2 65000       [{Origin: IGP}]

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>