### PR TITLE
test: disable go1.3 on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
   - docker
 
 go:
- - 1.3
  - 1.4
  - 1.5
  - 1.6
@@ -17,8 +16,6 @@ env:
 
 matrix:
   exclude:
-    - go: 1.3
-      env: SCENARIO=true
     - go: 1.4
       env: SCENARIO=true
     - go: 1.5


### PR DESCRIPTION
Travis-ci fails to set up go1.3 environment. Disables go1.3 for now.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>