### PR TITLE
introduce marshalling option infra for BGP packet encoding/decoding

### DIFF
--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -30,6 +30,27 @@ import (
 
 type MarshallingOption interface{}
 
+type AS2Option struct{}
+
+func excludeAS2Option(options []MarshallingOption) []MarshallingOption {
+	o := make([]MarshallingOption, 0, len(options))
+	for _, opt := range options {
+		if _, y := opt.(AS2Option); !y {
+			o = append(o, opt)
+		}
+	}
+	return o
+}
+
+func HasAS2Option(options []MarshallingOption) bool {
+	for _, opt := range options {
+		if _, y := opt.(AS2Option); y {
+			return true
+		}
+	}
+	return false
+}
+
 const (
 	AFI_IP    = 1
 	AFI_IP6   = 2
@@ -3401,32 +3422,40 @@ var asPathParamFormatMap = map[uint8]*AsPathParamFormat{
 	BGP_ASPATH_ATTR_TYPE_CONFED_SEQ: &AsPathParamFormat{"[", "]", ","},
 }
 
-type AsPathParamInterface interface {
-	Serialize() ([]byte, error)
-	DecodeFromBytes([]byte) error
-	Len() int
-	ASLen() int
-	MarshalJSON() ([]byte, error)
-	String() string
-}
-
 type AsPathParam struct {
 	Type uint8
 	Num  uint8
-	AS   []uint16
+	AS   []uint32
 }
 
-func (a *AsPathParam) Serialize() ([]byte, error) {
-	buf := make([]byte, 2+len(a.AS)*2)
-	buf[0] = uint8(a.Type)
+func (a *AsPathParam) Serialize(options ...MarshallingOption) ([]byte, error) {
+	size := 4
+	as2 := HasAS2Option(options)
+	if as2 {
+		size = 2
+	}
+	buf := make([]byte, 2+len(a.AS)*size)
+	buf[0] = a.Type
 	buf[1] = a.Num
 	for j, as := range a.AS {
-		binary.BigEndian.PutUint16(buf[2+j*2:], as)
+		if as2 {
+			if as > (1<<16)-1 {
+				as = AS_TRANS
+			}
+			binary.BigEndian.PutUint16(buf[2+j*size:], uint16(as))
+		} else {
+			binary.BigEndian.PutUint32(buf[2+j*size:], as)
+		}
 	}
 	return buf, nil
 }
 
-func (a *AsPathParam) DecodeFromBytes(data []byte) error {
+func (a *AsPathParam) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	size := 4
+	as2 := HasAS2Option(options)
+	if as2 {
+		size = 2
+	}
 	eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
 	eSubCode := uint8(BGP_ERROR_SUB_MALFORMED_AS_PATH)
 	if len(data) < 2 {
@@ -3435,18 +3464,26 @@ func (a *AsPathParam) DecodeFromBytes(data []byte) error {
 	a.Type = data[0]
 	a.Num = data[1]
 	data = data[2:]
-	if len(data) < int(a.Num*2) {
+	if len(data) < int(a.Num)*size {
 		return NewMessageError(eCode, eSubCode, nil, "AS param data length is short")
 	}
 	for i := 0; i < int(a.Num); i++ {
-		a.AS = append(a.AS, binary.BigEndian.Uint16(data))
-		data = data[2:]
+		if as2 {
+			a.AS = append(a.AS, uint32(binary.BigEndian.Uint16(data)))
+		} else {
+			a.AS = append(a.AS, binary.BigEndian.Uint32(data))
+		}
+		data = data[size:]
 	}
 	return nil
 }
 
-func (a *AsPathParam) Len() int {
-	return 2 + len(a.AS)*2
+func (a *AsPathParam) Len(options ...MarshallingOption) int {
+	size := 4
+	if HasAS2Option(options) {
+		size = 2
+	}
+	return 2 + len(a.AS)*size
 }
 
 func (a *AsPathParam) ASLen() int {
@@ -3481,93 +3518,6 @@ func (a *AsPathParam) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Type uint8    `json:"segment_type"`
 		Num  uint8    `json:"num"`
-		AS   []uint16 `json:"asns"`
-	}{
-		Type: a.Type,
-		Num:  a.Num,
-		AS:   a.AS,
-	})
-}
-
-func NewAsPathParam(segType uint8, as []uint16) *AsPathParam {
-	return &AsPathParam{
-		Type: segType,
-		Num:  uint8(len(as)),
-		AS:   as,
-	}
-}
-
-type As4PathParam struct {
-	Type uint8
-	Num  uint8
-	AS   []uint32
-}
-
-func (a *As4PathParam) Serialize() ([]byte, error) {
-	buf := make([]byte, 2+len(a.AS)*4)
-	buf[0] = a.Type
-	buf[1] = a.Num
-	for j, as := range a.AS {
-		binary.BigEndian.PutUint32(buf[2+j*4:], as)
-	}
-	return buf, nil
-}
-
-func (a *As4PathParam) DecodeFromBytes(data []byte) error {
-	eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
-	eSubCode := uint8(BGP_ERROR_SUB_MALFORMED_AS_PATH)
-	if len(data) < 2 {
-		return NewMessageError(eCode, eSubCode, nil, "AS4 param header length is short")
-	}
-	a.Type = data[0]
-	a.Num = data[1]
-	data = data[2:]
-	if len(data) < int(a.Num)*4 {
-		return NewMessageError(eCode, eSubCode, nil, "AS4 param data length is short")
-	}
-	for i := 0; i < int(a.Num); i++ {
-		a.AS = append(a.AS, binary.BigEndian.Uint32(data))
-		data = data[4:]
-	}
-	return nil
-}
-
-func (a *As4PathParam) Len() int {
-	return 2 + len(a.AS)*4
-}
-
-func (a *As4PathParam) ASLen() int {
-	switch a.Type {
-	case BGP_ASPATH_ATTR_TYPE_SEQ:
-		return len(a.AS)
-	case BGP_ASPATH_ATTR_TYPE_SET:
-		return 1
-	case BGP_ASPATH_ATTR_TYPE_CONFED_SET, BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
-		return 0
-	}
-	return 0
-}
-
-func (a *As4PathParam) String() string {
-	format, ok := asPathParamFormatMap[a.Type]
-	if !ok {
-		return fmt.Sprintf("%v", a.AS)
-	}
-	aspath := make([]string, 0, len(a.AS))
-	for _, asn := range a.AS {
-		aspath = append(aspath, fmt.Sprintf("%d", asn))
-	}
-	s := bytes.NewBuffer(make([]byte, 0, 32))
-	s.WriteString(format.start)
-	s.WriteString(strings.Join(aspath, format.separator))
-	s.WriteString(format.end)
-	return s.String()
-}
-
-func (a *As4PathParam) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		Type uint8    `json:"segment_type"`
-		Num  uint8    `json:"num"`
 		AS   []uint32 `json:"asns"`
 	}{
 		Type: a.Type,
@@ -3576,67 +3526,17 @@ func (a *As4PathParam) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func NewAs4PathParam(segType uint8, as []uint32) *As4PathParam {
-	return &As4PathParam{
+func NewAsPathParam(segType uint8, as []uint32) *AsPathParam {
+	return &AsPathParam{
 		Type: segType,
 		Num:  uint8(len(as)),
 		AS:   as,
 	}
 }
 
-type DefaultAsPath struct {
-}
-
-func (p *DefaultAsPath) isValidAspath(data []byte) (bool, error) {
-	eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
-	eSubCode := uint8(BGP_ERROR_SUB_MALFORMED_AS_PATH)
-	if len(data)%2 != 0 {
-		return false, NewMessageError(eCode, eSubCode, nil, "AS PATH length is not odd")
-	}
-
-	tryParse := func(data []byte, use4byte bool) (bool, error) {
-		for len(data) > 0 {
-			if len(data) < 2 {
-				return false, NewMessageError(eCode, eSubCode, nil, "AS PATH header is short")
-			}
-			segType := data[0]
-			if segType == 0 || segType > 4 {
-				return false, NewMessageError(eCode, eSubCode, nil, "unknown AS_PATH seg type")
-			}
-			asNum := data[1]
-			data = data[2:]
-			if asNum == 0 || int(asNum) > math.MaxUint8 {
-				return false, NewMessageError(eCode, eSubCode, nil, "AS PATH the number of AS is incorrect")
-			}
-			segLength := int(asNum)
-			if use4byte == true {
-				segLength *= 4
-			} else {
-				segLength *= 2
-			}
-			if int(segLength) > len(data) {
-				return false, NewMessageError(eCode, eSubCode, nil, "seg length is short")
-			}
-			data = data[segLength:]
-		}
-		return true, nil
-	}
-	_, err := tryParse(data, true)
-	if err == nil {
-		return true, nil
-	}
-
-	_, err = tryParse(data, false)
-	if err == nil {
-		return false, nil
-	}
-	return false, NewMessageError(eCode, eSubCode, nil, "can't parse AS_PATH")
-}
-
 type PathAttributeAsPath struct {
-	DefaultAsPath
 	PathAttribute
-	Value []AsPathParamInterface
+	Value []*AsPathParam
 }
 
 func (p *PathAttributeAsPath) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
@@ -3648,28 +3548,15 @@ func (p *PathAttributeAsPath) DecodeFromBytes(data []byte, options ...Marshallin
 		// ibgp or something
 		return nil
 	}
-	as4Bytes, err := p.DefaultAsPath.isValidAspath(p.PathAttribute.Value)
-	if err != nil {
-		err.(*MessageError).Data = data[:p.Len(options...)]
-		return err
-	}
 	v := p.PathAttribute.Value
 	for len(v) > 0 {
-		var tuple AsPathParamInterface
-		if as4Bytes == true {
-			tuple = &As4PathParam{}
-		} else {
-			tuple = &AsPathParam{}
-		}
-		err := tuple.DecodeFromBytes(v)
-		if err != nil {
+		tuple := &AsPathParam{}
+		if err := tuple.DecodeFromBytes(v, options...); err != nil {
+			err.(*MessageError).Data = data
 			return err
 		}
 		p.Value = append(p.Value, tuple)
-		if tuple.Len() > len(v) {
-
-		}
-		v = v[tuple.Len():]
+		v = v[tuple.Len(options...):]
 	}
 	return nil
 }
@@ -3677,7 +3564,7 @@ func (p *PathAttributeAsPath) DecodeFromBytes(data []byte, options ...Marshallin
 func (p *PathAttributeAsPath) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 0)
 	for _, v := range p.Value {
-		vbuf, err := v.Serialize()
+		vbuf, err := v.Serialize(options...)
 		if err != nil {
 			return nil, err
 		}
@@ -3697,15 +3584,15 @@ func (p *PathAttributeAsPath) String() string {
 
 func (p *PathAttributeAsPath) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Type  BGPAttrType            `json:"type"`
-		Value []AsPathParamInterface `json:"as_paths"`
+		Type  BGPAttrType    `json:"type"`
+		Value []*AsPathParam `json:"as_paths"`
 	}{
 		Type:  p.GetType(),
 		Value: p.Value,
 	})
 }
 
-func NewPathAttributeAsPath(value []AsPathParamInterface) *PathAttributeAsPath {
+func NewPathAttributeAsPath(value []*AsPathParam) *PathAttributeAsPath {
 	t := BGP_ATTR_TYPE_AS_PATH
 	return &PathAttributeAsPath{
 		PathAttribute: PathAttribute{
@@ -5484,8 +5371,7 @@ func NewPathAttributeExtendedCommunities(value []ExtendedCommunityInterface) *Pa
 
 type PathAttributeAs4Path struct {
 	PathAttribute
-	Value []*As4PathParam
-	DefaultAsPath
+	Value []*AsPathParam
 }
 
 func (p *PathAttributeAs4Path) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
@@ -5496,29 +5382,26 @@ func (p *PathAttributeAs4Path) DecodeFromBytes(data []byte, options ...Marshalli
 	eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
 	eSubCode := uint8(BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST)
 	v := p.PathAttribute.Value
-	as4Bytes, err := p.DefaultAsPath.isValidAspath(p.PathAttribute.Value)
-	if err != nil {
-		return err
-	}
-	if as4Bytes == false {
-		return NewMessageError(eCode, eSubCode, nil, "AS4 PATH param is malformed")
-	}
 	for len(v) > 0 {
-		tuple := &As4PathParam{}
-		tuple.DecodeFromBytes(v)
+		tuple := &AsPathParam{}
+		options4 := excludeAS2Option(options)
+		if err := tuple.DecodeFromBytes(v, options4...); err != nil {
+			return err
+		}
 		p.Value = append(p.Value, tuple)
-		if len(v) < tuple.Len() {
+		if len(v) < tuple.Len(options4...) {
 			return NewMessageError(eCode, eSubCode, nil, "AS4 PATH param is malformed")
 		}
-		v = v[tuple.Len():]
+		v = v[tuple.Len(options4...):]
 	}
 	return nil
 }
 
 func (p *PathAttributeAs4Path) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 0)
+	options4 := excludeAS2Option(options)
 	for _, v := range p.Value {
-		vbuf, err := v.Serialize()
+		vbuf, err := v.Serialize(options4...)
 		if err != nil {
 			return nil, err
 		}
@@ -5536,7 +5419,7 @@ func (p *PathAttributeAs4Path) String() string {
 	return strings.Join(params, " ")
 }
 
-func NewPathAttributeAs4Path(value []*As4PathParam) *PathAttributeAs4Path {
+func NewPathAttributeAs4Path(value []*AsPathParam) *PathAttributeAs4Path {
 	t := BGP_ATTR_TYPE_AS4_PATH
 	return &PathAttributeAs4Path{
 		PathAttribute: PathAttribute{

--- a/packet/bgp.go
+++ b/packet/bgp.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 )
 
+type MarshallingOption interface{}
+
 const (
 	AFI_IP    = 1
 	AFI_IP6   = 2
@@ -650,7 +652,7 @@ type BGPOpen struct {
 	OptParams   []OptionParameterInterface
 }
 
-func (msg *BGPOpen) DecodeFromBytes(data []byte) error {
+func (msg *BGPOpen) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	msg.Version = data[0]
 	msg.MyAS = binary.BigEndian.Uint16(data[1:3])
 	msg.HoldTime = binary.BigEndian.Uint16(data[3:5])
@@ -685,7 +687,7 @@ func (msg *BGPOpen) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (msg *BGPOpen) Serialize() ([]byte, error) {
+func (msg *BGPOpen) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 10)
 	buf[0] = msg.Version
 	binary.BigEndian.PutUint16(buf[1:3], msg.MyAS)
@@ -712,11 +714,11 @@ func NewBGPOpenMessage(myas uint16, holdtime uint16, id string, optparams []Opti
 }
 
 type AddrPrefixInterface interface {
-	DecodeFromBytes([]byte) error
-	Serialize() ([]byte, error)
+	DecodeFromBytes([]byte, ...MarshallingOption) error
+	Serialize(...MarshallingOption) ([]byte, error)
 	AFI() uint16
 	SAFI() uint8
-	Len() int
+	Len(...MarshallingOption) int
 	String() string
 	MarshalJSON() ([]byte, error)
 }
@@ -756,7 +758,7 @@ func (r *IPAddrPrefixDefault) serializePrefix(bitlen uint8) ([]byte, error) {
 	return buf, nil
 }
 
-func (r *IPAddrPrefixDefault) Len() int {
+func (r *IPAddrPrefixDefault) Len(options ...MarshallingOption) int {
 	return 1 + ((int(r.Length) + 7) / 8)
 }
 
@@ -777,7 +779,7 @@ type IPAddrPrefix struct {
 	addrlen uint8
 }
 
-func (r *IPAddrPrefix) DecodeFromBytes(data []byte) error {
+func (r *IPAddrPrefix) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	if len(data) < 1 {
 		eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
 		eSubCode := uint8(BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST)
@@ -790,7 +792,7 @@ func (r *IPAddrPrefix) DecodeFromBytes(data []byte) error {
 	return r.decodePrefix(data[1:], r.Length, r.addrlen)
 }
 
-func (r *IPAddrPrefix) Serialize() ([]byte, error) {
+func (r *IPAddrPrefix) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 1)
 	buf[0] = r.Length
 	pbuf, err := r.serializePrefix(r.Length)
@@ -1216,7 +1218,7 @@ type LabeledVPNIPAddrPrefix struct {
 	addrlen uint8
 }
 
-func (l *LabeledVPNIPAddrPrefix) DecodeFromBytes(data []byte) error {
+func (l *LabeledVPNIPAddrPrefix) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	l.Length = uint8(data[0])
 	data = data[1:]
 	l.Labels.DecodeFromBytes(data)
@@ -1231,7 +1233,7 @@ func (l *LabeledVPNIPAddrPrefix) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (l *LabeledVPNIPAddrPrefix) Serialize() ([]byte, error) {
+func (l *LabeledVPNIPAddrPrefix) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 1)
 	buf[0] = l.Length
 	lbuf, err := l.Labels.Serialize()
@@ -1329,7 +1331,7 @@ func (r *LabeledIPAddrPrefix) SAFI() uint8 {
 	return SAFI_MPLS_LABEL
 }
 
-func (l *LabeledIPAddrPrefix) DecodeFromBytes(data []byte) error {
+func (l *LabeledIPAddrPrefix) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	l.Length = uint8(data[0])
 	data = data[1:]
 	l.Labels.DecodeFromBytes(data)
@@ -1342,7 +1344,7 @@ func (l *LabeledIPAddrPrefix) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (l *LabeledIPAddrPrefix) Serialize() ([]byte, error) {
+func (l *LabeledIPAddrPrefix) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 1)
 	buf[0] = l.Length
 	restbits := int(l.Length) - 8*(l.Labels.Len())
@@ -1395,7 +1397,7 @@ type RouteTargetMembershipNLRI struct {
 	RouteTarget ExtendedCommunityInterface
 }
 
-func (n *RouteTargetMembershipNLRI) DecodeFromBytes(data []byte) error {
+func (n *RouteTargetMembershipNLRI) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	n.Length = data[0]
 	data = data[1:]
 	if len(data) == 0 {
@@ -1412,7 +1414,7 @@ func (n *RouteTargetMembershipNLRI) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (n *RouteTargetMembershipNLRI) Serialize() ([]byte, error) {
+func (n *RouteTargetMembershipNLRI) Serialize(options ...MarshallingOption) ([]byte, error) {
 	if n.RouteTarget == nil {
 		return []byte{0}, nil
 	}
@@ -1435,7 +1437,7 @@ func (n *RouteTargetMembershipNLRI) SAFI() uint8 {
 	return SAFI_ROUTE_TARGET_CONSTRTAINS
 }
 
-func (n *RouteTargetMembershipNLRI) Len() int {
+func (n *RouteTargetMembershipNLRI) Len(options ...MarshallingOption) int {
 	if n.AS == 0 && n.RouteTarget == nil {
 		return 1
 	}
@@ -1929,7 +1931,7 @@ type EVPNNLRI struct {
 	RouteTypeData EVPNRouteTypeInterface
 }
 
-func (n *EVPNNLRI) DecodeFromBytes(data []byte) error {
+func (n *EVPNNLRI) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	if len(data) < 2 {
 		return fmt.Errorf("Not all EVPNNLRI bytes available")
 	}
@@ -1947,7 +1949,7 @@ func (n *EVPNNLRI) DecodeFromBytes(data []byte) error {
 	return n.RouteTypeData.DecodeFromBytes(data[:n.Length])
 }
 
-func (n *EVPNNLRI) Serialize() ([]byte, error) {
+func (n *EVPNNLRI) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 2)
 	buf[0] = n.RouteType
 	tbuf, err := n.RouteTypeData.Serialize()
@@ -1968,7 +1970,7 @@ func (n *EVPNNLRI) SAFI() uint8 {
 	return SAFI_EVPN
 }
 
-func (n *EVPNNLRI) Len() int {
+func (n *EVPNNLRI) Len(options ...MarshallingOption) int {
 	return int(n.Length) + 2
 }
 
@@ -2005,7 +2007,7 @@ type EncapNLRI struct {
 	IPAddrPrefixDefault
 }
 
-func (n *EncapNLRI) DecodeFromBytes(data []byte) error {
+func (n *EncapNLRI) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	if len(data) < 4 {
 		eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
 		eSubCode := uint8(BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST)
@@ -2015,7 +2017,7 @@ func (n *EncapNLRI) DecodeFromBytes(data []byte) error {
 	return n.decodePrefix(data[1:], n.Length, n.Length/8)
 }
 
-func (n *EncapNLRI) Serialize() ([]byte, error) {
+func (n *EncapNLRI) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 1)
 	buf[0] = net.IPv6len * 8
 	if n.Prefix.To4() != nil {
@@ -2377,9 +2379,9 @@ func (t BGPFlowSpecType) String() string {
 }
 
 type FlowSpecComponentInterface interface {
-	DecodeFromBytes([]byte) error
-	Serialize() ([]byte, error)
-	Len() int
+	DecodeFromBytes([]byte, ...MarshallingOption) error
+	Serialize(...MarshallingOption) ([]byte, error)
+	Len(...MarshallingOption) int
 	Type() BGPFlowSpecType
 	String() string
 }
@@ -2389,22 +2391,22 @@ type flowSpecPrefix struct {
 	type_  BGPFlowSpecType
 }
 
-func (p *flowSpecPrefix) DecodeFromBytes(data []byte) error {
+func (p *flowSpecPrefix) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	p.type_ = BGPFlowSpecType(data[0])
-	return p.Prefix.DecodeFromBytes(data[1:])
+	return p.Prefix.DecodeFromBytes(data[1:], options...)
 }
 
-func (p *flowSpecPrefix) Serialize() ([]byte, error) {
+func (p *flowSpecPrefix) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := []byte{byte(p.Type())}
-	bbuf, err := p.Prefix.Serialize()
+	bbuf, err := p.Prefix.Serialize(options...)
 	if err != nil {
 		return nil, err
 	}
 	return append(buf, bbuf...), nil
 }
 
-func (p *flowSpecPrefix) Len() int {
-	buf, _ := p.Serialize()
+func (p *flowSpecPrefix) Len(options ...MarshallingOption) int {
+	buf, _ := p.Serialize(options...)
 	return len(buf)
 }
 
@@ -2434,16 +2436,16 @@ type flowSpecPrefix6 struct {
 
 // draft-ietf-idr-flow-spec-v6-06
 // <type (1 octet), prefix length (1 octet), prefix offset(1 octet), prefix>
-func (p *flowSpecPrefix6) DecodeFromBytes(data []byte) error {
+func (p *flowSpecPrefix6) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	p.type_ = BGPFlowSpecType(data[0])
 	p.Offset = data[2]
 	prefix := append([]byte{data[1]}, data[3:]...)
-	return p.Prefix.DecodeFromBytes(prefix)
+	return p.Prefix.DecodeFromBytes(prefix, options...)
 }
 
-func (p *flowSpecPrefix6) Serialize() ([]byte, error) {
+func (p *flowSpecPrefix6) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := []byte{byte(p.Type())}
-	bbuf, err := p.Prefix.Serialize()
+	bbuf, err := p.Prefix.Serialize(options...)
 	if err != nil {
 		return nil, err
 	}
@@ -2452,8 +2454,8 @@ func (p *flowSpecPrefix6) Serialize() ([]byte, error) {
 	return append(buf, bbuf[1:]...), nil
 }
 
-func (p *flowSpecPrefix6) Len() int {
-	buf, _ := p.Serialize()
+func (p *flowSpecPrefix6) Len(options ...MarshallingOption) int {
+	buf, _ := p.Serialize(options...)
 	return len(buf)
 }
 
@@ -2572,7 +2574,7 @@ type FlowSpecComponent struct {
 	type_ BGPFlowSpecType
 }
 
-func (p *FlowSpecComponent) DecodeFromBytes(data []byte) error {
+func (p *FlowSpecComponent) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	p.type_ = BGPFlowSpecType(data[0])
 	data = data[1:]
 	p.Items = make([]*FlowSpecComponentItem, 0)
@@ -2596,7 +2598,7 @@ func (p *FlowSpecComponent) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *FlowSpecComponent) Serialize() ([]byte, error) {
+func (p *FlowSpecComponent) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := []byte{byte(p.Type())}
 	for i, v := range p.Items {
 		//set end-of-list bit
@@ -2614,7 +2616,7 @@ func (p *FlowSpecComponent) Serialize() ([]byte, error) {
 	return buf, nil
 }
 
-func (p *FlowSpecComponent) Len() int {
+func (p *FlowSpecComponent) Len(options ...MarshallingOption) int {
 	l := 1
 	for _, item := range p.Items {
 		l += (item.Len() + 1)
@@ -2744,16 +2746,16 @@ type FlowSpecUnknown struct {
 	Value []byte
 }
 
-func (p *FlowSpecUnknown) DecodeFromBytes(data []byte) error {
+func (p *FlowSpecUnknown) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	p.Value = data
 	return nil
 }
 
-func (p *FlowSpecUnknown) Serialize() ([]byte, error) {
+func (p *FlowSpecUnknown) Serialize(options ...MarshallingOption) ([]byte, error) {
 	return p.Value, nil
 }
 
-func (p *FlowSpecUnknown) Len() int {
+func (p *FlowSpecUnknown) Len(options ...MarshallingOption) int {
 	return len(p.Value)
 }
 
@@ -2773,7 +2775,7 @@ type FlowSpecNLRI struct {
 	rf    RouteFamily
 }
 
-func (n *FlowSpecNLRI) decodeFromBytes(rf RouteFamily, data []byte) error {
+func (n *FlowSpecNLRI) decodeFromBytes(rf RouteFamily, data []byte, options ...MarshallingOption) error {
 	var length int
 	if (data[0] >> 4) == 0xf {
 		length = int(binary.BigEndian.Uint16(data[0:2]))
@@ -2823,28 +2825,28 @@ func (n *FlowSpecNLRI) decodeFromBytes(rf RouteFamily, data []byte) error {
 			i = &FlowSpecUnknown{}
 		}
 
-		err := i.DecodeFromBytes(data)
+		err := i.DecodeFromBytes(data, options...)
 		if err != nil {
 			i = &FlowSpecUnknown{data}
 		}
-		l -= i.Len()
-		data = data[i.Len():]
+		l -= i.Len(options...)
+		data = data[i.Len(options...):]
 		n.Value = append(n.Value, i)
 	}
 
 	return nil
 }
 
-func (n *FlowSpecNLRI) Serialize() ([]byte, error) {
+func (n *FlowSpecNLRI) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 0, 32)
 	for _, v := range n.Value {
-		b, err := v.Serialize()
+		b, err := v.Serialize(options...)
 		if err != nil {
 			return nil, err
 		}
 		buf = append(buf, b...)
 	}
-	length := n.Len()
+	length := n.Len(options...)
 	if length > 0xfff {
 		return nil, fmt.Errorf("Too large: %d", length)
 	} else if length < 0xf0 {
@@ -2860,10 +2862,10 @@ func (n *FlowSpecNLRI) Serialize() ([]byte, error) {
 	return buf, nil
 }
 
-func (n *FlowSpecNLRI) Len() int {
+func (n *FlowSpecNLRI) Len(options ...MarshallingOption) int {
 	l := 0
 	for _, v := range n.Value {
-		l += v.Len()
+		l += v.Len(options...)
 	}
 	if l < 0xf0 {
 		return l + 1
@@ -2892,8 +2894,8 @@ type FlowSpecIPv4Unicast struct {
 	FlowSpecNLRI
 }
 
-func (n *FlowSpecIPv4Unicast) DecodeFromBytes(data []byte) error {
-	return n.decodeFromBytes(AfiSafiToRouteFamily(n.AFI(), n.SAFI()), data)
+func (n *FlowSpecIPv4Unicast) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	return n.decodeFromBytes(AfiSafiToRouteFamily(n.AFI(), n.SAFI()), data, options...)
 }
 
 func (n *FlowSpecIPv4Unicast) AFI() uint16 {
@@ -2912,8 +2914,8 @@ type FlowSpecIPv4VPN struct {
 	FlowSpecNLRI
 }
 
-func (n *FlowSpecIPv4VPN) DecodeFromBytes(data []byte) error {
-	return n.decodeFromBytes(AfiSafiToRouteFamily(n.AFI(), n.SAFI()), data)
+func (n *FlowSpecIPv4VPN) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	return n.decodeFromBytes(AfiSafiToRouteFamily(n.AFI(), n.SAFI()), data, options...)
 }
 
 func (n *FlowSpecIPv4VPN) AFI() uint16 {
@@ -2932,8 +2934,8 @@ type FlowSpecIPv6Unicast struct {
 	FlowSpecNLRI
 }
 
-func (n *FlowSpecIPv6Unicast) DecodeFromBytes(data []byte) error {
-	return n.decodeFromBytes(AfiSafiToRouteFamily(n.AFI(), n.SAFI()), data)
+func (n *FlowSpecIPv6Unicast) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	return n.decodeFromBytes(AfiSafiToRouteFamily(n.AFI(), n.SAFI()), data, options...)
 }
 
 func (n *FlowSpecIPv6Unicast) AFI() uint16 {
@@ -2955,8 +2957,8 @@ type FlowSpecIPv6VPN struct {
 	FlowSpecNLRI
 }
 
-func (n *FlowSpecIPv6VPN) DecodeFromBytes(data []byte) error {
-	return n.decodeFromBytes(AfiSafiToRouteFamily(n.AFI(), n.SAFI()), data)
+func (n *FlowSpecIPv6VPN) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	return n.decodeFromBytes(AfiSafiToRouteFamily(n.AFI(), n.SAFI()), data, options...)
 }
 
 func (n *FlowSpecIPv6VPN) AFI() uint16 {
@@ -3239,9 +3241,9 @@ var pathAttrFlags map[BGPAttrType]BGPAttrFlag = map[BGPAttrType]BGPAttrFlag{
 }
 
 type PathAttributeInterface interface {
-	DecodeFromBytes([]byte) error
-	Serialize() ([]byte, error)
-	Len() int
+	DecodeFromBytes([]byte, ...MarshallingOption) error
+	Serialize(...MarshallingOption) ([]byte, error)
+	Len(...MarshallingOption) int
 	getFlags() BGPAttrFlag
 	GetType() BGPAttrType
 	String() string
@@ -3255,7 +3257,7 @@ type PathAttribute struct {
 	Value  []byte
 }
 
-func (p *PathAttribute) Len() int {
+func (p *PathAttribute) Len(options ...MarshallingOption) int {
 	if p.Length == 0 {
 		p.Length = uint16(len(p.Value))
 	}
@@ -3276,7 +3278,7 @@ func (p *PathAttribute) GetType() BGPAttrType {
 	return p.Type
 }
 
-func (p *PathAttribute) DecodeFromBytes(data []byte) error {
+func (p *PathAttribute) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	odata := data
 	eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
 	eSubCode := uint8(BGP_ERROR_SUB_ATTRIBUTE_LENGTH_ERROR)
@@ -3308,19 +3310,19 @@ func (p *PathAttribute) DecodeFromBytes(data []byte) error {
 
 	ok, eMsg := ValidateFlags(p.Type, p.Flags)
 	if !ok {
-		return NewMessageError(eCode, BGP_ERROR_SUB_ATTRIBUTE_FLAGS_ERROR, odata[:p.Len()], eMsg)
+		return NewMessageError(eCode, BGP_ERROR_SUB_ATTRIBUTE_FLAGS_ERROR, odata[:p.Len(options...)], eMsg)
 	}
 	return nil
 }
 
-func (p *PathAttribute) Serialize() ([]byte, error) {
+func (p *PathAttribute) Serialize(options ...MarshallingOption) ([]byte, error) {
 	p.Length = uint16(len(p.Value))
 	if p.Length > 255 {
 		p.Flags |= BGP_ATTR_FLAG_EXTENDED_LENGTH
 	} else {
 		p.Flags &^= BGP_ATTR_FLAG_EXTENDED_LENGTH
 	}
-	buf := make([]byte, p.Len())
+	buf := make([]byte, p.Len(options...))
 	buf[0] = uint8(p.Flags)
 	buf[1] = uint8(p.Type)
 	if p.Flags&BGP_ATTR_FLAG_EXTENDED_LENGTH != 0 {
@@ -3637,8 +3639,8 @@ type PathAttributeAsPath struct {
 	Value []AsPathParamInterface
 }
 
-func (p *PathAttributeAsPath) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeAsPath) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -3648,7 +3650,7 @@ func (p *PathAttributeAsPath) DecodeFromBytes(data []byte) error {
 	}
 	as4Bytes, err := p.DefaultAsPath.isValidAspath(p.PathAttribute.Value)
 	if err != nil {
-		err.(*MessageError).Data = data[:p.Len()]
+		err.(*MessageError).Data = data[:p.Len(options...)]
 		return err
 	}
 	v := p.PathAttribute.Value
@@ -3672,7 +3674,7 @@ func (p *PathAttributeAsPath) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *PathAttributeAsPath) Serialize() ([]byte, error) {
+func (p *PathAttributeAsPath) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 0)
 	for _, v := range p.Value {
 		vbuf, err := v.Serialize()
@@ -3682,7 +3684,7 @@ func (p *PathAttributeAsPath) Serialize() ([]byte, error) {
 		buf = append(buf, vbuf...)
 	}
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func (p *PathAttributeAsPath) String() string {
@@ -3719,8 +3721,8 @@ type PathAttributeNextHop struct {
 	Value net.IP
 }
 
-func (p *PathAttributeNextHop) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeNextHop) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -3733,9 +3735,9 @@ func (p *PathAttributeNextHop) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *PathAttributeNextHop) Serialize() ([]byte, error) {
+func (p *PathAttributeNextHop) Serialize(options ...MarshallingOption) ([]byte, error) {
 	p.PathAttribute.Value = p.Value
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func (p *PathAttributeNextHop) String() string {
@@ -3772,8 +3774,8 @@ type PathAttributeMultiExitDisc struct {
 	Value uint32
 }
 
-func (p *PathAttributeMultiExitDisc) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeMultiExitDisc) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -3786,11 +3788,11 @@ func (p *PathAttributeMultiExitDisc) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *PathAttributeMultiExitDisc) Serialize() ([]byte, error) {
+func (p *PathAttributeMultiExitDisc) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 4)
 	binary.BigEndian.PutUint32(buf, p.Value)
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func (p *PathAttributeMultiExitDisc) String() string {
@@ -3823,8 +3825,8 @@ type PathAttributeLocalPref struct {
 	Value uint32
 }
 
-func (p *PathAttributeLocalPref) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeLocalPref) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -3837,11 +3839,11 @@ func (p *PathAttributeLocalPref) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *PathAttributeLocalPref) Serialize() ([]byte, error) {
+func (p *PathAttributeLocalPref) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 4)
 	binary.BigEndian.PutUint32(buf, p.Value)
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func (p *PathAttributeLocalPref) String() string {
@@ -3906,8 +3908,8 @@ type PathAttributeAggregator struct {
 	Value PathAttributeAggregatorParam
 }
 
-func (p *PathAttributeAggregator) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeAggregator) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -3928,7 +3930,7 @@ func (p *PathAttributeAggregator) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *PathAttributeAggregator) Serialize() ([]byte, error) {
+func (p *PathAttributeAggregator) Serialize(options ...MarshallingOption) ([]byte, error) {
 	var buf []byte
 	switch p.Value.askind {
 	case reflect.Uint16:
@@ -3942,7 +3944,7 @@ func (p *PathAttributeAggregator) Serialize() ([]byte, error) {
 	}
 
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func (p *PathAttributeAggregator) String() string {
@@ -3982,8 +3984,8 @@ type PathAttributeCommunities struct {
 	Value []uint32
 }
 
-func (p *PathAttributeCommunities) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeCommunities) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -4000,13 +4002,13 @@ func (p *PathAttributeCommunities) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *PathAttributeCommunities) Serialize() ([]byte, error) {
+func (p *PathAttributeCommunities) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, len(p.Value)*4)
 	for i, v := range p.Value {
 		binary.BigEndian.PutUint32(buf[i*4:], v)
 	}
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 type WellKnownCommunity uint32
@@ -4099,8 +4101,8 @@ type PathAttributeOriginatorId struct {
 	Value net.IP
 }
 
-func (p *PathAttributeOriginatorId) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeOriginatorId) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -4127,11 +4129,11 @@ func (p *PathAttributeOriginatorId) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (p *PathAttributeOriginatorId) Serialize() ([]byte, error) {
+func (p *PathAttributeOriginatorId) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 4)
 	copy(buf, p.Value)
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func NewPathAttributeOriginatorId(value string) *PathAttributeOriginatorId {
@@ -4151,8 +4153,8 @@ type PathAttributeClusterList struct {
 	Value []net.IP
 }
 
-func (p *PathAttributeClusterList) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeClusterList) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -4169,13 +4171,13 @@ func (p *PathAttributeClusterList) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *PathAttributeClusterList) Serialize() ([]byte, error) {
+func (p *PathAttributeClusterList) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, len(p.Value)*4)
 	for i, v := range p.Value {
 		copy(buf[i*4:], v)
 	}
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func (p *PathAttributeClusterList) String() string {
@@ -4221,8 +4223,8 @@ type PathAttributeMpReachNLRI struct {
 	Value            []AddrPrefixInterface
 }
 
-func (p *PathAttributeMpReachNLRI) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeMpReachNLRI) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -4239,7 +4241,7 @@ func (p *PathAttributeMpReachNLRI) DecodeFromBytes(data []byte) error {
 	p.SAFI = safi
 	_, err = NewPrefixFromRouteFamily(afi, safi)
 	if err != nil {
-		return NewMessageError(eCode, BGP_ERROR_SUB_ATTRIBUTE_FLAGS_ERROR, data[:p.PathAttribute.Len()], err.Error())
+		return NewMessageError(eCode, BGP_ERROR_SUB_ATTRIBUTE_FLAGS_ERROR, data[:p.PathAttribute.Len(options...)], err.Error())
 	}
 	nexthopLen := value[3]
 	if len(value) < 4+int(nexthopLen) {
@@ -4278,22 +4280,22 @@ func (p *PathAttributeMpReachNLRI) DecodeFromBytes(data []byte) error {
 	for len(value) > 0 {
 		prefix, err := NewPrefixFromRouteFamily(afi, safi)
 		if err != nil {
-			return NewMessageError(eCode, BGP_ERROR_SUB_ATTRIBUTE_FLAGS_ERROR, data[:p.PathAttribute.Len()], err.Error())
+			return NewMessageError(eCode, BGP_ERROR_SUB_ATTRIBUTE_FLAGS_ERROR, data[:p.PathAttribute.Len(options...)], err.Error())
 		}
-		err = prefix.DecodeFromBytes(value)
+		err = prefix.DecodeFromBytes(value, options...)
 		if err != nil {
 			return err
 		}
-		if prefix.Len() > len(value) {
+		if prefix.Len(options...) > len(value) {
 			return NewMessageError(eCode, eSubCode, value, "prefix length is incorrect")
 		}
-		value = value[prefix.Len():]
+		value = value[prefix.Len(options...):]
 		p.Value = append(p.Value, prefix)
 	}
 	return nil
 }
 
-func (p *PathAttributeMpReachNLRI) Serialize() ([]byte, error) {
+func (p *PathAttributeMpReachNLRI) Serialize(options ...MarshallingOption) ([]byte, error) {
 	afi := p.AFI
 	safi := p.SAFI
 	nexthoplen := 4
@@ -4321,14 +4323,14 @@ func (p *PathAttributeMpReachNLRI) Serialize() ([]byte, error) {
 	}
 	buf = append(buf, make([]byte, 1)...)
 	for _, prefix := range p.Value {
-		pbuf, err := prefix.Serialize()
+		pbuf, err := prefix.Serialize(options...)
 		if err != nil {
 			return nil, err
 		}
 		buf = append(buf, pbuf...)
 	}
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func (p *PathAttributeMpReachNLRI) MarshalJSON() ([]byte, error) {
@@ -4386,8 +4388,8 @@ type PathAttributeMpUnreachNLRI struct {
 	Value []AddrPrefixInterface
 }
 
-func (p *PathAttributeMpUnreachNLRI) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeMpUnreachNLRI) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -4402,7 +4404,7 @@ func (p *PathAttributeMpUnreachNLRI) DecodeFromBytes(data []byte) error {
 	safi := value[2]
 	_, err = NewPrefixFromRouteFamily(afi, safi)
 	if err != nil {
-		return NewMessageError(eCode, BGP_ERROR_SUB_ATTRIBUTE_FLAGS_ERROR, data[:p.PathAttribute.Len()], err.Error())
+		return NewMessageError(eCode, BGP_ERROR_SUB_ATTRIBUTE_FLAGS_ERROR, data[:p.PathAttribute.Len(options...)], err.Error())
 	}
 	value = value[3:]
 	p.AFI = afi
@@ -4410,34 +4412,34 @@ func (p *PathAttributeMpUnreachNLRI) DecodeFromBytes(data []byte) error {
 	for len(value) > 0 {
 		prefix, err := NewPrefixFromRouteFamily(afi, safi)
 		if err != nil {
-			return NewMessageError(eCode, BGP_ERROR_SUB_ATTRIBUTE_FLAGS_ERROR, data[:p.PathAttribute.Len()], err.Error())
+			return NewMessageError(eCode, BGP_ERROR_SUB_ATTRIBUTE_FLAGS_ERROR, data[:p.PathAttribute.Len(options...)], err.Error())
 		}
-		err = prefix.DecodeFromBytes(value)
+		err = prefix.DecodeFromBytes(value, options...)
 		if err != nil {
 			return err
 		}
-		if prefix.Len() > len(value) {
-			return NewMessageError(eCode, eSubCode, data[:p.PathAttribute.Len()], "prefix length is incorrect")
+		if prefix.Len(options...) > len(value) {
+			return NewMessageError(eCode, eSubCode, data[:p.PathAttribute.Len(options...)], "prefix length is incorrect")
 		}
-		value = value[prefix.Len():]
+		value = value[prefix.Len(options...):]
 		p.Value = append(p.Value, prefix)
 	}
 	return nil
 }
 
-func (p *PathAttributeMpUnreachNLRI) Serialize() ([]byte, error) {
+func (p *PathAttributeMpUnreachNLRI) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 3)
 	binary.BigEndian.PutUint16(buf, p.AFI)
 	buf[2] = p.SAFI
 	for _, prefix := range p.Value {
-		pbuf, err := prefix.Serialize()
+		pbuf, err := prefix.Serialize(options...)
 		if err != nil {
 			return nil, err
 		}
 		buf = append(buf, pbuf...)
 	}
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func NewPathAttributeMpUnreachNLRI(nlri []AddrPrefixInterface) *PathAttributeMpUnreachNLRI {
@@ -5411,8 +5413,8 @@ func ParseExtended(data []byte) (ExtendedCommunityInterface, error) {
 	}
 }
 
-func (p *PathAttributeExtendedCommunities) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeExtendedCommunities) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -5433,7 +5435,7 @@ func (p *PathAttributeExtendedCommunities) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *PathAttributeExtendedCommunities) Serialize() ([]byte, error) {
+func (p *PathAttributeExtendedCommunities) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 0)
 	for _, p := range p.Value {
 		ebuf, err := p.Serialize()
@@ -5443,7 +5445,7 @@ func (p *PathAttributeExtendedCommunities) Serialize() ([]byte, error) {
 		buf = append(buf, ebuf...)
 	}
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func (p *PathAttributeExtendedCommunities) String() string {
@@ -5486,8 +5488,8 @@ type PathAttributeAs4Path struct {
 	DefaultAsPath
 }
 
-func (p *PathAttributeAs4Path) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeAs4Path) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -5513,7 +5515,7 @@ func (p *PathAttributeAs4Path) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *PathAttributeAs4Path) Serialize() ([]byte, error) {
+func (p *PathAttributeAs4Path) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 0)
 	for _, v := range p.Value {
 		vbuf, err := v.Serialize()
@@ -5523,7 +5525,7 @@ func (p *PathAttributeAs4Path) Serialize() ([]byte, error) {
 		buf = append(buf, vbuf...)
 	}
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func (p *PathAttributeAs4Path) String() string {
@@ -5550,8 +5552,8 @@ type PathAttributeAs4Aggregator struct {
 	Value PathAttributeAggregatorParam
 }
 
-func (p *PathAttributeAs4Aggregator) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeAs4Aggregator) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -5565,12 +5567,12 @@ func (p *PathAttributeAs4Aggregator) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *PathAttributeAs4Aggregator) Serialize() ([]byte, error) {
+func (p *PathAttributeAs4Aggregator) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 8)
 	binary.BigEndian.PutUint32(buf[0:], p.Value.AS)
 	copy(buf[4:], p.Value.Address.To4())
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func NewPathAttributeAs4Aggregator(as uint32, address string) *PathAttributeAs4Aggregator {
@@ -5731,8 +5733,8 @@ type PathAttributeTunnelEncap struct {
 	Value []*TunnelEncapTLV
 }
 
-func (p *PathAttributeTunnelEncap) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeTunnelEncap) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -5762,7 +5764,7 @@ func (p *PathAttributeTunnelEncap) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *PathAttributeTunnelEncap) Serialize() ([]byte, error) {
+func (p *PathAttributeTunnelEncap) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 0)
 	for _, t := range p.Value {
 		bbuf, err := t.Serialize()
@@ -5772,7 +5774,7 @@ func (p *PathAttributeTunnelEncap) Serialize() ([]byte, error) {
 		buf = append(buf, bbuf...)
 	}
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func NewPathAttributeTunnelEncap(value []*TunnelEncapTLV) *PathAttributeTunnelEncap {
@@ -5826,8 +5828,8 @@ type PathAttributePmsiTunnel struct {
 	TunnelID           PmsiTunnelIDInterface
 }
 
-func (p *PathAttributePmsiTunnel) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributePmsiTunnel) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -5852,7 +5854,7 @@ func (p *PathAttributePmsiTunnel) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *PathAttributePmsiTunnel) Serialize() ([]byte, error) {
+func (p *PathAttributePmsiTunnel) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 2)
 	if p.IsLeafInfoRequired {
 		buf[0] = 0x01
@@ -5867,7 +5869,7 @@ func (p *PathAttributePmsiTunnel) Serialize() ([]byte, error) {
 	}
 	buf = append(buf, ibuf...)
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func (p *PathAttributePmsiTunnel) String() string {
@@ -5996,8 +5998,8 @@ type PathAttributeAigp struct {
 	Values []AigpTLV
 }
 
-func (p *PathAttributeAigp) DecodeFromBytes(data []byte) error {
-	err := p.PathAttribute.DecodeFromBytes(data)
+func (p *PathAttributeAigp) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
+	err := p.PathAttribute.DecodeFromBytes(data, options...)
 	if err != nil {
 		return err
 	}
@@ -6036,7 +6038,7 @@ func (p *PathAttributeAigp) DecodeFromBytes(data []byte) error {
 	return NewMessageError(eCode, eSubCode, nil, "Aigp length is incorrect")
 }
 
-func (p *PathAttributeAigp) Serialize() ([]byte, error) {
+func (p *PathAttributeAigp) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 0)
 	for _, t := range p.Values {
 		bbuf, err := t.Serialize()
@@ -6046,7 +6048,7 @@ func (p *PathAttributeAigp) Serialize() ([]byte, error) {
 		buf = append(buf, bbuf...)
 	}
 	p.PathAttribute.Value = buf
-	return p.PathAttribute.Serialize()
+	return p.PathAttribute.Serialize(options...)
 }
 
 func (p *PathAttributeAigp) String() string {
@@ -6139,7 +6141,7 @@ type BGPUpdate struct {
 	NLRI                  []*IPAddrPrefix
 }
 
-func (msg *BGPUpdate) DecodeFromBytes(data []byte) error {
+func (msg *BGPUpdate) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 
 	// cache error codes
 	eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
@@ -6161,15 +6163,15 @@ func (msg *BGPUpdate) DecodeFromBytes(data []byte) error {
 	msg.WithdrawnRoutes = make([]*IPAddrPrefix, 0, msg.WithdrawnRoutesLen)
 	for routelen := msg.WithdrawnRoutesLen; routelen > 0; {
 		w := &IPAddrPrefix{}
-		err := w.DecodeFromBytes(data)
+		err := w.DecodeFromBytes(data, options...)
 		if err != nil {
 			return err
 		}
-		routelen -= uint16(w.Len())
-		if len(data) < w.Len() {
+		routelen -= uint16(w.Len(options...))
+		if len(data) < w.Len(options...) {
 			return NewMessageError(eCode, eSubCode, nil, "Withdrawn route length is short")
 		}
-		data = data[w.Len():]
+		data = data[w.Len(options...):]
 		msg.WithdrawnRoutes = append(msg.WithdrawnRoutes, w)
 	}
 
@@ -6192,40 +6194,40 @@ func (msg *BGPUpdate) DecodeFromBytes(data []byte) error {
 		if err != nil {
 			return err
 		}
-		err = p.DecodeFromBytes(data)
+		err = p.DecodeFromBytes(data, options...)
 		if err != nil {
 			return err
 		}
-		pathlen -= uint16(p.Len())
-		if len(data) < p.Len() {
+		pathlen -= uint16(p.Len(options...))
+		if len(data) < p.Len(options...) {
 			return NewMessageError(eCode, BGP_ERROR_SUB_ATTRIBUTE_LENGTH_ERROR, data, "attribute length is short")
 		}
-		data = data[p.Len():]
+		data = data[p.Len(options...):]
 		msg.PathAttributes = append(msg.PathAttributes, p)
 	}
 
 	msg.NLRI = make([]*IPAddrPrefix, 0)
 	for restlen := len(data); restlen > 0; {
 		n := &IPAddrPrefix{}
-		err := n.DecodeFromBytes(data)
+		err := n.DecodeFromBytes(data, options...)
 		if err != nil {
 			return err
 		}
-		restlen -= n.Len()
-		if len(data) < n.Len() {
+		restlen -= n.Len(options...)
+		if len(data) < n.Len(options...) {
 			return NewMessageError(eCode, BGP_ERROR_SUB_INVALID_NETWORK_FIELD, nil, "NLRI length is short")
 		}
-		data = data[n.Len():]
+		data = data[n.Len(options...):]
 		msg.NLRI = append(msg.NLRI, n)
 	}
 
 	return nil
 }
 
-func (msg *BGPUpdate) Serialize() ([]byte, error) {
+func (msg *BGPUpdate) Serialize(options ...MarshallingOption) ([]byte, error) {
 	wbuf := make([]byte, 2)
 	for _, w := range msg.WithdrawnRoutes {
-		onewbuf, err := w.Serialize()
+		onewbuf, err := w.Serialize(options...)
 		if err != nil {
 			return nil, err
 		}
@@ -6236,7 +6238,7 @@ func (msg *BGPUpdate) Serialize() ([]byte, error) {
 
 	pbuf := make([]byte, 2)
 	for _, p := range msg.PathAttributes {
-		onepbuf, err := p.Serialize()
+		onepbuf, err := p.Serialize(options...)
 		if err != nil {
 			return nil, err
 		}
@@ -6247,7 +6249,7 @@ func (msg *BGPUpdate) Serialize() ([]byte, error) {
 
 	buf := append(wbuf, pbuf...)
 	for _, n := range msg.NLRI {
-		nbuf, err := n.Serialize()
+		nbuf, err := n.Serialize(options...)
 		if err != nil {
 			return nil, err
 		}
@@ -6294,7 +6296,7 @@ type BGPNotification struct {
 	Data         []byte
 }
 
-func (msg *BGPNotification) DecodeFromBytes(data []byte) error {
+func (msg *BGPNotification) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	if len(data) < 2 {
 		return fmt.Errorf("Not all Notificaiton bytes available")
 	}
@@ -6306,7 +6308,7 @@ func (msg *BGPNotification) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (msg *BGPNotification) Serialize() ([]byte, error) {
+func (msg *BGPNotification) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 2)
 	buf[0] = msg.ErrorCode
 	buf[1] = msg.ErrorSubcode
@@ -6324,11 +6326,11 @@ func NewBGPNotificationMessage(errcode uint8, errsubcode uint8, data []byte) *BG
 type BGPKeepAlive struct {
 }
 
-func (msg *BGPKeepAlive) DecodeFromBytes(data []byte) error {
+func (msg *BGPKeepAlive) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	return nil
 }
 
-func (msg *BGPKeepAlive) Serialize() ([]byte, error) {
+func (msg *BGPKeepAlive) Serialize(options ...MarshallingOption) ([]byte, error) {
 	return nil, nil
 }
 
@@ -6345,7 +6347,7 @@ type BGPRouteRefresh struct {
 	SAFI        uint8
 }
 
-func (msg *BGPRouteRefresh) DecodeFromBytes(data []byte) error {
+func (msg *BGPRouteRefresh) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	if len(data) < 4 {
 		return fmt.Errorf("Not all RouteRefresh bytes available")
 	}
@@ -6355,7 +6357,7 @@ func (msg *BGPRouteRefresh) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (msg *BGPRouteRefresh) Serialize() ([]byte, error) {
+func (msg *BGPRouteRefresh) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 4)
 	binary.BigEndian.PutUint16(buf[0:2], msg.AFI)
 	buf[2] = msg.Demarcation
@@ -6371,8 +6373,8 @@ func NewBGPRouteRefreshMessage(afi uint16, demarcation uint8, safi uint8) *BGPMe
 }
 
 type BGPBody interface {
-	DecodeFromBytes([]byte) error
-	Serialize() ([]byte, error)
+	DecodeFromBytes([]byte, ...MarshallingOption) error
+	Serialize(...MarshallingOption) ([]byte, error)
 }
 
 const (
@@ -6386,7 +6388,7 @@ type BGPHeader struct {
 	Type   uint8
 }
 
-func (msg *BGPHeader) DecodeFromBytes(data []byte) error {
+func (msg *BGPHeader) DecodeFromBytes(data []byte, options ...MarshallingOption) error {
 	// minimum BGP message length
 	if uint16(len(data)) < BGP_HEADER_LENGTH {
 		return fmt.Errorf("Not all BGP message header")
@@ -6399,7 +6401,7 @@ func (msg *BGPHeader) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (msg *BGPHeader) Serialize() ([]byte, error) {
+func (msg *BGPHeader) Serialize(options ...MarshallingOption) ([]byte, error) {
 	buf := make([]byte, 19)
 	for i, _ := range buf[:16] {
 		buf[i] = 0xff
@@ -6414,7 +6416,7 @@ type BGPMessage struct {
 	Body   BGPBody
 }
 
-func parseBody(h *BGPHeader, data []byte) (*BGPMessage, error) {
+func parseBody(h *BGPHeader, data []byte, options ...MarshallingOption) (*BGPMessage, error) {
 	if len(data) < int(h.Len)-BGP_HEADER_LENGTH {
 		return nil, fmt.Errorf("Not all BGP message bytes available")
 	}
@@ -6434,28 +6436,28 @@ func parseBody(h *BGPHeader, data []byte) (*BGPMessage, error) {
 	default:
 		return nil, NewMessageError(BGP_ERROR_MESSAGE_HEADER_ERROR, BGP_ERROR_SUB_BAD_MESSAGE_TYPE, nil, "unknown message type")
 	}
-	err := msg.Body.DecodeFromBytes(data)
+	err := msg.Body.DecodeFromBytes(data, options...)
 	if err != nil {
 		return nil, err
 	}
 	return msg, nil
 }
 
-func ParseBGPMessage(data []byte) (*BGPMessage, error) {
+func ParseBGPMessage(data []byte, options ...MarshallingOption) (*BGPMessage, error) {
 	h := &BGPHeader{}
-	err := h.DecodeFromBytes(data)
+	err := h.DecodeFromBytes(data, options...)
 	if err != nil {
 		return nil, err
 	}
-	return parseBody(h, data[19:h.Len])
+	return parseBody(h, data[19:h.Len], options...)
 }
 
-func ParseBGPBody(h *BGPHeader, data []byte) (*BGPMessage, error) {
-	return parseBody(h, data)
+func ParseBGPBody(h *BGPHeader, data []byte, options ...MarshallingOption) (*BGPMessage, error) {
+	return parseBody(h, data, options...)
 }
 
-func (msg *BGPMessage) Serialize() ([]byte, error) {
-	b, err := msg.Body.Serialize()
+func (msg *BGPMessage) Serialize(options ...MarshallingOption) ([]byte, error) {
+	b, err := msg.Body.Serialize(options...)
 	if err != nil {
 		return nil, err
 	}
@@ -6465,7 +6467,7 @@ func (msg *BGPMessage) Serialize() ([]byte, error) {
 		}
 		msg.Header.Len = 19 + uint16(len(b))
 	}
-	h, err := msg.Header.Serialize()
+	h, err := msg.Header.Serialize(options...)
 	if err != nil {
 		return nil, err
 	}

--- a/packet/bgp_test.go
+++ b/packet/bgp_test.go
@@ -43,22 +43,22 @@ func update() *BGPMessage {
 	w2 := NewIPAddrPrefix(17, "100.33.3.0")
 	w := []*IPAddrPrefix{w1, w2}
 
-	aspath1 := []AsPathParamInterface{
-		NewAsPathParam(2, []uint16{1000}),
-		NewAsPathParam(1, []uint16{1001, 1002}),
-		NewAsPathParam(2, []uint16{1003, 1004}),
+	aspath1 := []*AsPathParam{
+		NewAsPathParam(2, []uint32{1000}),
+		NewAsPathParam(1, []uint32{1001, 1002}),
+		NewAsPathParam(2, []uint32{1003, 1004}),
 	}
 
-	aspath2 := []AsPathParamInterface{
-		NewAs4PathParam(2, []uint32{1000000}),
-		NewAs4PathParam(1, []uint32{1000001, 1002}),
-		NewAs4PathParam(2, []uint32{1003, 100004}),
+	aspath2 := []*AsPathParam{
+		NewAsPathParam(2, []uint32{1000000}),
+		NewAsPathParam(1, []uint32{1000001, 1002}),
+		NewAsPathParam(2, []uint32{1003, 100004}),
 	}
 
-	aspath3 := []*As4PathParam{
-		NewAs4PathParam(2, []uint32{1000000}),
-		NewAs4PathParam(1, []uint32{1000001, 1002}),
-		NewAs4PathParam(2, []uint32{1003, 100004}),
+	aspath3 := []*AsPathParam{
+		NewAsPathParam(2, []uint32{1000000}),
+		NewAsPathParam(1, []uint32{1000001, 1002}),
+		NewAsPathParam(2, []uint32{1003, 100004}),
 	}
 
 	isTransitive := true
@@ -122,7 +122,7 @@ func update() *BGPMessage {
 		NewPathAttributeMultiExitDisc(1 << 20),
 		NewPathAttributeLocalPref(1 << 22),
 		NewPathAttributeAtomicAggregate(),
-		NewPathAttributeAggregator(uint16(30002), "129.0.2.99"),
+		NewPathAttributeAggregator(uint32(30002), "129.0.2.99"),
 		NewPathAttributeAggregator(uint32(30002), "129.0.2.99"),
 		NewPathAttributeAggregator(uint32(300020), "129.0.2.99"),
 		NewPathAttributeCommunities([]uint32{1, 3}),
@@ -342,7 +342,7 @@ func Test_ASLen(t *testing.T) {
 
 	aspath := AsPathParam{
 		Num: 2,
-		AS:  []uint16{65000, 65001},
+		AS:  []uint32{65000, 65001},
 	}
 	aspath.Type = BGP_ASPATH_ATTR_TYPE_SEQ
 	assert.Equal(2, aspath.ASLen())
@@ -356,7 +356,7 @@ func Test_ASLen(t *testing.T) {
 	aspath.Type = BGP_ASPATH_ATTR_TYPE_CONFED_SET
 	assert.Equal(0, aspath.ASLen())
 
-	as4path := As4PathParam{
+	as4path := AsPathParam{
 		Num: 2,
 		AS:  []uint32{65000, 65001},
 	}

--- a/packet/mrt_test.go
+++ b/packet/mrt_test.go
@@ -99,10 +99,10 @@ func TestMrtPeerIndexTable(t *testing.T) {
 }
 
 func TestMrtRibEntry(t *testing.T) {
-	aspath1 := []AsPathParamInterface{
-		NewAsPathParam(2, []uint16{1000}),
-		NewAsPathParam(1, []uint16{1001, 1002}),
-		NewAsPathParam(2, []uint16{1003, 1004}),
+	aspath1 := []*AsPathParam{
+		NewAsPathParam(2, []uint32{1000}),
+		NewAsPathParam(1, []uint32{1001, 1002}),
+		NewAsPathParam(2, []uint32{1003, 1004}),
 	}
 
 	p := []PathAttributeInterface{
@@ -129,10 +129,10 @@ func TestMrtRibEntry(t *testing.T) {
 }
 
 func TestMrtRib(t *testing.T) {
-	aspath1 := []AsPathParamInterface{
-		NewAsPathParam(2, []uint16{1000}),
-		NewAsPathParam(1, []uint16{1001, 1002}),
-		NewAsPathParam(2, []uint16{1003, 1004}),
+	aspath1 := []*AsPathParam{
+		NewAsPathParam(2, []uint32{1000}),
+		NewAsPathParam(1, []uint32{1001, 1002}),
+		NewAsPathParam(2, []uint32{1003, 1004}),
 	}
 
 	p := []PathAttributeInterface{

--- a/packet/validate.go
+++ b/packet/validate.go
@@ -122,15 +122,8 @@ func ValidateAttribute(a PathAttributeInterface, rfs map[RouteFamily]bool, doCon
 		}
 	case *PathAttributeAsPath:
 		if doConfedCheck {
-			for _, paramIf := range p.Value {
-				var segType uint8
-				asParam, y := paramIf.(*As4PathParam)
-				if y {
-					segType = asParam.Type
-				} else {
-					segType = paramIf.(*AsPathParam).Type
-				}
-
+			for _, asParam := range p.Value {
+				segType := asParam.Type
 				if segType == BGP_ASPATH_ATTR_TYPE_CONFED_SET || segType == BGP_ASPATH_ATTR_TYPE_CONFED_SEQ {
 					return false, NewMessageError(eCode, eSubCodeMalformedAspath, nil, fmt.Sprintf("segment type confederation(%d) found", segType))
 				}

--- a/packet/validate_test.go
+++ b/packet/validate_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func bgpupdate() *BGPMessage {
-	aspath := []AsPathParamInterface{
-		NewAsPathParam(2, []uint16{65001}),
+	aspath := []*AsPathParam{
+		NewAsPathParam(2, []uint32{65001}),
 	}
 
 	p := []PathAttributeInterface{
@@ -23,8 +23,8 @@ func bgpupdate() *BGPMessage {
 }
 
 func bgpupdateV6() *BGPMessage {
-	aspath := []AsPathParamInterface{
-		NewAsPathParam(2, []uint16{65001}),
+	aspath := []*AsPathParam{
+		NewAsPathParam(2, []uint32{65001}),
 	}
 
 	mp_nlri := []AddrPrefixInterface{NewIPv6AddrPrefix(100,
@@ -300,8 +300,8 @@ func Test_Validate_aspath(t *testing.T) {
 	attrs := message.PathAttributes
 	for _, attr := range attrs {
 		if _, y := attr.(*PathAttributeAsPath); y {
-			aspath := []AsPathParamInterface{
-				NewAsPathParam(BGP_ASPATH_ATTR_TYPE_CONFED_SET, []uint16{65001}),
+			aspath := []*AsPathParam{
+				NewAsPathParam(BGP_ASPATH_ATTR_TYPE_CONFED_SET, []uint32{65001}),
 			}
 			newAttrs = append(newAttrs, NewPathAttributeAsPath(aspath))
 		} else {
@@ -323,8 +323,8 @@ func Test_Validate_aspath(t *testing.T) {
 	attrs = message.PathAttributes
 	for _, attr := range attrs {
 		if _, y := attr.(*PathAttributeAsPath); y {
-			aspath := []AsPathParamInterface{
-				NewAsPathParam(BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint16{65001}),
+			aspath := []*AsPathParam{
+				NewAsPathParam(BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint32{65001}),
 			}
 			newAttrs = append(newAttrs, NewPathAttributeAsPath(aspath))
 		} else {

--- a/server/rpki.go
+++ b/server/rpki.go
@@ -509,7 +509,7 @@ func validatePath(ownAs uint32, tree *radix.Tree, cidr string, asPath *bgp.PathA
 	if asPath == nil || len(asPath.Value) == 0 {
 		return config.RPKI_VALIDATION_RESULT_TYPE_NOT_FOUND, []*ROA{}
 	}
-	asParam := asPath.Value[len(asPath.Value)-1].(*bgp.As4PathParam)
+	asParam := asPath.Value[len(asPath.Value)-1]
 	switch asParam.Type {
 	case bgp.BGP_ASPATH_ATTR_TYPE_SEQ:
 		if len(asParam.AS) == 0 {

--- a/server/rpki_test.go
+++ b/server/rpki_test.go
@@ -49,7 +49,7 @@ func strToASParam(str string) *bgp.PathAttributeAsPath {
 		as = toList(str, " ")
 	}
 
-	return bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(atype, as)})
+	return bgp.NewPathAttributeAsPath([]*bgp.AsPathParam{bgp.NewAsPathParam(atype, as)})
 }
 
 func validateOne(tree *radix.Tree, cidr, aspathStr string) config.RpkiValidationResultType {

--- a/server/server.go
+++ b/server/server.go
@@ -40,7 +40,6 @@ type SenderMsg struct {
 	messages    []*bgp.BGPMessage
 	sendCh      chan *bgp.BGPMessage
 	destination string
-	twoBytesAs  bool
 }
 
 type broadcastMsg interface {
@@ -223,14 +222,6 @@ func (server *BgpServer) Serve() {
 			}
 
 			for _, b := range m.messages {
-				if m.twoBytesAs == false && b.Header.Type == bgp.BGP_MSG_UPDATE {
-					log.WithFields(log.Fields{
-						"Topic": "Peer",
-						"Key":   m.destination,
-						"Data":  b,
-					}).Debug("update for 2byte AS peer")
-					table.UpdatePathAttrs2ByteAs(b.Body.(*bgp.BGPUpdate))
-				}
 				w(m.sendCh, b)
 			}
 		}
@@ -432,12 +423,10 @@ func (server *BgpServer) Serve() {
 }
 
 func newSenderMsg(peer *Peer, messages []*bgp.BGPMessage) *SenderMsg {
-	_, y := peer.fsm.capMap[bgp.BGP_CAP_FOUR_OCTET_AS_NUMBER]
 	return &SenderMsg{
 		messages:    messages,
 		sendCh:      peer.outgoing,
 		destination: peer.conf.Config.NeighborAddress,
-		twoBytesAs:  y,
 	}
 }
 

--- a/table/destination_test.go
+++ b/table/destination_test.go
@@ -89,7 +89,7 @@ func DestCreatePath(peerD []*PeerInfo) []*Path {
 func updateMsgD1() *bgp.BGPMessage {
 
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65000})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65000})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.50.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -110,7 +110,7 @@ func updateMsgD1() *bgp.BGPMessage {
 func updateMsgD2() *bgp.BGPMessage {
 
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65100})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65100})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.100.1")
 	med := bgp.NewPathAttributeMultiExitDisc(100)
@@ -129,7 +129,7 @@ func updateMsgD2() *bgp.BGPMessage {
 }
 func updateMsgD3() *bgp.BGPMessage {
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65100})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65100})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.150.1")
 	med := bgp.NewPathAttributeMultiExitDisc(100)

--- a/table/message.go
+++ b/table/message.go
@@ -27,11 +27,9 @@ func UpdatePathAttrs2ByteAs(msg *bgp.BGPUpdate) error {
 	msg.PathAttributes = make([]bgp.PathAttributeInterface, len(ps))
 	copy(msg.PathAttributes, ps)
 	var asAttr *bgp.PathAttributeAsPath
-	idx := 0
-	for i, attr := range msg.PathAttributes {
+	for _, attr := range msg.PathAttributes {
 		if a, ok := attr.(*bgp.PathAttributeAsPath); ok {
 			asAttr = a
-			idx = i
 			break
 		}
 	}
@@ -40,32 +38,24 @@ func UpdatePathAttrs2ByteAs(msg *bgp.BGPUpdate) error {
 		return nil
 	}
 
-	as4Params := make([]*bgp.As4PathParam, 0, len(asAttr.Value))
-	as2Params := make([]bgp.AsPathParamInterface, 0, len(asAttr.Value))
+	as4Params := make([]*bgp.AsPathParam, 0, len(asAttr.Value))
 	mkAs4 := false
 	for _, param := range asAttr.Value {
-		as4Param := param.(*bgp.As4PathParam)
-		as2Path := make([]uint16, 0, len(as4Param.AS))
-		for _, as := range as4Param.AS {
+		for _, as := range param.AS {
 			if as > (1<<16)-1 {
 				mkAs4 = true
-				as2Path = append(as2Path, bgp.AS_TRANS)
-			} else {
-				as2Path = append(as2Path, uint16(as))
+				break
 			}
 		}
-		as2Params = append(as2Params, bgp.NewAsPathParam(as4Param.Type, as2Path))
-
 		// RFC 6793 4.2.2 Generating Updates
 		//
 		// Whenever the AS path information contains the AS_CONFED_SEQUENCE or
 		// AS_CONFED_SET path segment, the NEW BGP speaker MUST exclude such
 		// path segments from the AS4_PATH attribute being constructed.
-		if as4Param.Type != bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ && as4Param.Type != bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET {
-			as4Params = append(as4Params, as4Param)
+		if param.Type != bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ && param.Type != bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET {
+			as4Params = append(as4Params, param)
 		}
 	}
-	msg.PathAttributes[idx] = bgp.NewPathAttributeAsPath(as2Params)
 	if mkAs4 {
 		msg.PathAttributes = append(msg.PathAttributes, bgp.NewPathAttributeAs4Path(as4Params))
 	}
@@ -80,20 +70,8 @@ func UpdatePathAttrs4ByteAs(msg *bgp.BGPUpdate) error {
 	for i, attr := range msg.PathAttributes {
 		switch attr.(type) {
 		case *bgp.PathAttributeAsPath:
-			asAttr = attr.(*bgp.PathAttributeAsPath)
-			for j, param := range asAttr.Value {
-				as2Param, ok := param.(*bgp.AsPathParam)
-				if ok {
-					asPath := make([]uint32, 0, len(as2Param.AS))
-					for _, as := range as2Param.AS {
-						asPath = append(asPath, uint32(as))
-					}
-					as4Param := bgp.NewAs4PathParam(as2Param.Type, asPath)
-					asAttr.Value[j] = as4Param
-				}
-			}
 			asAttrPos = i
-			msg.PathAttributes[i] = asAttr
+			asAttr = attr.(*bgp.PathAttributeAsPath)
 		case *bgp.PathAttributeAs4Path:
 			as4AttrPos = i
 			as4Attr = attr.(*bgp.PathAttributeAs4Path)
@@ -110,21 +88,18 @@ func UpdatePathAttrs4ByteAs(msg *bgp.BGPUpdate) error {
 
 	asLen := 0
 	asConfedLen := 0
-	asParams := make([]*bgp.As4PathParam, 0, len(asAttr.Value))
 	for _, param := range asAttr.Value {
 		asLen += param.ASLen()
-		p := param.(*bgp.As4PathParam)
-		switch p.Type {
+		switch param.Type {
 		case bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET:
 			asConfedLen += 1
 		case bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
-			asConfedLen += len(p.AS)
+			asConfedLen += len(param.AS)
 		}
-		asParams = append(asParams, p)
 	}
 
 	as4Len := 0
-	as4Params := make([]*bgp.As4PathParam, 0, len(as4Attr.Value))
+	as4Params := make([]*bgp.AsPathParam, 0, len(as4Attr.Value))
 	if as4Attr != nil {
 		for _, p := range as4Attr.Value {
 			// RFC 6793 6. Error Handling
@@ -157,8 +132,8 @@ func UpdatePathAttrs4ByteAs(msg *bgp.BGPUpdate) error {
 
 	keepNum := asLen + asConfedLen - as4Len
 
-	newParams := make([]*bgp.As4PathParam, 0, len(asAttr.Value))
-	for _, param := range asParams {
+	newParams := make([]*bgp.AsPathParam, 0, len(asAttr.Value))
+	for _, param := range asAttr.Value {
 		if keepNum-param.ASLen() >= 0 {
 			newParams = append(newParams, param)
 			keepNum -= param.ASLen()
@@ -189,12 +164,7 @@ func UpdatePathAttrs4ByteAs(msg *bgp.BGPUpdate) error {
 		}
 	}
 
-	newIntfParams := make([]bgp.AsPathParamInterface, 0, len(asAttr.Value))
-	for _, p := range newParams {
-		newIntfParams = append(newIntfParams, p)
-	}
-
-	msg.PathAttributes[asAttrPos] = bgp.NewPathAttributeAsPath(newIntfParams)
+	msg.PathAttributes[asAttrPos] = bgp.NewPathAttributeAsPath(newParams)
 	return nil
 }
 

--- a/table/message_test.go
+++ b/table/message_test.go
@@ -29,18 +29,24 @@ import (
 //  as4-path : 65000, 4000, 400000, 300000, 40001
 func TestAsPathAs2Trans1(t *testing.T) {
 	as := []uint32{65000, 4000, 400000, 300000, 40001}
-	params := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
+	params := []*bgp.AsPathParam{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
 	aspath := bgp.NewPathAttributeAsPath(params)
 	msg := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{aspath}, nil).Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs2ByteAs(msg)
 	assert.Equal(t, len(msg.PathAttributes), 2)
 	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value), 1)
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.AsPathParam).AS), 5)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.AsPathParam).AS[0], uint16(65000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.AsPathParam).AS[1], uint16(4000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.AsPathParam).AS[2], uint16(bgp.AS_TRANS))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.AsPathParam).AS[3], uint16(bgp.AS_TRANS))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.AsPathParam).AS[4], uint16(40001))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS), 5)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[0], uint32(65000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[1], uint32(4000))
+	// translate to AS_TRANS when serializing
+	buf, err := msg.PathAttributes[0].Serialize(bgp.AS2Option{})
+	assert.Nil(t, err)
+	attr := bgp.NewPathAttributeAsPath(nil)
+	err = attr.DecodeFromBytes(buf, bgp.AS2Option{})
+	assert.Nil(t, err)
+	assert.Equal(t, attr.Value[0].AS[2], uint32(bgp.AS_TRANS))
+	assert.Equal(t, attr.Value[0].AS[3], uint32(bgp.AS_TRANS))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[4], uint32(40001))
 	assert.Equal(t, len(msg.PathAttributes[1].(*bgp.PathAttributeAs4Path).Value), 1)
 	assert.Equal(t, len(msg.PathAttributes[1].(*bgp.PathAttributeAs4Path).Value[0].AS), 5)
 	assert.Equal(t, msg.PathAttributes[1].(*bgp.PathAttributeAs4Path).Value[0].AS[0], uint32(65000))
@@ -56,18 +62,18 @@ func TestAsPathAs2Trans1(t *testing.T) {
 //  as-path  : 65000, 4000, 40000, 30000, 40001
 func TestAsPathAs2Trans2(t *testing.T) {
 	as := []uint32{65000, 4000, 40000, 30000, 40001}
-	params := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
+	params := []*bgp.AsPathParam{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
 	aspath := bgp.NewPathAttributeAsPath(params)
 	msg := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{aspath}, nil).Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs2ByteAs(msg)
 	assert.Equal(t, len(msg.PathAttributes), 1)
 	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value), 1)
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.AsPathParam).AS), 5)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.AsPathParam).AS[0], uint16(65000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.AsPathParam).AS[1], uint16(4000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.AsPathParam).AS[2], uint16(40000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.AsPathParam).AS[3], uint16(30000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.AsPathParam).AS[4], uint16(40001))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS), 5)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[0], uint32(65000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[1], uint32(4000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[2], uint32(40000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[3], uint32(30000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[4], uint32(40001))
 }
 
 // before:
@@ -76,23 +82,23 @@ func TestAsPathAs2Trans2(t *testing.T) {
 // expected result:
 //  as-path  : 65000, 4000, 400000, 300000, 40001
 func TestAsPathAs4Trans1(t *testing.T) {
-	as := []uint16{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
-	params := []bgp.AsPathParamInterface{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
+	as := []uint32{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
+	params := []*bgp.AsPathParam{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
 	aspath := bgp.NewPathAttributeAsPath(params)
 
 	as4 := []uint32{400000, 300000, 40001}
-	param4s := []*bgp.As4PathParam{bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)}
+	param4s := []*bgp.AsPathParam{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)}
 	as4path := bgp.NewPathAttributeAs4Path(param4s)
 	msg := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{aspath, as4path}, nil).Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(msg)
 	assert.Equal(t, len(msg.PathAttributes), 1)
 	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value), 1)
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS), 5)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[0], uint32(65000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[1], uint32(4000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[2], uint32(400000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[3], uint32(300000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[4], uint32(40001))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS), 5)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[0], uint32(65000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[1], uint32(4000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[2], uint32(400000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[3], uint32(300000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[4], uint32(40001))
 }
 
 // before:
@@ -101,33 +107,33 @@ func TestAsPathAs4Trans1(t *testing.T) {
 // expected result:
 //  as-path  : 65000, 4000, {10, 20, 30}, 400000, 300000, 40001
 func TestAsPathAs4Trans2(t *testing.T) {
-	as1 := []uint16{65000, 4000}
+	as1 := []uint32{65000, 4000}
 	param1 := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as1)
-	as2 := []uint16{10, 20, 30}
+	as2 := []uint32{10, 20, 30}
 	param2 := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, as2)
-	as3 := []uint16{bgp.AS_TRANS, bgp.AS_TRANS, 40001}
+	as3 := []uint32{bgp.AS_TRANS, bgp.AS_TRANS, 40001}
 	param3 := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as3)
-	params := []bgp.AsPathParamInterface{param1, param2, param3}
+	params := []*bgp.AsPathParam{param1, param2, param3}
 	aspath := bgp.NewPathAttributeAsPath(params)
 
 	as4 := []uint32{400000, 300000, 40001}
-	param4s := []*bgp.As4PathParam{bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)}
+	param4s := []*bgp.AsPathParam{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)}
 	as4path := bgp.NewPathAttributeAs4Path(param4s)
 	msg := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{aspath, as4path}, nil).Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(msg)
 	assert.Equal(t, len(msg.PathAttributes), 1)
 	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value), 3)
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS), 2)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[0], uint32(65000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[1], uint32(4000))
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].(*bgp.As4PathParam).AS), 3)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].(*bgp.As4PathParam).AS[0], uint32(10))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].(*bgp.As4PathParam).AS[1], uint32(20))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].(*bgp.As4PathParam).AS[2], uint32(30))
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].(*bgp.As4PathParam).AS), 3)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].(*bgp.As4PathParam).AS[0], uint32(400000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].(*bgp.As4PathParam).AS[1], uint32(300000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].(*bgp.As4PathParam).AS[2], uint32(40001))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS), 2)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[0], uint32(65000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[1], uint32(4000))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].AS), 3)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].AS[0], uint32(10))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].AS[1], uint32(20))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].AS[2], uint32(30))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].AS), 3)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].AS[0], uint32(400000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].AS[1], uint32(300000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].AS[2], uint32(40001))
 }
 
 // before:
@@ -136,29 +142,29 @@ func TestAsPathAs4Trans2(t *testing.T) {
 // expected result:
 //  as-path  : 65000, 4000, 3000, 400000, 300000, 40001
 func TestAsPathAs4Trans3(t *testing.T) {
-	as1 := []uint16{65000, 4000}
+	as1 := []uint32{65000, 4000}
 	param1 := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as1)
-	as2 := []uint16{10, 20, 30}
+	as2 := []uint32{10, 20, 30}
 	param2 := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, as2)
-	as3 := []uint16{bgp.AS_TRANS, bgp.AS_TRANS, 40001}
+	as3 := []uint32{bgp.AS_TRANS, bgp.AS_TRANS, 40001}
 	param3 := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as3)
-	params := []bgp.AsPathParamInterface{param1, param2, param3}
+	params := []*bgp.AsPathParam{param1, param2, param3}
 	aspath := bgp.NewPathAttributeAsPath(params)
 
 	as4 := []uint32{3000, 400000, 300000, 40001}
-	param4s := []*bgp.As4PathParam{bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)}
+	param4s := []*bgp.AsPathParam{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)}
 	as4path := bgp.NewPathAttributeAs4Path(param4s)
 	msg := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{aspath, as4path}, nil).Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(msg)
 	assert.Equal(t, len(msg.PathAttributes), 1)
 	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value), 1)
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS), 6)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[0], uint32(65000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[1], uint32(4000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[2], uint32(3000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[3], uint32(400000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[4], uint32(300000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[5], uint32(40001))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS), 6)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[0], uint32(65000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[1], uint32(4000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[2], uint32(3000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[3], uint32(400000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[4], uint32(300000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[5], uint32(40001))
 }
 
 // before:
@@ -167,29 +173,29 @@ func TestAsPathAs4Trans3(t *testing.T) {
 // expected result:
 //  as-path  : 65000, 400000, 300000, 40001, {10, 20, 30}
 func TestAsPathAs4Trans4(t *testing.T) {
-	as := []uint16{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
-	params := []bgp.AsPathParamInterface{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
+	as := []uint32{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
+	params := []*bgp.AsPathParam{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
 	aspath := bgp.NewPathAttributeAsPath(params)
 
 	as4 := []uint32{400000, 300000, 40001}
-	as4param1 := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)
+	as4param1 := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)
 	as5 := []uint32{10, 20, 30}
-	as4param2 := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, as5)
-	param4s := []*bgp.As4PathParam{as4param1, as4param2}
+	as4param2 := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, as5)
+	param4s := []*bgp.AsPathParam{as4param1, as4param2}
 	as4path := bgp.NewPathAttributeAs4Path(param4s)
 	msg := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{aspath, as4path}, nil).Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(msg)
 	assert.Equal(t, len(msg.PathAttributes), 1)
 	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value), 2)
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS), 4)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[0], uint32(65000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[1], uint32(400000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[2], uint32(300000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[3], uint32(40001))
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].(*bgp.As4PathParam).AS), 3)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].(*bgp.As4PathParam).AS[0], uint32(10))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].(*bgp.As4PathParam).AS[1], uint32(20))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].(*bgp.As4PathParam).AS[2], uint32(30))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS), 4)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[0], uint32(65000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[1], uint32(400000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[2], uint32(300000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[3], uint32(40001))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].AS), 3)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].AS[0], uint32(10))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].AS[1], uint32(20))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].AS[2], uint32(30))
 }
 
 // before:
@@ -198,30 +204,30 @@ func TestAsPathAs4Trans4(t *testing.T) {
 // expected result:
 //  as-path  : 65000, {10, 20, 30}, 400000, 300000, 40001
 func TestAsPathAs4Trans5(t *testing.T) {
-	as := []uint16{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
-	params := []bgp.AsPathParamInterface{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
+	as := []uint32{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
+	params := []*bgp.AsPathParam{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
 	aspath := bgp.NewPathAttributeAsPath(params)
 
 	as4 := []uint32{400000, 300000, 40001}
-	as4param1 := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)
+	as4param1 := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)
 	as5 := []uint32{10, 20, 30}
-	as4param2 := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, as5)
-	param4s := []*bgp.As4PathParam{as4param2, as4param1}
+	as4param2 := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, as5)
+	param4s := []*bgp.AsPathParam{as4param2, as4param1}
 	as4path := bgp.NewPathAttributeAs4Path(param4s)
 	msg := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{aspath, as4path}, nil).Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(msg)
 	assert.Equal(t, len(msg.PathAttributes), 1)
 	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value), 3)
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS), 1)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[0], uint32(65000))
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].(*bgp.As4PathParam).AS), 3)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].(*bgp.As4PathParam).AS[0], uint32(10))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].(*bgp.As4PathParam).AS[1], uint32(20))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].(*bgp.As4PathParam).AS[2], uint32(30))
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].(*bgp.As4PathParam).AS), 3)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].(*bgp.As4PathParam).AS[0], uint32(400000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].(*bgp.As4PathParam).AS[1], uint32(300000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].(*bgp.As4PathParam).AS[2], uint32(40001))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS), 1)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[0], uint32(65000))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].AS), 3)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].AS[0], uint32(10))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].AS[1], uint32(20))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[1].AS[2], uint32(30))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].AS), 3)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].AS[0], uint32(400000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].AS[1], uint32(300000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[2].AS[2], uint32(40001))
 }
 
 // before:
@@ -230,24 +236,24 @@ func TestAsPathAs4Trans5(t *testing.T) {
 // expected result:
 //  as-path  : 65000, 4000, 23456, 23456, 40001
 func TestAsPathAs4TransInvalid1(t *testing.T) {
-	as := []uint16{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
-	params := []bgp.AsPathParamInterface{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
+	as := []uint32{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
+	params := []*bgp.AsPathParam{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
 	aspath := bgp.NewPathAttributeAsPath(params)
 
 	as4 := []uint32{100000, 65000, 4000, 400000, 300000, 40001}
-	as4param1 := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)
-	param4s := []*bgp.As4PathParam{as4param1}
+	as4param1 := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)
+	param4s := []*bgp.AsPathParam{as4param1}
 	as4path := bgp.NewPathAttributeAs4Path(param4s)
 	msg := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{aspath, as4path}, nil).Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(msg)
 	assert.Equal(t, len(msg.PathAttributes), 1)
 	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value), 1)
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS), 5)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[0], uint32(65000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[1], uint32(4000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[2], uint32(bgp.AS_TRANS))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[3], uint32(bgp.AS_TRANS))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[4], uint32(40001))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS), 5)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[0], uint32(65000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[1], uint32(4000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[2], uint32(bgp.AS_TRANS))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[3], uint32(bgp.AS_TRANS))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[4], uint32(40001))
 }
 
 // before:
@@ -256,24 +262,24 @@ func TestAsPathAs4TransInvalid1(t *testing.T) {
 // expected result:
 //  as-path  : 65000, 4000, 23456, 300000, 40001
 func TestAsPathAs4TransInvalid2(t *testing.T) {
-	as := []uint16{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
-	params := []bgp.AsPathParamInterface{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
+	as := []uint32{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
+	params := []*bgp.AsPathParam{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
 	aspath := bgp.NewPathAttributeAsPath(params)
 
 	as4 := []uint32{300000, 40001}
-	as4param1 := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)
-	param4s := []*bgp.As4PathParam{as4param1}
+	as4param1 := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)
+	param4s := []*bgp.AsPathParam{as4param1}
 	as4path := bgp.NewPathAttributeAs4Path(param4s)
 	msg := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{aspath, as4path}, nil).Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(msg)
 	assert.Equal(t, len(msg.PathAttributes), 1)
 	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value), 1)
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS), 5)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[0], uint32(65000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[1], uint32(4000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[2], uint32(bgp.AS_TRANS))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[3], uint32(300000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[4], uint32(40001))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS), 5)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[0], uint32(65000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[1], uint32(4000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[2], uint32(bgp.AS_TRANS))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[3], uint32(300000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[4], uint32(40001))
 }
 
 // before:
@@ -282,20 +288,20 @@ func TestAsPathAs4TransInvalid2(t *testing.T) {
 // expected result:
 //  as-path  : 65000, 4000, 23456, 23456, 40001
 func TestAsPathAs4TransInvalid3(t *testing.T) {
-	as := []uint16{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
-	params := []bgp.AsPathParamInterface{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
+	as := []uint32{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
+	params := []*bgp.AsPathParam{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
 	aspath := bgp.NewPathAttributeAsPath(params)
 
 	msg := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{aspath}, nil).Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(msg)
 	assert.Equal(t, len(msg.PathAttributes), 1)
 	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value), 1)
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS), 5)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[0], uint32(65000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[1], uint32(4000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[2], uint32(bgp.AS_TRANS))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[3], uint32(bgp.AS_TRANS))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[4], uint32(40001))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS), 5)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[0], uint32(65000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[1], uint32(4000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[2], uint32(bgp.AS_TRANS))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[3], uint32(bgp.AS_TRANS))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[4], uint32(40001))
 }
 
 // before:
@@ -304,31 +310,31 @@ func TestAsPathAs4TransInvalid3(t *testing.T) {
 // expected result:
 //  as-path  : 65000, 4000, 23456, 23456, 40001
 func TestAsPathAs4TransInvalid4(t *testing.T) {
-	as := []uint16{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
-	params := []bgp.AsPathParamInterface{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
+	as := []uint32{65000, 4000, bgp.AS_TRANS, bgp.AS_TRANS, 40001}
+	params := []*bgp.AsPathParam{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as)}
 	aspath := bgp.NewPathAttributeAsPath(params)
 
 	as4 := []uint32{}
-	as4param1 := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)
-	param4s := []*bgp.As4PathParam{as4param1}
+	as4param1 := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as4)
+	param4s := []*bgp.AsPathParam{as4param1}
 	as4path := bgp.NewPathAttributeAs4Path(param4s)
 	msg := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{aspath, as4path}, nil).Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(msg)
 	assert.Equal(t, len(msg.PathAttributes), 1)
 	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value), 1)
-	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS), 5)
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[0], uint32(65000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[1], uint32(4000))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[2], uint32(bgp.AS_TRANS))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[3], uint32(bgp.AS_TRANS))
-	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[4], uint32(40001))
+	assert.Equal(t, len(msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS), 5)
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[0], uint32(65000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[1], uint32(4000))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[2], uint32(bgp.AS_TRANS))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[3], uint32(bgp.AS_TRANS))
+	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].AS[4], uint32(40001))
 }
 
 func TestBMP(t *testing.T) {
-	aspath1 := []bgp.AsPathParamInterface{
-		bgp.NewAs4PathParam(2, []uint32{1000000}),
-		bgp.NewAs4PathParam(1, []uint32{1000001, 1002}),
-		bgp.NewAs4PathParam(2, []uint32{1003, 100004}),
+	aspath1 := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{1000000}),
+		bgp.NewAsPathParam(1, []uint32{1000001, 1002}),
+		bgp.NewAsPathParam(2, []uint32{1003, 100004}),
 	}
 	mp_nlri := []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(100,
 		"fe80:1234:1234:5667:8967:af12:8912:1023")}

