### PR TITLE
pack multiple NLRIs into one BGP update message

### DIFF
--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -2703,6 +2703,9 @@ type PathAttribute struct {
 }
 
 func (p *PathAttribute) Len() int {
+	if p.Length == 0 {
+		p.Length = uint16(len(p.Value))
+	}
 	l := 2 + p.Length
 	if p.Flags&BGP_ATTR_FLAG_EXTENDED_LENGTH != 0 {
 		l += 2


### PR DESCRIPTION
With this patch, bobgpd packs multiple NLRIs into one BGP update
message (IOW, multiple paths into one update message).

We do only with ipv4 since we could have lots of routes. If you don't
have lots, it's not worth having the complicated logic for such route
families.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>