### PR TITLE
server: fix memory leak in infinite channel goroutine

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -703,7 +703,7 @@ func (server *BgpServer) handleFSMMessage(peer *Peer, e *FsmMsg) {
 			}
 		}
 
-		peer.outgoing.Close()
+		cleanInfiniteChannel(peer.outgoing)
 		peer.outgoing = channels.NewInfiniteChannel()
 		if nextState == bgp.BGP_FSM_ESTABLISHED {
 			// update for export policy
@@ -1740,6 +1740,7 @@ func (server *BgpServer) deleteNeighbor(c *config.Neighbor, code, subcode uint8)
 
 	n.fsm.sendNotification(code, subcode, nil, "")
 	n.stopPeerRestarting()
+	cleanInfiniteChannel(n.outgoing)
 
 	go func(addr string) {
 		t1 := time.AfterFunc(time.Minute*5, func() {

--- a/server/util.go
+++ b/server/util.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import "github.com/eapache/channels"
+
+func cleanInfiniteChannel(ch *channels.InfiniteChannel) {
+	ch.Close()
+	// drain all remaining items
+	for range ch.Out() {
+	}
+}


### PR DESCRIPTION
infinite channel has internal goroutine which won't stopp until all items in
the buffer are dequeued.

Signed-off-by: Wataru Ishida <ishida.wataru@lab.ntt.co.jp>