### PR TITLE
fix community-set match all evaluation

### DIFF
--- a/table/policy.go
+++ b/table/policy.go
@@ -1345,10 +1345,10 @@ func (c *CommunityCondition) ToApiStruct() *api.MatchSet {
 func (c *CommunityCondition) Evaluate(path *Path, _ *PolicyOptions) bool {
 	cs := path.GetCommunities()
 	result := false
-	for _, x := range cs {
+	for _, x := range c.set.list {
 		result = false
-		for _, y := range c.set.list {
-			if y.MatchString(fmt.Sprintf("%d:%d", x>>16, x&0x0000ffff)) {
+		for _, y := range cs {
+			if x.MatchString(fmt.Sprintf("%d:%d", y>>16, y&0x0000ffff)) {
 				result = true
 				break
 			}


### PR DESCRIPTION
Under the following condition:

[policy-definitions.statements.conditions.bgp-conditions.match-community-set]
  community-set = cs1
  match-set-options = "all"

match evaluation should return true if all the elements of cs1 are
included in the community-set path attr.

For instance, with the aforementioned condition if cs1 = [c0, c1, c2]
and the actual community path attr = [c0], it should be evaluated as
false. However the current code without this patch returns true.