### PR TITLE
server: avoid sending unnecessary udate messages with soft_reset_in f…

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2029,6 +2029,16 @@ func (server *BgpServer) handleGrpc(grpcReq *GrpcRequest) []*SenderMsg {
 				path.Filter(peer.ID(), table.POLICY_DIRECTION_NONE)
 				if server.policy.ApplyPolicy(peer.ID(), table.POLICY_DIRECTION_IN, path, nil) != nil {
 					pathList = append(pathList, path.Clone(false))
+					// this path still in rib's
+					// knownPathList. We can't
+					// drop
+					// table.POLICY_DIRECTION_IMPORT
+					// flag here. Otherwise, this
+					// path could be the old best
+					// path.
+					if peer.isRouteServerClient() {
+						path.Filter(peer.ID(), table.POLICY_DIRECTION_IMPORT)
+					}
 				} else {
 					path.Filter(peer.ID(), table.POLICY_DIRECTION_IN)
 					if exResult != table.POLICY_DIRECTION_IN {


### PR DESCRIPTION
…or route server

The current code sets a path to table.POLICY_DIRECTION_NONE, which is
still rib's knowPathList. Next time the best path selection happens,
the path is moved to oldKnownPathList and wrongly the best path
selection code could assume that it was the old best path, and sends
an unnecessary update message.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>