### PR TITLE
add RemoteRouterId to config.NeighborState

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -107,7 +107,7 @@ func (s *Server) GetNeighbor(ctx context.Context, arg *GetNeighborRequest) (*Get
 		return &Peer{
 			Conf: &PeerConf{
 				NeighborAddress:   pconf.Config.NeighborAddress,
-				Id:                s.Description,
+				Id:                s.RemoteRouterId,
 				PeerAs:            pconf.Config.PeerAs,
 				LocalAs:           pconf.Config.LocalAs,
 				PeerType:          uint32(pconf.Config.PeerType.ToInt()),

--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -2512,6 +2512,8 @@ type NeighborState struct {
 	Flops uint32 `mapstructure:"flops"`
 	// original -> gobgp:neighbor-interface
 	NeighborInterface string `mapstructure:"neighbor-interface"`
+	// original -> gobgp:remote-router-id
+	RemoteRouterId string `mapstructure:"remote-router-id"`
 }
 
 func (lhs *NeighborState) Equal(rhs *NeighborState) bool {
@@ -2587,6 +2589,9 @@ func (lhs *NeighborState) Equal(rhs *NeighborState) bool {
 		return false
 	}
 	if lhs.NeighborInterface != rhs.NeighborInterface {
+		return false
+	}
+	if lhs.RemoteRouterId != rhs.RemoteRouterId {
 		return false
 	}
 	return true

--- a/config/default.go
+++ b/config/default.go
@@ -176,7 +176,6 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn ui
 	}
 
 	n.State.Description = n.Config.Description
-	n.Config.Description = ""
 	n.State.AdminDown = n.Config.AdminDown
 
 	if n.GracefulRestart.Config.Enabled {

--- a/server/mrt.go
+++ b/server/mrt.go
@@ -104,7 +104,7 @@ func (m *mrtWriter) loop() error {
 				t := uint32(time.Now().Unix())
 				peers := make([]*mrt.Peer, 0, len(m.Neighbor))
 				for _, pconf := range m.Neighbor {
-					peers = append(peers, mrt.NewPeer(pconf.State.Description, pconf.Config.NeighborAddress, pconf.Config.PeerAs, true))
+					peers = append(peers, mrt.NewPeer(pconf.State.RemoteRouterId, pconf.Config.NeighborAddress, pconf.Config.PeerAs, true))
 				}
 				if bm, err := mrt.NewMRTMessage(t, mrt.TABLE_DUMPv2, mrt.PEER_INDEX_TABLE, mrt.NewPeerIndexTable(m.RouterId, "", peers)); err != nil {
 					break

--- a/server/peer.go
+++ b/server/peer.go
@@ -394,7 +394,7 @@ func (peer *Peer) ToConfig() *config.Neighbor {
 	}
 	conf.State.Capabilities.LocalList = localCap
 
-	conf.State.Description = peer.fsm.peerInfo.ID.To4().String()
+	conf.State.RemoteRouterId = peer.fsm.peerInfo.ID.To4().String()
 	conf.State.SessionState = config.IntToSessionStateMap[int(peer.fsm.state)]
 	conf.State.AdminState = peer.fsm.adminState.String()
 

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -667,6 +667,12 @@ module gobgp {
     }
   }
 
+  augment "/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:state" {
+    leaf remote-router-id {
+        type string;
+    }
+  }
+
   augment "/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:transport/bgp:config" {
     leaf remote-port {
       type inet:port-number;


### PR DESCRIPTION
Stop using config.NeighborState's Description in a hacky way for the
remote Router Id.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>