### PR TITLE
Update LARGE_COMMUNITY path attribute codepoint

### DIFF
--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -3715,7 +3715,7 @@ const (
 	_
 	_
 	BGP_ATTR_TYPE_AIGP                        // = 26
-	BGP_ATTR_TYPE_LARGE_COMMUNITY BGPAttrType = 41
+	BGP_ATTR_TYPE_LARGE_COMMUNITY BGPAttrType = 30
 )
 
 // NOTIFICATION Error Code  RFC 4271 4.5.


### PR DESCRIPTION
Early IANA Allocation assigned `30` as path attribute codepoint for LARGE_COMMUNITY http://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-2