### PR TITLE
server: fix soft reset out

### DIFF
--- a/table/table_manager.go
+++ b/table/table_manager.go
@@ -490,10 +490,19 @@ func (adj *AdjRib) GetOutCount(rf bgp.RouteFamily) int {
 	return len(adj.adjRibOut[rf])
 }
 
-func (adj *AdjRib) DropAll(rf bgp.RouteFamily) {
+func (adj *AdjRib) DropIn(rf bgp.RouteFamily) {
 	if _, ok := adj.adjRibIn[rf]; ok {
-		// replace old one
 		adj.adjRibIn[rf] = make(map[string]*Path)
+	}
+}
+
+func (adj *AdjRib) DropOut(rf bgp.RouteFamily) {
+	if _, ok := adj.adjRibIn[rf]; ok {
 		adj.adjRibOut[rf] = make(map[string]*Path)
 	}
+}
+
+func (adj *AdjRib) DropAll(rf bgp.RouteFamily) {
+	adj.DropIn(rf)
+	adj.DropOut(rf)
 }


### PR DESCRIPTION
soft reset out needs to use routes in the local table instead of the
adj-in. The export policy will be applied correctly.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>