### PR TITLE
mrt: use on-wire original update data for mrt

### DIFF
--- a/packet/bmp.go
+++ b/packet/bmp.go
@@ -136,7 +136,8 @@ func (h *BMPPeerHeader) Serialize() ([]byte, error) {
 }
 
 type BMPRouteMonitoring struct {
-	BGPUpdate *BGPMessage
+	BGPUpdate        *BGPMessage
+	BGPUpdatePayload []byte
 }
 
 func NewBMPRouteMonitoring(p BMPPeerHeader, update *BGPMessage) *BMPMessage {
@@ -162,6 +163,9 @@ func (body *BMPRouteMonitoring) ParseBody(msg *BMPMessage, data []byte) error {
 }
 
 func (body *BMPRouteMonitoring) Serialize() ([]byte, error) {
+	if body.BGPUpdatePayload != nil {
+		return body.BGPUpdatePayload, nil
+	}
 	return body.BGPUpdate.Serialize()
 }
 

--- a/packet/mrt.go
+++ b/packet/mrt.go
@@ -641,8 +641,9 @@ func NewBGP4MPStateChange(peeras, localas uint32, intfindex uint16, peerip, loca
 
 type BGP4MPMessage struct {
 	*BGP4MPHeader
-	BGPMessage *BGPMessage
-	isLocal    bool
+	BGPMessage        *BGPMessage
+	BGPMessagePayload []byte
+	isLocal           bool
 }
 
 func (m *BGP4MPMessage) DecodeFromBytes(data []byte) error {
@@ -667,6 +668,9 @@ func (m *BGP4MPMessage) Serialize() ([]byte, error) {
 	buf, err := m.serialize()
 	if err != nil {
 		return nil, err
+	}
+	if m.BGPMessagePayload != nil {
+		return append(buf, m.BGPMessagePayload...), nil
 	}
 	bbuf, err := m.BGPMessage.Serialize()
 	if err != nil {

--- a/server/bmp.go
+++ b/server/bmp.go
@@ -126,7 +126,10 @@ func bmpPeerDown(reason uint8, t int, policy bool, pd uint64, peeri *table.PeerI
 	return bgp.NewBMPPeerDownNotification(*ph, reason, nil, []byte{})
 }
 
-func bmpPeerRoute(t int, policy bool, pd uint64, peeri *table.PeerInfo, timestamp int64, u *bgp.BGPMessage) *bgp.BMPMessage {
+func bmpPeerRoute(t int, policy bool, pd uint64, peeri *table.PeerInfo, timestamp int64, payload []byte) *bgp.BMPMessage {
 	ph := bgp.NewBMPPeerHeader(uint8(t), policy, pd, peeri.Address.String(), peeri.AS, peeri.LocalID.String(), float64(timestamp))
-	return bgp.NewBMPRouteMonitoring(*ph, u)
+	m := bgp.NewBMPRouteMonitoring(*ph, nil)
+	body := m.Body.(*bgp.BMPRouteMonitoring)
+	body.BGPUpdatePayload = payload
+	return m
 }

--- a/server/server.go
+++ b/server/server.go
@@ -801,6 +801,7 @@ func (server *BgpServer) handleFSMMessage(peer *Peer, e *FsmMsg, incoming chan *
 						localAddress: net.ParseIP(l),
 						fourBytesAs:  y,
 						timestamp:    e.timestamp,
+						payload:      e.payload,
 					}
 					for _, ch := range listener {
 						bm := &broadcastWatcherMsg{

--- a/server/server.go
+++ b/server/server.go
@@ -333,7 +333,8 @@ func (server *BgpServer) Serve() {
 				for _, p := range targetPeer.adjRib.GetInPathList(targetPeer.configuredRFlist()) {
 					// avoid to merge for timestamp
 					u := table.CreateUpdateMsgFromPaths([]*table.Path{p})
-					bmpMsgList = append(bmpMsgList, bmpPeerRoute(bgp.BMP_PEER_TYPE_GLOBAL, false, 0, targetPeer.fsm.peerInfo, p.GetTimestamp().Unix(), u[0]))
+					buf, _ := u[0].Serialize()
+					bmpMsgList = append(bmpMsgList, bmpPeerRoute(bgp.BMP_PEER_TYPE_GLOBAL, false, 0, targetPeer.fsm.peerInfo, p.GetTimestamp().Unix(), buf))
 				}
 			}
 
@@ -815,7 +816,7 @@ func (server *BgpServer) handleFSMMessage(peer *Peer, e *FsmMsg, incoming chan *
 				if ch := server.bmpClient.send(); ch != nil {
 					bm := &broadcastBMPMsg{
 						ch:      ch,
-						msgList: []*bgp.BMPMessage{bmpPeerRoute(bgp.BMP_PEER_TYPE_GLOBAL, false, 0, peer.fsm.peerInfo, e.timestamp.Unix(), m)},
+						msgList: []*bgp.BMPMessage{bmpPeerRoute(bgp.BMP_PEER_TYPE_GLOBAL, false, 0, peer.fsm.peerInfo, e.timestamp.Unix(), e.payload)},
 					}
 					server.broadcastMsgs = append(server.broadcastMsgs, bm)
 				}

--- a/server/watcher.go
+++ b/server/watcher.go
@@ -64,6 +64,7 @@ type watcherEventUpdateMsg struct {
 	localAddress net.IP
 	fourBytesAs  bool
 	timestamp    time.Time
+	payload      []byte
 }
 
 type watcher interface {
@@ -115,7 +116,8 @@ func (w *mrtWatcher) loop() error {
 		write := func(ev watcherEvent) {
 			m := ev.(*watcherEventUpdateMsg)
 			subtype := bgp.MESSAGE_AS4
-			mp := bgp.NewBGP4MPMessage(m.peerAS, m.localAS, 0, m.peerAddress.String(), m.localAddress.String(), m.fourBytesAs, m.message)
+			mp := bgp.NewBGP4MPMessage(m.peerAS, m.localAS, 0, m.peerAddress.String(), m.localAddress.String(), m.fourBytesAs, nil)
+			mp.BGPMessagePayload = m.payload
 			if m.fourBytesAs == false {
 				subtype = bgp.MESSAGE
 			}


### PR DESCRIPTION
bgpd parse on-wire original update data to construct BGPMessage object
and serialize it. Sometimes the both data is not idential. For
example, the original data sets the extended length for attribute even
if the length is less than 256.

This commit fixes the above issue.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>