--- a/table/path.go
+++ b/table/path.go
@@ -145,12 +145,11 @@ func (path *Path) IsEOR() bool {
 }
 
 func cloneAsPath(asAttr *bgp.PathAttributeAsPath) *bgp.PathAttributeAsPath {
-	newASparams := make([]bgp.AsPathParamInterface, len(asAttr.Value))
+	newASparams := make([]*bgp.AsPathParam, len(asAttr.Value))
 	for i, param := range asAttr.Value {
-		asParam := param.(*bgp.As4PathParam)
-		as := make([]uint32, len(asParam.AS))
-		copy(as, asParam.AS)
-		newASparams[i] = bgp.NewAs4PathParam(asParam.Type, as)
+		as := make([]uint32, len(param.AS))
+		copy(as, param.AS)
+		newASparams[i] = bgp.NewAsPathParam(param.Type, as)
 	}
 	return bgp.NewPathAttributeAsPath(newASparams)
 }
@@ -367,7 +366,7 @@ func (path *Path) GetSourceAs() uint32 {
 		if len(asPathParam) == 0 {
 			return 0
 		}
-		asPath := asPathParam[len(asPathParam)-1].(*bgp.As4PathParam)
+		asPath := asPathParam[len(asPathParam)-1]
 		if asPath.Num == 0 {
 			return 0
 		}
@@ -546,8 +545,7 @@ func (path *Path) GetAsPathLen() int {
 func (path *Path) GetAsString() string {
 	s := bytes.NewBuffer(make([]byte, 0, 64))
 	if aspath := path.GetAsPath(); aspath != nil {
-		for i, paramIf := range aspath.Value {
-			segment := paramIf.(*bgp.As4PathParam)
+		for i, segment := range aspath.Value {
 			if i != 0 {
 				s.WriteString(" ")
 			}
@@ -586,8 +584,7 @@ func (path *Path) GetAsSeqList() []uint32 {
 func (path *Path) getAsListofSpecificType(getAsSeq, getAsSet bool) []uint32 {
 	asList := []uint32{}
 	if aspath := path.GetAsPath(); aspath != nil {
-		for _, paramIf := range aspath.Value {
-			segment := paramIf.(*bgp.As4PathParam)
+		for _, segment := range aspath.Value {
 			if getAsSeq && segment.Type == bgp.BGP_ASPATH_ATTR_TYPE_SEQ {
 				asList = append(asList, segment.AS...)
 				continue
@@ -633,13 +630,13 @@ func (path *Path) PrependAsn(asn uint32, repeat uint8) {
 
 	var asPath *bgp.PathAttributeAsPath
 	if original == nil {
-		asPath = bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{})
+		asPath = bgp.NewPathAttributeAsPath([]*bgp.AsPathParam{})
 	} else {
 		asPath = cloneAsPath(original)
 	}
 
 	if len(asPath.Value) > 0 {
-		fst := asPath.Value[0].(*bgp.As4PathParam)
+		fst := asPath.Value[0]
 		if fst.Type == bgp.BGP_ASPATH_ATTR_TYPE_SEQ {
 			if len(fst.AS)+int(repeat) > 255 {
 				repeat = uint8(255 - len(fst.AS))
@@ -651,8 +648,8 @@ func (path *Path) PrependAsn(asn uint32, repeat uint8) {
 	}
 
 	if len(asns) > 0 {
-		p := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, asns)
-		asPath.Value = append([]bgp.AsPathParamInterface{p}, asPath.Value...)
+		p := bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, asns)
+		asPath.Value = append([]*bgp.AsPathParam{p}, asPath.Value...)
 	}
 	path.setPathAttr(asPath)
 }

--- a/table/path_test.go
+++ b/table/path_test.go
@@ -67,11 +67,11 @@ func TestPathGetAttribute(t *testing.T) {
 func TestASPathLen(t *testing.T) {
 	assert := assert.New(t)
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint16{65001, 65002, 65003, 65004, 65004, 65004, 65004, 65004, 65005}),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, []uint16{65001, 65002, 65003, 65004, 65005}),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint16{65100, 65101, 65102}),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET, []uint16{65100, 65101})}
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65001, 65002, 65003, 65004, 65004, 65004, 65004, 65004, 65005}),
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, []uint32{65001, 65002, 65003, 65004, 65005}),
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint32{65100, 65101, 65102}),
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET, []uint32{65100, 65101})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.50.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -95,11 +95,11 @@ func TestASPathLen(t *testing.T) {
 func TestPathPrependAsnToExistingSeqAttr(t *testing.T) {
 	assert := assert.New(t)
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint16{65001, 65002, 65003, 65004, 65005}),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, []uint16{65001, 65002, 65003, 65004, 65005}),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint16{65100, 65101, 65102}),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET, []uint16{65100, 65101})}
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65001, 65002, 65003, 65004, 65005}),
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, []uint32{65001, 65002, 65003, 65004, 65005}),
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint32{65100, 65101, 65102}),
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET, []uint32{65100, 65101})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.50.1")
 
