### PR TITLE
server: fix error propagation

### DIFF
--- a/server/fsm.go
+++ b/server/fsm.go
@@ -651,7 +651,7 @@ func (h *FSMHandler) recvMessageWithError() (*FsmMsg, error) {
 			case bgp.BGP_MSG_UPDATE:
 				body := m.Body.(*bgp.BGPUpdate)
 				confedCheck := !config.IsConfederationMember(h.fsm.gConf, h.fsm.pConf) && config.IsEBGPPeer(h.fsm.gConf, h.fsm.pConf)
-				_, err := bgp.ValidateUpdateMsg(body, h.fsm.rfMap, confedCheck)
+				_, err = bgp.ValidateUpdateMsg(body, h.fsm.rfMap, confedCheck)
 				if err != nil {
 					log.WithFields(log.Fields{
 						"Topic": "Peer",
@@ -663,7 +663,7 @@ func (h *FSMHandler) recvMessageWithError() (*FsmMsg, error) {
 				} else {
 					// FIXME: we should use the original message for bmp/mrt
 					table.UpdatePathAttrs4ByteAs(body)
-					err := table.UpdatePathAggregator4ByteAs(body)
+					err = table.UpdatePathAggregator4ByteAs(body)
 					if err == nil {
 						fmsg.PathList = table.ProcessMessage(m, h.fsm.peerInfo, fmsg.timestamp)
 						id := h.fsm.pConf.Config.NeighborAddress


### PR DESCRIPTION
creating new `err` variable prevents proper error propagation which
leads to wrongly contine reading BGP messages even after receiving
an invalid update message.

Signed-off-by: Wataru Ishida <ishida.wataru@lab.ntt.co.jp>