### PR TITLE
grpc: disable tracing to avoid consuming massive memory

### DIFF
--- a/server/grpc_server.go
+++ b/server/grpc_server.go
@@ -483,6 +483,7 @@ func (r *GrpcResponse) Err() error {
 }
 
 func NewGrpcServer(port int, bgpServerCh chan *GrpcRequest) *Server {
+	grpc.EnableTracing = false
 	grpcServer := grpc.NewServer()
 	server := &Server{
 		grpcServer:  grpcServer,


### PR DESCRIPTION
By default, grpc traces rpc events, including responses. GoBGP sends a
load of data (e.g. showing global rib). As a result, GoBGP consumes
huge memory if you send/receive data via RPC. Let's disable tracing.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>