### PR TITLE
test: allow travis-ci failure on go1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
 matrix:
   allow_failures:
     - go: 1.3
+    - go: 1.4
   exclude:
     - go: 1.3
       env: SCENARIO=true


### PR DESCRIPTION
travis-ci can't set up go1.4 env for now. Let's accept the failure on
go1.4 and see if this failure is permanent or not.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>