### PR TITLE
mrt: skip MRT errors instead of just dying

### DIFF
--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -477,7 +477,7 @@ func checkAddressFamily(def bgp.RouteFamily) (bgp.RouteFamily, error) {
 	return rf, e
 }
 
-func exitWithError(err error) {
+func printError(err error) {
 	if globalOpts.Json {
 		j, _ := json.Marshal(struct {
 			Error string `json:"error"`
@@ -486,5 +486,9 @@ func exitWithError(err error) {
 	} else {
 		fmt.Println(err)
 	}
+}
+
+func exitWithError(err error) {
+	printError(err)
 	os.Exit(1)
 }

--- a/gobgp/cmd/mrt.go
+++ b/gobgp/cmd/mrt.go
@@ -73,7 +73,8 @@ func injectMrt(r string, filename string, count int, skip int) error {
 
 			msg, err := mrt.ParseMRTBody(h, buf)
 			if err != nil {
-				exitWithError(fmt.Errorf("failed to parse: %s", err))
+				printError(fmt.Errorf("failed to parse: %s", err))
+				continue
 			}
 
 			if globalOpts.Debug {


### PR DESCRIPTION
When trying to inject a full view from the router views project, it
seems that some entries have an unexpected flag (transitive flag
missing). Just skip those entries instead of dying.