### PR TITLE
server: fix active connection regression

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -270,8 +270,8 @@ func (server *BgpServer) Serve() {
 					conn.Close()
 					return
 				}
-				localAddrValid := func(laddr net.IP) bool {
-					if laddr == nil {
+				localAddrValid := func(laddr string) bool {
+					if laddr == "0.0.0.0" || laddr == "::" {
 						return true
 					}
 					l := conn.LocalAddr()
@@ -281,17 +281,17 @@ func (server *BgpServer) Serve() {
 					}
 
 					host, _, _ := net.SplitHostPort(l.String())
-					if host != laddr.String() {
+					if host != laddr {
 						log.WithFields(log.Fields{
 							"Topic":           "Peer",
 							"Key":             remoteAddr,
-							"Configured addr": laddr.String(),
+							"Configured addr": laddr,
 							"Addr":            host,
 						}).Info("Mismatched local address")
 						return false
 					}
 					return true
-				}(net.ParseIP(peer.fsm.pConf.Transport.Config.LocalAddress))
+				}(peer.fsm.pConf.Transport.Config.LocalAddress)
 				if localAddrValid == false {
 					conn.Close()
 					return

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -268,10 +268,11 @@ class GoBGPContainer(BGPContainer):
                  'timers': {'config': {
                      'connect-retry': 10,
                   }},
-                 'transport': {'config': {
-                     'local-address': info['local_addr'].split('/')[0],
-                  }},
+                 'transport': {'config': {}},
                  }
+
+            if ':' in info['local_addr']:
+                n['transport']['config']['local-address'] = info['local_addr'].split('/')[0]
 
             if info['passive']:
                 n['transport']['config']['passive-mode'] = True


### PR DESCRIPTION
regression introduced by 4c9cd88c61cb848e36a45657b7cbc63b9c783dc4

also fix test/lib to test configuration without local-address
(configure local-address only if neighbor-address is IPv6)

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>