### PR TITLE
server: avoid as loop check in filterpath() for rs peer

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -530,7 +530,7 @@ func filterpath(peer *Peer, path *table.Path) *table.Path {
 		return nil
 	}
 
-	if isASLoop(peer, path) {
+	if !peer.isRouteServerClient() && isASLoop(peer, path) {
 		return nil
 	}
 	return path.Clone(remoteAddr, path.IsWithdraw)


### PR DESCRIPTION
We don't import as loop path into rs peer's table. So no need to check
again.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>