### PR TITLE
api/cli: reuse api.Path in ModPathArguments

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -206,17 +206,21 @@ func (m *Arguments) String() string { return proto.CompactTextString(m) }
 func (*Arguments) ProtoMessage()    {}
 
 type ModPathArguments struct {
-	Resource           Resource `protobuf:"varint,1,opt,name=resource,enum=api.Resource" json:"resource,omitempty"`
-	Name               string   `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
-	IsWithdraw         bool     `protobuf:"varint,3,opt,name=is_withdraw" json:"is_withdraw,omitempty"`
-	RawNlri            []byte   `protobuf:"bytes,4,opt,name=raw_nlri,proto3" json:"raw_nlri,omitempty"`
-	RawPattrs          [][]byte `protobuf:"bytes,5,rep,name=raw_pattrs,proto3" json:"raw_pattrs,omitempty"`
-	NoImplicitWithdraw bool     `protobuf:"varint,6,opt,name=no_implicit_withdraw" json:"no_implicit_withdraw,omitempty"`
+	Resource Resource `protobuf:"varint,1,opt,name=resource,enum=api.Resource" json:"resource,omitempty"`
+	Name     string   `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
+	Path     *Path    `protobuf:"bytes,3,opt,name=path" json:"path,omitempty"`
 }
 
 func (m *ModPathArguments) Reset()         { *m = ModPathArguments{} }
 func (m *ModPathArguments) String() string { return proto.CompactTextString(m) }
 func (*ModPathArguments) ProtoMessage()    {}
