### PR TITLE
server: fix another regression of active connection

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2652,6 +2652,12 @@ func (server *BgpServer) handleAddNeighborRequest(grpcReq *GrpcRequest) ([]*Send
 			if a.Transport != nil {
 				pconf.Transport.Config.LocalAddress = a.Transport.LocalAddress
 				pconf.Transport.Config.PassiveMode = a.Transport.PassiveMode
+			} else {
+				if net.ParseIP(a.Conf.NeighborAddress).To4() != nil {
+					pconf.Transport.Config.LocalAddress = "0.0.0.0"
+				} else {
+					pconf.Transport.Config.LocalAddress = "::"
+				}
 			}
 			if a.EbgpMultihop != nil {
 				pconf.EbgpMultihop.Config.Enabled = a.EbgpMultihop.Enabled

--- a/test/scenario_test/bgp_router_test.py
+++ b/test/scenario_test/bgp_router_test.py
@@ -18,6 +18,7 @@ from fabric.api import local
 from lib import base
 from lib.gobgp import *
 from lib.quagga import *
+from lib.exabgp import *
 import sys
 import os
 import time
@@ -335,6 +336,18 @@ class GoBGPTestBase(unittest.TestCase):
         paths = g1.get_adj_rib_out(q2, '30.0.0.0/24')
         self.assertTrue(len(paths) == 1)
         self.assertTrue(paths[0]['source-id'] == '192.168.0.2')
+
+    def test_19_check_grpc_add_neighbor(self):
+        g1 = self.gobgp
+        e1 = ExaBGPContainer(name='e1', asn=65000, router_id='192.168.0.7')
+        time.sleep(e1.run())
+        e1.add_peer(g1)
+        n = e1.peers[g1]['local_addr'].split('/')[0]
+        g1.local('gobgp n add {0} as 65000'.format(n))
+        g1.add_peer(e1, reload_config=False) 
+
+        g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=e1)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Another regression introduced by 4c9cd88c61cb848e36a45657b7cbc63b9c783dc4

Previous fix (81bc3851b2c1f112f157b98a3cf60757a199a31a) fixes active
connection of neighbors configured via configuration file.
This fixes that of neighbors configured via gRPC API.

Test is also added.

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>