### PR TITLE
table: fix how to mark a path as best in ToApiStruct()

### DIFF
--- a/table/destination.go
+++ b/table/destination.go
@@ -152,7 +152,7 @@ func (dd *Destination) ToApiStruct() *api.Destination {
 		ret := make([]*api.Path, 0, len(arg))
 		for _, p := range arg {
 			pp := p.ToApiStruct()
-			if dd.GetBestPath().Equal(p) {
+			if dd.GetBestPath() == p {
 				pp.Best = true
 			}
 			ret = append(ret, pp)


### PR DESCRIPTION
When two peers advertise exactly same path, one will be marked as best, and
another will not. In this case, in ToApiStruct(), we mustn't mark a path
as best by Equal() method since Equal() compare path's content, not identity.

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>