### PR TITLE
packet: fix incompatible struct field tags

### DIFF
--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -330,7 +330,7 @@ func (c CapGracefulRestartTuples) MarshalJSON() ([]byte, error) {
 type CapGracefulRestartValue struct {
 	Flags  uint8                      `json:"flags"`
 	Time   uint16                     `json:"time"`
-	Tuples []CapGracefulRestartTuples `json"tuples"`
+	Tuples []CapGracefulRestartTuples `json:"tuples"`
 }
 
 type CapGracefulRestart struct {
@@ -405,8 +405,8 @@ func (c *CapFourOctetASNumber) Serialize() ([]byte, error) {
 
 func (c *CapFourOctetASNumber) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Code  BGPCapabilityCode `json"code"`
-		Value uint32            `json"value"`
+		Code  BGPCapabilityCode `json:"code"`
+		Value uint32            `json:"value"`
 	}{
 		Code:  c.Code(),
 		Value: c.CapValue,
@@ -472,7 +472,7 @@ func (c *CapAddPath) Serialize() ([]byte, error) {
 
 func (c *CapAddPath) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Code  BGPCapabilityCode `json"code"`
+		Code  BGPCapabilityCode `json:"code"`
 		Value RouteFamily       `json:"value"`
 		Mode  BGPAddPathMode    `json:"mode"`
 	}{


### PR DESCRIPTION
Will fix lint error of  these:
```
$ go vet packet/*.go
packet/bgp.go:333: struct field tag `json"tuples"` not compatible with reflect.StructTag.Get
packet/bgp.go:408: struct field tag `json"code"` not compatible with reflect.StructTag.Get
packet/bgp.go:409: struct field tag `json"value"` not compatible with reflect.StructTag.Get
packet/bgp.go:475: struct field tag `json"code"` not compatible with reflect.StructTag.Get
```