### PR TITLE
.gitignore: remove old gomrt/gomrt binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.pyc
 gobgp/gobgp
 gobgpd/gobgpd
-gomrt/gomrt
 
 # Folders
 _obj


### PR DESCRIPTION
It was remove long ago.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>