### PR TITLE
policy: fix as-path match optimization

### DIFF
--- a/docs/sources/policy.md
+++ b/docs/sources/policy.md
@@ -427,15 +427,17 @@ part. Like PrefixSets and NeighborSets, each can have multiple sets and each set
  |------------------|-------------------|------------|----------|
  | AsPathSet        | as path value     | "^65100"   |          |
 
- The AS path regular expression is compatible with [Quagga](http://www.nongnu.org/quagga/docs/docs-multi/AS-Path-Regular-Expression.html) and Cisco. Some examples follow:
+ The AS path regular expression is compatible with [Quagga](http://www.nongnu.org/quagga/docs/docs-multi/AS-Path-Regular-Expression.html) and Cisco.
+ Note Character `_` has special meaning. It is abbreviation for `(^|[,{}() ]|$)`.
 
-    - From: "^65100" means the route is passed from AS 65100 directly.
-    - Any: "65100" means the route comes through AS 65100.
-    - Origin: "65100$" means the route is originated by AS 65100.
-    - Only: "^65100$" means the route is originated by AS 65100 and comes from it directly.
-    - ^65100_65001
-    - 65100_[0-9]+_.*$
-    - ^6[0-9]_5.*_65.?00$
+ Some examples follow:
+    - From: `^65100_` means the route is passed from AS 65100 directly.
+    - Any: `_65100_` means the route comes through AS 65100.
+    - Origin: `_65100$` means the route is originated by AS 65100.
+    - Only: `^65100$` means the route is originated by AS 65100 and comes from it directly.
+    - `^65100_65001`
+    - `65100_[0-9]+_.*$`
+    - `^6[0-9]_5.*_65.?00$`
 
   ##### Examples
   - example 1
@@ -445,7 +447,7 @@ part. Like PrefixSets and NeighborSets, each can have multiple sets and each set
   # example 1
   [[defined-sets.bgp-defined-sets.as-path-sets]]
     as-path-set-name = "aspath1"
-    as-path-list = ["^65100"]
+    as-path-list = ["^65100_"]
   ```
 
   - example 2

--- a/table/policy_test.go
+++ b/table/policy_test.go
@@ -911,7 +911,7 @@ func TestAsPathCondition(t *testing.T) {
 		makeTest(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{1000, 7521, 100}, false),
 	}
 
-	tests["^65001.*65535$"] = []astest{
+	tests["^65001( |_.*_)65535$"] = []astest{
 		makeTest(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65001, 65535}, true),
 		makeTest(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65001, 65001, 65535}, true),
 		makeTest(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65001, 65002, 65003, 65535}, true),
@@ -919,6 +919,8 @@ func TestAsPathCondition(t *testing.T) {
 		makeTest(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65002, 65535}, false),
 		makeTest(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65002, 65001, 65535}, false),
 		makeTest(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65001, 65535, 65002}, false),
+		makeTest(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{650019, 65535}, false),
+		makeTest(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65001, 165535}, false),
 	}
 
 	for k, v := range tests {


### PR DESCRIPTION
following as-path pattern will be optimized

- ^<asn>_ # left-most
- _<asn>$ # origin
- _<asn>_ # include
- ^<asn>$ # only

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>