### PR TITLE
server: add mrt bgp4mp support

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -764,6 +764,12 @@ type Neighbors struct {
 	NeighborList []Neighbor
 }
 
+//struct for container gobgp:mrt
+type Mrt struct {
+	// original -> gobgp:file-name
+	FileName string
+}
+
 //struct for container bgp-mp:l2vpn-evpn
 type L2vpnEvpn struct {
 	// original -> bgp-mp:prefix-limit
@@ -1300,6 +1306,8 @@ type Global struct {
 	AfiSafis AfiSafis
 	// original -> rpol:apply-policy
 	ApplyPolicy ApplyPolicy
+	// original -> gobgp:mrt
+	Mrt Mrt
 }
 
 //struct for container bgp:bgp

--- a/server/dumper.go
+++ b/server/dumper.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/osrg/gobgp/packet"
+	"os"
+	"time"
+)
+
+type dumper struct {
+	ch chan *broadcastBGPMsg
+}
+
+func (d *dumper) sendCh() chan *broadcastBGPMsg {
+	return d.ch
+}
+
+func newDumper(filename string) (*dumper, error) {
+	f, err := os.Create(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := make(chan *broadcastBGPMsg, 16)
+
+	go func() {
+		for {
+			m := <-ch
+			subtype := bgp.MESSAGE_AS4
+			mp := bgp.NewBGP4MPMessage(m.peerAS, m.localAS, 0, m.peerAddress.String(), m.localAddress.String(), m.fourBytesAs, m.message)
+			if m.fourBytesAs == false {
+				subtype = bgp.MESSAGE
+			}
+			bm, err := bgp.NewMRTMessage(uint32(time.Now().Unix()), bgp.BGP4MP, subtype, mp)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"Topic": "mrt",
+					"Data":  m,
+				}).Warn(err)
+				continue
+			}
+			buf, err := bm.Serialize()
+			if err != nil {
+				log.WithFields(log.Fields{
+					"Topic": "mrt",
+					"Data":  m,
+				}).Warn(err)
+			} else {
+				f.Write(buf)
+			}
+		}
+	}()
+	return &dumper{
+		ch: ch,
+	}, nil
+}

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -554,7 +554,18 @@ module bgp-gobgp {
   augment "/bgp:bgp" {
     description "additional rpki configuration and state";
     uses gobgp-rpki-servers;
-
   }
 
+  augment "/bgp:bgp/bgp:global" {
+    description "additional mrt configuration";
+    container mrt {
+       description
+         "Configure dump bgp messages in the mrt format";
+      leaf file-name {
+        type string;
+        description
+          "Configures a file name to be written.";
+      }
+    }
+  }
 }


### PR DESCRIPTION
You can enable the feature like:

[Global]
  [Global.GlobalConfig]
    As = 64512
    RouterId = "10.0.255.254"
  [Global.Mrt]
    FileName = "update.dump"

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>