### PR TITLE
server: portability fix for setsockopt() on Linux

### DIFF
--- a/server/sockopt_bsd.go
+++ b/server/sockopt_bsd.go
@@ -43,12 +43,9 @@ func SetTcpMD5SigSockopts(l *net.TCPListener, address string, key string) error 
 
 	// always enable and assumes that the configuration is done by
 	// setkey()
-	t := int32(1)
-	_, _, e := syscall.Syscall6(syscall.SYS_SETSOCKOPT, fi.Fd(),
-		uintptr(syscall.IPPROTO_TCP), uintptr(TCP_MD5SIG),
-		uintptr(unsafe.Pointer(&t)), unsafe.Sizeof(t), 0)
-	if e > 0 {
-		return e
+	if err := syscall.SetsockoptInt(int(fi.Fd()),
+		syscall.IPPROTO_TCP, TCP_MD5SIG, 1); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
On some architecture, setsockopt() is a multiplexed syscall and is not
available directly (for example, on i386). Instead of invoking the
syscall directly, use syscall.SetsockoptString() which is safe as strings
are not null-terminated with Go.

On BSD, use syscall.SetsockoptInt(), but I don't know if there are
architectures with the same limitations as for Linux.

Signed-off-by: Vincent Bernat <vincent@bernat.im>