### PR TITLE
add RPKI support

### DIFF
--- a/api/gobgp.proto
+++ b/api/gobgp.proto
@@ -40,6 +40,7 @@ service Grpc {
   rpc MonitorBestChanged(Arguments) returns (stream Path) {}
   rpc MonitorPeerState(Arguments) returns (stream Peer) {}
   rpc GetMrt(MrtArguments) returns (stream MrtMessage) {}
+  rpc GetRPKI(Arguments) returns (stream ROA) {}
 }
 
 message Error {
@@ -496,4 +497,11 @@ message ApplyPolicy {
 
 message MrtMessage {
     bytes data = 1;
+}
+
+message ROA {
+    uint32 as = 1;
+    uint32 prefixlen = 2;
+    uint32 maxlen = 3;
+    string prefix = 4;
 }

--- a/gobgp/common.go
+++ b/gobgp/common.go
@@ -58,6 +58,7 @@ const (
 	CMD_MRT            = "mrt"
 	CMD_DUMP           = "dump"
 	CMD_INJECT         = "inject"
+	CMD_RPKI           = "rpki"
 )
 
 var subOpts struct {
@@ -269,6 +270,22 @@ func (p policyDefinitions) Swap(i, j int) {
 
 func (p policyDefinitions) Less(i, j int) bool {
 	return p[i].PolicyDefinitionName < p[j].PolicyDefinitionName
+}
+
+type roas []*api.ROA
+
+func (r roas) Len() int {
+	return len(r)
+}
+
+func (r roas) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+func (r roas) Less(i, j int) bool {
+	strings := sort.StringSlice{cidr2prefix(fmt.Sprintf("%s/%d", r[i].Prefix, r[i].Prefixlen)),
+		cidr2prefix(fmt.Sprintf("%s/%d", r[j].Prefix, r[j].Prefixlen))}
+	return strings.Less(0, 1)
 }
 
 func connGrpc() *grpc.ClientConn {

--- a/gobgp/main.go
+++ b/gobgp/main.go
@@ -60,6 +60,7 @@ func main() {
 	policyCmd := NewPolicyCmd()
 	monitorCmd := NewMonitorCmd()
 	mrtCmd := NewMrtCmd()
-	rootCmd.AddCommand(globalCmd, neighborCmd, policyCmd, monitorCmd, mrtCmd)
+	rpkiCmd := NewRPKICmd()
+	rootCmd.AddCommand(globalCmd, neighborCmd, policyCmd, monitorCmd, mrtCmd, rpkiCmd)
 	rootCmd.Execute()
 }

--- a/gobgp/rpki.go
+++ b/gobgp/rpki.go
@@ -1,0 +1,77 @@
+// Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"github.com/osrg/gobgp/api"
+	"github.com/osrg/gobgp/packet"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+	"io"
+	"sort"
+	"net"
+	"os"
+)
+
+func showRPKITable(args []string) error {
+	af, err := checkAddressFamily(net.IP{})
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	arg := &api.Arguments{
+		Af: af,
+	}
+	stream, err := client.GetRPKI(context.Background(), arg)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	l := roas{}
+	for {
+		r, err := stream.Recv()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+		l = append(l, r)
+	}
+	sort.Sort(l)
+	var format string
+	if af.Afi == bgp.AFI_IP {
+		format = "%-18s %-6s %s\n"
+	} else {
+		format = "%-42s %-6s %s\n"
+	}
+	fmt.Printf(format, "Network", "Maxlen", "AS")
+	for _, r := range l {
+		fmt.Printf(format, fmt.Sprintf("%s/%d", r.Prefix, r.Prefixlen), fmt.Sprint(r.Maxlen), fmt.Sprint(r.Maxlen))
+	}
+	return nil
+}
+
+func NewRPKICmd() *cobra.Command {
+	rpkiCmd := &cobra.Command{
+		Use: CMD_RPKI,
+		Run: func(cmd *cobra.Command, args []string) {
+			showRPKITable(args)
+		},
+	}
+	rpkiCmd.PersistentFlags().StringVarP(&subOpts.AddressFamily, "address-family", "a", "", "address family")
+	return rpkiCmd
+}

--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -46,6 +46,7 @@ func main() {
 		DisableStdlog bool   `long:"disable-stdlog" description:"disable standard logging"`
 		EnableZapi    bool   `short:"z" long:"enable-zapi" description:"enable zebra api"`
 		ZapiURL       string `long:"zapi-url" description:"specify zebra api url"`
+		RPKIServer    string `long:"rpki-server" description:"specify rpki server url"`
 	}
 	_, err := flags.Parse(&opts)
 	if err != nil {
@@ -141,7 +142,7 @@ func main() {
 	reloadCh := make(chan bool)
 	go config.ReadConfigfileServe(opts.ConfigFile, configCh, reloadCh)
 	reloadCh <- true
-	bgpServer := server.NewBgpServer(bgp.BGP_PORT)
+	bgpServer := server.NewBgpServer(bgp.BGP_PORT, opts.RPKIServer)
 	go bgpServer.Serve()
 
 	// start grpc Server

--- a/server/rpki.go
+++ b/server/rpki.go
@@ -1,0 +1,121 @@
+// Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/osrg/gobgp/api"
+	"github.com/osrg/gobgp/packet"
+	"net"
+)
+
+type roa struct {
+	AS        uint32
+	PrefixLen uint8
+	MaxLen    uint8
+	Prefix    net.IP
+}
+
+func (r *roa) key() string {
+	return fmt.Sprintf("%s/%d", r.Prefix.String(), r.PrefixLen)
+}
+
+func (r *roa) toApiStruct() *api.ROA {
+	return &api.ROA{
+		As:        r.AS,
+		Prefixlen: uint32(r.PrefixLen),
+		Maxlen:    uint32(r.MaxLen),
+		Prefix:    r.Prefix.String(),
+	}
+}
+
+type roaClient struct {
+	roas     map[bgp.RouteFamily]map[string]*roa
+	outgoing chan *roa
+}
+
+func (c *roaClient) recieveROA() chan *roa {
+	return c.outgoing
+}
+
+func (c *roaClient) handleRTRMsg(r *roa) {
+	if r.Prefix.To4() != nil {
+		c.roas[bgp.RF_IPv4_UC][r.key()] = r
+	} else {
+		c.roas[bgp.RF_IPv6_UC][r.key()] = r
+	}
+}
+
+func (c *roaClient) handleGRPC(grpcReq *GrpcRequest) {
+	if roas, ok := c.roas[grpcReq.RouteFamily]; ok {
+		for _, r := range roas {
+			result := &GrpcResponse{}
+			result.Data = r.toApiStruct()
+			grpcReq.ResponseCh <- result
+		}
+	}
+	close(grpcReq.ResponseCh)
+}
+
+func newROAClient(url string) (*roaClient, error) {
+	c := &roaClient{
+		roas: make(map[bgp.RouteFamily]map[string]*roa),
+	}
+	c.roas[bgp.RF_IPv4_UC] = make(map[string]*roa)
+	c.roas[bgp.RF_IPv6_UC] = make(map[string]*roa)
+
+	if url == "" {
+		return c, nil
+	}
+
+	conn, err := net.Dial("tcp", url)
+	if err != nil {
+		return c, err
+	}
+
+	r := bgp.NewRTRResetQuery()
+	data, _ := r.Serialize()
+	conn.Write(data)
+	reader := bufio.NewReader(conn)
+	scanner := bufio.NewScanner(reader)
+	scanner.Split(bgp.SplitRTR)
+
+	ch := make(chan *roa)
+	c.outgoing = ch
+
+	go func(ch chan *roa) {
+		for scanner.Scan() {
+			m, _ := bgp.ParseRTR(scanner.Bytes())
+			if m != nil {
+				switch msg := m.(type) {
+				case *bgp.RTRIPPrefix:
+					p := make([]byte, len(msg.Prefix))
+					copy(p, msg.Prefix)
+					ch <- &roa{
+						AS:        msg.AS,
+						PrefixLen: msg.PrefixLen,
+						MaxLen:    msg.MaxLen,
+						Prefix:    p,
+					}
+				}
+
+			}
+		}
+	}(ch)
+
+	return c, nil
+}


### PR DESCRIPTION
Just get info from ROA server. Not varidate any route yet.

Currently, "--rpki-server" option enables RPKI:

$ gobgpd --rpki-server 210.173.170.254:323

We'll use the configuration file for this later.

You can see ROAs via CLI:

$ gobgp rpki

For ipv6,

$ gobgp rpki -a v6

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>