### PR TITLE
server: immediately close newly accepted connection for admin-state-d…

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -263,6 +263,11 @@ func (server *BgpServer) Serve() {
 			remoteAddr, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
 			peer, found := server.neighborMap[remoteAddr]
 			if found {
+				if peer.fsm.adminState == ADMIN_STATE_DOWN {
+					log.Debug("new connection for admin-state-down peer ", remoteAddr)
+					conn.Close()
+					return
+				}
 				localAddrValid := func(laddr net.IP) bool {
 					if laddr == nil {
 						return true


### PR DESCRIPTION
…own peer

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>