### PR TITLE
enable to redistribute specific route type

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -799,6 +799,13 @@ type MplsLabelRange struct {
 	MaxLabel uint32
 }
 
+//struct for container gobgp:redistribute-route-type
+type RedistributeRouteType struct {
+	// original -> gobgp:route-type
+	//gobgp:route-type's original type is ptypes:install-protocol-type
+	RouteType string
+}
+
 //struct for container gobgp:zebra
 type Zebra struct {
 	// original -> gobgp:enabled
@@ -806,6 +813,8 @@ type Zebra struct {
 	Enabled bool
 	// original -> gobgp:url
 	Url string
+	// original -> gobgp:redistribute-route-type
+	RedistributeRouteTypeList []RedistributeRouteType
 }
 
 //struct for container gobgp:mrt

--- a/docs/sources/zebra.md
+++ b/docs/sources/zebra.md
@@ -21,13 +21,15 @@ You need to enable the zebra feature in the Global configuration as follows.
     [Global.Zebra]
         Enabled = true
         Url = "unix:/var/run/quagga/zserv.api"
-
+        [[Global.Zebra.RedistributeRouteTypeList]]
+            RouteType = "connect"
 ```
 
 You can skip Url. If it's skipped, GoBGP uses "unix:/var/run/quagga/zserv.api" as the Url.
 This configuration specifies unix domain socket in its Url and you can change it to the one using TCP.
 If you use TCP, Url can be like "tcp:192.168.24.1:2600".
-
+Specify which route type you want to redistribute through bgp.
+Here gobgp will redistribute connected routes which zebra has.
 
 ## <a name="section1">Check Routes from zebra
 

--- a/server/zclient.go
+++ b/server/zclient.go
@@ -127,7 +127,7 @@ func createPathFromIPRouteMessage(m *zebra.Message, peerInfo *table.PeerInfo) *t
 	med := bgp.NewPathAttributeMultiExitDisc(body.Metric)
 	pattr = append(pattr, med)
 
-	p := table.NewPath(peerInfo, nlri, isWithdraw, pattr, false, time.Now(), true)
+	p := table.NewPath(peerInfo, nlri, isWithdraw, pattr, false, time.Now(), false)
 	p.IsFromZebra = true
 	return p
 }

--- a/test/scenario_test/lib/gobgp.py
+++ b/test/scenario_test/lib/gobgp.py
@@ -275,7 +275,8 @@ class GoBGPContainer(BGPContainer):
             config['PolicyDefinitions'] = {'PolicyDefinitionList': policy_list}
 
         if self.zebra:
-            config['Global']['Zebra'] = {'Enabled': True}
+            config['Global']['Zebra'] = {'Enabled': True,
+                                         'RedistributeRouteTypeList':[{'RouteType': 'connect'}],}
 
         with open('{0}/gobgpd.conf'.format(self.config_dir), 'w') as f:
             print colors.yellow('[{0}\'s new config]'.format(self.name))
@@ -287,6 +288,10 @@ class GoBGPContainer(BGPContainer):
         c << 'hostname zebra'
         c << 'password zebra'
         c << 'log file {0}/zebra.log'.format(self.QUAGGA_VOLUME)
+        c << 'debug zebra packet'
+        c << 'debug zebra kernel'
+        c << 'debug zebra rib'
+        c << ''
 
         with open('{0}/zebra.conf'.format(self.config_dir), 'w') as f:
             print colors.yellow('[{0}\'s new config]'.format(self.name))

--- a/test/scenario_test/lib/quagga.py
+++ b/test/scenario_test/lib/quagga.py
@@ -225,6 +225,10 @@ class QuaggaBGPContainer(BGPContainer):
         c << 'hostname zebra'
         c << 'password zebra'
         c << 'log file {0}/zebra.log'.format(self.SHARED_VOLUME)
+        c << 'debug zebra packet'
+        c << 'debug zebra kernel'
+        c << 'debug zebra rib'
+        c << ''
 
         with open('{0}/zebra.conf'.format(self.config_dir), 'w') as f:
             print colors.yellow('[{0}\'s new config]'.format(self.name))

--- a/tools/pyang_plugins/bgpyang2golang.py
+++ b/tools/pyang_plugins/bgpyang2golang.py
@@ -531,6 +531,7 @@ _type_translation_map = {
     'identityref' : 'string',
     'inet:port-number': 'uint16',
     'yang:timeticks': 'int64',
+    'ptypes:install-protocol-type': 'string',
 }
 
 

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -10,6 +10,7 @@ module bgp-gobgp {
   // import some basic types
   import bgp { prefix bgp; }
   import routing-policy {prefix rpol; }
+  import policy-types {prefix ptypes; }
   import bgp-policy {prefix bgp-pol; }
   import ietf-inet-types { prefix inet; }
 
@@ -638,6 +639,11 @@ module bgp-gobgp {
         type string;
         description
           "Configure url for zebra.";
+      }
+      list redistribute-route-type {
+        leaf route-type {
+          type ptypes:install-protocol-type;
+        }
       }
     }
   }

--- a/zebra/zapi.go
+++ b/zebra/zapi.go
@@ -117,6 +117,30 @@ const (
 	ROUTE_MAX
 )
 
+var routeTypeValueMap = map[string]ROUTE_TYPE{
+	"system":  ROUTE_SYSTEM,
+	"kernel":  ROUTE_KERNEL,
+	"connect": ROUTE_CONNECT,
+	"static":  ROUTE_STATIC,
+	"rip":     ROUTE_RIP,
+	"ripng":   ROUTE_RIPNG,
+	"ospf":    ROUTE_OSPF,
+	"ospf3":   ROUTE_OSPF6,
+	"isis":    ROUTE_ISIS,
+	"bgp":     ROUTE_BGP,
+	"hsls":    ROUTE_HSLS,
+	"olsr":    ROUTE_OLSR,
+	"babel":   ROUTE_BABEL,
+}
+
+func RouteTypeFromString(typ string) (ROUTE_TYPE, error) {
+	t, ok := routeTypeValueMap[typ]
+	if ok {
+		return t, nil
+	}
+	return t, fmt.Errorf("unknown route type: %s", typ)
+}
+
 const (
 	MESSAGE_NEXTHOP  = 0x01
 	MESSAGE_IFINDEX  = 0x02
@@ -309,21 +333,16 @@ func (c *Client) SendInterfaceAdd() error {
 	return c.SendCommand(INTERFACE_ADD, nil)
 }
 
-func (c *Client) SendRedistribute() error {
-	for i := ROUTE_SYSTEM; i < ROUTE_MAX; i++ {
-		if c.redistDefault != i {
-			body := &RedistributeBody{
-				Redist: i,
-			}
-			if e := c.SendCommand(REDISTRIBUTE_ADD, body); e != nil {
-				return e
-			}
+func (c *Client) SendRedistribute(t ROUTE_TYPE) error {
+	if c.redistDefault != t {
+		body := &RedistributeBody{
+			Redist: t,
+		}
+		if e := c.SendCommand(REDISTRIBUTE_ADD, body); e != nil {
+			return e
 		}
 	}
 
-	if e := c.SendCommand(REDISTRIBUTE_DEFAULT_ADD, nil); e != nil {
-		return e
-	}
 	return nil
 }
 


### PR DESCRIPTION
Current implementation was to redistribute all route types include connected routes.
In typical deployment, we only want to redistribute IGP routes.
This PR enables to specify which route type you want to redistribute through gobgp.