### PR TITLE
policy: fix how to apply policy to follow openconfig description

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -113,6 +113,84 @@ func (x Operation) String() string {
 	return proto.EnumName(Operation_name, int32(x))
 }
 
+type DefinedType int32
+
+const (
+	DefinedType_PREFIX        DefinedType = 0
+	DefinedType_NEIGHBOR      DefinedType = 1
+	DefinedType_TAG           DefinedType = 2
+	DefinedType_AS_PATH       DefinedType = 3
+	DefinedType_COMMUNITY     DefinedType = 4
+	DefinedType_EXT_COMMUNITY DefinedType = 5
+)
+
+var DefinedType_name = map[int32]string{
+	0: "PREFIX",
+	1: "NEIGHBOR",
+	2: "TAG",
+	3: "AS_PATH",
+	4: "COMMUNITY",
+	5: "EXT_COMMUNITY",
+}
+var DefinedType_value = map[string]int32{
+	"PREFIX":        0,
+	"NEIGHBOR":      1,
+	"TAG":           2,
+	"AS_PATH":       3,
+	"COMMUNITY":     4,
+	"EXT_COMMUNITY": 5,
+}
+
+func (x DefinedType) String() string {
+	return proto.EnumName(DefinedType_name, int32(x))
+}
+
+type MatchType int32
+
+const (
+	MatchType_ANY    MatchType = 0
+	MatchType_ALL    MatchType = 1
+	MatchType_INVERT MatchType = 2
+)
+
+var MatchType_name = map[int32]string{
+	0: "ANY",
+	1: "ALL",
+	2: "INVERT",
+}
+var MatchType_value = map[string]int32{
+	"ANY":    0,
+	"ALL":    1,
+	"INVERT": 2,
+}
+
+func (x MatchType) String() string {
+	return proto.EnumName(MatchType_name, int32(x))
+}
+
+type AsPathLengthType int32
+
+const (
+	AsPathLengthType_EQ AsPathLengthType = 0
+	AsPathLengthType_GE AsPathLengthType = 1
+	AsPathLengthType_LE AsPathLengthType = 2
+)
+
+var AsPathLengthType_name = map[int32]string{
+	0: "EQ",
+	1: "GE",
+	2: "LE",
+}
+var AsPathLengthType_value = map[string]int32{
+	"EQ": 0,
+	"GE": 1,
+	"LE": 2,
+}
+
+func (x AsPathLengthType) String() string {
+	return proto.EnumName(AsPathLengthType_name, int32(x))
+}
+
 type RouteAction int32
 
 const (
@@ -134,6 +212,49 @@ var RouteAction_value = map[string]int32{
 
 func (x RouteAction) String() string {
 	return proto.EnumName(RouteAction_name, int32(x))
+}
+
+type CommunityActionType int32
+
+const (
+	CommunityActionType_COMMUNITY_ADD     CommunityActionType = 0
+	CommunityActionType_COMMUNITY_REMOVE  CommunityActionType = 1
+	CommunityActionType_COMMUNITY_REPLACE CommunityActionType = 2
+)
+
+var CommunityActionType_name = map[int32]string{
+	0: "COMMUNITY_ADD",
+	1: "COMMUNITY_REMOVE",
+	2: "COMMUNITY_REPLACE",
+}
+var CommunityActionType_value = map[string]int32{
+	"COMMUNITY_ADD":     0,
+	"COMMUNITY_REMOVE":  1,
+	"COMMUNITY_REPLACE": 2,
+}
+
+func (x CommunityActionType) String() string {
+	return proto.EnumName(CommunityActionType_name, int32(x))
+}
+
+type MedActionType int32
+
+const (
+	MedActionType_MED_MOD     MedActionType = 0
+	MedActionType_MED_REPLACE MedActionType = 1
+)
+
+var MedActionType_name = map[int32]string{
+	0: "MED_MOD",
+	1: "MED_REPLACE",
+}
+var MedActionType_value = map[string]int32{
+	"MED_MOD":     0,
+	"MED_REPLACE": 1,
+}
+
+func (x MedActionType) String() string {
+	return proto.EnumName(MedActionType_name, int32(x))
 }
 
 type PolicyType int32
@@ -278,11 +399,11 @@ type ModPolicyArguments struct {
 	Operation Operation `protobuf:"varint,1,opt,name=operation,enum=gobgpapi.Operation" json:"operation,omitempty"`
 	Policy    *Policy   `protobuf:"bytes,2,opt,name=policy" json:"policy,omitempty"`
 	// if this flag is set, gobgpd won't define new statements
-	// but refer existing statements using statement's names.
+	// but refer existing statements using statement's names in this arguments.
 	// this flag only works with Operation_ADD
 	ReferExistingStatements bool `protobuf:"varint,3,opt,name=refer_existing_statements" json:"refer_existing_statements,omitempty"`
 	// if this flag is set, gobgpd won't delete any statements
-	// even if the policy containing some statements are deleted.
+	// even if some statements get not used by any policy by this operation.
 	// this flag means nothing if it is used with Operation_ADD
 	PreserveStatements bool `protobuf:"varint,4,opt,name=preserve_statements" json:"preserve_statements,omitempty"`
 }
@@ -430,10 +551,10 @@ func (m *Prefix) String() string { return proto.CompactTextString(m) }
 func (*Prefix) ProtoMessage()    {}
 
 type DefinedSet struct {
-	Type     int32     `protobuf:"varint,1,opt,name=type" json:"type,omitempty"`
-	Name     string    `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
-	List     []string  `protobuf:"bytes,3,rep,name=list" json:"list,omitempty"`
-	Prefixes []*Prefix `protobuf:"bytes,4,rep,name=prefixes" json:"prefixes,omitempty"`
+	Type     DefinedType `protobuf:"varint,1,opt,name=type,enum=gobgpapi.DefinedType" json:"type,omitempty"`
+	Name     string      `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
+	List     []string    `protobuf:"bytes,3,rep,name=list" json:"list,omitempty"`
+	Prefixes []*Prefix   `protobuf:"bytes,4,rep,name=prefixes" json:"prefixes,omitempty"`
 }
 
 func (m *DefinedSet) Reset()         { *m = DefinedSet{} }
@@ -448,8 +569,8 @@ func (m *DefinedSet) GetPrefixes() []*Prefix {
 }
 
 type MatchSet struct {
-	Name   string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
-	Option int32  `protobuf:"varint,2,opt,name=option" json:"option,omitempty"`
+	Type MatchType `protobuf:"varint,1,opt,name=type,enum=gobgpapi.MatchType" json:"type,omitempty"`
+	Name string    `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
 }
 
 func (m *MatchSet) Reset()         { *m = MatchSet{} }
@@ -457,8 +578,8 @@ func (m *MatchSet) String() string { return proto.CompactTextString(m) }
 func (*MatchSet) ProtoMessage()    {}
 
 type AsPathLength struct {
-	Length uint32 `protobuf:"varint,1,opt,name=length" json:"length,omitempty"`
-	Type   int32  `protobuf:"varint,2,opt,name=type" json:"type,omitempty"`
+	Type   AsPathLengthType `protobuf:"varint,1,opt,name=type,enum=gobgpapi.AsPathLengthType" json:"type,omitempty"`
+	Length uint32           `protobuf:"varint,2,opt,name=length" json:"length,omitempty"`
 }
 
 func (m *AsPathLength) Reset()         { *m = AsPathLength{} }
@@ -522,8 +643,8 @@ func (m *Conditions) GetExtCommunitySet() *MatchSet {
 }
 
 type CommunityAction struct {
-	Communities []string `protobuf:"bytes,1,rep,name=communities" json:"communities,omitempty"`
-	Option      int32    `protobuf:"varint,2,opt,name=option" json:"option,omitempty"`
+	Type        CommunityActionType `protobuf:"varint,1,opt,name=type,enum=gobgpapi.CommunityActionType" json:"type,omitempty"`
+	Communities []string            `protobuf:"bytes,2,rep,name=communities" json:"communities,omitempty"`
 }
 
 func (m *CommunityAction) Reset()         { *m = CommunityAction{} }
@@ -531,8 +652,8 @@ func (m *CommunityAction) String() string { return proto.CompactTextString(m) }
 func (*CommunityAction) ProtoMessage()    {}
 
 type MedAction struct {
-	Type  int32 `protobuf:"varint,1,opt,name=type" json:"type,omitempty"`
-	Value int64 `protobuf:"varint,2,opt,name=value" json:"value,omitempty"`
+	Type  MedActionType `protobuf:"varint,1,opt,name=type,enum=gobgpapi.MedActionType" json:"type,omitempty"`
+	Value int64         `protobuf:"varint,2,opt,name=value" json:"value,omitempty"`
 }
 
 func (m *MedAction) Reset()         { *m = MedAction{} }
@@ -723,7 +844,12 @@ func (*Vrf) ProtoMessage()    {}
 func init() {
 	proto.RegisterEnum("gobgpapi.Resource", Resource_name, Resource_value)
 	proto.RegisterEnum("gobgpapi.Operation", Operation_name, Operation_value)
+	proto.RegisterEnum("gobgpapi.DefinedType", DefinedType_name, DefinedType_value)
+	proto.RegisterEnum("gobgpapi.MatchType", MatchType_name, MatchType_value)
+	proto.RegisterEnum("gobgpapi.AsPathLengthType", AsPathLengthType_name, AsPathLengthType_value)
 	proto.RegisterEnum("gobgpapi.RouteAction", RouteAction_name, RouteAction_value)
+	proto.RegisterEnum("gobgpapi.CommunityActionType", CommunityActionType_name, CommunityActionType_value)
+	proto.RegisterEnum("gobgpapi.MedActionType", MedActionType_name, MedActionType_value)
 	proto.RegisterEnum("gobgpapi.PolicyType", PolicyType_name, PolicyType_value)
 	proto.RegisterEnum("gobgpapi.Error_ErrorCode", Error_ErrorCode_name, Error_ErrorCode_value)
 }

--- a/api/gobgp.proto
+++ b/api/gobgp.proto
@@ -197,22 +197,42 @@ message Prefix {
     uint32 mask_length_max = 3;
 }
 
+enum DefinedType {
+    PREFIX = 0;
+    NEIGHBOR = 1;
+    TAG = 2;
+    AS_PATH = 3;
+    COMMUNITY = 4;
+    EXT_COMMUNITY = 5;
+}
+
 message DefinedSet {
-    int32 type = 1;
+    DefinedType type = 1;
     string name = 2;
     repeated string list = 3;
     repeated Prefix prefixes = 4;
 }
 
+enum MatchType {
+    ANY = 0;
+    ALL = 1;
+    INVERT = 2;
+}
+
 message MatchSet {
-    string name = 1;
-    // see table/policy.go MatchOption for the usage
-    int32 option = 2;
+    MatchType type = 1;
+    string name = 2;
+}
+
+enum AsPathLengthType {
+    EQ = 0;
+    GE = 1;
+    LE = 2;
 }
 
 message AsPathLength {
-    uint32 length = 1;
-    int32 type = 2;
+    AsPathLengthType type = 1;
+    uint32 length = 2;
 }
 
 message Conditions {
@@ -231,14 +251,24 @@ enum RouteAction {
     REJECT = 2;
 }
 
+enum CommunityActionType {
+    COMMUNITY_ADD = 0;
+    COMMUNITY_REMOVE = 1;
+    COMMUNITY_REPLACE = 2;
+}
+
 message CommunityAction {
-    repeated string communities = 1;
-    // see config/bgp_configs.go BgpSetCommunityOptionType for the usage
-    int32 option = 2;
+    CommunityActionType type = 1;
+    repeated string communities = 2;
+}
+
+enum MedActionType {
+    MED_MOD = 0;
+    MED_REPLACE = 1;
 }
 
 message MedAction {
-    int32 type = 1;
+    MedActionType type = 1;
     int64 value = 2;
 }
 

--- a/table/policy.go
+++ b/table/policy.go
@@ -1988,7 +1988,7 @@ func (s *Statement) ToApiStruct() *api.Statement {
 		}
 	}
 	as := &api.Actions{}
-	if s.RouteAction != nil {
+	if s.RouteAction != nil && !reflect.ValueOf(s.RouteAction).IsNil() {
 		as.RouteAction = s.RouteAction.(*RoutingAction).ToApiStruct()
 	}
 	for _, a := range s.ModActions {

--- a/table/policy.go
+++ b/table/policy.go
@@ -1894,6 +1894,13 @@ func (s *Statement) Apply(path *Path) (RouteType, *Path) {
 		"PolicyName": s.Name,
 	}).Debug("statement evaluate : ", result)
 	if result {
+		if len(s.ModActions) != 0 {
+			// apply all modification actions
+			path = path.Clone(path.Owner, path.IsWithdraw)
+			for _, action := range s.ModActions {
+				path = action.Apply(path)
+			}
+		}
 		//Routing action
 		if s.RouteAction == nil {
 			log.WithFields(log.Fields{
@@ -1901,21 +1908,13 @@ func (s *Statement) Apply(path *Path) (RouteType, *Path) {
 				"Path":       path,
 				"PolicyName": s.Name,
 			}).Warn("route action is nil")
-			return ROUTE_TYPE_REJECT, path
+			return ROUTE_TYPE_NONE, path
 		}
 		p := s.RouteAction.Apply(path)
 		if p == nil {
 			return ROUTE_TYPE_REJECT, path
 		}
-		if len(s.ModActions) == 0 {
-			return ROUTE_TYPE_ACCEPT, path
-		}
-		// apply all modification actions
-		cloned := path.Clone(p.Owner, p.IsWithdraw)
-		for _, action := range s.ModActions {
-			cloned = action.Apply(cloned)
-		}
-		return ROUTE_TYPE_ACCEPT, cloned
+		return ROUTE_TYPE_ACCEPT, path
 	}
 	return ROUTE_TYPE_NONE, path
 }
@@ -2254,7 +2253,8 @@ func (p *Policy) Name() string {
 // subsequent conditions are skipped.
 func (p *Policy) Apply(path *Path) (RouteType, *Path) {
 	for _, stmt := range p.Statements {
-		result, path := stmt.Apply(path)
+		var result RouteType
+		result, path = stmt.Apply(path)
 		if result != ROUTE_TYPE_NONE {
 			return result, path
 		}

--- a/table/policy.go
+++ b/table/policy.go
@@ -2367,7 +2367,10 @@ func NewPolicyFromApiStruct(a *api.Policy, dmap DefinedSetMap) (*Policy, error) 
 		return nil, fmt.Errorf("empty policy name")
 	}
 	stmts := make([]*Statement, 0, len(a.Statements))
-	for _, x := range a.Statements {
+	for idx, x := range a.Statements {
+		if x.Name == "" {
+			x.Name = fmt.Sprintf("%s_stmt%d", a.Name, idx)
+		}
 		y, err := NewStatementFromApiStruct(x, dmap)
 		if err != nil {
 			return nil, err

--- a/test/scenario_test/global_policy_test.py
+++ b/test/scenario_test/global_policy_test.py
@@ -115,7 +115,6 @@ class GoBGPTestBase(unittest.TestCase):
         self.gobgp.local('gobgp policy neighbor add ns0 {0}'.format(self.gobgp.peers[self.quaggas['q1']]['neigh_addr'].split('/')[0]))
         self.gobgp.local('gobgp policy statement add st0')
         self.gobgp.local('gobgp policy statement st0 add condition neighbor ns0')
-        self.gobgp.local('gobgp policy statement st0 add action accept')
         self.gobgp.local('gobgp policy statement st0 add action community add 65100:10')
         self.gobgp.local('gobgp policy add p0 st0')
         self.gobgp.local('gobgp global policy export add p0 default accept')

--- a/test/scenario_test/route_server_policy_grpc_test.py
+++ b/test/scenario_test/route_server_policy_grpc_test.py
@@ -106,6 +106,7 @@ class ImportPolicy(object):
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition prefix ps0')
         g1.local('gobgp policy statement st0 add condition neighbor ns0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -153,6 +154,7 @@ class ExportPolicy(object):
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition prefix ps0')
         g1.local('gobgp policy statement st0 add condition neighbor ns0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy export add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -221,6 +223,7 @@ class ImportPolicyUpdate(object):
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition prefix ps0')
         g1.local('gobgp policy statement st0 add condition neighbor ns0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -312,6 +315,7 @@ class ExportPolicyUpdate(object):
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition prefix ps0')
         g1.local('gobgp policy statement st0 add condition neighbor ns0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy export add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -415,6 +419,7 @@ class ImportPolicyIPV6(object):
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition prefix ps0')
         g1.local('gobgp policy statement st0 add condition neighbor ns0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -465,6 +470,7 @@ class ExportPolicyIPV6(object):
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition prefix ps0')
         g1.local('gobgp policy statement st0 add condition neighbor ns0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy export add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -529,6 +535,7 @@ class ImportPolicyIPV6Update(object):
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition prefix ps0')
         g1.local('gobgp policy statement st0 add condition neighbor ns0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -611,6 +618,7 @@ class ExportPolicyIPv6Update(object):
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition prefix ps0')
         g1.local('gobgp policy statement st0 add condition neighbor ns0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy export add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -676,6 +684,7 @@ class ImportPolicyAsPathLengthCondition(object):
 
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition as-path-length 10 ge')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -725,6 +734,7 @@ class ImportPolicyAsPathCondition(object):
         g1.local('gobgp policy as-path add as0 ^{0}'.format(e1.asn))
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition as-path as0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -766,6 +776,7 @@ class ImportPolicyAsPathAnyCondition(object):
         g1.local('gobgp policy as-path add as0 65098')
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition as-path as0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -807,6 +818,7 @@ class ImportPolicyAsPathOriginCondition(object):
         g1.local('gobgp policy as-path add as0 65090$')
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition as-path as0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -848,6 +860,7 @@ class ImportPolicyAsPathOnlyCondition(object):
         g1.local('gobgp policy as-path add as0 ^65100$')
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition as-path as0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -890,6 +903,7 @@ class ImportPolicyAsPathMismatchCondition(object):
         g1.local('gobgp policy community add cs0 65100:10')
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition community cs0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -939,6 +953,7 @@ class ImportPolicyCommunityCondition(object):
         g1.local('gobgp policy community add cs0 65100:10')
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition community cs0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -980,6 +995,7 @@ class ImportPolicyCommunityRegexp(object):
         g1.local('gobgp policy community add cs0 6[0-9]+:[0-9]+')
         g1.local('gobgp policy statement add st0')
         g1.local('gobgp policy statement st0 add condition community cs0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -1850,6 +1866,7 @@ class InPolicyReject(object):
 
         g1.local('gobgp policy community add cs0 65100:10')
         g1.local('gobgp policy statement st0 add condition community cs0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy in add policy0'.format(g1.peers[e1]['neigh_addr'].split('/')[0]))
 
@@ -1954,6 +1971,7 @@ class InPolicyUpdate(object):
         g1.local('gobgp policy neighbor add ns0 {0}'.format(g1.peers[e1]['neigh_addr'].split('/')[0]))
         g1.local('gobgp policy statement st0 add condition prefix ps0')
         g1.local('gobgp policy statement st0 add condition neighbor ns0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy in add policy0'.format(g1.peers[e1]['neigh_addr'].split('/')[0]))
 
@@ -2223,6 +2241,7 @@ class ImportPolicyExCommunityOriginCondition(object):
 
         g1.local('gobgp policy ext-community add es0 soo:65001.65100:200')
         g1.local('gobgp policy statement st0 add condition ext-community es0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -2260,6 +2279,7 @@ class ImportPolicyExCommunityTargetCondition(object):
 
         g1.local('gobgp policy ext-community add es0 rt:6[0-9]+:3[0-9]+')
         g1.local('gobgp policy statement st0 add condition ext-community es0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
@@ -2297,6 +2317,7 @@ class InPolicyPrefixCondition(object):
 
         g1.local('gobgp policy prefix add ps0 192.168.10.0/24')
         g1.local('gobgp policy statement st0 add condition prefix ps0')
+        g1.local('gobgp policy statement st0 add action reject')
         g1.local('gobgp policy add policy0 st0')
         g1.local('gobgp neighbor {0} policy in add policy0'.format(g1.peers[e1]['neigh_addr'].split('/')[0]))
 

--- a/test/scenario_test/route_server_policy_test.py
+++ b/test/scenario_test/route_server_policy_test.py
@@ -117,7 +117,8 @@ class ImportPolicy(object):
         st0 = {'Name': 'st0',
                'Conditions': {
                 'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -179,7 +180,8 @@ class ExportPolicy(object):
         st0 = {'Name': 'st0',
                'Conditions': {
                 'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'export',
@@ -261,7 +263,8 @@ class ImportPolicyUpdate(object):
         st0 = {'Name': 'st0',
                'Conditions': {
                 'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -310,7 +313,8 @@ class ImportPolicyUpdate(object):
 
         st0 = {'Name': 'st0',
                'Conditions': {'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                              'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                              'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -384,7 +388,8 @@ class ExportPolicyUpdate(object):
 
         st0 = {'Name': 'st0',
                'Conditions': {'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                              'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                              'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'export',
@@ -433,7 +438,8 @@ class ExportPolicyUpdate(object):
 
         st0 = {'Name': 'st0',
                'Conditions': {'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                              'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                              'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'export',
@@ -523,7 +529,8 @@ class ImportPolicyIPV6(object):
         st0 = {'Name': 'st0',
                'Conditions': {
                 'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -588,7 +595,8 @@ class ExportPolicyIPV6(object):
         st0 = {'Name': 'st0',
                'Conditions': {
                 'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'export',
@@ -666,7 +674,8 @@ class ImportPolicyIPV6Update(object):
         st0 = {'Name': 'st0',
                'Conditions': {
                 'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -711,7 +720,9 @@ class ImportPolicyIPV6Update(object):
         st0 = {'Name': 'st0',
                'Conditions': {
                 'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {
+                   'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -782,7 +793,8 @@ class ExportPolicyIPv6Update(object):
         st0 = {'Name': 'st0',
                'Conditions': {
                 'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'export',
@@ -827,7 +839,8 @@ class ExportPolicyIPv6Update(object):
         st0 = {'Name': 'st0',
                'Conditions': {
                 'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'export',
@@ -870,7 +883,8 @@ class ImportPolicyAsPathLengthCondition(object):
         q2 = env.q2
         st0 = {'Name': 'st0',
                'Conditions': {'BgpConditions': {'AsPathLength': {'Operator': 'ge',
-                                                                 'Value': 10}}}}
+                                                                 'Value': 10}}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -924,7 +938,8 @@ class ImportPolicyAsPathCondition(object):
         g1.set_bgp_defined_set(as0)
 
         st0 = {'Name': 'st0',
-               'Conditions': {'BgpConditions': {'MatchAsPathSet': {'AsPathSet': 'as0'}}}}
+               'Conditions': {'BgpConditions': {'MatchAsPathSet': {'AsPathSet': 'as0'}}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -970,7 +985,8 @@ class ImportPolicyAsPathAnyCondition(object):
         g1.set_bgp_defined_set(as0)
 
         st0 = {'Name': 'st0',
-               'Conditions': {'BgpConditions': {'MatchAsPathSet': {'AsPathSet': 'as0'}}}}
+               'Conditions': {'BgpConditions': {'MatchAsPathSet': {'AsPathSet': 'as0'}}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -1016,7 +1032,8 @@ class ImportPolicyAsPathOriginCondition(object):
         g1.set_bgp_defined_set(as0)
 
         st0 = {'Name': 'st0',
-               'Conditions': {'BgpConditions': {'MatchAsPathSet': {'AsPathSet': 'as0'}}}}
+               'Conditions': {'BgpConditions': {'MatchAsPathSet': {'AsPathSet': 'as0'}}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -1062,7 +1079,8 @@ class ImportPolicyAsPathOnlyCondition(object):
         g1.set_bgp_defined_set(as0)
 
         st0 = {'Name': 'st0',
-               'Conditions': {'BgpConditions': {'MatchAsPathSet': {'AsPathSet': 'as0'}}}}
+               'Conditions': {'BgpConditions': {'MatchAsPathSet': {'AsPathSet': 'as0'}}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -1111,7 +1129,8 @@ class ImportPolicyAsPathMismatchCondition(object):
         g1.set_bgp_defined_set(cs0)
 
         st0 = {'Name': 'st0',
-               'Conditions': {'BgpConditions': {'MatchCommunitySet': {'CommunitySet': 'cs0'}}}}
+               'Conditions': {'BgpConditions': {'MatchCommunitySet': {'CommunitySet': 'cs0'}}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -1166,7 +1185,8 @@ class ImportPolicyCommunityCondition(object):
         g1.set_bgp_defined_set(cs0)
 
         st0 = {'Name': 'st0',
-               'Conditions': {'BgpConditions': {'MatchCommunitySet': {'CommunitySet': 'cs0'}}}}
+               'Conditions': {'BgpConditions': {'MatchCommunitySet': {'CommunitySet': 'cs0'}}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -1213,7 +1233,8 @@ class ImportPolicyCommunityRegexp(object):
         g1.set_bgp_defined_set(cs0)
 
         st0 = {'Name': 'st0',
-               'Conditions': {'BgpConditions': {'MatchCommunitySet': {'CommunitySet': 'cs0'}}}}
+               'Conditions': {'BgpConditions': {'MatchCommunitySet': {'CommunitySet': 'cs0'}}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -2151,7 +2172,8 @@ class InPolicyReject(object):
         g1.set_bgp_defined_set(cs0)
 
         st0 = {'Name': 'st0',
-               'Conditions':{'BgpConditions':{'MatchCommunitySet':{'CommunitySet': 'cs0'}}}}
+               'Conditions':{'BgpConditions':{'MatchCommunitySet':{'CommunitySet': 'cs0'}}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'in',
@@ -2277,7 +2299,8 @@ class InPolicyUpdate(object):
         st0 = {'Name': 'st0',
                'Conditions': {
                 'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'in',
@@ -2327,7 +2350,8 @@ class InPolicyUpdate(object):
 
         st0 = {'Name': 'st0',
                'Conditions': {'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']},
-                          'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}}}
+                          'MatchNeighborSet': {'NeighborSet': ns0['NeighborSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'in',
@@ -2600,7 +2624,8 @@ class ImportPolicyExCommunityOriginCondition(object):
         g1.set_bgp_defined_set(es0)
 
         st0 = {'Name': 'st0',
-               'Conditions': {'BgpConditions':{'MatchExtCommunitySet':{'ExtCommunitySet': 'es0'}}}}
+               'Conditions': {'BgpConditions':{'MatchExtCommunitySet':{'ExtCommunitySet': 'es0'}}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -2645,7 +2670,8 @@ class ImportPolicyExCommunityTargetCondition(object):
         g1.set_bgp_defined_set(es0)
 
         st0 = {'Name': 'st0',
-               'Conditions': {'BgpConditions':{'MatchExtCommunitySet':{'ExtCommunitySet': 'es0'}}}}
+               'Conditions': {'BgpConditions':{'MatchExtCommunitySet':{'ExtCommunitySet': 'es0'}}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'import',
@@ -2692,7 +2718,8 @@ class InPolicyPrefixCondition(object):
 
         st0 = {'Name': 'st0',
                'Conditions': {
-                'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']}}}
+                'MatchPrefixSet': {'PrefixSet': ps0['PrefixSetName']}},
+               'Actions': {'RouteDisposition': {'AcceptRoute': False}}}
 
         policy = {'name': 'policy0',
                   'type': 'in',


### PR DESCRIPTION
OpenConfig model says for Route policy evaluation:

Evaluation of each policy definition proceeds by evaluating its
corresponding individual policy statements in order.  When a
condition statement in a policy statement is satisfied, the
corresponding action statement is executed.  If the action
statement has either accept-route or reject-route actions, policy
evaluation of the current policy definition stops, and no further
policy definitions in the chain are evaluated.

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>