### PR TITLE
policy: remove unnecessary regexp special charactor

### DIFF
--- a/table/policy.go
+++ b/table/policy.go
@@ -879,14 +879,14 @@ func ParseExtCommunity(arg string) (bgp.ExtendedCommunityInterface, error) {
 func ParseCommunityRegexp(arg string) (*regexp.Regexp, error) {
 	i, err := strconv.Atoi(arg)
 	if err == nil {
-		return regexp.MustCompile(fmt.Sprintf("^%d:%d$", i>>16, i&0x0000ffff)), nil
+		return regexp.MustCompile(fmt.Sprintf("%d:%d", i>>16, i&0x0000ffff)), nil
 	}
 	if regexp.MustCompile("(\\d+.)*\\d+:\\d+").MatchString(arg) {
-		return regexp.MustCompile(fmt.Sprintf("^%s$", arg)), nil
+		return regexp.MustCompile(fmt.Sprintf("%s", arg)), nil
 	}
 	for i, v := range bgp.WellKnownCommunityNameMap {
 		if strings.Replace(strings.ToLower(arg), "_", "-", -1) == v {
-			return regexp.MustCompile(fmt.Sprintf("^%d:%d$", i>>16, i&0x0000ffff)), nil
+			return regexp.MustCompile(fmt.Sprintf("%d:%d", i>>16, i&0x0000ffff)), nil
 		}
 	}
 	exp, err := regexp.Compile(arg)


### PR DESCRIPTION
Since communities/ext-communities are tested one by one in policy-condition,
we don't need '^' and '$' around match condition items.

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>