@@ -146,10 +146,10 @@ func TestPathPrependAsnToNewAsPathAttr(t *testing.T) {
 func TestPathPrependAsnToNewAsPathSeq(t *testing.T) {
 	assert := assert.New(t)
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, []uint16{65001, 65002, 65003, 65004, 65005}),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint16{65100, 65101, 65102}),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET, []uint16{65100, 65101})}
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, []uint32{65001, 65002, 65003, 65004, 65005}),
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint32{65100, 65101, 65102}),
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET, []uint32{65100, 65101})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.50.1")
 
@@ -175,11 +175,11 @@ func TestPathPrependAsnToNewAsPathSeq(t *testing.T) {
 func TestPathPrependAsnToEmptyAsPathAttr(t *testing.T) {
 	assert := assert.New(t)
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint16{}),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, []uint16{65001, 65002, 65003, 65004, 65005}),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint16{65100, 65101, 65102}),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET, []uint16{65100, 65101})}
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{}),
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, []uint32{65001, 65002, 65003, 65004, 65005}),
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint32{65100, 65101, 65102}),
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET, []uint32{65100, 65101})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.50.1")
 
@@ -206,16 +206,16 @@ func TestPathPrependAsnToFullPathAttr(t *testing.T) {
 	assert := assert.New(t)
 	origin := bgp.NewPathAttributeOrigin(0)
 
-	asns := make([]uint16, 255)
+	asns := make([]uint32, 255)
 	for i, _ := range asns {
-		asns[i] = 65000 + uint16(i)
+		asns[i] = 65000 + uint32(i)
 	}
 
-	aspathParam := []bgp.AsPathParamInterface{
+	aspathParam := []*bgp.AsPathParam{
 		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, asns),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, []uint16{65001, 65002, 65003, 65004, 65005}),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint16{65100, 65101, 65102}),
