### PR TITLE
server: clone withdrawal path to prepare for the as2path modification

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -576,6 +576,9 @@ func (server *BgpServer) dropPeerAllRoutes(peer *Peer) []*SenderMsg {
 				i := 0
 				for _, dst := range dsts {
 					feed := dst.NewFeed(targetPeer.TableID())
+					if feed != nil {
+						feed = feed.Clone(feed.Owner, true)
+					}
 					pathList[i] = feed
 					i++
 				}


### PR DESCRIPTION
withdrawal paths' aspath can be modified for as2 peers

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>