### PR TITLE
table: fix leftmostAS() in compareByMED

### DIFF
--- a/table/destination.go
+++ b/table/destination.go
@@ -682,7 +682,7 @@ func compareByMED(path1, path2 *Path) *Path {
 		leftmostAS := func(path *Path) uint32 {
 			if aspath := path.GetAsPath(); aspath != nil {
 				asPathParam := aspath.Value
-				for i := len(asPathParam) - 1; i >= 0; i-- {
+				for i := 0; i < len(asPathParam); i++ {
 					asPath := asPathParam[i].(*bgp.As4PathParam)
 					if asPath.Num == 0 {
 						continue
@@ -690,12 +690,12 @@ func compareByMED(path1, path2 *Path) *Path {
 					if asPath.Type == bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET || asPath.Type == bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ {
 						continue
 					}
-					return asPath.AS[asPath.Num-1]
+					return asPath.AS[0]
 				}
 			}
 			return 0
 		}
-		return leftmostAS(path1) == leftmostAS(path2)
+		return leftmostAS(path1) != 0 && leftmostAS(path1) == leftmostAS(path2)
 	}()
 
 	if SelectionOptions.AlwaysCompareMed || isInternal || isSameAS {


### PR DESCRIPTION
Needs the first AS in the AS_SEQUENCE is the same for multiple
paths. Any preceding AS_CONFED_SEQUENCE is ignored.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>