### PR TITLE
table: use received time as tie-breaker

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1660,6 +1660,8 @@ func (server *BgpServer) handleModConfig(grpcReq *GrpcRequest) error {
 			return err
 		}
 		server.bgpConfig.Global = *c
+		// update route selection options
+		table.SelectionOptions = c.RouteSelectionOptions.Config
 	case api.Operation_DEL_ALL:
 		for k, _ := range server.neighborMap {
 			_, err := server.handleGrpcModNeighbor(&GrpcRequest{

--- a/table/table_manager_test.go
+++ b/table/table_manager_test.go
@@ -1115,6 +1115,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 func TestProcessBGPUpdate_7_select_low_routerid_path_ipv4(t *testing.T) {
 
 	tm := NewTableManager([]bgp.RouteFamily{bgp.RF_IPv4_UC}, 0, 0)
+	SelectionOptions.ExternalCompareRouterId = true
 
 	// low origin message
 	origin1 := bgp.NewPathAttributeOrigin(0)

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -201,7 +201,13 @@ class GoBGPContainer(BGPContainer):
             self._create_config_zebra()
 
     def _create_config_bgp(self):
-        config = {'global': {'config': {'as': self.asn, 'router-id': self.router_id}}}
+        config = {'global': {'config': {'as': self.asn, 'router-id': self.router_id},
+                'route-selection-options':{
+                    'config': {
+                        'external-compare-router-id': True,
+                    },
+                },
+        }}
         for peer, info in self.peers.iteritems():
             afi_safi_list = []
             version = netaddr.IPNetwork(info['neigh_addr']).version


### PR DESCRIPTION
older path get preference

can be disabled by
`global.route-selection-options.external-compare-router-id = true`

close #806

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>