### PR TITLE
policy: fix aspath match

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -397,19 +397,10 @@ const (
 )
 
 type AsPathElement struct {
-	postiion  AsnPos
-	asStr     string
-	asRegExps []*regexp.Regexp
+	asRegExps *regexp.Regexp
 }
 
-// create AsPathCondition object
-// AsPathCondition supports only following regexp:
-// - ^100  (from as100)
-// - ^100$ (from as100 and originated by as100)
-// - 100$  (originated by as100)
-// - 100   (from or through or originated by as100)
 func NewAsPathCondition(matchSet config.MatchAsPathSet, defAsPathSetList []config.AsPathSet) *AsPathCondition {
-
 	asPathSetName := matchSet.AsPathSet
 	options := matchSet.MatchSetOptions
 
@@ -419,60 +410,25 @@ func NewAsPathCondition(matchSet config.MatchAsPathSet, defAsPathSetList []confi
 			for _, aspath := range asPathSet.AsPathList {
 				a := aspath.AsPath
 				if len(a) != 0 {
-					isTop := a[:1] == "^"
-					if isTop {
-						a = a[1:]
-					}
-					isEnd := a[len(a)-1:] == "$"
-					if isEnd {
-						a = a[:len(a)-1]
-					}
-					elems := strings.Split(a, "_")
-					asRegExps := make([]*regexp.Regexp, 0)
-					for _, el := range elems {
-						if len(el) == 0 {
-							log.WithFields(log.Fields{
-								"Topic": "Policy",
-								"Type":  "AsPath Condition",
-								"Value": aspath.AsPath,
-								"Elem":  el,
-							}).Error("invalid element. do not enter a blank.")
-							return nil
-						}
-						regElem, err := regexp.Compile(el)
-						if err != nil {
-							log.WithFields(log.Fields{
-								"Topic": "Policy",
-								"Type":  "AsPath Condition",
-								"Value": aspath.AsPath,
-								"Elem":  el,
-								"Error": err,
-							}).Error("can not comple AS_PATH values to Regular expressions.")
-							return nil
-						}
-						asRegExps = append(asRegExps, regElem)
+					r, err := regexp.Compile(strings.Replace(a, "_", "(^|[,{}() ]|$)", -1))
+					if err != nil {
+						log.WithFields(log.Fields{
+							"Topic": "Policy",
+							"Type":  "AsPath Condition",
+							"Value": aspath.AsPath,
+							"Error": err,
+						}).Error("can not comple AS_PATH values to Regular expressions.")
+						return nil
 					}
 
 					e := &AsPathElement{}
-					e.asRegExps = asRegExps
-					e.asStr = a
-					if isTop && isEnd {
-						e.postiion = AS_ONLY
-					} else if isTop && !isEnd {
-						e.postiion = AS_FROM
-					} else if !isTop && isEnd {
-						e.postiion = AS_ORIGIN
-					} else {
-						e.postiion = AS_ANY
-					}
+					e.asRegExps = r
 					asPathList = append(asPathList, e)
-
 				} else {
 					log.WithFields(log.Fields{
 						"Topic": "Policy",
 						"Type":  "AsPath Condition",
 					}).Error("does not parse AS_PATH condition value.")
-
 					return nil
 				}
 			}
@@ -486,101 +442,41 @@ func NewAsPathCondition(matchSet config.MatchAsPathSet, defAsPathSetList []confi
 	return nil
 }
 
-func (c *AsPathCondition) checkMembers(aspath []uint32, checkAll bool) bool {
-
-	checkElem := func(checkType AsnPos, regElems []*regexp.Regexp) bool {
-		aslen := len(aspath)
-		reglen := len(regElems)
-
-		if aslen < reglen {
-			return false
-		}
-
-		switch checkType {
-		case AS_ONLY:
-			if aslen != reglen {
-				return false
-			}
-			fallthrough
-		case AS_FROM:
-			for i := 0; i < reglen; i++ {
-				if !regElems[i].MatchString(fmt.Sprintf("%d", aspath[i])) {
-					return false
-				}
-			}
-		case AS_ORIGIN:
-			for i := 0; i < reglen; i++ {
-				if !regElems[reglen-i-1].MatchString(fmt.Sprintf("%d", aspath[aslen-i-1])) {
-					return false
-				}
-			}
-		case AS_ANY:
-			for i := 0; i < aslen; i++ {
-				eMatched := true
-				if aslen < i+reglen {
-					break
-				}
-				for j := 0; j < reglen; j++ {
-					if !regElems[j].MatchString(fmt.Sprintf("%d", aspath[i+j])) {
-						eMatched = false
-						break
-					}
-				}
-				if eMatched {
-					return true
-				}
-			}
-			return false
-		}
-		return true
-	}
-
-	result := false
-	if checkAll {
-		result = true
-	}
+func (c *AsPathCondition) checkMembers(aspathStr string, checkAll bool) bool {
 	for _, member := range c.AsPathList {
-		if checkElem(member.postiion, member.asRegExps) {
+		if member.asRegExps.MatchString(aspathStr) {
 			log.WithFields(log.Fields{
 				"Topic":     "Policy",
 				"Condition": "aspath length",
-				"ASN":       member.asStr,
-				"Position":  member.postiion,
+				"AS":        aspathStr,
+				"ASN":       member.asRegExps,
 			}).Debug("aspath condition matched")
 
 			if !checkAll {
-				result = true
-				break
+				return true
 			}
-
 		} else {
 			if checkAll {
-				result = false
-				break
+				return false
 			}
 		}
 	}
-
-	return result
+	return checkAll
 }
 
 // compare AS_PATH in the message's AS_PATH attribute with
 // the one in condition.
 func (c *AsPathCondition) evaluate(path *table.Path) bool {
 
-	aspath := path.GetAsSeqList()
-
-	if c == nil || len(aspath) == 0 {
-		return false
-	}
+	aspathStr := path.GetAsString()
 
 	result := false
 	if c.MatchOption == config.MATCH_SET_OPTIONS_TYPE_ALL {
-		result = c.checkMembers(aspath, true)
+		result = c.checkMembers(aspathStr, true)
 	} else if c.MatchOption == config.MATCH_SET_OPTIONS_TYPE_ANY {
-		result = c.checkMembers(aspath, false)
+		result = c.checkMembers(aspathStr, false)
 	} else if c.MatchOption == config.MATCH_SET_OPTIONS_TYPE_INVERT {
-		result = !c.checkMembers(aspath, false)
+		result = !c.checkMembers(aspathStr, false)
 	}
 
 	log.WithFields(log.Fields{

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -600,7 +600,6 @@ func TestAsPathConditionEvaluate(t *testing.T) {
 	path1 := table.ProcessMessage(updateMsg1, peer)[0]
 
 	aspathParam2 := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(2, []uint16{65010}),
 		bgp.NewAsPathParam(1, []uint16{65010}),
 	}
 	aspath2 := bgp.NewPathAttributeAsPath(aspathParam2)
@@ -653,7 +652,6 @@ func TestAsPathConditionEvaluate(t *testing.T) {
 		},
 	}
 
-
 	asPathSetList := []config.AsPathSet{asPathSet1, asPathSet2, asPathSet3,
 		asPathSet4, asPathSet5, asPathSet6}
 
@@ -681,7 +679,7 @@ func TestAsPathConditionEvaluate(t *testing.T) {
 	assert.Equal(t, true, p2.evaluate(path1))
 	assert.Equal(t, true, p3.evaluate(path1))
 	assert.Equal(t, false, p4.evaluate(path1))
-	assert.Equal(t, false, p5.evaluate(path1))
+	assert.Equal(t, true, p5.evaluate(path1))
 	assert.Equal(t, false, p6.evaluate(path1))
 	assert.Equal(t, true, p6.evaluate(path2))
 
@@ -708,7 +706,6 @@ func TestMultipleAsPathConditionEvaluate(t *testing.T) {
 	updateMsg1 := bgp.NewBGPUpdateMessage(withdrawnRoutes, pathAttributes, nlri)
 	table.UpdatePathAttrs4ByteAs(updateMsg1.Body.(*bgp.BGPUpdate))
 	path1 := table.ProcessMessage(updateMsg1, peer)[0]
-
 
 	// create match condition
 	asPathSet1 := config.AsPathSet{
@@ -742,7 +739,7 @@ func TestMultipleAsPathConditionEvaluate(t *testing.T) {
 	asPathSet5 := config.AsPathSet{
 		AsPathSetName: "asset5",
 		AsPathList: []config.AsPath{
-			config.AsPath{AsPath: "^65001_65000_54000_65004_65005$"},
+			config.AsPath{AsPath: "^65001 65000 54000 65004 65005 65001,65010,54000,65004,65005$"},
 		},
 	}
 
@@ -803,10 +800,9 @@ func TestMultipleAsPathConditionEvaluate(t *testing.T) {
 	assert.Equal(t, true, p5.evaluate(path1))
 	assert.Equal(t, true, p6.evaluate(path1))
 	assert.Equal(t, true, p7.evaluate(path1))
-	assert.Equal(t, false, p8.evaluate(path1))
+	assert.Equal(t, true, p8.evaluate(path1))
 	assert.Equal(t, false, p9.evaluate(path1))
 }
-
 
 func TestAsPathConditionWithOtherCondition(t *testing.T) {
 

--- a/table/path.go
+++ b/table/path.go
@@ -297,6 +297,34 @@ func (path *Path) GetAsPathLen() int {
 	return length
 }
 
+func (path *Path) GetAsString() string {
+	r := ""
+	if _, attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_AS_PATH); attr != nil {
+		aspath := attr.(*bgp.PathAttributeAsPath)
+		for i, paramIf := range aspath.Value {
+			segment := paramIf.(*bgp.As4PathParam)
+			if i != 0 {
+				r += " "
+			}
+
+			sep := " "
+			switch segment.Type {
+			case bgp.BGP_ASPATH_ATTR_TYPE_SET, bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET:
+				sep = ","
+			case bgp.BGP_ASPATH_ATTR_TYPE_SEQ, bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
+				sep = " "
+			}
+			for j, as := range segment.AS {
+				r += fmt.Sprintf("%d", as)
+				if j != len(segment.AS)-1 {
+					r += sep
+				}
+			}
+		}
+	}
+	return r
+}
+
 func (path *Path) GetAsList() []uint32 {
 	return path.getAsListofSpecificType(true, true)
 


### PR DESCRIPTION
AS Path Regular Expression works as quagga and cisco.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>