### PR TITLE
fix two-bytes AS translation

### DIFF
--- a/server/fsm.go
+++ b/server/fsm.go
@@ -217,6 +217,8 @@ func (fsm *FSM) StateChange(nextState bgp.FSMState) {
 	case bgp.BGP_FSM_ESTABLISHED:
 		fsm.pConf.Timers.State.Uptime = time.Now().Unix()
 		fsm.pConf.State.EstablishedCount++
+		// reset the state set by the previous session
+		fsm.twoByteAsTrans = false
 		if _, y := fsm.capMap[bgp.BGP_CAP_FOUR_OCTET_AS_NUMBER]; !y {
 			fsm.twoByteAsTrans = true
 			break


### PR DESCRIPTION
We can't use the two-bytes AS translation result by the previous
session. IOW, the peer might become 4bytes AS capable after the
session was down.

fix the regression of

commit 6f644ee1ca1be81e6ec96c8504e34c26b3d1f8a8
Author: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>
Date:   Tue Jun 28 10:44:07 2016 +0900

    fsm: do two-bytes AS translation if didn't sent 4byte cap

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>