### PR TITLE
rpki: fix showing rpki results

### DIFF
--- a/gobgp/cmd/neighbor.go
+++ b/gobgp/cmd/neighbor.go
@@ -285,12 +285,12 @@ func ShowRoute(pathList []*Path, showAge, showBest, showLabel, isMonitor, printH
 		}
 
 		best := ""
-		switch config.RpkiValidationResultType(p.Validation) {
-		case config.RPKI_VALIDATION_RESULT_TYPE_NOT_FOUND:
+		switch int(p.Validation) {
+		case config.RPKI_VALIDATION_RESULT_TYPE_NOT_FOUND.ToInt():
 			best += "N"
-		case config.RPKI_VALIDATION_RESULT_TYPE_VALID:
+		case config.RPKI_VALIDATION_RESULT_TYPE_VALID.ToInt():
 			best += "V"
-		case config.RPKI_VALIDATION_RESULT_TYPE_INVALID:
+		case config.RPKI_VALIDATION_RESULT_TYPE_INVALID.ToInt():
 			best += "I"
 		}
 		if showBest {


### PR DESCRIPTION
fix the regression due the following commit:

commit b0fbcc6b1b18d2c9fe67437fe6432914b67c5508
Author: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>
Date:   Fri Jan 8 11:52:07 2016 +0900

    config: change enum value type to string for ease of configuration

    Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>