### PR TITLE
server: fix race in fsm

### DIFF
--- a/server/fsm.go
+++ b/server/fsm.go
@@ -727,6 +727,10 @@ func (h *FSMHandler) sendMessageloop() error {
 	}
 
 	for {
+		var keepaliveCh <-chan time.Time
+		if fsm.keepaliveTicker != nil {
+			keepaliveCh = fsm.keepaliveTicker.C
+		}
 		select {
 		case <-h.t.Dying():
 			// a) if a configuration is deleted, we need
@@ -748,7 +752,7 @@ func (h *FSMHandler) sendMessageloop() error {
 			if err := send(m); err != nil {
 				return nil
 			}
-		case <-fsm.keepaliveTicker.C:
+		case <-keepaliveCh:
 			if err := send(bgp.NewBGPKeepAliveMessage()); err != nil {
 				return nil
 			}


### PR DESCRIPTION
When fsm state goes to idle from established, fsm.keepaliveTicker is set
to nil.
This can happen before <-h.t.Dying() case in sendMessageloop()

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>