### PR TITLE
mrt: add helper function for timestamp

### DIFF
--- a/packet/mrt.go
+++ b/packet/mrt.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"time"
 )
 
 const (
@@ -137,6 +138,11 @@ func NewMRTHeader(timestamp uint32, t MRTType, subtype MRTSubTyper, l uint32) (*
 		SubType:   subtype.ToUint16(),
 		Len:       l,
 	}, nil
+}
+
+func (h *MRTHeader) GetTime() time.Time {
+	t := int64(h.Timestamp)
+	return time.Unix(t, 0)
 }
 
 type MRTMessage struct {

--- a/packet/mrt_test.go
+++ b/packet/mrt_test.go
@@ -41,6 +41,17 @@ func TestMrtHdr(t *testing.T) {
 	assert.Equal(t, reflect.DeepEqual(h1, h2), true)
 }
 
+func TestMrtHdrTime(t *testing.T) {
+	h1, err := NewMRTHeader(10, TABLE_DUMPv2, RIB_IPV4_MULTICAST, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ttime := time.Unix(10, 0)
+	htime := h1.GetTime()
+	t.Logf("this timestamp should be 10s after epoch:%v", htime)
+	assert.Equal(t, h1.GetTime(), ttime)
+}
+
 func testPeer(t *testing.T, p1 *Peer) {
 	b1, err := p1.Serialize()
 	if err != nil {


### PR DESCRIPTION
Commiting helper function on MRTHeader to return a golang time.Time
from the timestamp. Also commiting the relevant test function.