### PR TITLE
fix 332766189685028c4f9852e4285fb1a9025223cc regression

### DIFF
--- a/server/peer.go
+++ b/server/peer.go
@@ -171,7 +171,9 @@ func (peer *Peer) processOutgoingPaths(paths, withdrawals []*table.Path) []*tabl
 	outgoing := make([]*table.Path, 0, len(paths))
 	for _, path := range withdrawals {
 		if path.IsLocal() {
-			outgoing = append(outgoing, path)
+			if _, ok := peer.fsm.rfMap[path.GetRouteFamily()]; ok {
+				outgoing = append(outgoing, path)
+			}
 		}
 	}
 


### PR DESCRIPTION
We can't send a path to a peer if the peer isn't configured for its
family.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>