### PR TITLE
mrt: fix rotation and dump interval handling in table mode

### DIFF
--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -239,7 +239,7 @@ class Container(object):
             interface = "eth0"
         if not filename:
             filename = '{0}.dump'.format(interface)
-        self.local("tcpdump -i {0} -w {1}/{2} {3}".format(interface, self.shared_volumes[0][1], filename, expr), detach=True)
+        self.local("tcpdump -U -i {0} -w {1}/{2} {3}".format(interface, self.shared_volumes[0][1], filename, expr), detach=True)
         return '{0}/{1}'.format(self.shared_volumes[0][0], filename)
 
     def stop_tcpdump(self):

--- a/test/pip-requires.txt
+++ b/test/pip-requires.txt
@@ -5,4 +5,4 @@ fabric
 netaddr
 nsenter
 docker-py
-ryu
+ryu==4.5


### PR DESCRIPTION
Having two interval options easily confuse users. With this, either
can be specified.

If you specify the rotation interval, gobgpd dumps a table and rotates
a log file every the rotation interval.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>