### PR TITLE
packet: update reference to 'draft-haas-idr-flowspec-redirect-rt-bis'

### DIFF
--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -4591,7 +4591,7 @@ func parseFlowSpecExtended(data []byte) (ExtendedCommunityInterface, error) {
 		sample := (data[7]>>1)&0x1 == 1
 		return NewTrafficActionExtended(terminal, sample), nil
 	case EC_SUBTYPE_FLOWSPEC_REDIRECT:
-		//draft-haas-idr-flowspec-redirect-rt-bis-05
+		//draft-ietf-idr-flowspec-redirect-rt-bis-05
 		switch typ {
 		case EC_TYPE_GENERIC_TRANSITIVE_EXPERIMENTAL:
 			as := binary.BigEndian.Uint16(data[2:4])


### PR DESCRIPTION
The draft was promoted to IETF WG item.

It is already enqueued to RFC editors in Aug. 2015. It's expected to be published as RFC soon.

Signed-off-by: Jun-ya Kato <kato.junya@lab.ntt.co.jp>