### PR TITLE
gobgp: restore --transport option for neighbor command

### DIFF
--- a/gobgp/cmd/neighbor.go
+++ b/gobgp/cmd/neighbor.go
@@ -816,5 +816,6 @@ func NewNeighborCmd() *cobra.Command {
 		},
 	}
 	neighborCmd.PersistentFlags().StringVarP(&subOpts.AddressFamily, "address-family", "a", "", "address family")
+	neighborCmd.PersistentFlags().StringVarP(&neighborsOpts.Transport, "transport", "t", "", "specifying a transport protocol")
 	return neighborCmd
 }


### PR DESCRIPTION
gobgp neighbor -t [ipv4|ipv6]

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>