### PR TITLE
mrt: add an option to only select the best path

### DIFF
--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -99,8 +99,7 @@ var actionOpts struct {
 }
 
 var mrtOpts struct {
-	OutputDir  string
-	FileFormat string
+	BestPath bool `short:"b" long:"best-path" description:"only keep best path routes"`
 }
 
 func formatTimedelta(d int64) string {

--- a/gobgp/cmd/mrt.go
+++ b/gobgp/cmd/mrt.go
@@ -27,7 +27,7 @@ import (
 	"strconv"
 )
 
-func injectMrt(r string, filename string, count int, skip int) error {
+func injectMrt(r string, filename string, count int, skip int, bestpath bool) error {
 
 	var resource api.Resource
 	switch r {
@@ -131,6 +131,11 @@ func injectMrt(r string, filename string, count int, skip int) error {
 					paths = append(paths, path)
 				}
 
+				if bestpath {
+					// Not really the best path
+					paths = paths[:1]
+				}
+
 				if idx >= skip {
 					ch <- &api.InjectMrtRequest{
 						Resource: resource,
@@ -190,12 +195,13 @@ func NewMrtCmd() *cobra.Command {
 					}
 				}
 			}
-			err := injectMrt(CMD_GLOBAL, filename, count, skip)
+			err := injectMrt(CMD_GLOBAL, filename, count, skip, mrtOpts.BestPath)
 			if err != nil {
 				exitWithError(err)
 			}
 		},
 	}
+	globalInjectCmd.PersistentFlags().BoolVarP(&mrtOpts.BestPath, "best-path", "b", false, "only keep best routes")
 
 	injectCmd := &cobra.Command{
 		Use: CMD_INJECT,


### PR DESCRIPTION
Not to be merged! This is a feature request with an incomplete implementation.

In fact, we assume the best path is the first one. There is no such
guarantee but since the main goal is to use less memory, this may work
for some people. Ideally, we should reuse what is done in
destination/path.go but the types are not compatible. Unsure about the
best way forward here. There is an obvious optimisation to not loop over
all entries if we need only the first, but the goal would be sort
correctly and this optimisation wouldn't hold.

The other problem is that we assume that each MRT segment will carry a
new prefix. This is usually true for MRT dumps. I don't think this is
important.