### PR TITLE
server: make mrt rpc request reliable

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1933,9 +1933,14 @@ func (server *BgpServer) handleMrt(grpcReq *GrpcRequest) {
 	select {
 	case <-grpcReq.EndCh:
 		return
-	case grpcReq.ResponseCh <- result:
 	default:
 	}
+
+	m := &broadcastMsg{
+		req:    grpcReq,
+		result: result,
+	}
+	server.broadcastMsgs = append(server.broadcastMsgs, m)
 
 	interval := int64(grpcReq.Data.(uint64))
 	if interval > 0 {


### PR DESCRIPTION
Currently, if a mrt request sender doesn't read from bgpd some time, a
message could be dropped. Instead, this makes bgpd keep messages in
memory until they are read.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>