### PR TITLE
server: add missing mutex lock when updating policy configuration

### DIFF
--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -225,7 +225,7 @@ func main() {
 					log.Fatalf("failed to set mrt config: %s", err)
 				}
 				p := config.ConfigSetToRoutingPolicy(newConfig)
-				if err := bgpServer.SetRoutingPolicy(*p); err != nil {
+				if err := bgpServer.UpdatePolicy(*p); err != nil {
 					log.Fatalf("failed to set routing policy: %s", err)
 				}
 


### PR DESCRIPTION
The useage of policyMutex is very hacky. It should be moved to table/policy.go

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>