### PR TITLE
Add bmp support

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -131,6 +131,33 @@ const (
 	BGP_ORIGIN_ATTR_TYPE_INCOMPLETE                   = 2
 )
 
+//struct for container gobgp:state
+type BmpServerState struct {
+}
+
+//struct for container gobgp:config
+type BmpServerConfig struct {
+	// original -> gobgp:address
+	//gobgp:address's original type is inet:ip-address
+	Address net.IP
+	// original -> gobgp:port
+	Port uint32
+}
+
+//struct for container gobgp:bmp-server
+type BmpServer struct {
+	// original -> gobgp:bmp-server-config
+	BmpServerConfig BmpServerConfig
+	// original -> gobgp:bmp-server-state
+	BmpServerState BmpServerState
+}
+
+//struct for container gobgp:bmp-servers
+type BmpServers struct {
+	// original -> gobgp:bmp-server
+	BmpServerList []BmpServer
+}
+
 //struct for container gobgp:rpki-received
 type RpkiReceived struct {
 	// original -> gobgp:serial-notify
@@ -1320,6 +1347,8 @@ type Bgp struct {
 	PeerGroups PeerGroups
 	// original -> gobgp:rpki-servers
 	RpkiServers RpkiServers
+	// original -> gobgp:bmp-servers
+	BmpServers BmpServers
 }
 
 //struct for container bgp-pol:set-ext-community-method

--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -179,6 +179,7 @@ func main() {
 				bgpServer.SetGlobalType(newConfig.Bgp.Global)
 				bgpConfig = &newConfig.Bgp
 				bgpServer.SetRpkiConfig(newConfig.Bgp.RpkiServers)
+				bgpServer.SetBmpConfig(newConfig.Bgp.BmpServers)
 				added = newConfig.Bgp.Neighbors.NeighborList
 				deleted = []config.Neighbor{}
 				updated = []config.Neighbor{}

--- a/packet/bmp.go
+++ b/packet/bmp.go
@@ -34,6 +34,11 @@ const (
 	BMP_PEER_HEADER_SIZE = 42
 )
 
+const (
+	BMP_PEER_TYPE_GLOBAL = iota
+	BMP_PEER_TYPE_L3VPN
+)
+
 func (h *BMPHeader) DecodeFromBytes(data []byte) error {
 	h.Version = data[0]
 	if data[0] != 3 {
@@ -242,7 +247,9 @@ func (body *BMPPeerDownNotification) Serialize() ([]byte, error) {
 			}
 		}
 	default:
-		buf = append(buf, body.Data...)
+		if body.Data != nil {
+			buf = append(buf, body.Data...)
+		}
 	}
 	return buf, nil
 }

--- a/server/bmp.go
+++ b/server/bmp.go
@@ -1,0 +1,132 @@
+// Copyright (C) 2015 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/osrg/gobgp/config"
+	"github.com/osrg/gobgp/packet"
+	"github.com/osrg/gobgp/table"
+	"net"
+	"strconv"
+	"time"
+)
+
+type broadcastBMPMsg struct {
+	ch      chan *broadcastBMPMsg
+	msgList []*bgp.BMPMessage
+	conn    *net.TCPConn
+	addr    string
+}
+
+func (m *broadcastBMPMsg) send() {
+	m.ch <- m
+}
+
+type bmpConn struct {
+	conn *net.TCPConn
+	addr string
+}
+
+type bmpClient struct {
+	ch     chan *broadcastBMPMsg
+	connCh chan *bmpConn
+}
+
+func newBMPClient(conf config.BmpServers, connCh chan *bmpConn) (*bmpClient, error) {
+	b := &bmpClient{}
+	if len(conf.BmpServerList) == 0 {
+		return b, nil
+	}
+
+	b.ch = make(chan *broadcastBMPMsg)
+	b.connCh = connCh
+
+	tryConnect := func(addr string) {
+		for {
+			conn, err := net.Dial("tcp", addr)
+			if err != nil {
+				time.Sleep(30 * time.Second)
+			} else {
+				log.Info("bmp server is connected, ", addr)
+				connCh <- &bmpConn{
+					conn: conn.(*net.TCPConn),
+					addr: addr,
+				}
+				break
+			}
+		}
+	}
+
+	for _, c := range conf.BmpServerList {
+		b := c.BmpServerConfig
+		go tryConnect(net.JoinHostPort(b.Address.String(), strconv.Itoa(int(b.Port))))
+	}
+
+	go func() {
+		connMap := make(map[string]*net.TCPConn)
+		for {
+			select {
+			case m := <-b.ch:
+				if m.conn != nil {
+					i := bgp.NewBMPInitiation([]bgp.BMPTLV{})
+					buf, _ := i.Serialize()
+					_, err := m.conn.Write(buf)
+					if err == nil {
+						connMap[m.addr] = m.conn
+					}
+				}
+
+				for addr, conn := range connMap {
+					if m.conn != nil && m.conn != conn {
+						continue
+					}
+
+					for _, msg := range m.msgList {
+						b, _ := msg.Serialize()
+						_, err := conn.Write(b)
+						if err != nil {
+							delete(connMap, addr)
+							go tryConnect(addr)
+							break
+						}
+					}
+				}
+			}
+		}
+	}()
+
+	return b, nil
+}
+
+func (c *bmpClient) send() chan *broadcastBMPMsg {
+	return c.ch
+}
+
+func bmpPeerUp(laddr string, lport, rport uint16, sent, recv *bgp.BGPMessage, t int, policy bool, pd uint64, peeri *table.PeerInfo, timestamp int64) *bgp.BMPMessage {
+	ph := bgp.NewBMPPeerHeader(uint8(t), policy, pd, peeri.Address.String(), peeri.AS, peeri.LocalID.String(), float64(timestamp))
+	return bgp.NewBMPPeerUpNotification(*ph, laddr, lport, rport, sent, recv)
+}
+
+func bmpPeerDown(reason uint8, t int, policy bool, pd uint64, peeri *table.PeerInfo, timestamp int64) *bgp.BMPMessage {
+	ph := bgp.NewBMPPeerHeader(uint8(t), policy, pd, peeri.Address.String(), peeri.AS, peeri.LocalID.String(), float64(timestamp))
+	return bgp.NewBMPPeerDownNotification(*ph, reason, nil, []byte{})
+}
+
+func bmpPeerRoute(t int, policy bool, pd uint64, peeri *table.PeerInfo, timestamp int64, u *bgp.BGPMessage) *bgp.BMPMessage {
+	ph := bgp.NewBMPPeerHeader(uint8(t), policy, pd, peeri.Address.String(), peeri.AS, peeri.LocalID.String(), float64(timestamp))
+	return bgp.NewBMPRouteMonitoring(*ph, u)
+}

