### PR TITLE
Allow creating a server with a user specified grpc server.

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -41,14 +41,17 @@ type Server struct {
 }
 
 func NewGrpcServer(b *server.BgpServer, hosts string) *Server {
+	return NewServer(b, grpc.NewServer(), hosts)
+}
+
+func NewServer(b *server.BgpServer, g *grpc.Server, hosts string) *Server {
 	grpc.EnableTracing = false
-	grpcServer := grpc.NewServer()
 	server := &Server{
 		bgpServer:  b,
-		grpcServer: grpcServer,
+		grpcServer: g,
 		hosts:      hosts,
 	}
-	RegisterGobgpApiServer(grpcServer, server)
+	RegisterGobgpApiServer(g, server)
 	return server
 }
 


### PR DESCRIPTION
Hello, I'm Chris. The README.md at this projects root advertises a relaxed contribution policy but allow me to apologize in advance if I missed any process that should have proceeded this pull request.

Motivated by the need for [authentication](http://www.grpc.io/docs/guides/auth.html) on the `grpc.Server` object this change will allow a user to provide their own [grpc.Server](https://godoc.org/google.golang.org/grpc#NewServer) and apply any options like [grpc.Creds](https://godoc.org/google.golang.org/grpc#Creds) for example.

I couldn't find a way to do this without modifying the API since the `api.Server` structs `grpcServer` field is private. I considered adding a getter for the `grpcServer` field but figured that pre-initialization would best align with the original authors intent. I would be glad to take a more succinct approach if I missed something though. Thanks!