### PR TITLE
server: fix aca6fd6ad4409b4cb63682bff3c79fca8ca2800d regression

### DIFF
--- a/server/monitor.go
+++ b/server/monitor.go
@@ -41,13 +41,7 @@ func (w *grpcWatcher) stop() {
 }
 
 func (w *grpcWatcher) watchingEventTypes() []watcherEventType {
-	types := make([]watcherEventType, 0, 4)
-	for _, t := range []watcherEventType{WATCHER_EVENT_UPDATE_MSG, WATCHER_EVENT_POST_POLICY_UPDATE_MSG, WATCHER_EVENT_BESTPATH_CHANGE, WATCHER_EVENT_STATE_CHANGE} {
-		if len(w.reqs[t]) > 0 {
-			types = append(types, t)
-		}
-	}
-	return types
+	return []watcherEventType{WATCHER_EVENT_UPDATE_MSG, WATCHER_EVENT_POST_POLICY_UPDATE_MSG, WATCHER_EVENT_BESTPATH_CHANGE, WATCHER_EVENT_STATE_CHANGE}
 }
 
 func (w *grpcWatcher) loop() error {


### PR DESCRIPTION
Fix the bug introduced by the following commit:

commit aca6fd6ad4409b4cb63682bff3c79fca8ca2800d
Author: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>
Date:   Tue May 24 05:47:52 2016 +0000

server: refactoring for monitorbestchanged api. use watcher infra

The fix is a workaround. We need to rewrite monitor.go shortly to
remove the dependency of grpc from server package. So we fix this in a
cleaner way soon.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>