### PR TITLE
cmd/api: get peer remote router id not neighbor address

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -540,13 +540,12 @@ type Peer struct {
 	ErrorHandling    *ErrorHandling       `protobuf:"bytes,7,opt,name=error_handling" json:"error_handling,omitempty"`
 	GracefulRestart  *PeerGracefulRestart `protobuf:"bytes,8,opt,name=graceful_restart" json:"graceful_restart,omitempty"`
 	LoggingOptions   *LoggingOptions      `protobuf:"bytes,9,opt,name=logging_options" json:"logging_options,omitempty"`
-	NighborAddress   string               `protobuf:"bytes,10,opt,name=nighbor_address" json:"nighbor_address,omitempty"`
-	RouteReflector   *RouteReflector      `protobuf:"bytes,11,opt,name=route_reflector" json:"route_reflector,omitempty"`
-	Info             *PeerState           `protobuf:"bytes,12,opt,name=info" json:"info,omitempty"`
-	Timers           *Timers              `protobuf:"bytes,13,opt,name=timers" json:"timers,omitempty"`
-	Transport        *Transport           `protobuf:"bytes,14,opt,name=transport" json:"transport,omitempty"`
-	UseMultiplePaths *UseMultiplePaths    `protobuf:"bytes,15,opt,name=use_multiple_paths" json:"use_multiple_paths,omitempty"`
-	RouteServer      *RouteServer         `protobuf:"bytes,16,opt,name=route_server" json:"route_server,omitempty"`
+	RouteReflector   *RouteReflector      `protobuf:"bytes,10,opt,name=route_reflector" json:"route_reflector,omitempty"`
+	Info             *PeerState           `protobuf:"bytes,11,opt,name=info" json:"info,omitempty"`
+	Timers           *Timers              `protobuf:"bytes,12,opt,name=timers" json:"timers,omitempty"`
+	Transport        *Transport           `protobuf:"bytes,13,opt,name=transport" json:"transport,omitempty"`
+	UseMultiplePaths *UseMultiplePaths    `protobuf:"bytes,14,opt,name=use_multiple_paths" json:"use_multiple_paths,omitempty"`
+	RouteServer      *RouteServer         `protobuf:"bytes,15,opt,name=route_server" json:"route_server,omitempty"`
 }
 
 func (m *Peer) Reset()         { *m = Peer{} }
@@ -957,6 +956,7 @@ type PeerConf struct {
 	SendCommunity    uint32   `protobuf:"varint,10,opt,name=send_community" json:"send_community,omitempty"`
 	RemoteCap        [][]byte `protobuf:"bytes,11,rep,name=remote_cap,proto3" json:"remote_cap,omitempty"`
 	LocalCap         [][]byte `protobuf:"bytes,12,rep,name=local_cap,proto3" json:"local_cap,omitempty"`
+	Id               string   `protobuf:"bytes,13,opt,name=id" json:"id,omitempty"`
 }
 
 func (m *PeerConf) Reset()         { *m = PeerConf{} }

--- a/api/gobgp.proto
+++ b/api/gobgp.proto
@@ -168,13 +168,12 @@ message Peer {
   ErrorHandling error_handling = 7;
   PeerGracefulRestart graceful_restart = 8;
   LoggingOptions logging_options = 9;
-  string nighbor_address = 10;
-  RouteReflector route_reflector = 11;
-  PeerState info = 12;
-  Timers timers = 13;
-  Transport transport = 14;
-  UseMultiplePaths use_multiple_paths = 15;
-  RouteServer route_server = 16;
+  RouteReflector route_reflector = 10;
+  PeerState info = 11;
+  Timers timers = 12;
+  Transport transport = 13;
+  UseMultiplePaths use_multiple_paths = 14;
+  RouteServer route_server = 15;
 }
 
 message AddPaths {
@@ -270,6 +269,7 @@ message PeerConf {
   uint32 send_community = 10;
   repeated bytes remote_cap = 11;
   repeated bytes local_cap = 12;
+  string id = 13;
 }
 
 message EbgpMultihop {

--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -255,7 +255,7 @@ func ApiStruct2Peer(p *gobgpapi.Peer) *Peer {
 	}
 	conf := PeerConf{
 		RemoteIp:  net.ParseIP(p.Conf.NeighborAddress),
-		Id:        net.ParseIP(p.Conf.NeighborAddress),
+		Id:        net.ParseIP(p.Conf.Id),
 		RemoteAs:  p.Conf.PeerAs,
 		RemoteCap: remoteCaps,
 		LocalCap:  localCaps,

--- a/server/peer.go
+++ b/server/peer.go
@@ -299,6 +299,7 @@ func (peer *Peer) ToApiStruct() *api.Peer {
 
 	conf := &api.PeerConf{
 		NeighborAddress:  c.NeighborConfig.NeighborAddress.String(),
+		Id:               peer.peerInfo.ID.To4().String(),
 		PeerAs:           c.NeighborConfig.PeerAs,
 		LocalAs:          c.NeighborConfig.LocalAs,
 		PeerType:         uint32(c.NeighborConfig.PeerType),

--- a/server/server.go
+++ b/server/server.go
@@ -1766,6 +1766,7 @@ func (server *BgpServer) handleGrpcModNeighbor(grpcReq *GrpcRequest) (sMsgs []*S
 			var pconf config.Neighbor
 			if a.Conf != nil {
 				pconf.NeighborAddress = net.ParseIP(a.Conf.NeighborAddress)
+				pconf.NeighborConfig.NeighborAddress = net.ParseIP(a.Conf.NeighborAddress)
 				pconf.NeighborConfig.PeerAs = a.Conf.PeerAs
 				pconf.NeighborConfig.LocalAs = a.Conf.LocalAs
 				if pconf.NeighborConfig.PeerAs != server.bgpConfig.Global.GlobalConfig.As {


### PR DESCRIPTION
bug fix: get neighbor cmd get neighbor address as remote router id.

Signed-off-by: YujiOshima <yuji.oshima0x3fd@gmail.com>