### PR TITLE
test: add change of best paths from ibgp and ebgp

### DIFF
--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -47,6 +47,19 @@ BGP_ATTR_TYPE_EXTENDED_COMMUNITIES = 16
 env.abort_exception = RuntimeError
 output.stderr = False
 
+def wait_for_completion(f, timeout=120):
+    interval = 1
+    count = 0
+    while True:
+        if f():
+            return
+
+        time.sleep(interval)
+        count += interval
+        if count >= timeout:
+            raise Exception('timeout')
+
+
 def try_several_times(f, t=3, s=1):
     e = None
     for i in range(t):

--- a/test/scenario_test/bgp_router_test.py
+++ b/test/scenario_test/bgp_router_test.py
@@ -432,9 +432,9 @@ class GoBGPTestBase(unittest.TestCase):
 
         g2.local('gobgp global rib add 50.0.0.0/24')
 
-        g1.add_peer(g2)
+        g1.add_peer(g2, passive=True)
         g2.add_peer(g1)
-        g1.add_peer(g3)
+        g1.add_peer(g3, passive=True)
         g3.add_peer(g1)
 
         self.test_01_neighbor_established()


### PR DESCRIPTION
gobgp has two ibgp peers and one ebgp.

1. the best path is from ebgp so advertise it to ibgp peers.
2. one of ibgp peer sends the same path so now the path from ibgp
becomes best.
3. gobgp doesn't advertise it to another ibgp and needs to withdraw
the best from ebgp.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>