### PR TITLE
server: fix wrong usage of zapi

### DIFF
--- a/server/zclient.go
+++ b/server/zclient.go
@@ -186,8 +186,5 @@ func NewZclient(url string, redistRouteTypes []config.InstallProtocolType) (*zeb
 		}
 		cli.SendRedistribute(t)
 	}
-	if e := cli.SendCommand(zebra.REDISTRIBUTE_DEFAULT_ADD, nil); e != nil {
-		return nil, e
-	}
 	return cli, nil
 }


### PR DESCRIPTION
sending REDISTRIBUTE_DEFAULT_ADD command causes getting every routes
zebra has which is not desirable behavior

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>