### PR TITLE
scenario_test: preserve test logs

### DIFF
--- a/test/scenario_test/ci-scripts/jenkins-build-script.sh
+++ b/test/scenario_test/ci-scripts/jenkins-build-script.sh
@@ -32,4 +32,22 @@ $GOROOT/bin/go get -v
 
 cd $GOBGP/test/scenario_test
 
+if [ "${BUILD_TAG}" != "" ]; then
+    sudo rm /var/log/upstart/docker.log
+    sudo touch /var/log/upstart/docker.log
+fi
+
 ./run_all_tests.sh
+
+if [ "${BUILD_TAG}" != "" ]; then
+    cd ${WS}
+    mkdir jenkins-log-${BUILD_NUMBER}
+    sudo cp *.xml jenkins-log-${BUILD_NUMBER}/
+    sudo cp /var/log/upstart/docker.log jenkins-log-${BUILD_NUMBER}/docker.log
+    sudo chown -R jenkins:jenkins jenkins-log-${BUILD_NUMBER}
+
+    tar cvzf jenkins-log-${BUILD_NUMBER}.tar.gz jenkins-log-${BUILD_NUMBER}
+    s3cmd put jenkins-log-${BUILD_NUMBER}.tar.gz s3://gobgp/jenkins/
+    rm -rf jenkins-log-${BUILD_NUMBER} jenkins-log-${BUILD_NUMBER}.tar.gz
+fi
+


### PR DESCRIPTION
This patch copies docker.log and nosetest logs to object storage.
It copies files only when the test is invoked by jenkins.
