### PR TITLE
Allow creating a GoBGPClient using a user specific GRPC connection and client.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -65,8 +65,8 @@ func NewWith(ctx context.Context, target string, opts ...grpc.DialOption) (*GoBG
 
 // NewFrom returns a new GoBGPClient, using the given conn and cli for the
 // underlying connection. The given grpc.ClientConn connection is expected to be
-// initialized and paired with the api client. See NewGoBGPClient to have the
-// connection dialed for you.
+// initialized and paired with the api client. See New to have the connection
+// dialed for you.
 func NewFrom(conn *grpc.ClientConn, cli api.GobgpApiClient) *GoBGPClient {
 	return &GoBGPClient{conn: conn, cli: cli}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -39,6 +39,14 @@ func defaultGRPCOptions() []grpc.DialOption {
 	return []grpc.DialOption{grpc.WithTimeout(time.Second), grpc.WithBlock(), grpc.WithInsecure()}
 }
 
+// NewClient returns a new GoBGPClient, using the given conn and cli for the
+// underlying connection. The given grpc.ClientConn connection is expected to be
+// initialized and paired with the api client. See NewGoBGPClient to have the
+// connection dialed for you.
+func NewClient(conn *grpc.ClientConn, cli api.GobgpApiClient) *GoBGPClient {
+	return &GoBGPClient{conn: conn, cli: cli}
+}
+
 func NewGoBGPClient(target string, opts ...grpc.DialOption) (*GoBGPClient, error) {
 	if target == "" {
 		target = ":50051"

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -30,7 +30,7 @@ func TestGetNeighbor(test *testing.T) {
 	go s.Serve()
 	g := api.NewGrpcServer(s, ":50051")
 	go g.Serve()
-	cli, err := NewGoBGPClient("")
+	cli, err := New("")
 	err = cli.StartServer(&config.Global{
 		Config: config.GlobalConfig{
 			As:       1,

--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -223,7 +223,7 @@ func (v vrfs) Less(i, j int) bool {
 
 func newClient() *cli.GoBGPClient {
 	target := net.JoinHostPort(globalOpts.Host, strconv.Itoa(globalOpts.Port))
-	client, err := cli.NewGoBGPClient(target)
+	client, err := cli.New(target)
 	if err != nil {
 		exitWithError(err)
 	}


### PR DESCRIPTION
I touched more on this on Slack, but this allows wrapping the dialer, implementing your own wrapped GobgpApiClient or dialing with a context for cancelation on unreliable endpoints.