-		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET, []uint16{65100, 65101})}
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, []uint32{65001, 65002, 65003, 65004, 65005}),
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint32{65100, 65101, 65102}),
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET, []uint32{65100, 65101})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.50.1")
 
@@ -277,7 +277,7 @@ func PathCreatePath(peerP []*PeerInfo) []*Path {
 func updateMsgP1() *bgp.BGPMessage {
 
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65000})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65000})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.50.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -296,7 +296,7 @@ func updateMsgP1() *bgp.BGPMessage {
 func updateMsgP2() *bgp.BGPMessage {
 
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65100})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65100})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.100.1")
 	med := bgp.NewPathAttributeMultiExitDisc(100)
@@ -314,7 +314,7 @@ func updateMsgP2() *bgp.BGPMessage {
 
 func updateMsgP3() *bgp.BGPMessage {
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65100})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65100})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.150.1")
 	med := bgp.NewPathAttributeMultiExitDisc(100)

--- a/table/policy_test.go
+++ b/table/policy_test.go
@@ -38,7 +38,7 @@ func TestPrefixCalcurateNoRange(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -62,7 +62,7 @@ func TestPrefixCalcurateAddress(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -83,7 +83,7 @@ func TestPrefixCalcurateLength(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -104,7 +104,7 @@ func TestPrefixCalcurateLengthRange(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -129,7 +129,7 @@ func TestPrefixCalcurateNoRangeIPv6(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("2001::192:168:50:1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	mpnlri := []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}
 	mpreach := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1", mpnlri)
@@ -153,7 +153,7 @@ func TestPrefixCalcurateAddressIPv6(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("2001::192:168:50:1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	mpnlri := []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}
 	mpreach := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1", mpnlri)
@@ -174,7 +174,7 @@ func TestPrefixCalcurateLengthIPv6(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("2001::192:168:50:1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	mpnlri := []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}
 	mpreach := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1", mpnlri)
@@ -195,7 +195,7 @@ func TestPrefixCalcurateLengthRangeIPv6(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("2001::192:168:50:1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	mpnlri := []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}
 	mpreach := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1", mpnlri)
@@ -219,7 +219,7 @@ func TestPolicyNotMatch(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -250,7 +250,7 @@ func TestPolicyMatchAndReject(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -281,7 +281,7 @@ func TestPolicyMatchAndAccept(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -313,7 +313,7 @@ func TestPolicyRejectOnlyPrefixSet(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.1.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.1.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -324,7 +324,7 @@ func TestPolicyRejectOnlyPrefixSet(t *testing.T) {
 
 	peer = &PeerInfo{AS: 65002, Address: net.ParseIP("10.0.2.2")}
 	origin = bgp.NewPathAttributeOrigin(0)
-	aspathParam = []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65002})}
+	aspathParam = []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65002})}
 	aspath = bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop = bgp.NewPathAttributeNextHop("10.0.2.2")
 	med = bgp.NewPathAttributeMultiExitDisc(0)
@@ -360,7 +360,7 @@ func TestPolicyRejectOnlyNeighborSet(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.1.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.1.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -371,7 +371,7 @@ func TestPolicyRejectOnlyNeighborSet(t *testing.T) {
 
 	peer = &PeerInfo{AS: 65002, Address: net.ParseIP("10.0.2.2")}
 	origin = bgp.NewPathAttributeOrigin(0)
-	aspathParam = []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65002})}
+	aspathParam = []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65002})}
 	aspath = bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop = bgp.NewPathAttributeNextHop("10.0.2.2")
 	med = bgp.NewPathAttributeMultiExitDisc(0)
@@ -406,7 +406,7 @@ func TestPolicyDifferentRoutefamilyOfPathAndPolicy(t *testing.T) {
 	// create path ipv4
 	peerIPv4 := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	originIPv4 := bgp.NewPathAttributeOrigin(0)
-	aspathParamIPv4 := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParamIPv4 := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspathIPv4 := bgp.NewPathAttributeAsPath(aspathParamIPv4)
 	nexthopIPv4 := bgp.NewPathAttributeNextHop("10.0.0.1")
 	medIPv4 := bgp.NewPathAttributeMultiExitDisc(0)
@@ -417,7 +417,7 @@ func TestPolicyDifferentRoutefamilyOfPathAndPolicy(t *testing.T) {
 	// create path ipv6
 	peerIPv6 := &PeerInfo{AS: 65001, Address: net.ParseIP("2001::192:168:50:1")}
 	originIPv6 := bgp.NewPathAttributeOrigin(0)
-	aspathParamIPv6 := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParamIPv6 := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspathIPv6 := bgp.NewPathAttributeAsPath(aspathParamIPv6)
 	mpnlriIPv6 := []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}
 	mpreachIPv6 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1", mpnlriIPv6)
@@ -461,9 +461,9 @@ func TestAsPathLengthConditionEvaluate(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(2, []uint16{65001, 65000, 65004, 65005}),
-		bgp.NewAsPathParam(1, []uint16{65001, 65000, 65004, 65005}),
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{65001, 65000, 65004, 65005}),
+		bgp.NewAsPathParam(1, []uint32{65001, 65000, 65004, 65005}),
 	}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
@@ -510,9 +510,9 @@ func TestAsPathLengthConditionWithOtherCondition(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(2, []uint16{65001, 65000, 65004, 65004, 65005}),
-		bgp.NewAsPathParam(1, []uint16{65001, 65000, 65004, 65005}),
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{65001, 65000, 65004, 65004, 65005}),
+		bgp.NewAsPathParam(1, []uint32{65001, 65000, 65004, 65005}),
 	}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
@@ -558,14 +558,14 @@ func TestAs4PathLengthConditionEvaluate(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAs4PathParam(2, []uint32{
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{
 			createAs4Value("65001.1"),
 			createAs4Value("65000.1"),
 			createAs4Value("65004.1"),
 			createAs4Value("65005.1"),
 		}),
-		bgp.NewAs4PathParam(1, []uint32{
+		bgp.NewAsPathParam(1, []uint32{
 			createAs4Value("65001.1"),
 			createAs4Value("65000.1"),
 			createAs4Value("65004.1"),
@@ -617,15 +617,15 @@ func TestAs4PathLengthConditionWithOtherCondition(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAs4PathParam(2, []uint32{
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{
 			createAs4Value("65001.1"),
 			createAs4Value("65000.1"),
 			createAs4Value("65004.1"),
 			createAs4Value("65004.1"),
 			createAs4Value("65005.1"),
 		}),
-		bgp.NewAs4PathParam(1, []uint32{
+		bgp.NewAsPathParam(1, []uint32{
 			createAs4Value("65001.1"),
 			createAs4Value("65000.1"),
 			createAs4Value("65004.1"),
@@ -676,8 +676,8 @@ func TestAsPathConditionEvaluate(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam1 := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(2, []uint16{65001, 65000, 65010, 65004, 65005}),
+	aspathParam1 := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{65001, 65000, 65010, 65004, 65005}),
 	}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam1)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
@@ -688,8 +688,8 @@ func TestAsPathConditionEvaluate(t *testing.T) {
 	UpdatePathAttrs4ByteAs(updateMsg1.Body.(*bgp.BGPUpdate))
 	path1 := ProcessMessage(updateMsg1, peer, time.Now())[0]
 
-	aspathParam2 := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(2, []uint16{65010}),
+	aspathParam2 := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{65010}),
 	}
 	aspath2 := bgp.NewPathAttributeAsPath(aspathParam2)
 	pathAttributes = []bgp.PathAttributeInterface{origin, aspath2, nexthop, med}
@@ -770,8 +770,8 @@ func TestMultipleAsPathConditionEvaluate(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam1 := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(2, []uint16{65001, 65000, 54000, 65004, 65005}),
+	aspathParam1 := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{65001, 65000, 54000, 65004, 65005}),
 	}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam1)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
@@ -872,8 +872,8 @@ func TestAsPathCondition(t *testing.T) {
 	}
 
 	makeTest := func(asPathAttrType uint8, ases []uint32, result bool) astest {
-		aspathParam := []bgp.AsPathParamInterface{
-			bgp.NewAs4PathParam(asPathAttrType, ases),
+		aspathParam := []*bgp.AsPathParam{
+			bgp.NewAsPathParam(asPathAttrType, ases),
 		}
 		pathAttributes := []bgp.PathAttributeInterface{bgp.NewPathAttributeAsPath(aspathParam)}
 		p := NewPath(nil, nil, false, pathAttributes, time.Time{}, false)
@@ -940,9 +940,9 @@ func TestAsPathConditionWithOtherCondition(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(1, []uint16{65001, 65000, 65004, 65005}),
-		bgp.NewAsPathParam(2, []uint16{65001, 65000, 65004, 65004, 65005}),
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(1, []uint32{65001, 65000, 65004, 65005}),
+		bgp.NewAsPathParam(2, []uint32{65001, 65000, 65004, 65004, 65005}),
 	}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
@@ -990,8 +990,8 @@ func TestAs4PathConditionEvaluate(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam1 := []bgp.AsPathParamInterface{
-		bgp.NewAs4PathParam(2, []uint32{
+	aspathParam1 := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{
 			createAs4Value("65001.1"),
 			createAs4Value("65000.1"),
 			createAs4Value("65010.1"),
@@ -1008,8 +1008,8 @@ func TestAs4PathConditionEvaluate(t *testing.T) {
 	UpdatePathAttrs4ByteAs(updateMsg1.Body.(*bgp.BGPUpdate))
 	path1 := ProcessMessage(updateMsg1, peer, time.Now())[0]
 
-	aspathParam2 := []bgp.AsPathParamInterface{
-		bgp.NewAs4PathParam(2, []uint32{
+	aspathParam2 := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{
 			createAs4Value("65010.1"),
 		}),
 	}
@@ -1103,8 +1103,8 @@ func TestMultipleAs4PathConditionEvaluate(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam1 := []bgp.AsPathParamInterface{
-		bgp.NewAs4PathParam(2, []uint32{
+	aspathParam1 := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{
 			createAs4Value("65001.1"),
 			createAs4Value("65000.1"),
 			createAs4Value("54000.1"),
@@ -1223,14 +1223,14 @@ func TestAs4PathConditionWithOtherCondition(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAs4PathParam(1, []uint32{
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(1, []uint32{
 			createAs4Value("65001.1"),
 			createAs4Value("65000.1"),
 			createAs4Value("65004.1"),
 			createAs4Value("65005.1"),
 		}),
-		bgp.NewAs4PathParam(2, []uint32{
+		bgp.NewAsPathParam(2, []uint32{
 			createAs4Value("65001.1"),
 			createAs4Value("65000.1"),
 			createAs4Value("65004.1"),
@@ -1283,8 +1283,8 @@ func TestAs4PathConditionEvaluateMixedWith2byteAS(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam1 := []bgp.AsPathParamInterface{
-		bgp.NewAs4PathParam(2, []uint32{
+	aspathParam1 := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{
 			createAs4Value("65001.1"),
 			createAs4Value("65000.1"),
 			createAs4Value("54000.1"),
@@ -1383,9 +1383,9 @@ func TestCommunityConditionEvaluate(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam1 := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(2, []uint16{65001, 65000, 65004, 65005}),
-		bgp.NewAsPathParam(1, []uint16{65001, 65010, 65004, 65005}),
+	aspathParam1 := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{65001, 65000, 65004, 65005}),
+		bgp.NewAsPathParam(1, []uint32{65001, 65010, 65004, 65005}),
 	}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam1)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
@@ -1527,9 +1527,9 @@ func TestCommunityConditionEvaluateWithOtherCondition(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(1, []uint16{65001, 65000, 65004, 65005}),
-		bgp.NewAsPathParam(2, []uint16{65001, 65000, 65004, 65004, 65005}),
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(1, []uint32{65001, 65000, 65004, 65005}),
+		bgp.NewAsPathParam(2, []uint32{65001, 65000, 65004, 65004, 65005}),
 	}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
@@ -1607,7 +1607,7 @@ func TestPolicyMatchAndAddCommunities(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -1649,7 +1649,7 @@ func TestPolicyMatchAndReplaceCommunities(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -1695,7 +1695,7 @@ func TestPolicyMatchAndRemoveCommunities(t *testing.T) {
 	community2 := "65000:200"
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -1740,7 +1740,7 @@ func TestPolicyMatchAndRemoveCommunitiesRegexp(t *testing.T) {
 	community3 := "65100:100"
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -1786,7 +1786,7 @@ func TestPolicyMatchAndRemoveCommunitiesRegexp2(t *testing.T) {
 	community3 := "45686:2"
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -1831,7 +1831,7 @@ func TestPolicyMatchAndClearCommunities(t *testing.T) {
 	community2 := "65000:200"
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -1879,9 +1879,9 @@ func TestExtCommunityConditionEvaluate(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam1 := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(2, []uint16{65001, 65000, 65004, 65005}),
-		bgp.NewAsPathParam(1, []uint16{65001, 65010, 65004, 65005}),
+	aspathParam1 := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{65001, 65000, 65004, 65005}),
+		bgp.NewAsPathParam(1, []uint32{65001, 65010, 65004, 65005}),
 	}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam1)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
@@ -2058,9 +2058,9 @@ func TestExtCommunityConditionEvaluateWithOtherCondition(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.2.1.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAsPathParam(1, []uint16{65001, 65000, 65004, 65005}),
-		bgp.NewAsPathParam(2, []uint16{65001, 65000, 65004, 65004, 65005}),
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(1, []uint32{65001, 65000, 65004, 65005}),
+		bgp.NewAsPathParam(2, []uint32{65001, 65000, 65004, 65004, 65005}),
 	}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.2.1.1")
@@ -2185,7 +2185,7 @@ func TestPolicyMatchAndReplaceMed(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(100)
@@ -2229,7 +2229,7 @@ func TestPolicyMatchAndAddingMed(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(100)
@@ -2273,7 +2273,7 @@ func TestPolicyMatchAndAddingMedOverFlow(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(1)
@@ -2319,7 +2319,7 @@ func TestPolicyMatchAndSubtractMed(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(100)
@@ -2365,7 +2365,7 @@ func TestPolicyMatchAndSubtractMedUnderFlow(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(100)
@@ -2411,7 +2411,7 @@ func TestPolicyMatchWhenPathHaveNotMed(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 
@@ -2454,7 +2454,7 @@ func TestPolicyAsPathPrepend(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001, 65000})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65001, 65000})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -2498,7 +2498,7 @@ func TestPolicyAsPathPrependLastAs(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65002, 65001, 65000})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65002, 65001, 65000})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -2543,8 +2543,8 @@ func TestPolicyAs4PathPrepend(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAs4PathParam(2, []uint32{
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{
 			createAs4Value("65001.1"),
 			createAs4Value("65000.1"),
 		}),
@@ -2597,8 +2597,8 @@ func TestPolicyAs4PathPrependLastAs(t *testing.T) {
 	// create path
 	peer := &PeerInfo{AS: 65001, Address: net.ParseIP("10.0.0.1")}
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{
-		bgp.NewAs4PathParam(2, []uint32{
+	aspathParam := []*bgp.AsPathParam{
+		bgp.NewAsPathParam(2, []uint32{
 			createAs4Value("65002.1"),
 			createAs4Value("65001.1"),
 			createAs4Value("65000.1"),

--- a/table/table.go
+++ b/table/table.go
@@ -146,19 +146,6 @@ func (t *Table) validatePath(path *Path) {
 			"ReceivedRf": path.GetRouteFamily().String(),
 		}).Error("Invalid path. RouteFamily mismatch")
 	}
-	if attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_AS_PATH); attr != nil {
-		pathParam := attr.(*bgp.PathAttributeAsPath).Value
-		for _, as := range pathParam {
-			_, y := as.(*bgp.As4PathParam)
-			if !y {
-				log.WithFields(log.Fields{
-					"Topic": "Table",
-					"Key":   t.routeFamily,
-					"As":    as,
-				}).Fatal("AsPathParam must be converted to As4PathParam")
-			}
-		}
-	}
 	if attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_AS4_PATH); attr != nil {
 		log.WithFields(log.Fields{
 			"Topic": "Table",

--- a/table/table_manager_test.go
+++ b/table/table_manager_test.go
@@ -2112,7 +2112,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 
 func TestProcessBGPUpdate_Timestamp(t *testing.T) {
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{65000})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65000})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.50.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -2165,7 +2165,7 @@ func TestProcessBGPUpdate_Timestamp(t *testing.T) {
 func update_fromR1() *bgp.BGPMessage {
 
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{65000})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65000})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.50.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -2185,7 +2185,7 @@ func update_fromR1() *bgp.BGPMessage {
 func update_fromR1_ipv6() *bgp.BGPMessage {
 
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{65000})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65000})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 
 	mp_nlri := []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}
@@ -2204,7 +2204,7 @@ func update_fromR1_ipv6() *bgp.BGPMessage {
 func update_fromR2() *bgp.BGPMessage {
 
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{65100})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65100})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.100.1")
 	med := bgp.NewPathAttributeMultiExitDisc(100)
@@ -2238,7 +2238,7 @@ func update_fromR2_ipv6() *bgp.BGPMessage {
 }
 
 func createAsPathAttribute(ases []uint32) *bgp.PathAttributeAsPath {
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, ases)}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, ases)}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	return aspath
 }
@@ -2257,7 +2257,7 @@ func createMpUNReach(nlri string, len uint8) *bgp.PathAttributeMpUnreachNLRI {
 func update_fromR2viaR1() *bgp.BGPMessage {
 
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{65000, 65100})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65000, 65100})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.50.1")
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -115,7 +115,7 @@ func TableCreatePath(peerT []*PeerInfo) []*Path {
 func updateMsgT1() *bgp.BGPMessage {
 
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65000})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65000})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.50.1")
 	med := bgp.NewPathAttributeMultiExitDisc(0)
@@ -134,7 +134,7 @@ func updateMsgT1() *bgp.BGPMessage {
 func updateMsgT2() *bgp.BGPMessage {
 
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65100})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65100})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.100.1")
 	med := bgp.NewPathAttributeMultiExitDisc(100)
@@ -151,7 +151,7 @@ func updateMsgT2() *bgp.BGPMessage {
 }
 func updateMsgT3() *bgp.BGPMessage {
 	origin := bgp.NewPathAttributeOrigin(0)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65100})}
+	aspathParam := []*bgp.AsPathParam{bgp.NewAsPathParam(2, []uint32{65100})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nexthop := bgp.NewPathAttributeNextHop("192.168.150.1")
 	med := bgp.NewPathAttributeMultiExitDisc(100)


### PR DESCRIPTION
this infra can be used for ADDPATH support or switching encoding manner between various BGP dialects(e.g. always flag EXTENDED_LENGTH bit for path attributes or not etc..)

also add first user of this infra for unifying AS/AS4 path attribute handling.