### PR TITLE
Unstrict config parsing

### DIFF
--- a/config/serve.go
+++ b/config/serve.go
@@ -57,6 +57,9 @@ func ReadConfigfileServeExtensive(path, format string, configCh chan *BgpConfigS
 		}
 		cnt++
 		configCh <- c
+		if viperCh != nil {
+			viperCh <- v
+		}
 		goto NEXT
 	ERROR:
 		if cnt == 0 {


### PR DESCRIPTION
Gives a developer who uses gobgp as a lib the possibility to add own config structures to the configuration file.

Will not break backwards comparability since i reimplemented the ReadConfigfileServe with the same arguments as before but its just calling the new ReadConfigfileServeExtensive.