### PR TITLE
server: print correct reason of state change by configuration change

### DIFF
--- a/server/fsm.go
+++ b/server/fsm.go
@@ -247,13 +247,14 @@ func (fsm *FSM) LocalHostPort() (string, uint16) {
 	return hostport(fsm.conn.LocalAddr())
 }
 
-func (fsm *FSM) sendNotificatonFromErrorMsg(e *bgp.MessageError) error {
+func (fsm *FSM) sendNotificationFromErrorMsg(e *bgp.MessageError) error {
 	if fsm.h != nil && fsm.h.conn != nil {
 		m := bgp.NewBGPNotificationMessage(e.TypeCode, e.SubTypeCode, e.Data)
 		b, _ := m.Serialize()
 		_, err := fsm.h.conn.Write(b)
-		if err != nil {
+		if err == nil {
 			fsm.bgpMessageStateUpdate(m.Header.Type, false)
+			fsm.h.sentNotification = bgp.NewNotificationErrorCode(e.TypeCode, e.SubTypeCode).String()
 		}
 		fsm.h.conn.Close()
 		log.WithFields(log.Fields{
@@ -268,7 +269,7 @@ func (fsm *FSM) sendNotificatonFromErrorMsg(e *bgp.MessageError) error {
 
 func (fsm *FSM) sendNotification(code, subType uint8, data []byte, msg string) error {
 	e := bgp.NewMessageError(code, subType, data, msg)
-	return fsm.sendNotificatonFromErrorMsg(e.(*bgp.MessageError))
+	return fsm.sendNotificationFromErrorMsg(e.(*bgp.MessageError))
 }
 
 func (fsm *FSM) connectLoop() error {
@@ -364,6 +365,7 @@ type FSMHandler struct {
 	stateCh          chan *FsmMsg
 	outgoing         chan *FsmOutgoingMsg
 	holdTimerResetCh chan bool
+	sentNotification string
 }
 
 func NewFSMHandler(fsm *FSM, incoming *channels.InfiniteChannel, stateCh chan *FsmMsg, outgoing chan *FsmOutgoingMsg) *FSMHandler {
@@ -777,7 +779,7 @@ func (h *FSMHandler) opensent() (bgp.FSMState, FsmStateReason) {
 					body := m.Body.(*bgp.BGPOpen)
 					err := bgp.ValidateOpenMsg(body, fsm.pConf.Config.PeerAs)
 					if err != nil {
-						fsm.sendNotificatonFromErrorMsg(err.(*bgp.MessageError))
+						fsm.sendNotificationFromErrorMsg(err.(*bgp.MessageError))
 						return bgp.BGP_FSM_IDLE, FSM_INVALID_MSG
 					}
 					fsm.peerInfo.ID = body.ID
@@ -847,7 +849,7 @@ func (h *FSMHandler) opensent() (bgp.FSMState, FsmStateReason) {
 					return bgp.BGP_FSM_IDLE, FSM_INVALID_MSG
 				}
 			case *bgp.MessageError:
-				fsm.sendNotificatonFromErrorMsg(e.MsgData.(*bgp.MessageError))
+				fsm.sendNotificationFromErrorMsg(e.MsgData.(*bgp.MessageError))
 				return bgp.BGP_FSM_IDLE, FSM_INVALID_MSG
 			default:
 				log.WithFields(log.Fields{
@@ -958,7 +960,7 @@ func (h *FSMHandler) openconfirm() (bgp.FSMState, FsmStateReason) {
 				h.conn.Close()
 				return bgp.BGP_FSM_IDLE, FSM_INVALID_MSG
 			case *bgp.MessageError:
-				fsm.sendNotificatonFromErrorMsg(e.MsgData.(*bgp.MessageError))
+				fsm.sendNotificationFromErrorMsg(e.MsgData.(*bgp.MessageError))
 				return bgp.BGP_FSM_IDLE, FSM_INVALID_MSG
 			default:
 				log.WithFields(log.Fields{
@@ -1235,11 +1237,17 @@ func (h *FSMHandler) loop() error {
 	}
 
 	if oldState == bgp.BGP_FSM_ESTABLISHED {
+		// The main goroutine sent the notificaiton due to
+		// deconfiguration or something.
+		reason := fsm.reason
+		if fsm.h.sentNotification != "" {
+			reason = FsmStateReason(fmt.Sprintf("%s %s", FSM_NOTIFICATION_SENT, fsm.h.sentNotification))
+		}
 		log.WithFields(log.Fields{
 			"Topic":  "Peer",
 			"Key":    fsm.pConf.Config.NeighborAddress,
 			"State":  fsm.state.String(),
-			"Reason": fsm.reason,
+			"Reason": reason,
 		}).Info("Peer Down")
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -2410,6 +2410,9 @@ func (server *BgpServer) handleDelNeighbor(c *config.Neighbor, code, subcode uin
 		SetTcpMD5SigSockopts(l, addr, "")
 	}
 	log.Info("Delete a peer configuration for ", addr)
+
+	n.fsm.sendNotification(code, subcode, nil, "")
+
 	go func(addr string) {
 		t := time.AfterFunc(time.Minute*5, func() { log.Fatal("failed to free the fsm.h.t for ", addr) })
 		n.fsm.h.t.Kill(nil)
@@ -2422,9 +2425,6 @@ func (server *BgpServer) handleDelNeighbor(c *config.Neighbor, code, subcode uin
 	}(addr)
 	delete(server.neighborMap, addr)
 	m := server.dropPeerAllRoutes(n, n.configuredRFlist())
-
-	n.fsm.sendNotification(code, subcode, nil, "")
-
 	return m, nil
 }
 


### PR DESCRIPTION
Changing some of configuration leads to sending a notification. So the
reason of the BGP state change should be the notification.

The main goroutine sends a notification, closes the connection, kill
goroutines for the peer. So With the current code, the reason could be
"rx failure", "tx failure", or "dying". To avoid that, this patch adds
kinda workaround.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>