### PR TITLE
cli: remove redundant line

### DIFF
--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -754,7 +754,6 @@ func NewGlobalCmd() *cobra.Command {
 		Use: CMD_POLICY,
 		Run: func(cmd *cobra.Command, args []string) {
 			for _, v := range []string{CMD_IMPORT, CMD_EXPORT} {
-				fmt.Printf("%s policy:\n", strings.Title(v))
 				if err := showNeighborPolicy(nil, v, 4); err != nil {
 					fmt.Println(err)
 					os.Exit(1)


### PR DESCRIPTION
before:
$ gobgp global policy
Import policy:
Import policy:
    Default: ACCEPT
Export policy:
Export policy:
    Default: ACCEPT

after:
$ gobgp global policy
Import policy:
    Default: ACCEPT
Export policy:
    Default: ACCEPT

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>