### PR TITLE
packet: bmp localaddress in peerup message

### DIFF
--- a/packet/bmp.go
+++ b/packet/bmp.go
@@ -297,7 +297,7 @@ func (body *BMPPeerUpNotification) ParseBody(msg *BMPMessage, data []byte) error
 	if msg.PeerHeader.Flags&(1<<7) != 0 {
 		body.LocalAddress = net.IP(data[:16]).To16()
 	} else {
-		body.LocalAddress = net.IP(data[:4]).To4()
+		body.LocalAddress = net.IP(data[12:16]).To4()
 	}
 
 	body.LocalPort = binary.BigEndian.Uint16(data[16:18])
@@ -320,7 +320,7 @@ func (body *BMPPeerUpNotification) ParseBody(msg *BMPMessage, data []byte) error
 func (body *BMPPeerUpNotification) Serialize() ([]byte, error) {
 	buf := make([]byte, 20)
 	if body.LocalAddress.To4() != nil {
-		copy(buf[:4], body.LocalAddress.To4())
+		copy(buf[12:16], body.LocalAddress.To4())
 	} else {
 		copy(buf[:16], body.LocalAddress.To16())
 	}


### PR DESCRIPTION
Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>