--- a/server/fsm.go
+++ b/server/fsm.go
@@ -170,16 +170,25 @@ func (fsm *FSM) StateChange(nextState bgp.FSMState) {
 	}
 }
 
-func (fsm *FSM) LocalAddr() net.IP {
-	addr := fsm.conn.LocalAddr()
+func hostport(addr net.Addr) (string, uint16) {
 	if addr != nil {
-		host, _, err := net.SplitHostPort(addr.String())
+		host, port, err := net.SplitHostPort(addr.String())
 		if err != nil {
-			return nil
+			return "", 0
 		}
-		return net.ParseIP(host)
+		p, _ := strconv.Atoi(port)
+		return host, uint16(p)
 	}
-	return nil
+	return "", 0
+}
+
+func (fsm *FSM) RemoteHostPort() (string, uint16) {
+	return hostport(fsm.conn.RemoteAddr())
+
+}
+
+func (fsm *FSM) LocalHostPort() (string, uint16) {
+	return hostport(fsm.conn.LocalAddr())
 }
 
 func (fsm *FSM) sendNotificatonFromErrorMsg(conn net.Conn, e *bgp.MessageError) {

--- a/server/peer.go
+++ b/server/peer.go
@@ -44,6 +44,7 @@ type Peer struct {
 	inPolicies            []*policy.Policy
 	defaultInPolicy       config.DefaultPolicyType
 	isConfederationMember bool
+	recvOpen              *bgp.BGPMessage
 }
 
 func NewPeer(g config.Global, conf config.Neighbor) *Peer {
@@ -121,6 +122,7 @@ func (peer *Peer) handleBGPmessage(m *bgp.BGPMessage) ([]*table.Path, bool, []*b
 
 	switch m.Header.Type {
 	case bgp.BGP_MSG_OPEN:
+		peer.recvOpen = m
 		body := m.Body.(*bgp.BGPOpen)
 		peer.peerInfo.ID = m.Body.(*bgp.BGPOpen).ID
 		r := make(map[bgp.RouteFamily]bool)

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -395,6 +395,56 @@ module bgp-gobgp {
     }
   }
 
+  grouping gobgp-bmp-server-config {
+    description "additional BMP config";
+
+    leaf address {
+      type inet:ip-address;
+      description
+        "Reference to the address of the BMP server used as
+         a key in the BMP server list";
+    }
+    leaf port {
+      type uint32;
+      description
+        "Reference to the port of the BMP server";
+    }
+  }
+
+  grouping gobgp-bmp-server-state {
+    description "additional BMP state";
+  }
+
+  grouping gobgp-bmp-server-set {
+    description "additional BMP configuration and state";
+
+    container config {
+      description
+        "Configuration parameters relating to BMP server";
+      uses gobgp-bmp-server-config;
+    }
+
+    container state {
+      description
+        "Configuration parameters relating to BMP server";
+      uses gobgp-bmp-server-state;
+    }
+  }
+
+  grouping gobgp-bmp-servers {
+    description "BGP Monitoring Protocol servers";
+
+    container bmp-servers {
+      description
+        "List of BMP servers configured on the local system";
+      list bmp-server {
+        container bmp-server {
+          uses gobgp-bmp-server-set;
+        }
+      }
+    }
+  }
+
   // augment statements
   augment "/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:state/bgp:messages/bgp:sent" {
     description "additional counters";
@@ -554,6 +604,11 @@ module bgp-gobgp {
   augment "/bgp:bgp" {
     description "additional rpki configuration and state";
     uses gobgp-rpki-servers;
+  }
+
+  augment "/bgp:bgp" {
+    description "additional bmp configuration";
+    uses gobgp-bmp-servers;
   }
 
   augment "/bgp:bgp/bgp:global" {


### PR DESCRIPTION
Can be enabled like:

[Global]
  [Global.GlobalConfig]
    As = 64512
    RouterId = "10.0.255.254"

[BmpServers]
  [[BmpServers.BmpServerList]]
    [BmpServers.BmpServerList.BmpServerConfig]
      Address = "127.0.0.1"
      Port=11019

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>