### PR TITLE
rpki: 'rpki server' command shows port

### DIFF
--- a/gobgp/cmd/rpki.go
+++ b/gobgp/cmd/rpki.go
@@ -36,7 +36,7 @@ func showRPKIServer(args []string) error {
 		fmt.Println(err)
 		return err
 	}
-	format := "%-18s %-6s %-10s %s\n"
+	format := "%-23s %-6s %-10s %s\n"
 	fmt.Printf(format, "Session", "State", "Uptime", "#IPv4/IPv6 records")
 	for {
 		r, err := stream.Recv()
@@ -52,7 +52,7 @@ func showRPKIServer(args []string) error {
 			uptime = fmt.Sprint(formatTimedelta(int64(time.Now().Sub(time.Unix(r.State.Uptime, 0)).Seconds())))
 		}
 
-		fmt.Printf(format, fmt.Sprintf(r.Conf.Address), s, uptime, fmt.Sprintf("%d/%d", r.State.ReceivedIpv4, r.State.ReceivedIpv6))
+		fmt.Printf(format, net.JoinHostPort(r.Conf.Address, strconv.Itoa(int(r.Conf.RemotePort))), s, uptime, fmt.Sprintf("%d/%d", r.State.ReceivedIpv4, r.State.ReceivedIpv6))
 	}
 	return nil
 }

--- a/server/rpki.go
+++ b/server/rpki.go
@@ -267,10 +267,11 @@ func (c *roaManager) handleGRPC(grpcReq *GrpcRequest) {
 		for _, client := range c.clientMap {
 			state := client.state
 			received := &state.RpkiMessages.RpkiReceived
-			addr, _ := splitHostPort(client.host)
+			addr, port := splitHostPort(client.host)
 			rpki := &api.RPKI{
 				Conf: &api.RPKIConf{
-					Address: addr,
+					Address:    addr,
+					RemotePort: uint32(port),
 				},
 				State: &api.RPKIState{
 					Uptime:       state.Uptime,


### PR DESCRIPTION
Session                 State  Uptime     #IPv4/IPv6 records
210.173.170.254:323     Up     00:01:39   17112/2517
141.22.28.222:8282      Up     00:01:39   17411/2604

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>