### PR TITLE
policy: improve ipPrefixCalculate performance slightly

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1407,7 +1407,7 @@ func ipPrefixCalculate(path *table.Path, cPrefix Prefix) bool {
 		return false
 	}
 
-	return cPrefix.Prefix.Contains(pAddr) && (cPrefix.MasklengthRangeMin <= pMasklen && pMasklen <= cPrefix.MasklengthRangeMax)
+	return (cPrefix.MasklengthRangeMin <= pMasklen && pMasklen <= cPrefix.MasklengthRangeMax) && cPrefix.Prefix.Contains(pAddr)
 }
 
 const (


### PR DESCRIPTION
Contains() is very slow so let's avoid it if possible.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>