### PR TITLE
bmp: support post-policy routing monitoring

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -112,6 +112,15 @@ const (
 	BGP_SET_COMMUNITY_OPTION_TYPE_REPLACE
 )
 
+// typedef for typedef gobgp:bmp-route-monitoring-policy-type
+type BmpRouteMonitoringPolicyType int
+
+const (
+	BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY  BmpRouteMonitoringPolicyType = 0
+	BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY                              = 1
+	BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH                                     = 2
+)
+
 // typedef for typedef gobgp:rpki-validation-result-type
 type RpkiValidationResultType int
 
@@ -142,6 +151,8 @@ type BmpServerConfig struct {
 	Address net.IP
 	// original -> gobgp:port
 	Port uint32
+	// original -> gobgp:route-monitoring-policy
+	RouteMonitoringPolicy BmpRouteMonitoringPolicyType
 }
 
 //struct for container gobgp:bmp-server

--- a/server/zclient.go
+++ b/server/zclient.go
@@ -157,7 +157,7 @@ func handleZapiMsg(msg *zebra.Message, server *BgpServer) []*SenderMsg {
 
 		if b.Prefix != nil && len(b.Nexthops) > 0 && b.Type != zebra.ROUTE_KERNEL {
 			p := createPathFromIPRouteMessage(msg, pi)
-			msgs := server.propagateUpdate(nil, []*table.Path{p})
+			msgs, _ := server.propagateUpdate(nil, []*table.Path{p})
 			return msgs
 		}
 	}

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -48,6 +48,23 @@ module bgp-gobgp {
     }
   }
 
+  typedef bmp-route-monitoring-policy-type {
+    type enumeration {
+      enum PRE-POLICY {
+        value 0;
+        description "send pre-policy routes";
+      }
+      enum POST-POLICY {
+        value 1;
+        description "send post-policy routes";
+      }
+      enum BOTH {
+        value 2;
+        description "send both pre and post-policy routes";
+      }
+    }
+  }
+
   grouping gobgp-message-counter {
     description
       "Counters for all BGPMessage types";
@@ -409,6 +426,10 @@ module bgp-gobgp {
       type uint32;
       description
         "Reference to the port of the BMP server";
+    }
+    leaf route-monitoring-policy {
+      type bmp-route-monitoring-policy-type;
+      default PRE-POLICY;
     }
   }
 


### PR DESCRIPTION
"RouteMonitoringPolicy" option added:

0: pre-policy (by default)
1: post-policy
2: both

=
[BmpServers]
  [[BmpServers.BmpServerList]]
    [BmpServers.BmpServerList.BmpServerConfig]
      Address = "127.0.0.1"
      Port = 11019
      RouteMonitoringPolicy = 2

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>