### PR TITLE
gobgpd: make blank bmpconfig when no config file

### DIFF
--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -170,6 +170,11 @@ func main() {
 	grpcServer := server.NewGrpcServer(server.GRPC_PORT, bgpServer.GrpcReqCh)
 	go grpcServer.Serve()
 
+	if opts.ConfigFile == "" {
+		bgpServer.SetBmpConfig(config.BmpServers{
+			BmpServerList: []config.BmpServer{},
+		})
+	}
 	var bgpConfig *config.Bgp = nil
 	var policyConfig *config.RoutingPolicy = nil
 	for {


### PR DESCRIPTION
To start with no config file, server.bmpClient should be initialised before a peer is established.

Signed-off-by: YujiOshima <yuji.oshima0x3fd@gmail.com>