### PR TITLE
bmp: fix ParseBMPMessage to handle failure of parsing header

### DIFF
--- a/packet/bmp.go
+++ b/packet/bmp.go
@@ -541,7 +541,10 @@ const (
 
 func ParseBMPMessage(data []byte) (*BMPMessage, error) {
 	msg := &BMPMessage{}
-	msg.Header.DecodeFromBytes(data)
+	err := msg.Header.DecodeFromBytes(data)
+	if err != nil {
+		return nil, err
+	}
 	data = data[BMP_HEADER_SIZE:msg.Header.Length]
 
 	switch msg.Header.Type {
@@ -564,7 +567,7 @@ func ParseBMPMessage(data []byte) (*BMPMessage, error) {
 		data = data[BMP_PEER_HEADER_SIZE:]
 	}
 
-	err := msg.Body.ParseBody(msg, data)
+	err = msg.Body.ParseBody(msg, data)
 	if err != nil {
 		return nil, err
 	}

--- a/packet/bmp_test.go
+++ b/packet/bmp_test.go
@@ -16,6 +16,7 @@
 package bgp
 
 import (
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 )
@@ -63,4 +64,10 @@ func Test_RouteMonitoring(t *testing.T) {
 	m := update()
 	p0 := NewBMPPeerHeader(0, false, 1000, "fe80::6e40:8ff:feab:2c2a", 70000, "10.0.0.2", 1)
 	verify(t, NewBMPRouteMonitoring(*p0, m))
+}
+
+func Test_BogusHeader(t *testing.T) {
+	h, err := ParseBMPMessage(make([]byte, 10))
+	assert.Nil(t, h)
+	assert.NotNil(t, err)
 }


### PR DESCRIPTION
Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>