### PR TITLE
*: fix wrong types of print verbs

### DIFF
--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -1419,7 +1419,7 @@ func (esi *EthernetSegmentIdentifier) DecodeFromBytes(data []byte) error {
 	switch esi.Type {
 	case ESI_LACP, ESI_MSTP, ESI_ROUTERID, ESI_AS:
 		if esi.Value[8] != 0x00 {
-			return fmt.Errorf("invalid %s. last octet must be 0x00 (0x%02x)", esi.Type, esi.Value[8])
+			return fmt.Errorf("invalid %s. last octet must be 0x00 (0x%02x)", esi.Type.String(), esi.Value[8])
 		}
 	}
 	return nil
@@ -1443,7 +1443,7 @@ func isZeroBuf(buf []byte) bool {
 
 func (esi *EthernetSegmentIdentifier) String() string {
 	s := bytes.NewBuffer(make([]byte, 0, 64))
-	s.WriteString(fmt.Sprintf("%s | ", esi.Type))
+	s.WriteString(fmt.Sprintf("%s | ", esi.Type.String()))
 	switch esi.Type {
 	case ESI_ARBITRARY:
 		if isZeroBuf(esi.Value) {
@@ -1546,7 +1546,7 @@ func (er *EVPNEthernetAutoDiscoveryRoute) Serialize() ([]byte, error) {
 }
 
 func (er *EVPNEthernetAutoDiscoveryRoute) String() string {
-	return fmt.Sprintf("[type:A-D][rd:%s][esi:%s][etag:%d][label:%d]", er.RD, er.ESI, er.ETag, er.Label)
+	return fmt.Sprintf("[type:A-D][rd:%s][esi:%s][etag:%d][label:%d]", er.RD, er.ESI.String(), er.ETag, er.Label)
 }
 
 func (er *EVPNEthernetAutoDiscoveryRoute) MarshalJSON() ([]byte, error) {
@@ -3233,7 +3233,7 @@ func (p *PathAttribute) Serialize() ([]byte, error) {
 }
 
 func (p *PathAttribute) String() string {
-	return fmt.Sprintf("%s %s %s", p.Type, p.Flags, []byte(p.Value))
+	return fmt.Sprintf("%s %s %s", p.Type.String(), p.Flags, []byte(p.Value))
 }
 
 func (p *PathAttribute) MarshalJSON() ([]byte, error) {

--- a/packet/mrt.go
+++ b/packet/mrt.go
@@ -700,7 +700,7 @@ func (m *BGP4MPMessage) String() string {
 	if m.isLocal {
 		title += "_LOCAL"
 	}
-	return fmt.Sprintf("%s: PeerAS [%d] LocalAS [%d] InterfaceIndex [%d] PeerIP [%s] LocalIP [%s] BGPMessage [%s]", title, m.PeerAS, m.LocalAS, m.InterfaceIndex, m.PeerIpAddress, m.LocalIpAddress, m.BGPMessage.String())
+	return fmt.Sprintf("%s: PeerAS [%d] LocalAS [%d] InterfaceIndex [%d] PeerIP [%s] LocalIP [%s] BGPMessage [%v]", title, m.PeerAS, m.LocalAS, m.InterfaceIndex, m.PeerIpAddress, m.LocalIpAddress, m.BGPMessage)
 }
 
 //This function can be passed into a bufio.Scanner.Split() to read buffered mrt msgs
@@ -746,7 +746,7 @@ func ParseMRTBody(h *MRTHeader, data []byte) (*MRTMessage, error) {
 			rf = RF_IPv6_MC
 		case RIB_GENERIC:
 		default:
-			return nil, fmt.Errorf("unsupported table dumpv2 subtype: %s\n", subType.String())
+			return nil, fmt.Errorf("unsupported table dumpv2 subtype: %v\n", subType)
 		}
 
 		if subType != PEER_INDEX_TABLE {
@@ -781,10 +781,10 @@ func ParseMRTBody(h *MRTHeader, data []byte) (*MRTMessage, error) {
 				isLocal:      true,
 			}
 		default:
-			return nil, fmt.Errorf("unsupported bgp4mp subtype: %s\n", subType.String())
+			return nil, fmt.Errorf("unsupported bgp4mp subtype: %v\n", subType)
 		}
 	default:
-		return nil, fmt.Errorf("unsupported type: %s\n", h.Type.String())
+		return nil, fmt.Errorf("unsupported type: %v\n", h.Type)
 	}
 	err := msg.Body.DecodeFromBytes(data)
 	if err != nil {

--- a/packet/mrt.go
+++ b/packet/mrt.go
@@ -700,7 +700,7 @@ func (m *BGP4MPMessage) String() string {
 	if m.isLocal {
 		title += "_LOCAL"
 	}
-	return fmt.Sprintf("%s: PeerAS [%d] LocalAS [%d] InterfaceIndex [%d] PeerIP [%s] LocalIP [%s] BGPMessage [%s]", title, m.PeerAS, m.LocalAS, m.InterfaceIndex, m.PeerIpAddress, m.LocalIpAddress, m.BGPMessage)
+	return fmt.Sprintf("%s: PeerAS [%d] LocalAS [%d] InterfaceIndex [%d] PeerIP [%s] LocalIP [%s] BGPMessage [%s]", title, m.PeerAS, m.LocalAS, m.InterfaceIndex, m.PeerIpAddress, m.LocalIpAddress, m.BGPMessage.String())
 }
 
 //This function can be passed into a bufio.Scanner.Split() to read buffered mrt msgs
@@ -746,7 +746,7 @@ func ParseMRTBody(h *MRTHeader, data []byte) (*MRTMessage, error) {
 			rf = RF_IPv6_MC
 		case RIB_GENERIC:
 		default:
-			return nil, fmt.Errorf("unsupported table dumpv2 subtype: %s\n", subType)
+			return nil, fmt.Errorf("unsupported table dumpv2 subtype: %s\n", subType.String())
 		}
 
 		if subType != PEER_INDEX_TABLE {
@@ -781,10 +781,10 @@ func ParseMRTBody(h *MRTHeader, data []byte) (*MRTMessage, error) {
 				isLocal:      true,
 			}
 		default:
-			return nil, fmt.Errorf("unsupported bgp4mp subtype: %s\n", subType)
+			return nil, fmt.Errorf("unsupported bgp4mp subtype: %s\n", subType.String())
 		}
 	default:
-		return nil, fmt.Errorf("unsupported type: %s\n", h.Type)
+		return nil, fmt.Errorf("unsupported type: %s\n", h.Type.String())
 	}
 	err := msg.Body.DecodeFromBytes(data)
 	if err != nil {

--- a/table/policy.go
+++ b/table/policy.go
@@ -808,7 +808,7 @@ func NewExtCommunityCondition(matchSet config.MatchExtCommunitySet, defExtComSet
 							log.WithFields(log.Fields{
 								"Topic": "Policy",
 								"Type":  "Extended Community Condition",
-							}).Errorf("failed to parse the local administrator %d.", elem[2])
+							}).Errorf("failed to parse the local administrator %s.", elem[2])
 							return nil
 						}
 						e.localAdmin = uint32(lAdmin)
@@ -869,7 +869,7 @@ func getECommunityElem(gAdmin string) (bool, bgp.ExtendedCommunityAttrType, inte
 			log.WithFields(log.Fields{
 				"Topic": "Policy",
 				"Type":  "Extended Community Condition",
-			}).Errorf("failed to parse the global administrator %d.", gAdmin)
+			}).Errorf("failed to parse the global administrator %s.", gAdmin)
 		}
 		return true, bgp.EC_TYPE_TRANSITIVE_TWO_OCTET_AS_SPECIFIC, uint16(as)
 	}
@@ -882,7 +882,7 @@ func getECommunityElem(gAdmin string) (bool, bgp.ExtendedCommunityAttrType, inte
 			log.WithFields(log.Fields{
 				"Topic": "Policy",
 				"Type":  "Extended Community Condition",
-			}).Errorf("failed to parse the global administrator %d.", gAdmin)
+			}).Errorf("failed to parse the global administrator %s.", gAdmin)
 		}
 		return true, bgp.EC_TYPE_TRANSITIVE_FOUR_OCTET_AS_SPECIFIC, uint32(highAs<<16 | lowAs)
 	}


