### PR TITLE
drop go 1.3 and 1.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ services:
   - docker
 
 go:
- - 1.3
- - 1.4
  - 1.5
  - 1.6
  - tip
@@ -17,14 +15,8 @@ env:
 
 matrix:
   allow_failures:
-    - go: 1.3
-    - go: 1.4
     - go: tip
   exclude:
-    - go: 1.3
-      env: SCENARIO=true
-    - go: 1.4
-      env: SCENARIO=true
     - go: 1.5
       env: SCENARIO=true
     - go: tip


### PR DESCRIPTION
Seems like golang.org/x/net/http2 will not support 1.3 and 1.4
any more. Let's stop testing with both on travis.ci.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>