### PR TITLE
server: fix per-asn regression

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2295,8 +2295,12 @@ func (server *BgpServer) handleGrpcModNeighbor(grpcReq *GrpcRequest) (sMsgs []*S
 				pconf.NeighborAddress = a.Conf.NeighborAddress
 				pconf.Config.NeighborAddress = a.Conf.NeighborAddress
 				pconf.Config.PeerAs = a.Conf.PeerAs
-				pconf.Config.LocalAs = a.Conf.LocalAs
-				if pconf.Config.PeerAs != server.bgpConfig.Global.Config.As {
+				if a.Conf.LocalAs == 0 {
+					pconf.Config.LocalAs = server.bgpConfig.Global.Config.As
+				} else {
+					pconf.Config.LocalAs = a.Conf.LocalAs
+				}
+				if pconf.Config.PeerAs != pconf.Config.LocalAs {
 					pconf.Config.PeerType = config.PEER_TYPE_EXTERNAL
 				} else {
 					pconf.Config.PeerType = config.PEER_TYPE_INTERNAL


### PR DESCRIPTION
AS in an OpenMsg is set to zero if a peer is configured via grpc.

commit 0b78f57ccdf63591fd211ade0b571189e070f598
Author: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>
Date:   Fri Feb 19 15:40:30 2016 +0900

    config/server: support per-peer asn

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>