### PR DESCRIPTION
Should be fixed these lint errors.
```
$ go vet packet/bgp.go
--- snip ---
packet/bgp.go:1422: arg esi.Type for printf verb %s of wrong type: bgp.ESIType
packet/bgp.go:1446: arg esi.Type for printf verb %s of wrong type: bgp.ESIType
packet/bgp.go:1549: arg er.ESI for printf verb %s of wrong type: bgp.EthernetSegmentIdentifier
--- snip ---
packet/bgp.go:3236: arg p.Type for printf verb %s of wrong type: bgp.BGPAttrType
exit status 1
$ go vet packet/mrt.go
packet/mrt.go:749: arg subType for printf verb %s of wrong type: bgp.MRTSubTypeTableDumpv2
packet/mrt.go:784: arg subType for printf verb %s of wrong type: bgp.MRTSubTypeBGP4MP
packet/mrt.go:787: arg h.Type for printf verb %s of wrong type: bgp.MRTType
exit status 1
$ go vet table/policy.go
--- snip ---
table/policy.go:808: arg elem[2] for printf verb %d of wrong type: string
table/policy.go:869: arg gAdmin for printf verb %d of wrong type: string
table/policy.go:882: arg gAdmin for printf verb %d of wrong type: string
--- snip ---
exit status 1
$
```