### PR TITLE
assign mpls labels to locally generated vpn routes automatically

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -791,6 +791,14 @@ type Neighbors struct {
 	NeighborList []Neighbor
 }
 
+//struct for container gobgp:mpls-label-range
+type MplsLabelRange struct {
+	// original -> gobgp:min-label
+	MinLabel uint32
+	// original -> gobgp:max-label
+	MaxLabel uint32
+}
+
 //struct for container gobgp:zebra
 type Zebra struct {
 	// original -> gobgp:enabled
@@ -1346,6 +1354,8 @@ type Global struct {
 	Mrt Mrt
 	// original -> gobgp:zebra
 	Zebra Zebra
+	// original -> gobgp:mpls-label-range
+	MplsLabelRange MplsLabelRange
 }
 
 //struct for container bgp:bgp

--- a/config/default.go
+++ b/config/default.go
@@ -10,6 +10,8 @@ const (
 	DEFAULT_HOLDTIME                  = 90
 	DEFAULT_IDLE_HOLDTIME_AFTER_RESET = 30
 	DEFAULT_CONNECT_RETRY             = 120
+	DEFAULT_MPLS_LABEL_MIN            = 16000
+	DEFAULT_MPLS_LABEL_MAX            = 1048575
 )
 
 type neighbor struct {
@@ -43,6 +45,14 @@ func SetDefaultConfigValues(md toml.MetaData, bt *Bgp) error {
 			AfiSafi{AfiSafiName: "ipv6-flowspec"},
 			AfiSafi{AfiSafiName: "l3vpn-ipv6-flowspec"},
 		}
+	}
+
+	if _, ok := global["Global.MplsLabelRange.MinLabel"]; !ok {
+		bt.Global.MplsLabelRange.MinLabel = DEFAULT_MPLS_LABEL_MIN
+	}
+
+	if _, ok := global["Global.MplsLabelRange.MaxLabel"]; !ok {
+		bt.Global.MplsLabelRange.MaxLabel = DEFAULT_MPLS_LABEL_MAX
 	}
 
 	nidx := 0

--- a/server/peer.go
+++ b/server/peer.go
@@ -383,9 +383,9 @@ type LocalRib struct {
 	defaultExportPolicy config.DefaultPolicyType
 }
 
-func NewLocalRib(owner string, rfList []bgp.RouteFamily, policyMap map[string]*policy.Policy) *LocalRib {
+func NewLocalRib(owner string, rfList []bgp.RouteFamily, minLabel, maxLabel uint32) *LocalRib {
 	return &LocalRib{
-		rib: table.NewTableManager(owner, rfList),
+		rib: table.NewTableManager(owner, rfList, minLabel, maxLabel),
 	}
 }
 

--- a/table/table_manager_test.go
+++ b/table/table_manager_test.go
@@ -69,7 +69,7 @@ func peerR3() *PeerInfo {
 // test best path calculation and check the result path is from R1
 func TestProcessBGPUpdate_0_select_onlypath_ipv4(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_0_select_onlypath_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_0_select_onlypath_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC}, 0, 0)
 
 	bgpMessage := update_fromR1()
 	peer := peerR1()
@@ -119,7 +119,7 @@ func TestProcessBGPUpdate_0_select_onlypath_ipv4(t *testing.T) {
 // test best path calculation and check the result path is from R1
 func TestProcessBGPUpdate_0_select_onlypath_ipv6(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_0_select_onlypath_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_0_select_onlypath_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC}, 0, 0)
 
 	bgpMessage := update_fromR1_ipv6()
 	peer := peerR1()
@@ -170,7 +170,7 @@ func TestProcessBGPUpdate_0_select_onlypath_ipv6(t *testing.T) {
 // test: compare localpref
 func TestProcessBGPUpdate_1_select_high_localpref_ipv4(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_1_select_high_localpref_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_1_select_high_localpref_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC}, 0, 0)
 	var err error
 
 	// low localpref message
@@ -251,7 +251,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_1_select_high_localpref_ipv6(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_1_select_high_localpref_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_1_select_high_localpref_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC}, 0, 0)
 	var err error
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -334,7 +334,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv6(t *testing.T) {
 // test: compare localOrigin
 func TestProcessBGPUpdate_2_select_local_origin_ipv4(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_2_select_local_origin_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_2_select_local_origin_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC}, 0, 0)
 	var err error
 
 	// low localpref message
@@ -417,7 +417,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_2_select_local_origin_ipv6(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_2_select_local_origin_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_2_select_local_origin_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC}, 0, 0)
 	var err error
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -503,7 +503,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv6(t *testing.T) {
 // test: compare AS_PATH
 func TestProcessBGPUpdate_3_select_aspath_ipv4(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_3_select_aspath_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_3_select_aspath_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC}, 0, 0)
 	var err error
 
 	bgpMessage1 := update_fromR2viaR1()
@@ -559,7 +559,7 @@ func TestProcessBGPUpdate_3_select_aspath_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_3_select_aspath_ipv6(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_3_select_aspath_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_3_select_aspath_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC}, 0, 0)
 	var err error
 
 	bgpMessage1 := update_fromR2viaR1_ipv6()
