### PR TITLE
packet/bgp: fix handling of IPv4 mapped IPv6 prefixes

### DIFF
--- a/packet/bgp/bgp_test.go
+++ b/packet/bgp/bgp_test.go
@@ -538,3 +538,43 @@ func Test_CompareFlowSpecNLRI(t *testing.T) {
 	assert.Nil(err)
 	assert.True(r < 0)
 }
+
+func Test_NLRIwithIPv4MappedIPv6prefix(t *testing.T) {
+	assert := assert.New(t)
+	n1 := NewIPv6AddrPrefix(120, "::ffff:10.0.0.1")
+	buf1, err := n1.Serialize()
+	assert.Nil(err)
+	n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_IPv6_UC))
+	assert.Nil(err)
+	err = n2.DecodeFromBytes(buf1)
+	assert.Nil(err)
+	buf2, _ := n2.Serialize()
+	if reflect.DeepEqual(n1, n2) {
+		t.Log("OK")
+	} else {
+		t.Error("Something wrong")
+		t.Error(len(buf1), n1, buf1)
+		t.Error(len(buf2), n2, buf2)
+		t.Log(bytes.Equal(buf1, buf2))
+	}
+
+	label := NewMPLSLabelStack(2)
+
+	n3 := NewLabeledIPv6AddrPrefix(120, "::ffff:10.0.0.1", *label)
+	buf1, err = n3.Serialize()
+	assert.Nil(err)
+	n4, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_IPv6_MPLS))
+	assert.Nil(err)
+	err = n4.DecodeFromBytes(buf1)
+	assert.Nil(err)
+	buf2, _ = n3.Serialize()
+	t.Log(n3, n4)
+	if reflect.DeepEqual(n3, n4) {
+		t.Log("OK")
+	} else {
+		t.Error("Something wrong")
+		t.Error(len(buf1), n3, buf1)
+		t.Error(len(buf2), n4, buf2)
+		t.Log(bytes.Equal(buf1, buf2))
+	}
+}

--- a/table/destination_test.go
+++ b/table/destination_test.go
@@ -399,6 +399,7 @@ func TestRadixkey(t *testing.T) {
 	assert.Equal(t, "000010100000001100100000", CidrToRadixkey("10.3.32.0/24"))
 	assert.Equal(t, "000010100000001100100000", IpToRadixkey(net.ParseIP("10.3.32.0").To4(), 24))
 	assert.Equal(t, "000010100000001100100000", IpToRadixkey(net.ParseIP("10.3.32.0").To4(), 24))
+	assert.Equal(t, CidrToRadixkey("::ffff:0.0.0.0/96")+"000010100000001100100000", CidrToRadixkey("::ffff:10.3.32.0/120"))
 }
 
 func TestMultipath(t *testing.T) {


### PR DESCRIPTION
closes #1117

Signed-off-by: Wataru Ishida <ishida.wataru@lab.ntt.co.jp>