### PR TITLE
test: allow travis-ci failure on go1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
  - SCENARIO=true
 
 matrix:
+  allow_failures:
+    - go: 1.3
   exclude:
     - go: 1.3
       env: SCENARIO=true


### PR DESCRIPTION
travis-ci can't set up go1.3 env for now. Let's accept the failure on
go1.3 and see if this failure is permanent or not.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>