### PR TITLE
table: MP_UNREACH_NLRI shouldn't carry any other path attributes

### DIFF
--- a/table/message.go
+++ b/table/message.go
@@ -298,15 +298,7 @@ func createUpdateMsgFromPath(path *Path, msg *bgp.BGPMessage) *bgp.BGPMessage {
 				} else {
 					nlris = []bgp.AddrPrefixInterface{path.GetNlri()}
 				}
-
-				clonedAttrs := path.GetPathAttrs()
-				for i, a := range clonedAttrs {
-					if a.GetType() == bgp.BGP_ATTR_TYPE_MP_UNREACH_NLRI || a.GetType() == bgp.BGP_ATTR_TYPE_MP_REACH_NLRI {
-						clonedAttrs[i] = bgp.NewPathAttributeMpUnreachNLRI(nlris)
-						break
-					}
-				}
-				return bgp.NewBGPUpdateMessage(nil, clonedAttrs, nil)
+				return bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{bgp.NewPathAttributeMpUnreachNLRI(nlris)}, nil)
 			}
 		} else {
 			if msg != nil {


### PR DESCRIPTION
RFC4760 says:

An UPDATE message that contains the MP_UNREACH_NLRI is not required to
carry any other path attributes.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>