### PR TITLE
server: fix fsm.keepaliveTicker race

### DIFF
--- a/server/fsm_test.go
+++ b/server/fsm_test.go
@@ -163,9 +163,8 @@ func TestFSMHandlerOpensent_HoldTimerExpired(t *testing.T) {
 	// push mock connection
 	p.fsm.conn = m
 
-	// set up keepalive ticker
-	sec := time.Second * 1
-	p.fsm.keepaliveTicker = time.NewTicker(sec)
+	// set keepalive ticker
+	p.fsm.negotiatedHoldTime = 3
 
 	// set holdtime
 	p.fsm.opensentHoldTime = 2
@@ -213,9 +212,8 @@ func TestFSMHandlerEstablish_HoldTimerExpired(t *testing.T) {
 	// push mock connection
 	p.fsm.conn = m
 
-	// set up keepalive ticker
-	sec := time.Second * 1
-	p.fsm.keepaliveTicker = time.NewTicker(sec)
+	// set keepalive ticker
+	p.fsm.negotiatedHoldTime = 3
 
 	msg := keepalive()
 	header, _ := msg.Header.Serialize()
@@ -273,10 +271,8 @@ func TestFSMHandlerEstablished_HoldtimeZero(t *testing.T) {
 	// push mock connection
 	p.fsm.conn = m
 
-	// set up keepalive ticker
-	sec := time.Second * 1
-	p.fsm.keepaliveTicker = time.NewTicker(sec)
-	p.fsm.keepaliveTicker.Stop()
+	// set keepalive ticker
+	p.fsm.negotiatedHoldTime = 3
 
 	// set holdtime
 	p.fsm.negotiatedHoldTime = 0


### PR DESCRIPTION
When fsm state goes to idle from established, fsm.keepaliveTicker is
set to nil. This can happen before <-h.t.Dying() case in
sendMessageloop().

This removes fsm.keepaliveTicker. Ticker is created locally. With
this, a keepalive message could be sent from openconfirm to
established with a shorter interval. But it should not break anything.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>