### PR TITLE
config: simplify config structures

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -937,8 +937,6 @@ func (lhs *BmpServerConfig) Equal(rhs *BmpServerConfig) bool {
 //struct for container gobgp:bmp-server
 type BmpServer struct {
 	// original -> gobgp:address
-	//gobgp:address's original type is inet:ip-address
-	Address string `mapstructure:"address"`
 	// original -> gobgp:bmp-server-config
 	Config BmpServerConfig `mapstructure:"config"`
 	// original -> gobgp:bmp-server-state
@@ -947,9 +945,6 @@ type BmpServer struct {
 
 func (lhs *BmpServer) Equal(rhs *BmpServer) bool {
 	if lhs == nil || rhs == nil {
-		return false
-	}
-	if lhs.Address != rhs.Address {
 		return false
 	}
 	if !lhs.Config.Equal(&(rhs.Config)) {
@@ -1130,8 +1125,6 @@ func (lhs *RpkiServerConfig) Equal(rhs *RpkiServerConfig) bool {
 //struct for container gobgp:rpki-server
 type RpkiServer struct {
 	// original -> gobgp:address
-	//gobgp:address's original type is inet:ip-address
-	Address string `mapstructure:"address"`
 	// original -> gobgp:rpki-server-config
 	Config RpkiServerConfig `mapstructure:"config"`
 	// original -> gobgp:rpki-server-state
@@ -1140,9 +1133,6 @@ type RpkiServer struct {
 
 func (lhs *RpkiServer) Equal(rhs *RpkiServer) bool {
 	if lhs == nil || rhs == nil {
-		return false
-	}
-	if lhs.Address != rhs.Address {
 		return false
 	}
 	if !lhs.Config.Equal(&(rhs.Config)) {
@@ -1285,7 +1275,6 @@ func (lhs *PeerGroupConfig) Equal(rhs *PeerGroupConfig) bool {
 //struct for container bgp:peer-group
 type PeerGroup struct {
 	// original -> bgp:peer-group-name
-	PeerGroupName string `mapstructure:"peer-group-name"`
 	// original -> bgp:peer-group-config
 	Config PeerGroupConfig `mapstructure:"config"`
 	// original -> bgp:peer-group-state
@@ -1320,9 +1309,6 @@ type PeerGroup struct {
 
 func (lhs *PeerGroup) Equal(rhs *PeerGroup) bool {
 	if lhs == nil || rhs == nil {
-		return false
-	}
-	if lhs.PeerGroupName != rhs.PeerGroupName {
 		return false
 	}
 	if !lhs.Config.Equal(&(rhs.Config)) {
@@ -1361,10 +1347,10 @@ func (lhs *PeerGroup) Equal(rhs *PeerGroup) bool {
 	{
 		lmap := make(map[string]*AfiSafi)
 		for _, l := range lhs.AfiSafis {
-			lmap[string(l.AfiSafiName)] = &l
+			lmap[string(l.Config.AfiSafiName)] = &l
 		}
 		for _, r := range rhs.AfiSafis {
-			if l, y := lmap[string(r.AfiSafiName)]; !y {
+			if l, y := lmap[string(r.Config.AfiSafiName)]; !y {
 				return false
 			} else if !r.Equal(l) {
 				return false
@@ -2399,8 +2385,6 @@ func (lhs *NeighborConfig) Equal(rhs *NeighborConfig) bool {
 //struct for container bgp:neighbor
 type Neighbor struct {
 	// original -> bgp:neighbor-address
-	//bgp:neighbor-address's original type is inet:ip-address
-	NeighborAddress string `mapstructure:"neighbor-address"`
 	// original -> bgp:neighbor-config
 	Config NeighborConfig `mapstructure:"config"`
 	// original -> bgp:neighbor-state
@@ -2435,9 +2419,6 @@ type Neighbor struct {
 
 func (lhs *Neighbor) Equal(rhs *Neighbor) bool {
 	if lhs == nil || rhs == nil {
-		return false
-	}
-	if lhs.NeighborAddress != rhs.NeighborAddress {
 		return false
 	}
 	if !lhs.Config.Equal(&(rhs.Config)) {
@@ -2476,10 +2457,10 @@ func (lhs *Neighbor) Equal(rhs *Neighbor) bool {
 	{
 		lmap := make(map[string]*AfiSafi)
 		for _, l := range lhs.AfiSafis {
-			lmap[string(l.AfiSafiName)] = &l
+			lmap[string(l.Config.AfiSafiName)] = &l
 		}
 		for _, r := range rhs.AfiSafis {
-			if l, y := lmap[string(r.AfiSafiName)]; !y {
+			if l, y := lmap[string(r.Config.AfiSafiName)]; !y {
 				return false
 			} else if !r.Equal(l) {
 				return false
@@ -3205,7 +3186,6 @@ func (lhs *MpGracefulRestart) Equal(rhs *MpGracefulRestart) bool {
 //struct for container bgp-mp:afi-safi
 type AfiSafi struct {
 	// original -> bgp-mp:afi-safi-name
-	AfiSafiName AfiSafiType `mapstructure:"afi-safi-name"`
 	// original -> bgp-mp:mp-graceful-restart
 	MpGracefulRestart MpGracefulRestart `mapstructure:"mp-graceful-restart"`
 	// original -> bgp-mp:afi-safi-config
@@ -3246,9 +3226,6 @@ type AfiSafi struct {
 
 func (lhs *AfiSafi) Equal(rhs *AfiSafi) bool {
 	if lhs == nil || rhs == nil {
-		return false
-	}
-	if lhs.AfiSafiName != rhs.AfiSafiName {
 		return false
 	}
 	if !lhs.MpGracefulRestart.Equal(&(rhs.MpGracefulRestart)) {
@@ -3996,10 +3973,10 @@ func (lhs *Global) Equal(rhs *Global) bool {
 	{
 		lmap := make(map[string]*AfiSafi)
 		for _, l := range lhs.AfiSafis {
-			lmap[string(l.AfiSafiName)] = &l
+			lmap[string(l.Config.AfiSafiName)] = &l
 		}
 		for _, r := range rhs.AfiSafis {
-			if l, y := lmap[string(r.AfiSafiName)]; !y {
+			if l, y := lmap[string(r.Config.AfiSafiName)]; !y {
 				return false
 			} else if !r.Equal(l) {
 				return false
@@ -4053,10 +4030,10 @@ func (lhs *Bgp) Equal(rhs *Bgp) bool {
 	{
 		lmap := make(map[string]*Neighbor)
 		for _, l := range lhs.Neighbors {
-			lmap[string(l.NeighborAddress)] = &l
+			lmap[string(l.Config.NeighborAddress)] = &l
 		}
 		for _, r := range rhs.Neighbors {
-			if l, y := lmap[string(r.NeighborAddress)]; !y {
+			if l, y := lmap[string(r.Config.NeighborAddress)]; !y {
 				return false
 			} else if !r.Equal(l) {
 				return false
@@ -4069,10 +4046,10 @@ func (lhs *Bgp) Equal(rhs *Bgp) bool {
 	{
 		lmap := make(map[string]*PeerGroup)
 		for _, l := range lhs.PeerGroups {
-			lmap[string(l.PeerGroupName)] = &l
+			lmap[string(l.Config.PeerGroupName)] = &l
 		}
 		for _, r := range rhs.PeerGroups {
-			if l, y := lmap[string(r.PeerGroupName)]; !y {
+			if l, y := lmap[string(r.Config.PeerGroupName)]; !y {
 				return false
 			} else if !r.Equal(l) {
 				return false
@@ -4085,10 +4062,10 @@ func (lhs *Bgp) Equal(rhs *Bgp) bool {
 	{
 		lmap := make(map[string]*RpkiServer)
 		for _, l := range lhs.RpkiServers {
-			lmap[string(l.Address)] = &l
+			lmap[string(l.Config.Address)] = &l
 		}
 		for _, r := range rhs.RpkiServers {
-			if l, y := lmap[string(r.Address)]; !y {
+			if l, y := lmap[string(r.Config.Address)]; !y {
 				return false
 			} else if !r.Equal(l) {
 				return false
@@ -4101,10 +4078,10 @@ func (lhs *Bgp) Equal(rhs *Bgp) bool {
 	{
 		lmap := make(map[string]*BmpServer)
 		for _, l := range lhs.BmpServers {
-			lmap[string(l.Address)] = &l
+			lmap[string(l.Config.Address)] = &l
 		}
 		for _, r := range rhs.BmpServers {
-			if l, y := lmap[string(r.Address)]; !y {
+			if l, y := lmap[string(r.Config.Address)]; !y {
 				return false
 			} else if !r.Equal(l) {
 				return false

--- a/config/default.go
+++ b/config/default.go
@@ -24,7 +24,6 @@ func SetDefaultConfigValues(v *viper.Viper, b *BgpConfigSet) error {
 
 	defaultAfiSafi := func(typ AfiSafiType, enable bool) AfiSafi {
 		return AfiSafi{
-			AfiSafiName: typ,
 			Config: AfiSafiConfig{
 				AfiSafiName: typ,
 				Enabled:     enable,
@@ -132,8 +131,7 @@ func SetDefaultConfigValues(v *viper.Viper, b *BgpConfigSet) error {
 				if len(afs) > i {
 					vvv.Set("afi-safi", afs[i])
 				}
-				af.Config.AfiSafiName = af.AfiSafiName
-				af.State.AfiSafiName = af.AfiSafiName
+				af.State.AfiSafiName = af.Config.AfiSafiName
 				if !vvv.IsSet("afi-safi.config") {
 					af.Config.Enabled = true
 				}

--- a/config/util.go
+++ b/config/util.go
@@ -40,9 +40,9 @@ type AfiSafis []AfiSafi
 func (c AfiSafis) ToRfList() ([]bgp.RouteFamily, error) {
 	rfs := make([]bgp.RouteFamily, 0, len(c))
 	for _, rf := range c {
-		k, err := bgp.GetRouteFamily(string(rf.AfiSafiName))
+		k, err := bgp.GetRouteFamily(string(rf.Config.AfiSafiName))
 		if err != nil {
-			return nil, fmt.Errorf("invalid address family: %s", rf.AfiSafiName)
+			return nil, fmt.Errorf("invalid address family: %s", rf.Config.AfiSafiName)
 		}
 		rfs = append(rfs, k)
 	}
@@ -60,7 +60,7 @@ func CreateRfMap(p *Neighbor) map[bgp.RouteFamily]bool {
 
 func GetAfiSafi(p *Neighbor, family bgp.RouteFamily) *AfiSafi {
 	for _, a := range p.AfiSafis {
-		if string(a.AfiSafiName) == family.String() {
+		if string(a.Config.AfiSafiName) == family.String() {
 			return &a
 		}
 	}

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -63,29 +63,43 @@
         route-reflector-client = true
         route-reflector-cluster-id = "192.168.0.1"
     [[neighbors.afi-safis]]
+        [neighbors.afi-safis.config]
         afi-safi-name = "ipv4-unicast"
         [neighbors.afi-safis.prefix-limit.config]
            max-prefixes = 1000
            shutdown-threshold-pct = 80
     [[neighbors.afi-safis]]
+        [neighbors.afi-safis.config]
         afi-safi-name = "ipv6-unicast"
     [[neighbors.afi-safis]]
+        [neighbors.afi-safis.config]
         afi-safi-name = "ipv4-labelled-unicast"
     [[neighbors.afi-safis]]
+        [neighbors.afi-safis.config]
         afi-safi-name = "ipv6-labelled-unicast"
     [[neighbors.afi-safis]]
+        [neighbors.afi-safis.config]
         afi-safi-name = "l3vpn-ipv4-unicast"
     [[neighbors.afi-safis]]
+        [neighbors.afi-safis.config]
         afi-safi-name = "l3vpn-ipv6-unicast"
     [[neighbors.afi-safis]]
+        [neighbors.afi-safis.config]
         afi-safi-name = "l2vpn-evpn"
     [[neighbors.afi-safis]]
+        [neighbors.afi-safis.config]
         afi-safi-name = "rtc"
     [[neighbors.afi-safis]]
-        afi-safi-name = "encap"
+        [neighbors.afi-safis.config]
+        afi-safi-name = "ipv4-encap"
     [[neighbors.afi-safis]]
+        [neighbors.afi-safis.config]
+        afi-safi-name = "ipv6-encap"
+    [[neighbors.afi-safis]]
+        [neighbors.afi-safis.config]
         afi-safi-name = "ipv4-flowspec"
     [[neighbors.afi-safis]]
+        [neighbors.afi-safis.config]
         afi-safi-name = "ipv6-flowspec"
     [neighbors.apply-policy.config]
         import-policy-list = ["policy1"]

--- a/docs/sources/evpn.md
+++ b/docs/sources/evpn.md
@@ -28,6 +28,7 @@ implementations can interchange EVPN messages.
   neighbor-address = "10.0.255.1"
   peer-as = 64512
 [[neighbors.afi-safis]]
+  [neighbors.afi-safis.config]
   afi-safi-name = "l2vpn-evpn"
 
 [[neighbors]]
@@ -35,6 +36,7 @@ implementations can interchange EVPN messages.
   neighbor-address = "10.0.255.2"
   peer-as = 64512
 [[neighbors.afi-safis]]
+  [neighbors.afi-safis.config]
   afi-safi-name = "l2vpn-evpn"
 ```
 

--- a/docs/sources/flowspec.md
+++ b/docs/sources/flowspec.md
@@ -28,10 +28,13 @@ afi-safis like below.
   neighbor-address = "10.0.255.1"
   peer-as = 64512
 [[neighbors.afi-safis]]
+  [neighbors.afi-safis.config]
   afi-safi-name = "ipv4-flowspec"
 [[neighbors.afi-safis]]
+  [neighbors.afi-safis.config]
   afi-safi-name = "ipv6-flowspec"
 [[neighbors.afi-safis]]
+  [neighbors.afi-safis.config]
   afi-safi-name = "l2vpn-flowspec"
 ```
 

--- a/docs/sources/graceful-restart.md
+++ b/docs/sources/graceful-restart.md
@@ -77,6 +77,7 @@ To support restarting speaker behavior, try the configuration below.
     enabled = true
     restart-time = 120
   [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
     afi-safi-name = "ipv4-unicast"
     [neighbors.afi-safis.mp-graceful-restart.config]
         enabled = true

--- a/server/fsm.go
+++ b/server/fsm.go
@@ -516,7 +516,7 @@ func capabilitiesFromConfig(pConf *config.Neighbor) []bgp.ParameterCapabilityInt
 	caps := make([]bgp.ParameterCapabilityInterface, 0, 4)
 	caps = append(caps, bgp.NewCapRouteRefresh())
 	for _, rf := range pConf.AfiSafis {
-		family, _ := bgp.GetRouteFamily(string(rf.AfiSafiName))
+		family, _ := bgp.GetRouteFamily(string(rf.Config.AfiSafiName))
 		caps = append(caps, bgp.NewCapMultiProtocol(family))
 	}
 	caps = append(caps, bgp.NewCapFourOctetASNumber(pConf.Config.LocalAs))
@@ -533,7 +533,7 @@ func capabilitiesFromConfig(pConf *config.Neighbor) []bgp.ParameterCapabilityInt
 		if !c.HelperOnly {
 			for i, rf := range pConf.AfiSafis {
 				if rf.MpGracefulRestart.Config.Enabled {
-					k, _ := bgp.GetRouteFamily(string(rf.AfiSafiName))
+					k, _ := bgp.GetRouteFamily(string(rf.Config.AfiSafiName))
 					// When restarting, always flag forwaring bit.
 					// This can be a lie, depending on how gobgpd is used.
 					// For a route-server use-case, since a route-server
@@ -829,7 +829,7 @@ func (h *FSMHandler) opensent() (bgp.FSMState, FsmStateReason) {
 						for _, t := range cap.Tuples {
 							n := bgp.AddressFamilyNameMap[bgp.AfiSafiToRouteFamily(t.AFI, t.SAFI)]
 							for i, a := range fsm.pConf.AfiSafis {
-								if string(a.AfiSafiName) == n {
+								if string(a.Config.AfiSafiName) == n {
 									fsm.pConf.AfiSafis[i].MpGracefulRestart.State.Enabled = true
 									fsm.pConf.AfiSafis[i].MpGracefulRestart.State.Received = true
 									break

--- a/server/peer.go
+++ b/server/peer.go
@@ -105,7 +105,7 @@ func (peer *Peer) forwardingPreservedFamilies() ([]bgp.RouteFamily, []bgp.RouteF
 	list := []bgp.RouteFamily{}
 	for _, a := range peer.fsm.pConf.AfiSafis {
 		if s := a.MpGracefulRestart.State; s.Enabled && s.Received {
-			f, _ := bgp.GetRouteFamily(string(a.AfiSafiName))
+			f, _ := bgp.GetRouteFamily(string(a.Config.AfiSafiName))
 			list = append(list, f)
 		}
 	}
@@ -263,7 +263,7 @@ func (peer *Peer) updatePrefixLimitConfig(c []config.AfiSafi) ([]*SenderMsg, err
 	}
 	m := make(map[bgp.RouteFamily]config.PrefixLimitConfig)
 	for _, e := range x {
-		k, err := bgp.GetRouteFamily(string(e.AfiSafiName))
+		k, err := bgp.GetRouteFamily(string(e.Config.AfiSafiName))
 		if err != nil {
 			return nil, err
 		}
@@ -271,7 +271,7 @@ func (peer *Peer) updatePrefixLimitConfig(c []config.AfiSafi) ([]*SenderMsg, err
 	}
 	msgs := make([]*SenderMsg, 0, len(y))
 	for _, e := range y {
-		k, err := bgp.GetRouteFamily(string(e.AfiSafiName))
+		k, err := bgp.GetRouteFamily(string(e.Config.AfiSafiName))
 		if err != nil {
 			return nil, err
 		}
@@ -281,7 +281,7 @@ func (peer *Peer) updatePrefixLimitConfig(c []config.AfiSafi) ([]*SenderMsg, err
 			log.WithFields(log.Fields{
 				"Topic":                   "Peer",
 				"Key":                     peer.ID(),
-				"AddressFamily":           e.AfiSafiName,
+				"AddressFamily":           e.Config.AfiSafiName,
 				"OldMaxPrefixes":          p.MaxPrefixes,
 				"NewMaxPrefixes":          e.PrefixLimit.Config.MaxPrefixes,
 				"OldShutdownThresholdPct": p.ShutdownThresholdPct,
@@ -308,7 +308,7 @@ func (peer *Peer) handleUpdate(e *FsmMsg) ([]*table.Path, []bgp.RouteFamily, *bg
 	if len(e.PathList) > 0 {
 		peer.adjRibIn.Update(e.PathList)
 		for _, family := range peer.fsm.pConf.AfiSafis {
-			k, _ := bgp.GetRouteFamily(string(family.AfiSafiName))
+			k, _ := bgp.GetRouteFamily(string(family.Config.AfiSafiName))
 			if msg := peer.doPrefixLimit(k, &family.PrefixLimit.Config); msg != nil {
 				return nil, nil, msg
 			}
@@ -382,7 +382,7 @@ func (peer *Peer) ToApiStruct() *api.Peer {
 	prefixLimits := make([]*api.PrefixLimit, 0, len(peer.fsm.pConf.AfiSafis))
 	for _, family := range peer.fsm.pConf.AfiSafis {
 		if c := family.PrefixLimit.Config; c.MaxPrefixes > 0 {
-			k, _ := bgp.GetRouteFamily(string(family.AfiSafiName))
+			k, _ := bgp.GetRouteFamily(string(family.Config.AfiSafiName))
 			prefixLimits = append(prefixLimits, &api.PrefixLimit{
 				Family:               uint32(k),
 				MaxPrefixes:          c.MaxPrefixes,

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -212,24 +212,23 @@ class GoBGPContainer(BGPContainer):
             afi_safi_list = []
             version = netaddr.IPNetwork(info['neigh_addr']).version
             if version == 4:
-                afi_safi_list.append({'afi-safi-name': 'ipv4-unicast'})
+                afi_safi_list.append({'config':{'afi-safi-name': 'ipv4-unicast'}})
             elif version == 6:
-                afi_safi_list.append({'afi-safi-name': 'ipv6-unicast'})
+                afi_safi_list.append({'config':{'afi-safi-name': 'ipv6-unicast'}})
             else:
                 Exception('invalid ip address version. {0}'.format(version))
 
             if info['vpn']:
-                afi_safi_list.append({'afi-safi-name': 'l3vpn-ipv4-unicast'})
-                afi_safi_list.append({'afi-safi-name': 'l3vpn-ipv6-unicast'})
-                afi_safi_list.append({'afi-safi-name': 'l2vpn-evpn'})
-                afi_safi_list.append({'afi-safi-name': 'rtc',
-                    'route-target-membership': {'deferral-time': 10}})
+                afi_safi_list.append({'config': {'afi-safi-name': 'l3vpn-ipv4-unicast'}})
+                afi_safi_list.append({'config': {'afi-safi-name': 'l3vpn-ipv6-unicast'}})
+                afi_safi_list.append({'config': {'afi-safi-name': 'l2vpn-evpn'}})
+                afi_safi_list.append({'config': {'afi-safi-name': 'rtc'}, 'route-target-membership': {'deferral-time': 10}})
 
             if info['flowspec']:
-                afi_safi_list.append({'afi-safi-name': 'ipv4-flowspec'})
-                afi_safi_list.append({'afi-safi-name': 'l3vpn-ipv4-flowspec'})
-                afi_safi_list.append({'afi-safi-name': 'ipv6-flowspec'})
-                afi_safi_list.append({'afi-safi-name': 'l3vpn-ipv6-flowspec'})
+                afi_safi_list.append({'config': {'afi-safi-name': 'ipv4-flowspec'}})
+                afi_safi_list.append({'config': {'afi-safi-name': 'l3vpn-ipv4-flowspec'}})
+                afi_safi_list.append({'config': {'afi-safi-name': 'ipv6-flowspec'}})
+                afi_safi_list.append({'config': {'afi-safi-name': 'l3vpn-ipv6-flowspec'}})
 
             n = {'config':
                  {'neighbor-address': info['neigh_addr'].split('/')[0],

--- a/tools/config/example_toml.go
+++ b/tools/config/example_toml.go
@@ -23,8 +23,16 @@ func main() {
 					NeighborAddress: "192.168.177.33",
 				},
 				AfiSafis: []config.AfiSafi{
-					config.AfiSafi{AfiSafiName: "ipv4-unicast"},
-					config.AfiSafi{AfiSafiName: "ipv6-unicast"},
+					config.AfiSafi{
+						Config: config.AfiSafiConfig{
+							AfiSafiName: "ipv4-unicast",
+						},
+					},
+					config.AfiSafi{
+						Config: config.AfiSafiConfig{
+							AfiSafiName: "ipv6-unicast",
+						},
+					},
 				},
 				ApplyPolicy: config.ApplyPolicy{
 

--- a/tools/pyang_plugins/bgpyang2golang.py
+++ b/tools/pyang_plugins/bgpyang2golang.py
@@ -168,6 +168,8 @@ def emit_class_def(ctx, yang_statement, struct_name, prefix):
 
             # case leafref
             elif type_name == 'leafref':
+                if type_obj.search_one('path').arg.startswith('../config'):
+                    continue
                 t = dig_leafref(type_obj)
                 if is_translation_required(t):
                     print >> o, '  //%s:%s\'s original type is %s' \
@@ -243,7 +245,10 @@ def emit_class_def(ctx, yang_statement, struct_name, prefix):
                 l = t.i_children[0]
                 emit_type_name = '[]' + l.golang_name
                 equal_type = EQUAL_TYPE_MAP
-                equal_data = t.i_children[0].search_one('key').arg
+                equal_data = l.search_one('key').arg
+                leaf = l.search_one('leaf').search_one('type')
+                if leaf.arg == 'leafref' and leaf.search_one('path').arg.startswith('../config'):
+                    equal_data = 'config.' + equal_data
             else:
                 emit_type_name = t.golang_name
                 equal_type = EQUAL_TYPE_CONTAINER
@@ -692,9 +697,9 @@ def translate_type(key):
 
 # 'hoge-hoge' -> 'HogeHoge'
 def convert_to_golang(type_string):
-    a = type_string.split('-')
+    a = type_string.split('.')
     a = map(lambda x: x.capitalize(), a)  # XXX locale sensitive
-    return ''.join(a)
+    return '.'.join( ''.join(t.capitalize() for t in x.split('-')) for x in a)
 
 
 # 'hoge-hoge' -> 'HOGE_HOGE'


### PR DESCRIPTION
stop generating self-contained leafref fields in openconfig model.
(e.g. bgp:neighbor/bgp:neighbor-address )

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>