### PR TITLE
test: fix malformed gobgpd.conf

### DIFF
--- a/test/scenario_test/lib/base.py
+++ b/test/scenario_test/lib/base.py
@@ -229,7 +229,7 @@ class BGPContainer(Container):
         super(BGPContainer, self).run()
         return self.WAIT_FOR_BOOT
 
-    def add_peer(self, peer, passwd=None, evpn=False, is_rs_client=False,
+    def add_peer(self, peer, passwd="", evpn=False, is_rs_client=False,
                  policies=None, passive=False,
                  is_rr_client=False, cluster_id='',
                  flowspec=False):


### PR DESCRIPTION
Avoid the following line in a generated config file:

AuthPassword = None

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>