### PR TITLE
server: enable to start without configuration file

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -18,6 +18,7 @@ It has these top-level messages:
 	ModStatementArguments
 	ModPolicyArguments
 	ModPolicyAssignmentArguments
+	ModGlobalConfigArguments
 	Path
 	Destination
 	PeerConf
@@ -41,6 +42,7 @@ It has these top-level messages:
 	RPKI
 	ROA
 	Vrf
+	Global
 */
 package gobgpapi
 
@@ -431,6 +433,22 @@ func (*ModPolicyAssignmentArguments) ProtoMessage()    {}
 func (m *ModPolicyAssignmentArguments) GetAssignment() *PolicyAssignment {
 	if m != nil {
 		return m.Assignment
+	}
+	return nil
+}
+
+type ModGlobalConfigArguments struct {
+	Operation Operation `protobuf:"varint,1,opt,name=operation,enum=gobgpapi.Operation" json:"operation,omitempty"`
+	Global    *Global   `protobuf:"bytes,2,opt,name=global" json:"global,omitempty"`
+}
+
+func (m *ModGlobalConfigArguments) Reset()         { *m = ModGlobalConfigArguments{} }
+func (m *ModGlobalConfigArguments) String() string { return proto.CompactTextString(m) }
+func (*ModGlobalConfigArguments) ProtoMessage()    {}
+
+func (m *ModGlobalConfigArguments) GetGlobal() *Global {
+	if m != nil {
+		return m.Global
 	}
 	return nil
 }
@@ -841,6 +859,15 @@ func (m *Vrf) Reset()         { *m = Vrf{} }
 func (m *Vrf) String() string { return proto.CompactTextString(m) }
 func (*Vrf) ProtoMessage()    {}
 
