### PR TITLE
packet: handle malformed option param length in OpenMessage

### DIFF
--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -666,6 +666,9 @@ func (msg *BGPOpen) DecodeFromBytes(data []byte) error {
 	for rest := msg.OptParamLen; rest > 0; {
 		paramtype := data[0]
 		paramlen := data[1]
+		if rest < paramlen+2 {
+			return fmt.Errorf("Malformed BGP Open message")
+		}
 		rest -= paramlen + 2
 
 		if paramtype == BGP_OPT_CAPABILITY {


### PR DESCRIPTION
Fixes a possible crash in  BGPOpen's DecodeFromBytes().

fixes #818

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>