### PR TITLE
test: fix missing sudo to remove useless docker images correctly

### DIFF
--- a/test/scenario_test/ci-scripts/jenkins-build-script.sh
+++ b/test/scenario_test/ci-scripts/jenkins-build-script.sh
@@ -15,7 +15,7 @@ cd $GOBGP
 ls -al
 git log | head -20
 
-sudo docker rmi $(docker images | grep "^<none>" | awk "{print $3}")
+sudo docker rmi $(sudo docker images | grep "^<none>" | awk '{print $3}')
 
 sudo fab -f $GOBGP/test/scenario_test/lib/base.py make_gobgp_ctn --set tag=$GOBGP_IMAGE
 


### PR DESCRIPTION
Tested-by: Hiroshi Yokoi <yokoi.hirochi@po.ntts.co.jp>
Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>