### PR TITLE
api/cli: support showing longer-prefix

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -22,9 +22,9 @@ It has these top-level messages:
 	ModPolicyArguments
 	ModPolicyAssignmentArguments
 	ModGlobalConfigArguments
-	Table
 	Path
 	Destination
+	Table
 	Peer
 	AddPaths
 	AfiSafis
@@ -518,24 +518,6 @@ func (m *ModGlobalConfigArguments) GetGlobal() *Global {
 	return nil
 }
 
-type Table struct {
-	Type         Resource       `protobuf:"varint,1,opt,name=type,enum=gobgpapi.Resource" json:"type,omitempty"`
-	Name         string         `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
-	Family       uint32         `protobuf:"varint,3,opt,name=family" json:"family,omitempty"`
-	Destinations []*Destination `protobuf:"bytes,4,rep,name=destinations" json:"destinations,omitempty"`
-}
-
-func (m *Table) Reset()         { *m = Table{} }
-func (m *Table) String() string { return proto.CompactTextString(m) }
-func (*Table) ProtoMessage()    {}
-
-func (m *Table) GetDestinations() []*Destination {
-	if m != nil {
-		return m.Destinations
-	}
-	return nil
-}
-
 type Path struct {
 	Nlri               []byte   `protobuf:"bytes,1,opt,name=nlri,proto3" json:"nlri,omitempty"`
 	Pattrs             [][]byte `protobuf:"bytes,2,rep,name=pattrs,proto3" json:"pattrs,omitempty"`
@@ -555,8 +537,9 @@ func (m *Path) String() string { return proto.CompactTextString(m) }
 func (*Path) ProtoMessage()    {}
 
 type Destination struct {
-	Prefix string  `protobuf:"bytes,1,opt,name=prefix" json:"prefix,omitempty"`
-	Paths  []*Path `protobuf:"bytes,2,rep,name=paths" json:"paths,omitempty"`
+	Prefix       string  `protobuf:"bytes,1,opt,name=prefix" json:"prefix,omitempty"`
+	Paths        []*Path `protobuf:"bytes,2,rep,name=paths" json:"paths,omitempty"`
+	LongerPrefix bool    `protobuf:"varint,3,opt,name=longer_prefix" json:"longer_prefix,omitempty"`
 }
 
 func (m *Destination) Reset()         { *m = Destination{} }
@@ -566,6 +549,24 @@ func (*Destination) ProtoMessage()    {}
 func (m *Destination) GetPaths() []*Path {
 	if m != nil {
 		return m.Paths
+	}
+	return nil
+}
+
+type Table struct {
+	Type         Resource       `protobuf:"varint,1,opt,name=type,enum=gobgpapi.Resource" json:"type,omitempty"`
+	Name         string         `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
+	Family       uint32         `protobuf:"varint,3,opt,name=family" json:"family,omitempty"`
+	Destinations []*Destination `protobuf:"bytes,4,rep,name=destinations" json:"destinations,omitempty"`
+}
+
+func (m *Table) Reset()         { *m = Table{} }
+func (m *Table) String() string { return proto.CompactTextString(m) }
+func (*Table) ProtoMessage()    {}
+
+func (m *Table) GetDestinations() []*Destination {
+	if m != nil {
+		return m.Destinations
 	}
 	return nil
 }

--- a/api/gobgp.proto
+++ b/api/gobgp.proto
@@ -170,6 +170,7 @@ message Path {
 message Destination {
     string prefix = 1;
     repeated Path paths = 2;
+    bool longer_prefix = 3;
 }
 
 message Table {

--- a/docs/sources/cli-command-syntax.md
+++ b/docs/sources/cli-command-syntax.md
@@ -27,7 +27,7 @@ gobgp has six subcommands.
 # show all Route information
 % gobgp global rib [-a <address family>]
 # show a specific route information
-% gobgp global rib [<prefix>|<host>] [-a <address family>]
+% gobgp global rib [<prefix>|<host>] [longer-prefix] [-a <address family>]
 ```
 
 #### - example
@@ -84,7 +84,7 @@ The following options can be specified in the global subcommand:
 # show all routes in [local|adj-in|adj-out] table
 % gobgp neighbor <neighbor address> [local|adj-in|adj-out] [-a <address family>]
 # show a specific route in [local|adj-in|adj-out] table
-% gobgp neighbor <neighbor address> [local|adj-in|adj-out] [<prefix>|<host>] [-a <address family>]
+% gobgp neighbor <neighbor address> [local|adj-in|adj-out] [<prefix>|<host>] [longer-prefix] [-a <address family>]
 ```
 
 #### - example

--- a/gobgp/cmd/neighbor.go
+++ b/gobgp/cmd/neighbor.go
@@ -410,9 +410,17 @@ func showNeighborRib(r string, name string, args []string) error {
 		if rf != bgp.RF_IPv4_UC && rf != bgp.RF_IPv6_UC {
 			return fmt.Errorf("route filtering is only supported for IPv4/IPv6 unicast routes")
 		}
+		longerPrefix := false
+		if len(args) > 1 {
+			if args[1] != "longer-prefix" {
+				return fmt.Errorf("invalid format for route filtering")
+			}
+			longerPrefix = true
+		}
 		arg.Destinations = []*api.Destination{
 			&api.Destination{
-				Prefix: args[0],
+				Prefix:       args[0],
+				LongerPrefix: longerPrefix,
 			},
 		}
 	}


### PR DESCRIPTION
$ gobgp global rib
    Network      Next Hop  AS_PATH  Age       Attrs
*>  10.0.0.0/24  0.0.0.0            00:00:01  [{Origin: ?}]

$ gobgp global rib 10.0.0.0/20
Network not in table

$ gobgp global rib 10.0.0.0/20 longer-prefix
    Network      Next Hop  AS_PATH  Age       Attrs
*>  10.0.0.0/24  0.0.0.0            00:00:01  [{Origin: ?}]

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>