### PR TITLE
policy: fix insufficient nil check

### DIFF
--- a/table/policy.go
+++ b/table/policy.go
@@ -2151,7 +2151,7 @@ func (s *Statement) Apply(path *Path) (RouteType, *Path) {
 			}
 		}
 		//Routing action
-		if s.RouteAction == nil {
+		if s.RouteAction == nil || reflect.ValueOf(s.RouteAction).IsNil() {
 			log.WithFields(log.Fields{
 				"Topic":      "Policy",
 				"Path":       path,


### PR DESCRIPTION
RouteAction is interface. we have to check the contained value is also
nil.

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>