### PR TITLE
table: fix bug of incomplete withdrawal handling

### DIFF
--- a/table/destination.go
+++ b/table/destination.go
@@ -306,7 +306,6 @@ func (dest *Destination) explicitWithdraw() paths {
 	// delete them first.
 	matches := make([]*Path, 0, len(dest.withdrawList)/2)
 	newKnownPaths := make([]*Path, 0, len(dest.knownPathList)/2)
-	newWithdrawPaths := make([]*Path, 0, len(dest.withdrawList)/2)
 
 	// Match all withdrawals from destination paths.
 	for _, withdraw := range dest.withdrawList {
@@ -326,19 +325,8 @@ func (dest *Destination) explicitWithdraw() paths {
 				"Topic": "Table",
 				"Key":   dest.GetNlri().String(),
 				"Path":  withdraw,
-			}).Debug("No matching path for withdraw found, may be path was not installed into table")
-			newWithdrawPaths = append(newWithdrawPaths, withdraw)
+			}).Warn("No matching path for withdraw found, may be path was not installed into table")
 		}
-	}
-
-	// If we have partial match.
-	if len(newWithdrawPaths) > 0 {
-		log.WithFields(log.Fields{
-			"Topic":          "Table",
-			"Key":            dest.GetNlri().String(),
-			"MatchLength":    len(matches),
-			"WithdrawLength": len(dest.withdrawList),
-		}).Debug("Did not find match for some withdrawals.")
 	}
 
 	for _, path := range dest.knownPathList {
@@ -348,7 +336,7 @@ func (dest *Destination) explicitWithdraw() paths {
 	}
 
 	dest.knownPathList = newKnownPaths
-	dest.withdrawList = newWithdrawPaths
+	dest.withdrawList = make([]*Path, 0)
 	return matches
 }
 

--- a/table/destination.go
+++ b/table/destination.go
@@ -317,8 +317,6 @@ func (dest *Destination) explicitWithdraw() paths {
 				isFound = true
 				path.IsWithdraw = true
 				matches = append(matches, path)
-				// One withdraw can remove only one path.
-				break
 			}
 		}
 

--- a/table/destination_test.go
+++ b/table/destination_test.go
@@ -160,6 +160,63 @@ func TestCalculate2(t *testing.T) {
 	assert.Equal(t, len(d.knownPathList), 3)
 }
 
+func TestImplicitWithdrawCalculate(t *testing.T) {
+	origin := bgp.NewPathAttributeOrigin(0)
+	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{65001})}
+	aspath := bgp.NewPathAttributeAsPath(aspathParam)
+	nexthop := bgp.NewPathAttributeNextHop("10.0.0.1")
+	med := bgp.NewPathAttributeMultiExitDisc(0)
+	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
+	nlri := bgp.NewIPAddrPrefix(24, "10.10.0.101")
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	peer1 := &PeerInfo{AS: 1, Address: net.IP{1, 1, 1, 1}}
+	path1 := ProcessMessage(updateMsg, peer1, time.Now())[0]
+	path1.Filter("1", POLICY_DIRECTION_IMPORT)
+
+	// suppose peer2 has import policy to prepend as-path
+	action := &AsPathPrependAction{
+		asn:    100,
+		repeat: 1,
+	}
+
+	path2 := action.Apply(path1.Clone(false))
+	path1.Filter("2", POLICY_DIRECTION_IMPORT)
+	path2.Filter("1", POLICY_DIRECTION_IMPORT)
+	path2.Filter("3", POLICY_DIRECTION_IMPORT)
+
+	d := NewDestination(nlri)
+	d.addNewPath(path1)
+	d.addNewPath(path2)
+
+	d.Calculate(nil)
+
+	assert.Equal(t, len(d.GetKnownPathList("1")), 0) // peer "1" is the originator
+	assert.Equal(t, len(d.GetKnownPathList("2")), 1)
+	assert.Equal(t, d.GetKnownPathList("2")[0].GetAsString(), "100 65001") // peer "2" has modified path {100, 65001}
+	assert.Equal(t, len(d.GetKnownPathList("3")), 1)
+	assert.Equal(t, d.GetKnownPathList("3")[0].GetAsString(), "65001") // peer "3" has original path {65001}
+	assert.Equal(t, len(d.knownPathList), 2)
+
+	// say, we removed peer2's import policy and
+	// peer1 advertised new path with the same prefix
+	aspathParam = []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{65001, 65002})}
+	aspath = bgp.NewPathAttributeAsPath(aspathParam)
+	pathAttributes = []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
+	updateMsg = bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	path3 := ProcessMessage(updateMsg, peer1, time.Now())[0]
+	path3.Filter("1", POLICY_DIRECTION_IMPORT)
+
+	d.addNewPath(path3)
+	d.Calculate(nil)
+
+	assert.Equal(t, len(d.GetKnownPathList("1")), 0) // peer "1" is the originator
+	assert.Equal(t, len(d.GetKnownPathList("2")), 1)
+	assert.Equal(t, d.GetKnownPathList("2")[0].GetAsString(), "65001 65002") // peer "2" has new original path {65001, 65002}
+	assert.Equal(t, len(d.GetKnownPathList("3")), 1)
+	assert.Equal(t, d.GetKnownPathList("3")[0].GetAsString(), "65001 65002") // peer "3" has new original path {65001, 65002}
+	assert.Equal(t, len(d.knownPathList), 1)
+}
+
 func DestCreatePeer() []*PeerInfo {
 	peerD1 := &PeerInfo{AS: 65000}
 	peerD2 := &PeerInfo{AS: 65001}


### PR DESCRIPTION
When mod action is used in route server configuration,
`Destination.knownPathList` holds multiple modified paths whose original path
is same.
In that case, when the original path is withdrawn, we must remove all
modified paths.
There was a wrong `break` in `Destination.explicitWithdraw()` which avoids
this.
test is also added to check the behavior.

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>