### PR TITLE
fix IPv4-mapped addresss handling

### DIFF
--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -794,6 +794,21 @@ func (r *IPv6AddrPrefix) AFI() uint16 {
 	return AFI_IP6
 }
 
+func (r *IPv6AddrPrefix) String() string {
+	isZero := func(p net.IP) bool {
+		for i := 0; i < len(p); i++ {
+			if p[i] != 0 {
+				return false
+			}
+		}
+		return true
+	}(r.Prefix[0:10])
+	if isZero && r.Prefix[10] == 0xff && r.Prefix[11] == 0xff {
+		return fmt.Sprintf("::ffff:%s/%d", r.Prefix.String(), r.Length)
+	}
+	return fmt.Sprintf("%s/%d", r.Prefix.String(), r.Length)
+}
+
 func NewIPv6AddrPrefix(length uint8, prefix string) *IPv6AddrPrefix {
 	return &IPv6AddrPrefix{
 		IPAddrPrefix{


### PR DESCRIPTION
net.IP handles IPv4-mapped addresss as ipv4 so leads to the following
crash:

gobgpd[857]: /usr/lib/go/src/pkg/runtime/panic.c:279 +0xf5
gobgpd[857]: github.com/osrg/gobgp/table.CidrToRadixkey(0xc2080ffec0, 0xa, 0x0, 0x0)
gobgpd[857]: /usr/local/opt/go/src/github.com/osrg/gobgp/table/destination.go:63 +0xb2

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>