+type Global struct {
+	As       uint32 `protobuf:"varint,1,opt,name=as" json:"as,omitempty"`
+	RouterId string `protobuf:"bytes,2,opt,name=router_id" json:"router_id,omitempty"`
+}
+
+func (m *Global) Reset()         { *m = Global{} }
+func (m *Global) String() string { return proto.CompactTextString(m) }
+func (*Global) ProtoMessage()    {}
+
 func init() {
 	proto.RegisterEnum("gobgpapi.Resource", Resource_name, Resource_value)
 	proto.RegisterEnum("gobgpapi.Operation", Operation_name, Operation_value)
@@ -861,6 +888,8 @@ var _ grpc.ClientConn
 // Client API for GobgpApi service
 
 type GobgpApiClient interface {
+	GetGlobalConfig(ctx context.Context, in *Arguments, opts ...grpc.CallOption) (*Global, error)
+	ModGlobalConfig(ctx context.Context, in *ModGlobalConfigArguments, opts ...grpc.CallOption) (*Error, error)
 	GetNeighbors(ctx context.Context, in *Arguments, opts ...grpc.CallOption) (GobgpApi_GetNeighborsClient, error)
 	GetNeighbor(ctx context.Context, in *Arguments, opts ...grpc.CallOption) (*Peer, error)
 	GetRib(ctx context.Context, in *Arguments, opts ...grpc.CallOption) (GobgpApi_GetRibClient, error)
@@ -898,6 +927,24 @@ type gobgpApiClient struct {
 
 func NewGobgpApiClient(cc *grpc.ClientConn) GobgpApiClient {
 	return &gobgpApiClient{cc}
+}
+
+func (c *gobgpApiClient) GetGlobalConfig(ctx context.Context, in *Arguments, opts ...grpc.CallOption) (*Global, error) {
+	out := new(Global)
+	err := grpc.Invoke(ctx, "/gobgpapi.GobgpApi/GetGlobalConfig", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *gobgpApiClient) ModGlobalConfig(ctx context.Context, in *ModGlobalConfigArguments, opts ...grpc.CallOption) (*Error, error) {
+	out := new(Error)
+	err := grpc.Invoke(ctx, "/gobgpapi.GobgpApi/ModGlobalConfig", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *gobgpApiClient) GetNeighbors(ctx context.Context, in *Arguments, opts ...grpc.CallOption) (GobgpApi_GetNeighborsClient, error) {
@@ -1442,6 +1489,8 @@ func (c *gobgpApiClient) ModPolicyAssignment(ctx context.Context, in *ModPolicyA
 // Server API for GobgpApi service
 
 type GobgpApiServer interface {
+	GetGlobalConfig(context.Context, *Arguments) (*Global, error)
+	ModGlobalConfig(context.Context, *ModGlobalConfigArguments) (*Error, error)
 	GetNeighbors(*Arguments, GobgpApi_GetNeighborsServer) error
 	GetNeighbor(context.Context, *Arguments) (*Peer, error)
 	GetRib(*Arguments, GobgpApi_GetRibServer) error
@@ -1475,6 +1524,30 @@ type GobgpApiServer interface {
 
 func RegisterGobgpApiServer(s *grpc.Server, srv GobgpApiServer) {
 	s.RegisterService(&_GobgpApi_serviceDesc, srv)
+}
+
+func _GobgpApi_GetGlobalConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(Arguments)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(GobgpApiServer).GetGlobalConfig(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func _GobgpApi_ModGlobalConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(ModGlobalConfigArguments)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(GobgpApiServer).ModGlobalConfig(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func _GobgpApi_GetNeighbors_Handler(srv interface{}, stream grpc.ServerStream) error {
@@ -1942,6 +2015,14 @@ var _GobgpApi_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "gobgpapi.GobgpApi",
 	HandlerType: (*GobgpApiServer)(nil),
 	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "GetGlobalConfig",
+			Handler:    _GobgpApi_GetGlobalConfig_Handler,
+		},
+		{
+			MethodName: "ModGlobalConfig",
+			Handler:    _GobgpApi_ModGlobalConfig_Handler,
+		},
 		{
 			MethodName: "GetNeighbor",
 			Handler:    _GobgpApi_GetNeighbor_Handler,

--- a/api/gobgp.proto
+++ b/api/gobgp.proto
@@ -20,6 +20,8 @@ package gobgpapi;
 // Interface exported by the server.
 
 service GobgpApi {
+  rpc GetGlobalConfig(Arguments) returns (Global) {}
+  rpc ModGlobalConfig(ModGlobalConfigArguments) returns (Error) {}
   rpc GetNeighbors(Arguments) returns (stream Peer) {}
   rpc GetNeighbor(Arguments) returns (Peer) {}
   rpc GetRib(Arguments) returns (stream Destination) {}
@@ -110,6 +112,11 @@ message ModPolicyArguments {
 message ModPolicyAssignmentArguments {
     Operation operation = 1;
     PolicyAssignment assignment = 2;
+}
+
+message ModGlobalConfigArguments {
+    Operation operation = 1;
+    Global global = 2;
 }
 
 enum Resource {
@@ -343,4 +350,9 @@ message Vrf {
     bytes rd = 2;
     repeated bytes import_rt = 3;
     repeated bytes export_rt = 4;
+}
+
+message Global {
+    uint32 as = 1;
+    string router_id = 2;
 }

--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -148,14 +148,12 @@ func main() {
 
 	log.Info("gobgpd started")
 
-	if opts.ConfigFile == "" {
-		opts.ConfigFile = "gobgpd.conf"
-	}
-
 	configCh := make(chan config.BgpConfigSet)
 	reloadCh := make(chan bool)
-	go config.ReadConfigfileServe(opts.ConfigFile, configCh, reloadCh)
-	reloadCh <- true
+	if opts.ConfigFile != "" {
+		go config.ReadConfigfileServe(opts.ConfigFile, configCh, reloadCh)
+		reloadCh <- true
+	}
 	bgpServer := server.NewBgpServer(bgp.BGP_PORT)
 	go bgpServer.Serve()
 

--- a/server/grpc_server.go
+++ b/server/grpc_server.go
@@ -28,6 +28,8 @@ import (
 
 const (
 	_ = iota
+	REQ_GLOBAL_CONFIG
+	REQ_MOD_GLOBAL_CONFIG
 	REQ_NEIGHBOR
 	REQ_NEIGHBORS
 	REQ_ADJ_RIB_IN
@@ -378,6 +380,18 @@ func (s *Server) GetPolicyAssignment(ctx context.Context, arg *api.PolicyAssignm
 
 func (s *Server) ModPolicyAssignment(ctx context.Context, arg *api.ModPolicyAssignmentArguments) (*api.Error, error) {
 	return s.mod(REQ_MOD_POLICY_ASSIGNMENT, arg)
+}
+
+func (s *Server) GetGlobalConfig(ctx context.Context, arg *api.Arguments) (*api.Global, error) {
+	d, err := s.get(REQ_GLOBAL_CONFIG, arg)
+	if err != nil {
+		return nil, err
+	}
+	return d.(*api.Global), nil
+}
+
+func (s *Server) ModGlobalConfig(ctx context.Context, arg *api.ModGlobalConfigArguments) (*api.Error, error) {
+	return s.mod(REQ_MOD_GLOBAL_CONFIG, arg)
 }
 
 type GrpcRequest struct {


### PR DESCRIPTION
add grpc api to configure global as/router-id

$ gobgp global as 65000 router-id 10.0.0.1

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>