### PR TITLE
server: add missing default policy setting in (*BgpServer).Start()

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1173,8 +1173,7 @@ func (s *BgpServer) Start(c *config.Global) (err error) {
 
 		rfs, _ := config.AfiSafis(c.AfiSafis).ToRfList()
 		s.globalRib = table.NewTableManager(rfs, c.MplsLabelRange.MinLabel, c.MplsLabelRange.MaxLabel)
-
-		if err = s.policy.Reset(&config.RoutingPolicy{}, map[string]config.ApplyPolicy{}); err != nil {
+		if err = s.policy.Reset(&config.RoutingPolicy{}, map[string]config.ApplyPolicy{table.GLOBAL_RIB_NAME: c.ApplyPolicy}); err != nil {
 			return
 		}
 		s.bgpConfig.Global = *c


### PR DESCRIPTION
policy.Reset() won't initialize global policy unless we pass a map
with key table.GLOBAL_RIB_NAME

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>