### PR TITLE
server: make initial active connect faster

### DIFF
--- a/server/fsm.go
+++ b/server/fsm.go
@@ -336,7 +336,7 @@ func (fsm *FSM) connectLoop() error {
 		case <-ticker.C:
 			connect()
 		case <-fsm.getActiveCh:
-			time.Sleep(time.Duration(r.Intn(tick)+MIN_CONNECT_RETRY) * time.Second)
+			time.Sleep(time.Duration(r.Intn(MIN_CONNECT_RETRY)+MIN_CONNECT_RETRY) * time.Second)
 			connect()
 			ticker = time.NewTicker(time.Duration(tick) * time.Second)
 		}


### PR DESCRIPTION
give random.Intn() MIN_CONNECT_RETRY(10s) instead of connect-retry
(120s by default).

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>