### PR TITLE
packet: fix FlowSpecComponent Len()

### DIFF
--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -2523,32 +2523,38 @@ func (v *FlowSpecComponentItem) Serialize() ([]byte, error) {
 	}
 	if v.Op < 0 || v.Op > math.MaxUint8 {
 		return nil, fmt.Errorf("invalid op size: %d", v.Op)
+
+	}
+	order := uint32(math.Log2(float64(v.Len())))
+	// we don't know if not initialized properly or initialized to
+	// zero...
+	if order == 0 {
+		order = func() uint32 {
+			for i := 0; i < 3; i++ {
+				if v.Value < (1 << ((1 << uint(i)) * 8)) {
+					return uint32(i)
+				}
+			}
+			// return invalid order
+			return 4
+		}()
 	}
 
-	for i := 0; i < 3; i++ {
-		if v.Value < (1 << ((1 << uint(i)) * 8)) {
-			buf := make([]byte, 1+(1<<uint(i)))
-			switch i {
-			case 0:
-				buf[1] = byte(v.Value)
-				v.Op &^= 0x30
-			case 1:
-				binary.BigEndian.PutUint16(buf[1:], uint16(v.Value))
-				v.Op |= 0x10
-				v.Op &^= 0x20
-			case 2:
-				binary.BigEndian.PutUint32(buf[1:], uint32(v.Value))
-				v.Op &^= 0x10
-				v.Op |= 0x20
-			case 3:
-				binary.BigEndian.PutUint64(buf[1:], uint64(v.Value))
-				v.Op |= 0x30
-			}
-			buf[0] = byte(v.Op)
-			return buf, nil
-		}
+	buf := make([]byte, 1+(1<<order))
+	buf[0] = byte(uint32(v.Op) | order << 4)
+	switch order {
+	case 0:
+		buf[1] = byte(v.Value)
+	case 1:
+		binary.BigEndian.PutUint16(buf[1:], uint16(v.Value))
+	case 2:
+		binary.BigEndian.PutUint32(buf[1:], uint32(v.Value))
+	case 3:
+		binary.BigEndian.PutUint64(buf[1:], uint64(v.Value))
+	default:
+		return nil, fmt.Errorf("invalid value size(too big): %d", v.Value)
 	}
-	return nil, fmt.Errorf("invalid value size(too big): %d", v.Value)
+	return buf, nil
 }
 
 func NewFlowSpecComponentItem(op int, value int) *FlowSpecComponentItem {

--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -2513,6 +2513,10 @@ type FlowSpecComponentItem struct {
 	Value int `json:"value"`
 }
 
+func (v *FlowSpecComponentItem) Len() int {
+	return 1 << ((uint32(v.Op) >> 4) & 0x3)
+}
+
 func (v *FlowSpecComponentItem) Serialize() ([]byte, error) {
 	if v.Value < 0 {
 		return nil, fmt.Errorf("invalid value size(too small): %d", v.Value)
@@ -2599,8 +2603,11 @@ func (p *FlowSpecComponent) Serialize() ([]byte, error) {
 }
 
 func (p *FlowSpecComponent) Len() int {
-	buf, _ := p.Serialize()
-	return len(buf)
+	l := 1
+	for _, item := range p.Items {
+		l += (item.Len() + 1)
+	}
+	return l
 }
 
 func (p *FlowSpecComponent) Type() BGPFlowSpecType {


### PR DESCRIPTION
We don't need to serialize to get the length of FlowSpecComponent.

Also we need to fix FlowSpecComponent()'s serialize bug that it
wrongly assumes that the length can be calculated by it's value.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>