### PR TITLE
test: Adopt to the updated Ryu BGP Packet lib API

### DIFF
--- a/test/pip-requires.txt
+++ b/test/pip-requires.txt
@@ -5,4 +5,4 @@ fabric
 netaddr
 nsenter
 docker-py
-ryu==4.5
+ryu

--- a/test/scenario_test/bgp_router_test.py
+++ b/test/scenario_test/bgp_router_test.py
@@ -353,7 +353,7 @@ class GoBGPTestBase(unittest.TestCase):
         e1.add_peer(g1)
         n = e1.peers[g1]['local_addr'].split('/')[0]
         g1.local('gobgp n add {0} as 65000'.format(n))
-        g1.add_peer(e1, reload_config=False) 
+        g1.add_peer(e1, reload_config=False)
 
         g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=e1)
 
@@ -381,18 +381,17 @@ class GoBGPTestBase(unittest.TestCase):
         time.sleep(1)
 
         cnt = 0
-        for pkt in pcap.Reader(open(dumpfile)):
-            last = Packet(pkt[1]).protocols[-1]
-            if type(last) == str:
-                pkt = BGPMessage.parser(last)[0]
-                if type(pkt) == BGPUpdate:
-                    cnt += len(pkt.withdrawn_routes)
+        for _, buf in pcap.Reader(open(dumpfile)):
+            pkt = Packet(buf).get_protocol(BGPMessage)
+            if isinstance(pkt, BGPUpdate):
+                cnt += len(pkt.withdrawn_routes)
 
         self.assertTrue(cnt == 1)
 
     def test_21_check_cli_sorted(self):
         g1 = self.gobgp
         cnt = 0
+
         def next_prefix():
             for i in range(100, 105):
                 for j in range(100, 105):


### PR DESCRIPTION
From Ryu v4.6, the Packet library can parse the entire BGP packet
via packet.Packet() API.
This patch fixes to adopt bgp_router_test.py to the updated API,
and reverts the Ryu version in pip-requires.txt to the latest.

Note: This patch requires  the following patch should be merged
into the upstream of Ryu. (It might be done at the next release.)
https://sourceforge.net/p/ryu/mailman/message/35393517/

Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>