### PR TITLE
bmp: fix post-policy bmp message creation

### DIFF
--- a/table/message.go
+++ b/table/message.go
@@ -160,8 +160,15 @@ func createUpdateMsgFromPath(path *Path, msg *bgp.BGPMessage) *bgp.BGPMessage {
 			} else {
 				clonedAttrs := cloneAttrSlice(path.GetPathAttrs())
 				idx, attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_MP_REACH_NLRI)
-				reach := attr.(*bgp.PathAttributeMpReachNLRI)
-				clonedAttrs[idx] = bgp.NewPathAttributeMpUnreachNLRI(reach.Value)
+				if attr == nil {
+					// for bmp post-policy
+					idx, attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_MP_UNREACH_NLRI)
+					reach := attr.(*bgp.PathAttributeMpUnreachNLRI)
+					clonedAttrs[idx] = bgp.NewPathAttributeMpUnreachNLRI(reach.Value)
+				} else {
+					reach := attr.(*bgp.PathAttributeMpReachNLRI)
+					clonedAttrs[idx] = bgp.NewPathAttributeMpUnreachNLRI(reach.Value)
+				}
 				return bgp.NewBGPUpdateMessage(nil, clonedAttrs, nil)
 			}
 		} else {

--- a/table/message_test.go
+++ b/table/message_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func updateMsg1(as []uint16) *bgp.BGPMessage {
@@ -98,4 +99,26 @@ func TestAs4PathUnchanged(t *testing.T) {
 			assert.Equal(t, v, as4[i])
 		}
 	}
+}
+
+func TestBMP(t *testing.T) {
+	aspath1 := []bgp.AsPathParamInterface{
+		bgp.NewAs4PathParam(2, []uint32{1000000}),
+		bgp.NewAs4PathParam(1, []uint32{1000001, 1002}),
+		bgp.NewAs4PathParam(2, []uint32{1003, 100004}),
+	}
+	mp_nlri := []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(100,
+		"fe80:1234:1234:5667:8967:af12:8912:1023")}
+
+	p := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(3),
+		bgp.NewPathAttributeAsPath(aspath1),
+		bgp.NewPathAttributeMpUnreachNLRI(mp_nlri),
+	}
+	w := []*bgp.IPAddrPrefix{}
+	n := []*bgp.IPAddrPrefix{}
+
+	msg := bgp.NewBGPUpdateMessage(w, p, n)
+	pList := ProcessMessage(msg, peerR1(), time.Now())
+	CreateUpdateMsgFromPaths(pList)
 }


### PR DESCRIPTION
post-policy code creates paths from bgp update and then create the
message from the modified paths. MP_UNREACH needs to be handled
diffently.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>