### PR TITLE
Revert "fsm: remove redundant connection close"

### DIFF
--- a/server/fsm.go
+++ b/server/fsm.go
@@ -1005,6 +1005,7 @@ func (h *FSMHandler) sendMessageloop() error {
 		}
 		if err := conn.SetWriteDeadline(time.Now().Add(time.Second * time.Duration(fsm.pConf.Timers.State.NegotiatedHoldTime))); err != nil {
 			h.errorCh <- FSM_WRITE_FAILED
+			conn.Close()
 			return fmt.Errorf("failed to set write deadline")
 		}
 		_, err = conn.Write(b)
@@ -1016,6 +1017,7 @@ func (h *FSMHandler) sendMessageloop() error {
 				"Data":  err,
 			}).Warn("failed to send")
 			h.errorCh <- FSM_WRITE_FAILED
+			conn.Close()
 			return fmt.Errorf("closed")
 		}
 		fsm.bgpMessageStateUpdate(m.Header.Type, false)
@@ -1028,6 +1030,7 @@ func (h *FSMHandler) sendMessageloop() error {
 				"Data":  m,
 			}).Warn("sent notification")
 			h.errorCh <- FSM_NOTIFICATION_SENT
+			conn.Close()
 			return fmt.Errorf("closed")
 		} else {
 			log.WithFields(log.Fields{


### PR DESCRIPTION
when hold timer expires, established() goroutine exits so even if tx()
goroutine writes to errorCh, nobody closes the connection. The, rx()
goroutine doesn't finish, so gobgpd hits panic().

This reverts commit 38bd31856b5eff046a4874e83b53cb7d3e45cdaf.

Conflicts:
	server/fsm.go