### PR TITLE
table: ensure compatibility with archs where int == int32

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -1296,7 +1296,7 @@ func NewMedActionFromApiStruct(a *MedAction) (*table.MedAction, error) {
 	if a == nil {
 		return nil, nil
 	}
-	return table.NewMedActionFromApiStruct(table.MedActionType(a.Type), int(a.Value)), nil
+	return table.NewMedActionFromApiStruct(table.MedActionType(a.Type), a.Value), nil
 }
 
 func NewLocalPrefActionFromApiStruct(a *LocalPrefAction) (*table.LocalPrefAction, error) {

--- a/table/policy.go
+++ b/table/policy.go
@@ -751,7 +751,7 @@ func (s *CommunitySet) ToConfig() *config.CommunitySet {
 }
 
 func ParseCommunity(arg string) (uint32, error) {
-	i, err := strconv.Atoi(arg)
+	i, err := strconv.ParseUint(arg, 10, 32)
 	if err == nil {
 		return uint32(i), nil
 	}
@@ -802,7 +802,7 @@ func ParseExtCommunity(arg string) (bgp.ExtendedCommunityInterface, error) {
 }
 
 func ParseCommunityRegexp(arg string) (*regexp.Regexp, error) {
-	i, err := strconv.Atoi(arg)
+	i, err := strconv.ParseUint(arg, 10, 32)
 	if err == nil {
 		return regexp.MustCompile(fmt.Sprintf("^%d:%d$", i>>16, i&0x0000ffff)), nil
 	}
@@ -1618,7 +1618,7 @@ func NewExtCommunityAction(c config.SetExtCommunity) (*ExtCommunityAction, error
 }
 
 type MedAction struct {
-	value  int
+	value  int64
 	action MedActionType
 }
 
@@ -1630,9 +1630,9 @@ func (a *MedAction) Apply(path *Path, _ *PolicyOptions) *Path {
 	var err error
 	switch a.action {
 	case MED_ACTION_MOD:
-		err = path.SetMed(int64(a.value), false)
+		err = path.SetMed(a.value, false)
 	case MED_ACTION_REPLACE:
-		err = path.SetMed(int64(a.value), true)
+		err = path.SetMed(a.value, true)
 	}
 
 	if err != nil {
@@ -1666,14 +1666,14 @@ func NewMedAction(c config.BgpSetMedType) (*MedAction, error) {
 	case "+", "-":
 		action = MED_ACTION_MOD
 	}
-	value, _ := strconv.Atoi(string(c))
+	value, _ := strconv.ParseInt(string(c), 10, 64)
 	return &MedAction{
 		value:  value,
 		action: action,
 	}, nil
 }
 
-func NewMedActionFromApiStruct(action MedActionType, value int) *MedAction {
+func NewMedActionFromApiStruct(action MedActionType, value int64) *MedAction {
 	return &MedAction{action: action, value: value}
 }
 
@@ -1768,7 +1768,7 @@ func NewAsPathPrependAction(action config.SetAsPathPrepend) (*AsPathPrependActio
 	case "last-as":
 		a.useLeftMost = true
 	default:
-		asn, err := strconv.Atoi(action.As)
+		asn, err := strconv.ParseUint(action.As, 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("As number string invalid")
 		}

--- a/table/policy_test.go
+++ b/table/policy_test.go
@@ -2335,7 +2335,7 @@ func TestPolicyMatchAndAddingMedOverFlow(t *testing.T) {
 	ds.PrefixSets = []config.PrefixSet{ps}
 	ds.NeighborSets = []config.NeighborSet{ns}
 
-	m := fmt.Sprintf("+%d", math.MaxUint32)
+	m := fmt.Sprintf("+%d", uint32(math.MaxUint32))
 	ma := "1"
 
 	s := createStatement("statement1", "ps1", "ns1", true)
@@ -2623,7 +2623,8 @@ func TestPolicyAs4PathPrepend(t *testing.T) {
 	//test
 	r := NewRoutingPolicy()
 	r.reload(pl)
-	p, _ := NewPolicy(pl.PolicyDefinitions[0])
+	p, err := NewPolicy(pl.PolicyDefinitions[0])
+	assert.Nil(err)
 	addPolicy(r, p)
 
 	pType, newPath := p.Apply(path, nil)


### PR DESCRIPTION
MED actions are expected to be int64 and AS are expected to be
uint32. Use ParseInt/ParseUint instead of Atoi for those until the tests
pass on ARM.

This is not an exhaustive audit, just the minimal modifications to make all tests pass and gobgp/gobgpd build correctly on both amd64 and arm platforms.