### PR TITLE
improve multihop ttl support

### DIFF
--- a/server/fsm.go
+++ b/server/fsm.go
@@ -341,7 +341,9 @@ func (h *FSMHandler) active() bgp.FSMState {
 				if fsm.pConf.EbgpMultihop.EbgpMultihopConfig.Enabled == true {
 					ttl = int(fsm.pConf.EbgpMultihop.EbgpMultihopConfig.MultihopTtl)
 				}
-				SetTcpTTLSockopts(conn.(*net.TCPConn), ttl)
+				if ttl != 0 {
+					SetTcpTTLSockopts(conn.(*net.TCPConn), ttl)
+				}
 			}
 			// we don't implement delayed open timer so move to opensent right
 			// away.


### PR DESCRIPTION
if you don't specify ttl, then we use the OS-default ttl.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>