### PR TITLE
server: fix bug of re-establish

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -634,7 +634,7 @@ func (server *BgpServer) handleFSMMessage(peer *Peer, e *fsmMsg, incoming chan *
 				pathList = applyPolicies(peer, loc, POLICY_DIRECTION_EXPORT, peer.getBests(loc))
 			} else {
 				peer.conf.Transport.TransportConfig.LocalAddress = peer.fsm.LocalAddr()
-				for _, path := range peer.getBests(globalRib) {
+				for _, path := range filterpath(peer, peer.getBests(globalRib)) {
 					p := path.Clone(path.IsWithdraw)
 					p.UpdatePathAttrs(&server.bgpConfig.Global, &peer.conf)
 					pathList = append(pathList, p)

--- a/test/scenario_test/ibgp_router_test.py
+++ b/test/scenario_test/ibgp_router_test.py
@@ -42,7 +42,7 @@ class GoBGPTestBase(unittest.TestCase):
         qs = [q1, q2]
         ctns = [g1, q1, q2]
 
-        # advertise a route from q1, q2, q3
+        # advertise a route from q1, q2
         for idx, c in enumerate(qs):
             route = '10.0.{0}.0/24'.format(idx+1)
             c.add_route(route)
@@ -199,6 +199,43 @@ class GoBGPTestBase(unittest.TestCase):
             # bgp router mustn't change aspath of routes from eBGP peers
             # which are sent to iBGP peers
             self.assertTrue(self.gobgp._get_as_path(path) == [q3.asn])
+
+    # disable ebgp peer, check ebgp routes are removed
+    def test_11_disable_ebgp_peer(self):
+        q3 = self.quaggas['q3']
+        self.gobgp.disable_peer(q3)
+        del self.quaggas['q3']
+        self.gobgp.wait_for(expected_state=BGP_FSM_IDLE, peer=q3)
+
+        for route in q3.routes.iterkeys():
+            dst = self.gobgp.get_global_rib(route)
+            self.assertTrue(len(dst) == 0)
+
+        for q in self.quaggas.itervalues():
+            paths = self.gobgp.get_adj_rib_out(q)
+            # only gobgp's locally generated routes must exists
+            print paths
+            self.assertTrue(len(paths) == len(self.gobgp.routes))
+
+    def test_12_disable_ibgp_peer(self):
+        q1 = self.quaggas['q1']
+        self.gobgp.disable_peer(q1)
+        self.gobgp.wait_for(expected_state=BGP_FSM_IDLE, peer=q1)
+
+        for route in q1.routes.iterkeys():
+            dst = self.gobgp.get_global_rib(route)
+            self.assertTrue(len(dst) == 0)
+
+    def test_13_enable_ibgp_peer(self):
+        q1 = self.quaggas['q1']
+        self.gobgp.enable_peer(q1)
+        self.gobgp.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=q1)
+
+    def test_14_check_gobgp_adj_rib_out(self):
+        for q in self.quaggas.itervalues():
+            paths = self.gobgp.get_adj_rib_out(q)
+            # only gobgp's locally generated routes must exists
+            self.assertTrue(len(paths) == len(self.gobgp.routes))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
we must call filterpath() in case of re-establish.
scenario_test is also added to check this.

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>