### PR TITLE
zebra: add NEXTHOP_LOOKUP and IMPORT_LOOKUP

### DIFF
--- a/zebra/zapi_test.go
+++ b/zebra/zapi_test.go
@@ -318,3 +318,129 @@ func Test_IPRouteBody_IPv6(t *testing.T) {
 	err = r.DecodeFromBytes(buf)
 	assert.Equal(nil, err)
 }
+
+func Test_NexthopLookupBody(t *testing.T) {
+	assert := assert.New(t)
+
+	//ipv4
+	//DecodeFromBytes
+	pos := 0
+	buf := make([]byte, 18)
+	ip := net.ParseIP("192.168.50.0").To4()
+	copy(buf[0:4], []byte(ip))
+	pos += 4
+	binary.BigEndian.PutUint32(buf[pos:], 10)
+	pos += 4
+	buf[pos] = byte(1)
+	pos += 1
+	buf[pos] = byte(4)
+	pos += 1
+	ip = net.ParseIP("172.16.1.101").To4()
+	copy(buf[pos:pos+4], []byte(ip))
+	pos += 4
+	binary.BigEndian.PutUint32(buf[pos:], 3)
+
+	b := &NexthopLookupBody{Api: IPV4_NEXTHOP_LOOKUP}
+	err := b.DecodeFromBytes(buf)
+	assert.Equal(nil, err)
+	assert.Equal("192.168.50.0", b.Addr.String())
+	assert.Equal(uint32(10), b.Metric)
+	assert.Equal(uint32(3), b.Nexthops[0].Ifindex)
+	assert.Equal(NEXTHOP_FLAG(4), b.Nexthops[0].Type)
+	assert.Equal("172.16.1.101", b.Nexthops[0].Addr.String())
+
+	//Serialize
+	buf, err = b.Serialize()
+	ip = net.ParseIP("192.168.50.0").To4()
+	assert.Equal(nil, err)
+	assert.Equal([]byte(ip)[0:4], buf[0:4])
+
+	// length invalid
+	buf = make([]byte, 3)
+	b = &NexthopLookupBody{Api: IPV4_NEXTHOP_LOOKUP}
+	err = b.DecodeFromBytes(buf)
+	assert.NotEqual(nil, err)
+
+	//ipv6
+	//DecodeFromBytes
+	pos = 0
+	buf = make([]byte, 46)
+	ip = net.ParseIP("2001:db8:0:f101::").To16()
+	copy(buf[0:16], []byte(ip))
+	pos += 16
+	binary.BigEndian.PutUint32(buf[pos:], 10)
+	pos += 4
+	buf[pos] = byte(1)
+	pos += 1
+	buf[pos] = byte(4)
+	pos += 1
+	ip = net.ParseIP("2001:db8:0:1111::1").To16()
+	copy(buf[pos:pos+16], []byte(ip))
+	pos += 16
+	binary.BigEndian.PutUint32(buf[pos:], 3)
+
+	b = &NexthopLookupBody{Api: IPV6_NEXTHOP_LOOKUP}
+	err = b.DecodeFromBytes(buf)
+	assert.Equal(nil, err)
+	assert.Equal("2001:db8:0:f101::", b.Addr.String())
+	assert.Equal(uint32(10), b.Metric)
+	assert.Equal(uint32(3), b.Nexthops[0].Ifindex)
+	assert.Equal(NEXTHOP_FLAG(4), b.Nexthops[0].Type)
+	assert.Equal("2001:db8:0:1111::1", b.Nexthops[0].Addr.String())
+
+	//Serialize
+	buf, err = b.Serialize()
+	ip = net.ParseIP("2001:db8:0:f101::").To16()
+	assert.Equal(nil, err)
+	assert.Equal([]byte(ip)[0:16], buf[0:16])
+
+	// length invalid
+	buf = make([]byte, 15)
+	b = &NexthopLookupBody{Api: IPV6_NEXTHOP_LOOKUP}
+	err = b.DecodeFromBytes(buf)
+	assert.NotEqual(nil, err)
+}
+
+func Test_ImportLookupBody(t *testing.T) {
+	assert := assert.New(t)
+
+	//DecodeFromBytes
+	pos := 0
+	buf := make([]byte, 18)
+	ip := net.ParseIP("192.168.50.0").To4()
+	copy(buf[0:4], []byte(ip))
+	pos += 4
+	binary.BigEndian.PutUint32(buf[pos:], 10)
+	pos += 4
+	buf[pos] = byte(1)
+	pos += 1
+	buf[pos] = byte(4)
+	pos += 1
+	ip = net.ParseIP("172.16.1.101").To4()
+	copy(buf[pos:pos+4], []byte(ip))
+	pos += 4
+	binary.BigEndian.PutUint32(buf[pos:], 3)
+
+	b := &ImportLookupBody{Api: IPV4_IMPORT_LOOKUP}
+	err := b.DecodeFromBytes(buf)
+	assert.Equal(nil, err)
+	assert.Equal("192.168.50.0", b.Addr.String())
+	assert.Equal(uint32(10), b.Metric)
+	assert.Equal(uint32(3), b.Nexthops[0].Ifindex)
+	assert.Equal(NEXTHOP_FLAG(4), b.Nexthops[0].Type)
+	assert.Equal("172.16.1.101", b.Nexthops[0].Addr.String())
+
+	//Serialize
+	b.PrefixLength = uint8(24)
+	buf, err = b.Serialize()
+	ip = net.ParseIP("192.168.50.0").To4()
+	assert.Equal(nil, err)
+	assert.Equal(uint8(24), buf[0])
+	assert.Equal([]byte(ip)[0:4], buf[1:5])
+
+	// length invalid
+	buf = make([]byte, 3)
+	b = &ImportLookupBody{Api: IPV4_IMPORT_LOOKUP}
+	err = b.DecodeFromBytes(buf)
+	assert.NotEqual(nil, err)
+}


### PR DESCRIPTION
I added parser and serializer for IPV4_NEXTHOP_LOOKUP, IPV6_NEXTHOP_LOOKUP and IPV4_IMPORT_LOOKUP zebra API messages.
I also added String() for those messages.