@@ -617,7 +617,7 @@ func TestProcessBGPUpdate_3_select_aspath_ipv6(t *testing.T) {
 // test: compare Origin
 func TestProcessBGPUpdate_4_select_low_origin_ipv4(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_4_select_low_origin_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_4_select_low_origin_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC}, 0, 0)
 	var err error
 
 	// low origin message
@@ -698,7 +698,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_4_select_low_origin_ipv6(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_4_select_low_origin_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_4_select_low_origin_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC}, 0, 0)
 	var err error
 
 	origin1 := bgp.NewPathAttributeOrigin(1)
@@ -781,7 +781,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv6(t *testing.T) {
 // test: compare MED
 func TestProcessBGPUpdate_5_select_low_med_ipv4(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_5_select_low_med_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_5_select_low_med_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC}, 0, 0)
 	var err error
 
 	// low origin message
@@ -862,7 +862,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_5_select_low_med_ipv6(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_5_select_low_med_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_5_select_low_med_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC}, 0, 0)
 	var err error
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -945,7 +945,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv6(t *testing.T) {
 // test: compare AS_NUMBER(prefer eBGP path)
 func TestProcessBGPUpdate_6_select_ebgp_path_ipv4(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_6_select_ebgp_path_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_6_select_ebgp_path_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC}, 0, 0)
 
 	var err error
 
@@ -1027,7 +1027,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_6_select_ebgp_path_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_6_select_ebgp_path_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC}, 0, 0)
 	var err error
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -1112,7 +1112,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 // test: compare Router ID
 func TestProcessBGPUpdate_7_select_low_routerid_path_ipv4(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_7_select_low_routerid_path_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_7_select_low_routerid_path_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC}, 0, 0)
 
 	var err error
 
@@ -1194,7 +1194,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_7_select_low_routerid_path_ipv6(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_7_select_low_routerid_path_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_7_select_low_routerid_path_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC}, 0, 0)
 	var err error
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -1277,7 +1277,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv6(t *testing.T) {
 // test: withdraw and mpunreach path
 func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_8_withdraw_path_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_8_withdraw_path_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC}, 0, 0)
 	//setLogger(getLogger(log.DebugLevel))
 	var err error
 
@@ -1382,7 +1382,7 @@ func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 // TODO MP_UNREACH
 func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_8_mpunreach_path_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_8_mpunreach_path_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC}, 0, 0)
 	var err error
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -1511,7 +1511,7 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 // handle bestpath lost
 func TestProcessBGPUpdate_bestpath_lost_ipv4(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_bestpath_lost_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_bestpath_lost_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC}, 0, 0)
 	//setLogger(getLogger(log.DebugLevel))
 	var err error
 
@@ -1583,7 +1583,7 @@ func TestProcessBGPUpdate_bestpath_lost_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_bestpath_lost_ipv6(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_bestpath_lost_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_bestpath_lost_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC}, 0, 0)
 	var err error
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -1655,7 +1655,7 @@ func TestProcessBGPUpdate_bestpath_lost_ipv6(t *testing.T) {
 // test: implicit withdrawal case
 func TestProcessBGPUpdate_implicit_withdrwal_ipv4(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_implicit_withdrwal_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_implicit_withdrwal_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC}, 0, 0)
 	//setLogger(getLogger(log.DebugLevel))
 	var err error
 
@@ -1738,7 +1738,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_implicit_withdrwal_ipv6(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_implicit_withdrwal_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_implicit_withdrwal_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC}, 0, 0)
 	var err error
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -1846,7 +1846,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv6(t *testing.T) {
 // check multiple paths
 func TestProcessBGPUpdate_multiple_nlri_ipv4(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_multiple_nlri_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_multiple_nlri_ipv4", []bgp.RouteFamily{bgp.RF_IPv4_UC}, 0, 0)
 	//setLogger(getLogger(log.DebugLevel))
 	var err error
 
@@ -1981,7 +1981,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv4(t *testing.T) {
 // check multiple paths
 func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 
-	tm := NewTableManager("TestProcessBGPUpdate_multiple_nlri_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager("TestProcessBGPUpdate_multiple_nlri_ipv6", []bgp.RouteFamily{bgp.RF_IPv6_UC}, 0, 0)
 	//setLogger(getLogger(log.DebugLevel))
 	var err error
 

--- a/table/vrf.go
+++ b/table/vrf.go
@@ -25,6 +25,7 @@ type Vrf struct {
 	Rd       bgp.RouteDistinguisherInterface
 	ImportRt []bgp.ExtendedCommunityInterface
 	ExportRt []bgp.ExtendedCommunityInterface
+	LabelMap map[string]uint32
 }
 
 func (v *Vrf) ToApiStruct() *api.Vrf {

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -641,4 +641,17 @@ module bgp-gobgp {
       }
     }
   }
+
+  augment "/bgp:bgp/bgp:global" {
+    container mpls-label-range {
+      description "mpls labal range";
+
+      leaf min-label {
+          type uint32;
+      }
+      leaf max-label {
+          type uint32;
+      }
+    }
+  }
 }


### PR DESCRIPTION
TODO: recycle unused mpls labels