### PR TITLE
support multihop ttl

### DIFF
--- a/server/peer.go
+++ b/server/peer.go
@@ -226,10 +226,6 @@ func (peer *Peer) startFSMHandler(incoming chan *fsmMsg) {
 }
 
 func (peer *Peer) PassConn(conn *net.TCPConn) {
-	if peer.isEBGPPeer() {
-		ttl := 1
-		SetTcpTTLSockopts(conn, ttl)
-	}
 	select {
 	case peer.fsm.connCh <- conn:
 	default:


### PR DESCRIPTION
You can enable the feature like the following:

[Neighbors]
  [[Neighbors.NeighborList]]
    [Neighbors.NeighborList.NeighborConfig]
      PeerAs = 65001
      NeighborAddress = "10.0.255.1"
    [Neighbors.NeighborList.EbgpMultihop]
      [Neighbors.NeighborList.EbgpMultihop.EbgpMultihopConfig]
        Enabled = true
        MultihopTtl = 8

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>