+
+func (m *ModPathArguments) GetPath() *Path {
+	if m != nil {
+		return m.Path
+	}
+	return nil
+}
 
 type PolicyArguments struct {
 	Resource         Resource          `protobuf:"varint,1,opt,name=resource,enum=api.Resource" json:"resource,omitempty"`
@@ -317,12 +321,13 @@ func (m *Capability) GetGracefulRestart() *GracefulRestart {
 }
 
 type Path struct {
-	Nlri       []byte   `protobuf:"bytes,1,opt,name=nlri,proto3" json:"nlri,omitempty"`
-	Pattrs     [][]byte `protobuf:"bytes,2,rep,name=pattrs,proto3" json:"pattrs,omitempty"`
-	Age        int64    `protobuf:"varint,3,opt,name=age" json:"age,omitempty"`
-	Best       bool     `protobuf:"varint,4,opt,name=best" json:"best,omitempty"`
-	IsWithdraw bool     `protobuf:"varint,5,opt,name=is_withdraw" json:"is_withdraw,omitempty"`
-	Validation int32    `protobuf:"varint,6,opt,name=validation" json:"validation,omitempty"`
+	Nlri               []byte   `protobuf:"bytes,1,opt,name=nlri,proto3" json:"nlri,omitempty"`
+	Pattrs             [][]byte `protobuf:"bytes,2,rep,name=pattrs,proto3" json:"pattrs,omitempty"`
+	Age                int64    `protobuf:"varint,3,opt,name=age" json:"age,omitempty"`
+	Best               bool     `protobuf:"varint,4,opt,name=best" json:"best,omitempty"`
+	IsWithdraw         bool     `protobuf:"varint,5,opt,name=is_withdraw" json:"is_withdraw,omitempty"`
+	Validation         int32    `protobuf:"varint,6,opt,name=validation" json:"validation,omitempty"`
+	NoImplicitWithdraw bool     `protobuf:"varint,7,opt,name=no_implicit_withdraw" json:"no_implicit_withdraw,omitempty"`
 }
 
 func (m *Path) Reset()         { *m = Path{} }

--- a/api/gobgp.proto
+++ b/api/gobgp.proto
@@ -62,10 +62,7 @@ message Arguments {
 message ModPathArguments {
     Resource resource = 1;
     string name = 2;
-    bool is_withdraw = 3;
-    bytes raw_nlri = 4;
-    repeated bytes raw_pattrs = 5;
-    bool no_implicit_withdraw = 6;
+    Path path = 3;
 }
 
 message PolicyArguments {
@@ -145,6 +142,7 @@ message Path {
     bool best = 4;
     bool is_withdraw = 5;
     int32 validation = 6;
+    bool no_implicit_withdraw = 7;
 }
 
 message Destination {

--- a/gobgp/vrf.go
+++ b/gobgp/vrf.go
@@ -23,10 +23,8 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 	"io"
-	"net"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 )
 
@@ -169,166 +167,6 @@ func modVrf(typ string, args []string) error {
 	return err
 }
 
-func modVrfPath(modtype string, vrf string, args []string) error {
-	rf, err := checkAddressFamily(net.IP{})
-	if err != nil {
-		return err
-	}
-
-	var nlri bgp.AddrPrefixInterface
-	var nexthop string
-
-	switch rf {
-	case bgp.RF_IPv4_UC, bgp.RF_IPv6_UC:
-		if len(args) != 1 {
-			return fmt.Errorf("usage: vrf %s rib %s <prefix> -a { ipv4 | ipv6 }", vrf, modtype)
-		}
-		ip, net, _ := net.ParseCIDR(args[0])
-		if rf == bgp.RF_IPv4_UC {
-			if ip.To4() == nil {
-				return fmt.Errorf("invalid ipv4 prefix")
-			}
-			nexthop = "0.0.0.0"
-			ones, _ := net.Mask.Size()
-			nlri = bgp.NewNLRInfo(uint8(ones), ip.String())
-		} else {
-			if ip.To16() == nil {
-				return fmt.Errorf("invalid ipv6 prefix")
-			}
-			nexthop = "::"
-			ones, _ := net.Mask.Size()
-			nlri = bgp.NewIPv6AddrPrefix(uint8(ones), ip.String())
-		}
-	case bgp.RF_EVPN:
-		if len(args) < 1 {
-			return fmt.Errorf("usage: vrf %s rib %s { macadv | multicast } ... -a evpn", vrf, modtype)
-		}
-		subtype := args[0]
-		args = args[1:]
-
-		switch subtype {
-		case "macadv":
-			if len(args) < 4 {
-				return fmt.Errorf("usage: vrf %s rib %s macadv <mac address> <ip address> <etag> <label> -a evpn", vrf, modtype)
-			}
-			mac, err := net.ParseMAC(args[0])
-			if err != nil {
-				return fmt.Errorf("invalid mac: %s", args[0])
-			}
-			var ip net.IP
-			iplen := 0
-			if args[1] != "0.0.0.0" || args[1] != "::" {
-				ip = net.ParseIP(args[1])
-				if ip == nil {
-					return fmt.Errorf("invalid ip prefix: %s", args[1])
-				}
-				iplen = net.IPv4len * 8
-				if ip.To4() == nil {
-					iplen = net.IPv6len * 8
-				}
-			}
-			eTag, err := strconv.Atoi(args[2])
-			if err != nil {
-				return fmt.Errorf("invalid eTag: %s. err: %s", args[2], err)
-			}
-			label, err := strconv.Atoi(args[3])
-			if err != nil {
-				return fmt.Errorf("invalid label: %s. err: %s", args[3], err)
-			}
-			macIpAdv := &bgp.EVPNMacIPAdvertisementRoute{
-				ESI: bgp.EthernetSegmentIdentifier{
-					Type: bgp.ESI_ARBITRARY,
-				},
-				MacAddressLength: 48,
-				MacAddress:       mac,
-				IPAddressLength:  uint8(iplen),
-				IPAddress:        ip,
-				Labels:           []uint32{uint32(label)},
-				ETag:             uint32(eTag),
-			}
-			nlri = bgp.NewEVPNNLRI(bgp.EVPN_ROUTE_TYPE_MAC_IP_ADVERTISEMENT, 0, macIpAdv)
-		case "multicast":
-			if len(args) < 2 {
-				return fmt.Errorf("usage : vrf %s rib %s multicast <ip address> <etag> -a evpn", vrf, modtype)
-			}
-
-			var ip net.IP
-			iplen := 0
-			if args[0] != "0.0.0.0" || args[0] != "::" {
-				ip = net.ParseIP(args[0])
-				if ip == nil {
-					return fmt.Errorf("invalid ip prefix: %s", args[0])
-				}
-				iplen = net.IPv4len * 8
-				if ip.To4() == nil {
-					iplen = net.IPv6len * 8
-				}
-			}
-
-			eTag, err := strconv.Atoi(args[1])
-			if err != nil {
-				return fmt.Errorf("invalid eTag: %s. err: %s", args[1], err)
-			}
-
-			multicastEtag := &bgp.EVPNMulticastEthernetTagRoute{
-				IPAddressLength: uint8(iplen),
-				IPAddress:       ip,
-				ETag:            uint32(eTag),
-			}
-			nlri = bgp.NewEVPNNLRI(bgp.EVPN_INCLUSIVE_MULTICAST_ETHERNET_TAG, 0, multicastEtag)
-		default:
-			return fmt.Errorf("usage: vrf %s rib %s { macadv | multicast | ... -a evpn", vrf, modtype)
-		}
-		nexthop = "0.0.0.0"
-	default:
-		return fmt.Errorf("Unsupported route family: %s", rf)
-	}
-
-	arg := &api.ModPathArguments{
-		Resource:  api.Resource_VRF,
-		Name:      vrf,
-		RawPattrs: make([][]byte, 0),
-	}
-
-	switch modtype {
-	case CMD_ADD:
-		arg.IsWithdraw = false
-	case CMD_DEL:
-		arg.IsWithdraw = true
-	}
-
-	if rf == bgp.RF_IPv4_UC {
-		arg.RawNlri, _ = nlri.Serialize()
-		n, _ := bgp.NewPathAttributeNextHop(nexthop).Serialize()
-		arg.RawPattrs = append(arg.RawPattrs, n)
-	} else {
-		mpreach, _ := bgp.NewPathAttributeMpReachNLRI(nexthop, []bgp.AddrPrefixInterface{nlri}).Serialize()
-		arg.RawPattrs = append(arg.RawPattrs, mpreach)
-	}
-
-	origin, _ := bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP).Serialize()
-	arg.RawPattrs = append(arg.RawPattrs, origin)
-
-	stream, err := client.ModPath(context.Background())
-	if err != nil {
-		return err
-	}
-	err = stream.Send(arg)
-	if err != nil {
-		return err
-	}
-	stream.CloseSend()
-
-	res, e := stream.CloseAndRecv()
-	if e != nil {
-		return e
-	}
-	if res.Code != api.Error_SUCCESS {
-		return fmt.Errorf("error: code: %d, msg: %s", res.Code, res.Msg)
-	}
-	return nil
-}
-
 func NewVrfCmd() *cobra.Command {
 
 	ribCmd := &cobra.Command{
@@ -351,7 +189,7 @@ func NewVrfCmd() *cobra.Command {
 		cmd := &cobra.Command{
 			Use: v,
 			Run: func(cmd *cobra.Command, args []string) {
-				err := modVrfPath(cmd.Use, args[len(args)-1], args[:len(args)-1])
+				err := modPath(api.Resource_VRF, args[len(args)-1], cmd.Use, args[:len(args)-1])
 				if err != nil {
 					fmt.Println(err)
 					os.Exit(1)


### PR DESCRIPTION
kill redundant lines

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>