### PR TITLE
gobgpd: support force GC and return free memory to OS

### DIFF
--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -30,13 +30,14 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"syscall"
 )
 
 func main() {
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGTERM)
+	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGUSR1)
 
 	var opts struct {
 		ConfigFile      string `short:"f" long:"config-file" description:"specifying a config file"`
@@ -260,6 +261,9 @@ func main() {
 				reloadCh <- true
 			case syscall.SIGKILL, syscall.SIGTERM:
 				bgpServer.Shutdown()
+			case syscall.SIGUSR1:
+				runtime.GC()
+				debug.FreeOSMemory()
 			}
 		}
 	}


### PR DESCRIPTION
Sending signal USR1 to run GC and return free memory to OS. It's for
debugging memory leak.

Maybe we could support this feature via the GRPC API.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>