### PR TITLE
config: fix community-set match all evaluation

### DIFF
--- a/gobgp/cmd/policy.go
+++ b/gobgp/cmd/policy.go
@@ -119,6 +119,10 @@ func formatDefinedSet(head bool, typ string, indent int, list []*api.DefinedSet)
 			buff.WriteString(fmt.Sprintf(format, s.Name, ""))
 		}
 		for i, x := range s.List {
+			if typ == "COMMUNITY" || typ == "EXT-COMMUNITY" {
+				exp := regexp.MustCompile("\\^(\\S+)\\$")
+				x = exp.ReplaceAllString(x, "$1")
+			}
 			if i == 0 {
 				buff.WriteString(fmt.Sprintf(format, s.Name, x))
 			} else {
@@ -446,7 +450,8 @@ func printStatement(indent int, s *api.Statement) {
 	formatComAction := func(c *api.CommunityAction) string {
 		option := c.Type.String()
 		if len(c.Communities) != 0 {
-			communities := strings.Join(c.Communities, ",")
+			exp := regexp.MustCompile("[\\^\\$]")
+			communities := exp.ReplaceAllString(strings.Join(c.Communities, ","), "")
 			option = fmt.Sprintf("%s[%s]", c.Type, communities)
 		}
 		return option

--- a/table/policy.go
+++ b/table/policy.go
@@ -1347,7 +1347,7 @@ func (c *CommunityCondition) Evaluate(path *Path, _ *PolicyOptions) bool {
 	result := false
 	for _, x := range c.set.list {
 		result = false
-    for _, y := range cs {
+		for _, y := range cs {
 			if x.MatchString(fmt.Sprintf("%d:%d", y>>16, y&0x0000ffff)) {
 				result = true
 				break

--- a/table/policy.go
+++ b/table/policy.go
@@ -1345,10 +1345,10 @@ func (c *CommunityCondition) ToApiStruct() *api.MatchSet {
 func (c *CommunityCondition) Evaluate(path *Path, _ *PolicyOptions) bool {
 	cs := path.GetCommunities()
 	result := false
-	for _, x := range cs {
+	for _, x := range c.set.list {
 		result = false
-		for _, y := range c.set.list {
-			if y.MatchString(fmt.Sprintf("%d:%d", x>>16, x&0x0000ffff)) {
+    for _, y := range cs {
+			if x.MatchString(fmt.Sprintf("%d:%d", y>>16, y&0x0000ffff)) {
 				result = true
 				break
 			}

--- a/table/policy.go
+++ b/table/policy.go
@@ -879,14 +879,14 @@ func ParseExtCommunity(arg string) (bgp.ExtendedCommunityInterface, error) {
 func ParseCommunityRegexp(arg string) (*regexp.Regexp, error) {
 	i, err := strconv.Atoi(arg)
 	if err == nil {
-		return regexp.MustCompile(fmt.Sprintf("%d:%d", i>>16, i&0x0000ffff)), nil
+		return regexp.MustCompile(fmt.Sprintf("^%d:%d$", i>>16, i&0x0000ffff)), nil
 	}
 	if regexp.MustCompile("(\\d+.)*\\d+:\\d+").MatchString(arg) {
-		return regexp.MustCompile(fmt.Sprintf("%s", arg)), nil
+		return regexp.MustCompile(fmt.Sprintf("^%s$", arg)), nil
 	}
 	for i, v := range bgp.WellKnownCommunityNameMap {
 		if strings.Replace(strings.ToLower(arg), "_", "-", -1) == v {
-			return regexp.MustCompile(fmt.Sprintf("%d:%d", i>>16, i&0x0000ffff)), nil
+			return regexp.MustCompile(fmt.Sprintf("^%d:%d$", i>>16, i&0x0000ffff)), nil
 		}
 	}
 	exp, err := regexp.Compile(arg)
@@ -1356,7 +1356,7 @@ func (c *CommunityCondition) Evaluate(path *Path, _ *PolicyOptions) bool {
 		if c.option == MATCH_OPTION_ALL && !result {
 			break
 		}
-		if c.option == MATCH_OPTION_ANY && result {
+		if (c.option == MATCH_OPTION_ANY || c.option == MATCH_OPTION_INVERT) && result {
 			break
 		}
 	}


### PR DESCRIPTION
Under the following condition:
```
[policy-definitions.statements.conditions.bgp-conditions.match-community-set]
  community-set = cs1
  match-set-options = "all"
```
match evaluation should return true if all the elements of cs1 are included in the community-set path attr.

For instance, with the aforementioned condition if cs1 = [c0, c1, c2] and the actual community path attr = [c0], it should be evaluated as false. However the current code without this patch returns true.

It was necessary to revert the previous commit 76525a9, which would cause erroneous regexp evaluations, for instance matching ”65000:100" against "65000:1" as true. 

Changes in gobgp/cmd/policy.go are meant to maintain legibility in cli output. 