### PR TITLE
table: use int for key in tableId instead of string

### DIFF
--- a/server/fsm_test.go
+++ b/server/fsm_test.go
@@ -294,7 +294,7 @@ func makePeerAndHandler() (*Peer, *FSMHandler) {
 		capMap: make(map[bgp.BGPCapabilityCode][]bgp.ParameterCapabilityInterface),
 	}
 
-	p.fsm = NewFSM(&gConf, &pConf, table.NewRoutingPolicy())
+	p.fsm = NewFSM(&gConf, &pConf, table.NewRoutingPolicy(), 0)
 
 	incoming := make(chan *FsmMsg, 4096)
 	p.outgoing = make(chan *bgp.BGPMessage, 4096)

--- a/table/adj.go
+++ b/table/adj.go
@@ -21,12 +21,12 @@ import (
 )
 
 type AdjRib struct {
-	id       string
+	id       uint32
 	accepted map[bgp.RouteFamily]int
 	table    map[bgp.RouteFamily]map[string]*Path
 }
 
-func NewAdjRib(id string, rfList []bgp.RouteFamily) *AdjRib {
+func NewAdjRib(id uint32, rfList []bgp.RouteFamily) *AdjRib {
 	table := make(map[bgp.RouteFamily]map[string]*Path)
 	for _, rf := range rfList {
 		table[rf] = make(map[string]*Path)

--- a/table/destination.go
+++ b/table/destination.go
@@ -135,7 +135,7 @@ func NewDestination(nlri bgp.AddrPrefixInterface) *Destination {
 	return d
 }
 
-func (dd *Destination) ToApiStruct(id string) *api.Destination {
+func (dd *Destination) ToApiStruct(id uint32) *api.Destination {
 	prefix := dd.GetNlri().String()
 	paths := func(arg []*Path) []*api.Path {
 		ret := make([]*api.Path, 0, len(arg))
@@ -178,7 +178,7 @@ func (dd *Destination) setNlri(nlri bgp.AddrPrefixInterface) {
 	dd.nlri = nlri
 }
 
-func (dd *Destination) GetKnownPathList(id string) []*Path {
+func (dd *Destination) GetKnownPathList(id uint32) []*Path {
 	list := make([]*Path, 0, len(dd.knownPathList))
 	for _, p := range dd.knownPathList {
 		if p.filtered[id] == POLICY_DIRECTION_NONE {
@@ -188,7 +188,7 @@ func (dd *Destination) GetKnownPathList(id string) []*Path {
 	return list
 }
 
-func (dd *Destination) GetBestPath(id string) *Path {
+func (dd *Destination) GetBestPath(id uint32) *Path {
 	for _, p := range dd.knownPathList {
 		if p.filtered[id] == POLICY_DIRECTION_NONE {
 			return p
@@ -197,7 +197,7 @@ func (dd *Destination) GetBestPath(id string) *Path {
 	return nil
 }
 
-func (dd *Destination) oldBest(id string) *Path {
+func (dd *Destination) oldBest(id uint32) *Path {
 	for _, p := range dd.oldKnownPathList {
 		if p.filtered[id] == POLICY_DIRECTION_NONE {
 			return p
@@ -248,7 +248,7 @@ func (dest *Destination) Calculate() {
 	dest.computeKnownBestPath()
 }
 
-func (dest *Destination) NewFeed(id string) *Path {
+func (dest *Destination) NewFeed(id uint32) *Path {
 	old := dest.oldBest(id)
 	best := dest.GetBestPath(id)
 	if best != nil && best.Equal(old) {

--- a/table/path.go
+++ b/table/path.go
@@ -40,7 +40,7 @@ type Path struct {
 	IsFromZebra            bool
 	Owner                  net.IP
 	reason                 BestPathReason
-	filtered               map[string]PolicyDirection
+	filtered               map[uint32]PolicyDirection
 	key                    string
 }
 
@@ -68,7 +68,7 @@ func NewPath(source *PeerInfo, nlri bgp.AddrPrefixInterface, isWithdraw bool, pa
 		timestamp:              timestamp,
 		NoImplicitWithdraw:     noImplicitWithdraw,
 		Owner:                  owner,
-		filtered:               make(map[string]PolicyDirection),
+		filtered:               make(map[uint32]PolicyDirection),
 	}
 }
 
@@ -190,7 +190,7 @@ func (path *Path) IsIBGP() bool {
 	return path.source.AS == path.source.LocalAS
 }
 
-func (path *Path) ToApiStruct(id string) *api.Path {
+func (path *Path) ToApiStruct(id uint32) *api.Path {
 	nlri := path.GetNlri()
 	n, _ := nlri.Serialize()
 	rf := uint32(bgp.AfiSafiToRouteFamily(nlri.AFI(), nlri.SAFI()))
@@ -227,11 +227,11 @@ func (path *Path) Clone(owner net.IP, isWithdraw bool) *Path {
 	return p
 }
 
-func (path *Path) Filter(id string, reason PolicyDirection) {
+func (path *Path) Filter(id uint32, reason PolicyDirection) {
 	path.filtered[id] = reason
 }
 
-func (path *Path) Filtered(id string) PolicyDirection {
+func (path *Path) Filtered(id uint32) PolicyDirection {
 	return path.filtered[id]
 }
 
@@ -653,7 +653,7 @@ func (lhs *Path) Equal(rhs *Path) bool {
 		return true
 	}
 	f := func(p *Path) []byte {
-		s := p.ToApiStruct(GLOBAL_RIB_NAME)
+		s := p.ToApiStruct(GLOBAL_RIB_ID)
 		s.Age = 0
 		buf, _ := json.Marshal(s)
 		return buf

--- a/table/policy.go
+++ b/table/policy.go
@@ -2622,10 +2622,10 @@ type RoutingPolicy struct {
 	DefinedSetMap DefinedSetMap
 	PolicyMap     map[string]*Policy
 	StatementMap  map[string]*Statement
-	AssignmentMap map[string]*Assignment
+	AssignmentMap map[uint32]*Assignment
 }
 
-func (r *RoutingPolicy) ApplyPolicy(id string, dir PolicyDirection, before *Path) *Path {
+func (r *RoutingPolicy) ApplyPolicy(id uint32, dir PolicyDirection, before *Path) *Path {
 	if before == nil {
 		return nil
 	}
@@ -2651,7 +2651,7 @@ func (r *RoutingPolicy) ApplyPolicy(id string, dir PolicyDirection, before *Path
 	}
 }
 
-func (r *RoutingPolicy) GetPolicy(id string, dir PolicyDirection) []*Policy {
+func (r *RoutingPolicy) GetPolicy(id uint32, dir PolicyDirection) []*Policy {
 	a, ok := r.AssignmentMap[id]
 	if !ok {
 		return nil
@@ -2668,7 +2668,7 @@ func (r *RoutingPolicy) GetPolicy(id string, dir PolicyDirection) []*Policy {
 	}
 }
 
-func (r *RoutingPolicy) GetDefaultPolicy(id string, dir PolicyDirection) RouteType {
+func (r *RoutingPolicy) GetDefaultPolicy(id uint32, dir PolicyDirection) RouteType {
 	a, ok := r.AssignmentMap[id]
 	if !ok {
 		return ROUTE_TYPE_NONE
@@ -2686,7 +2686,7 @@ func (r *RoutingPolicy) GetDefaultPolicy(id string, dir PolicyDirection) RouteTy
 
 }
 
-func (r *RoutingPolicy) SetPolicy(id string, dir PolicyDirection, policies []*Policy) error {
+func (r *RoutingPolicy) SetPolicy(id uint32, dir PolicyDirection, policies []*Policy) error {
 	a, ok := r.AssignmentMap[id]
 	if !ok {
 		a = &Assignment{}
@@ -2703,7 +2703,7 @@ func (r *RoutingPolicy) SetPolicy(id string, dir PolicyDirection, policies []*Po
 	return nil
 }
 
-func (r *RoutingPolicy) SetDefaultPolicy(id string, dir PolicyDirection, typ RouteType) error {
+func (r *RoutingPolicy) SetDefaultPolicy(id uint32, dir PolicyDirection, typ RouteType) error {
 	a, ok := r.AssignmentMap[id]
 	if !ok {
 		a = &Assignment{}
@@ -2848,7 +2848,7 @@ func (r *RoutingPolicy) Reload(c config.RoutingPolicy) error {
 	r.DefinedSetMap = dmap
 	r.PolicyMap = pmap
 	r.StatementMap = smap
-	r.AssignmentMap = make(map[string]*Assignment)
+	r.AssignmentMap = make(map[uint32]*Assignment)
 	return nil
 }
 
@@ -2857,7 +2857,7 @@ func NewRoutingPolicy() *RoutingPolicy {
 		DefinedSetMap: make(map[DefinedType]map[string]DefinedSet),
 		PolicyMap:     make(map[string]*Policy),
 		StatementMap:  make(map[string]*Statement),
-		AssignmentMap: make(map[string]*Assignment),
+		AssignmentMap: make(map[uint32]*Assignment),
 	}
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -211,7 +211,7 @@ func (t *Table) tableKey(nlri bgp.AddrPrefixInterface) string {
 	return nlri.String()
 }
 
-func (t *Table) Bests(id string) []*Path {
+func (t *Table) Bests(id uint32) []*Path {
 	paths := make([]*Path, 0, len(t.destinations))
 	for _, dst := range t.destinations {
 		path := dst.GetBestPath(id)
@@ -222,7 +222,7 @@ func (t *Table) Bests(id string) []*Path {
 	return paths
 }
 
-func (t *Table) GetKnownPathList(id string) []*Path {
+func (t *Table) GetKnownPathList(id uint32) []*Path {
 	paths := make([]*Path, 0, len(t.destinations))
 	for _, dst := range t.destinations {
 		paths = append(paths, dst.GetKnownPathList(id)...)

--- a/table/table_manager.go
+++ b/table/table_manager.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	GLOBAL_RIB_NAME = "global"
+	GLOBAL_RIB_ID uint32 = 0
 )
 
 func nlri2Path(m *bgp.BGPMessage, p *PeerInfo, now time.Time) []*Path {
@@ -276,7 +276,7 @@ func (manager *TableManager) handleMacMobility(path *Path) []*Destination {
 	if path.IsWithdraw || path.IsLocal() || nlri.RouteType != bgp.EVPN_ROUTE_TYPE_MAC_IP_ADVERTISEMENT {
 		return nil
 	}
-	for _, path2 := range manager.GetPathList(GLOBAL_RIB_NAME, bgp.RF_EVPN) {
+	for _, path2 := range manager.GetPathList(GLOBAL_RIB_ID, bgp.RF_EVPN) {
 		if !path2.IsLocal() || path2.GetNlri().(*bgp.EVPNNLRI).RouteType != bgp.EVPN_ROUTE_TYPE_MAC_IP_ADVERTISEMENT {
 			continue
 		}
@@ -313,7 +313,7 @@ func (manager *TableManager) getDestinationCount(rfList []bgp.RouteFamily) int {
 	return count
 }
 
-func (manager *TableManager) GetBestPathList(id string, rfList []bgp.RouteFamily) []*Path {
+func (manager *TableManager) GetBestPathList(id uint32, rfList []bgp.RouteFamily) []*Path {
 	paths := make([]*Path, 0, manager.getDestinationCount(rfList))
 	for _, rf := range rfList {
 		if t, ok := manager.Tables[rf]; ok {
@@ -323,7 +323,7 @@ func (manager *TableManager) GetBestPathList(id string, rfList []bgp.RouteFamily
 	return paths
 }
 
-func (manager *TableManager) GetPathList(id string, rf bgp.RouteFamily) []*Path {
+func (manager *TableManager) GetPathList(id uint32, rf bgp.RouteFamily) []*Path {
 	if t, ok := manager.Tables[rf]; ok {
 		return t.GetKnownPathList(id)
 	}

--- a/table/table_manager_test.go
+++ b/table/table_manager_test.go
@@ -33,7 +33,7 @@ func (manager *TableManager) ProcessUpdate(fromPeer *PeerInfo, message *bgp.BGPM
 	dsts := manager.ProcessPaths(paths)
 	paths2 := make([]*Path, 0, len(paths))
 	for _, dst := range dsts {
-		p := dst.NewFeed(GLOBAL_RIB_NAME)
+		p := dst.NewFeed(GLOBAL_RIB_ID)
 		if p != nil {
 			paths2 = append(paths2, p)
 		}
@@ -2127,7 +2127,7 @@ func TestProcessBGPUpdate_Timestamp(t *testing.T) {
 
 	nlri := []*bgp.IPAddrPrefix{bgp.NewIPAddrPrefix(24, "10.10.10.0")}
 
-	adjRib := NewAdjRib("test", []bgp.RouteFamily{bgp.RF_IPv4_UC, bgp.RF_IPv6_UC})
+	adjRib := NewAdjRib(0, []bgp.RouteFamily{bgp.RF_IPv4_UC, bgp.RF_IPv6_UC})
 	m1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, nlri)
 	peer := peerR1()
 	pList1 := ProcessMessage(m1, peer, time.Now())

--- a/test/performance_test/main.go
+++ b/test/performance_test/main.go
@@ -29,9 +29,9 @@ import (
 	"github.com/osrg/gobgp/table"
 )
 
-func newPeer(g config.Global, p config.Neighbor, incoming chan *server.FsmMsg) *server.Peer {
+func newPeer(g config.Global, p config.Neighbor, incoming chan *server.FsmMsg, id uint32) *server.Peer {
 	tbl := table.NewTableManager([]bgp.RouteFamily{bgp.RF_IPv4_UC, bgp.RF_IPv6_UC}, 0, 0)
-	peer := server.NewPeer(g, p, tbl, table.NewRoutingPolicy())
+	peer := server.NewPeer(g, p, tbl, id, table.NewRoutingPolicy())
 	server.NewFSMHandler(peer.Fsm(), incoming, peer.Outgoing())
 	return peer
 }
@@ -72,7 +72,7 @@ func main() {
 				},
 			},
 		}
-		peer := newPeer(g, p, incoming)
+		peer := newPeer(g, p, incoming, uint32(i+1))
 		peerMap[p.Transport.TransportConfig.LocalAddress.String()] = peer
 	}
 	established := 0


### PR DESCRIPTION
Using string as a key to indentify a peer in table isn't good for
performance. Let's use uint32 instead.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>