### PR TITLE
table: fix gracefull restart regression

### DIFF
--- a/table/path.go
+++ b/table/path.go
@@ -99,6 +99,7 @@ func NewEOR(family bgp.RouteFamily) *Path {
 			nlri: nlri,
 			eor:  true,
 		},
+		filtered:   make(map[string]PolicyDirection),
 	}
 }
 


### PR DESCRIPTION
eor path needs a filter map. Otherwise gobgpd crashes.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>