### PR TITLE
server: fix fixed timeout for write

### DIFF
--- a/server/fsm.go
+++ b/server/fsm.go
@@ -827,7 +827,7 @@ func (h *FSMHandler) sendMessageloop() error {
 			fsm.bgpMessageStateUpdate(0, false)
 			return nil
 		}
-		if err := conn.SetWriteDeadline(time.Now().Add(time.Second * 30)); err != nil {
+		if err := conn.SetWriteDeadline(time.Now().Add(time.Second * time.Duration(fsm.negotiatedHoldTime))); err != nil {
 			h.errorCh <- true
 			conn.Close()
 			return fmt.Errorf("failed to set write deadline")


### PR DESCRIPTION
using 30 secs is a bad idea. Let's use negotiated holdtime
instead. But I think that we should not use timeout for write. when a
timeout for write expires, we shuld just check:

a) if the conneciton is still valid
b) a peer is not de-configured

a) nor b) is not the case, we should try write again.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>