### PR TITLE
table: fix leftmostAS() in compareByMED

### DIFF
--- a/table/destination.go
+++ b/table/destination.go
@@ -679,10 +679,10 @@ func compareByMED(path1, path2 *Path) *Path {
 	isInternal := func() bool { return path1.GetAsPathLen() == 0 && path2.GetAsPathLen() == 0 }()
 
 	isSameAS := func() bool {
-		leftmostAS := func(path *Path) uint32 {
+		firstAS := func(path *Path) uint32 {
 			if aspath := path.GetAsPath(); aspath != nil {
 				asPathParam := aspath.Value
-				for i := len(asPathParam) - 1; i >= 0; i-- {
+				for i := 0; i < len(asPathParam); i++ {
 					asPath := asPathParam[i].(*bgp.As4PathParam)
 					if asPath.Num == 0 {
 						continue
@@ -690,12 +690,12 @@ func compareByMED(path1, path2 *Path) *Path {
 					if asPath.Type == bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET || asPath.Type == bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ {
 						continue
 					}
-					return asPath.AS[asPath.Num-1]
+					return asPath.AS[0]
 				}
 			}
 			return 0
 		}
-		return leftmostAS(path1) == leftmostAS(path2)
+		return firstAS(path1) != 0 && firstAS(path1) == firstAS(path2)
 	}()
 
 	if SelectionOptions.AlwaysCompareMed || isInternal || isSameAS {

--- a/table/destination_test.go
+++ b/table/destination_test.go
@@ -227,7 +227,7 @@ func TestMedTieBreaker(t *testing.T) {
 	}()
 
 	p1 := func() *Path {
-		aspath := bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65001, 65002}), bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65003, 65004})})
+		aspath := bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65001, 65002}), bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65003, 65005})})
 		attrs := []bgp.PathAttributeInterface{aspath, bgp.NewPathAttributeMultiExitDisc(10)}
 		return NewPath(nil, nlri, false, attrs, time.Now(), false)
 	}()
@@ -245,7 +245,7 @@ func TestMedTieBreaker(t *testing.T) {
 	assert.Equal(t, compareByMED(p0, p2), (*Path)(nil))
 
 	p3 := func() *Path {
-		aspath := bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65001, 65002}), bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint32{65003, 65004})})
+		aspath := bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ, []uint32{65003, 65004}), bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65001, 65003})})
 		attrs := []bgp.PathAttributeInterface{aspath, bgp.NewPathAttributeMultiExitDisc(0)}
 		return NewPath(nil, nlri, false, attrs, time.Now(), false)
 	}()

--- a/test/scenario_test/route_server_test.py
+++ b/test/scenario_test/route_server_test.py
@@ -173,6 +173,7 @@ class GoBGPTestBase(unittest.TestCase):
     def test_09_check_rs_clients_rib(self):
         self.check_rs_client_rib()
 
+    @unittest.skip("med shouldn't work with different AS peers by default")
     def test_10_add_distant_relative(self):
         q1 = self.quaggas['q1']
         q2 = self.quaggas['q2']


### PR DESCRIPTION
Needs the first AS in the AS_SEQUENCE is the same for multiple
paths. Any preceding AS_CONFED_SEQUENCE is ignored.

Also rename the function name to 'firstAS'.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>