### PR TITLE
scenario_test: preserve test logs

### DIFF
--- a/test/scenario_test/ci-scripts/jenkins-build-script.sh
+++ b/test/scenario_test/ci-scripts/jenkins-build-script.sh
@@ -9,6 +9,11 @@ export GOROOT=/usr/local/go
 export GOBGP=/usr/local/jenkins/src/github.com/osrg/gobgp
 export WS=`pwd`
 
+# clear docker.log
+if [ "${BUILD_TAG}" != "" ]; then
+    sudo sh -c ": > /var/log/upstart/docker.log"
+fi
+
 rm -r ${WS}/nosetest*.xml
 cp -r ../workspace $GOBGP
 pwd
@@ -31,5 +36,17 @@ cd $GOBGP/gobgpd
 $GOROOT/bin/go get -v
 
 cd $GOBGP/test/scenario_test
-
 ./run_all_tests.sh
+
+if [ "${BUILD_TAG}" != "" ]; then
+    cd ${WS}
+    mkdir jenkins-log-${BUILD_NUMBER}
+    sudo cp *.xml jenkins-log-${BUILD_NUMBER}/
+    sudo cp /var/log/upstart/docker.log jenkins-log-${BUILD_NUMBER}/docker.log
+    sudo chown -R jenkins:jenkins jenkins-log-${BUILD_NUMBER}
+
+    tar cvzf jenkins-log-${BUILD_NUMBER}.tar.gz jenkins-log-${BUILD_NUMBER}
+    s3cmd put jenkins-log-${BUILD_NUMBER}.tar.gz s3://gobgp/jenkins/
+    rm -rf jenkins-log-${BUILD_NUMBER} jenkins-log-${BUILD_NUMBER}.tar.gz
+fi
+


### PR DESCRIPTION
This patch copies docker.log and nosetest logs of the test which is invoked by Jenkins to object storage.
In addition, it clears docker.log before removing previous docker containers.

