### PR TITLE
doc: fix formatting in policy configuration documentation

### DIFF
--- a/docs/sources/policy.md
+++ b/docs/sources/policy.md
@@ -97,7 +97,7 @@ PrefixSets and NeighborSets section are prefix match part and neighbor match par
 
 - DefinedSets example
 
-```toml
+ ```toml
 # prefix match part
 [[defined-sets.prefix-sets]]
   prefix-set-name = "ps1"
@@ -109,7 +109,7 @@ PrefixSets and NeighborSets section are prefix match part and neighbor match par
 [[defined-sets.neighbor-sets]]
   prefix-set-name = "ps1"
   neighbor-info-list = ["10.0.255.1"]
-```
+ ```
 
   ----
 
@@ -136,49 +136,49 @@ PrefixSets and NeighborSets section are prefix match part and neighbor match par
     - Match routes whose high order 2 octets of NLRI is 10.33 and its prefix length is between from 21 to 24
     - If you define a PrefixList that doesn't have MasklengthRange, it matches routes that have just 10.33.0.0/16 as NLRI.
 
-```toml
-# example 1
-[[defined-sets.prefix-sets]]
-  prefix-set-name = "ps1"
-  [[defined-sets.prefix-sets.prefix-list]]
-    ip-prefix = "10.33.0.0/16"
-    masklength-range = "21..24"
-```
+  ```toml
+  # example 1
+  [[defined-sets.prefix-sets]]
+    prefix-set-name = "ps1"
+    [[defined-sets.prefix-sets.prefix-list]]
+      ip-prefix = "10.33.0.0/16"
+      masklength-range = "21..24"
+  ```
 
 
  - example 2
     - If you want to evaluate multiple routes with a single PrefixSetList, you can do this by adding an another PrefixList like this:
     - This PrefixSetList match checks if a route has 10.33.0.0/21 to 24 or 10.50.0.0/21 to 24.
 
-```toml
-# example 2
-[[defined-sets.prefix-sets]]
-  prefix-set-name = "ps1"
-  [[defined-sets.prefix-sets.prefix-list]]
-    ip-prefix = "10.33.0.0/16"
-    masklength-range = "21..24"
-  [[defined-sets.prefix-sets.prefix-list]]
-    ip-prefix = "10.50.0.0/16"
-    masklength-range = "21..24"
-```
+  ```toml
+  # example 2
+  [[defined-sets.prefix-sets]]
+    prefix-set-name = "ps1"
+    [[defined-sets.prefix-sets.prefix-list]]
+      ip-prefix = "10.33.0.0/16"
+      masklength-range = "21..24"
+    [[defined-sets.prefix-sets.prefix-list]]
+      ip-prefix = "10.50.0.0/16"
+      masklength-range = "21..24"
+  ```
 
  - example 3
     - PrefixSetName under PrefixSetList is reference to a single PrefixSet.
     - If you want to add different PrefixSet more, you can add other blocks that form the same structure with example 1.
 
-```toml
-# example 3
-[[defined-sets.prefix-sets]]
-  prefix-set-name = "ps1"
-  [[defined-sets.prefix-sets.prefix-list]]
-    ip-prefix = "10.33.0.0/16"
-    masklength-range = "21..24"
-[[defined-sets.prefix-sets]]
-  prefix-set-name = "ps2"
-  [[defined-sets.prefix-sets.prefix-list]]
-    ip-prefix = "10.50.0.0/16"
-    masklength-range = "21..24"
-```
+  ```toml
+  # example 3
+  [[defined-sets.prefix-sets]]
+    prefix-set-name = "ps1"
+    [[defined-sets.prefix-sets.prefix-list]]
+      ip-prefix = "10.33.0.0/16"
+      masklength-range = "21..24"
+  [[defined-sets.prefix-sets]]
+    prefix-set-name = "ps2"
+    [[defined-sets.prefix-sets.prefix-list]]
+      ip-prefix = "10.50.0.0/16"
+      masklength-range = "21..24"
+  ```
 
   ----
 
@@ -202,23 +202,24 @@ PrefixSets and NeighborSets section are prefix match part and neighbor match par
  ##### Examples
 
  - example 1
-```toml
-# example 1
-[[defined-sets.neighbor-sets]]
-  prefix-set-name = "ns1"
-  neighbor-info-list = ["10.0.255.1"]
-```
+  ```toml
+  # example 1
+  [[defined-sets.neighbor-sets]]
+    prefix-set-name = "ns1"
+    neighbor-info-list = ["10.0.255.1"]
+  ```
 
  - example 2
     - As with PrefixSetList, NeighborSetList can have multiple NeighborInfoList like this.
 
-```toml
-# example 2
-[[defined-sets.neighbor-sets]]
-  prefix-set-name = "ns1"
-  neighbor-info-list = ["10.0.255.1", "10.0.255.2"]
-```
-- example 3
+  ```toml
+  # example 2
+  [[defined-sets.neighbor-sets]]
+    prefix-set-name = "ns1"
+    neighbor-info-list = ["10.0.255.1", "10.0.255.2"]
+  ```
+
+ - example 3
     - As with PrefixSetList, multiple NeighborSetLists can be defined. 
  
   ```toml


### PR DESCRIPTION
Due to a bad indentation, tables and titles weren't rendered properly on
GitHub.

Signed-off-by: Vincent Bernat <vincent@bernat.im>