### PR TITLE
server: use ID() for path's Filter and Filtered methods instead of Ta…

### DIFF
--- a/server/peer.go
+++ b/server/peer.go
@@ -214,7 +214,7 @@ func (peer *Peer) handleBGPmessage(e *FsmMsg) ([]*table.Path, []*bgp.BGPMessage)
 			peer.adjRibIn.Update(e.PathList)
 			paths := make([]*table.Path, 0, len(e.PathList))
 			for _, path := range e.PathList {
-				if path.Filtered(peer.TableID()) != table.POLICY_DIRECTION_IN {
+				if path.Filtered(peer.ID()) != table.POLICY_DIRECTION_IN {
 					paths = append(paths, path)
 				}
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -656,7 +656,7 @@ func (server *BgpServer) propagateUpdate(peer *Peer, pathList []*table.Path) []*
 	rib := server.globalRib
 	if peer != nil && peer.isRouteServerClient() {
 		for _, path := range pathList {
-			path.Filter(peer.TableID(), table.POLICY_DIRECTION_IMPORT)
+			path.Filter(peer.ID(), table.POLICY_DIRECTION_IMPORT)
 			path.Filter(table.GLOBAL_RIB_NAME, table.POLICY_DIRECTION_IMPORT)
 		}
 		moded := []*table.Path{}
@@ -667,14 +667,14 @@ func (server *BgpServer) propagateUpdate(peer *Peer, pathList []*table.Path) []*
 			for _, before := range pathList {
 				after := server.policy.ApplyPolicy(targetPeer.TableID(), table.POLICY_DIRECTION_IMPORT, before)
 				if after == nil {
-					before.Filter(targetPeer.TableID(), table.POLICY_DIRECTION_IMPORT)
+					before.Filter(targetPeer.ID(), table.POLICY_DIRECTION_IMPORT)
 				} else if after != before {
-					before.Filter(targetPeer.TableID(), table.POLICY_DIRECTION_IMPORT)
+					before.Filter(targetPeer.ID(), table.POLICY_DIRECTION_IMPORT)
 					for _, n := range server.neighborMap {
 						if n == targetPeer {
 							continue
 						}
-						after.Filter(n.TableID(), table.POLICY_DIRECTION_IMPORT)
+						after.Filter(n.ID(), table.POLICY_DIRECTION_IMPORT)
 					}
 					moded = append(moded, after)
 				}


### PR DESCRIPTION
…bleID()

Needs to use ID() for path's Filter and Filtered methods instead of
TableID(). We don't hit any bugs because:

- With a RS client, both methods returns the same.
- No IN POLICY support for non RS clients

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>