### PR TITLE
Go vet fix

### DIFF
--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -274,7 +274,7 @@ func ParseEvpnMacAdvArgs(args []string) (bgp.AddrPrefixInterface, []string, erro
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid mac: %s", args[0])
 	}
-	if args[1] != "0.0.0.0" || args[1] != "::" {
+	if args[1] != "0.0.0.0" && args[1] != "::" {
 		ip = net.ParseIP(args[1])
 		if ip == nil {
 			return nil, nil, fmt.Errorf("invalid ip prefix: %s", args[1])
@@ -326,7 +326,7 @@ func ParseEvpnMulticastArgs(args []string) (bgp.AddrPrefixInterface, []string, e
 	var ip net.IP
 	iplen := 0
 
-	if args[0] != "0.0.0.0" || args[0] != "::" {
+	if args[0] != "0.0.0.0" && args[0] != "::" {
 		ip = net.ParseIP(args[0])
 		if ip == nil {
 			return nil, nil, fmt.Errorf("invalid ip prefix: %s", args[0])

--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -1458,7 +1458,7 @@ func (esi *EthernetSegmentIdentifier) String() string {
 		s.WriteString(fmt.Sprintf("priority %d", binary.BigEndian.Uint16(esi.Value[6:8])))
 	case ESI_MAC:
 		s.WriteString(fmt.Sprintf("system mac %s, ", net.HardwareAddr(esi.Value[:6]).String()))
-		s.WriteString(fmt.Sprintf("local discriminator %d", esi.Value[6]<<16|esi.Value[7]<<8|esi.Value[8]))
+		s.WriteString(fmt.Sprintf("local discriminator %d", uint32(esi.Value[6])<<16|uint32(esi.Value[7])<<8|uint32(esi.Value[8])))
 	case ESI_ROUTERID:
 		s.WriteString(fmt.Sprintf("router id %s, ", net.IP(esi.Value[:4])))
 		s.WriteString(fmt.Sprintf("local discriminator %d", binary.BigEndian.Uint32(esi.Value[4:8])))

--- a/packet/bmp.go
+++ b/packet/bmp.go
@@ -35,7 +35,7 @@ const (
 )
 
 const (
-	BMP_DEFAULT_PORT     = 11019
+	BMP_DEFAULT_PORT = 11019
 )
 
 const (
@@ -497,7 +497,7 @@ type BMPMessage struct {
 
 func (msg *BMPMessage) Serialize() ([]byte, error) {
 	buf := make([]byte, 0)
-	if msg.Header.Type != BMP_MSG_INITIATION && msg.Header.Type != BMP_MSG_INITIATION {
+	if msg.Header.Type != BMP_MSG_INITIATION {
 		p, err := msg.PeerHeader.Serialize()
 		if err != nil {
 			return nil, err
@@ -555,7 +555,7 @@ func ParseBMPMessage(data []byte) (*BMPMessage, error) {
 		msg.Body = &BMPTermination{}
 	}
 
-	if msg.Header.Type != BMP_MSG_INITIATION && msg.Header.Type != BMP_MSG_INITIATION {
+	if msg.Header.Type != BMP_MSG_INITIATION {
 		msg.PeerHeader.DecodeFromBytes(data)
 		data = data[BMP_PEER_HEADER_SIZE:]
 	}


### PR DESCRIPTION
I fixed warnings detected by  ```go vet``` in global.go, bgp.go and bmp.go.