### PR TITLE
server: fix bug of deleteNeighbor()

### DIFF
--- a/test/scenario_test/bgp_router_test.py
+++ b/test/scenario_test/bgp_router_test.py
@@ -353,13 +353,21 @@ class GoBGPTestBase(unittest.TestCase):
         e1 = ExaBGPContainer(name='e1', asn=65000, router_id='192.168.0.7')
         time.sleep(e1.run())
         e1.add_peer(g1)
+        self.quaggas['e1'] = e1
         n = e1.peers[g1]['local_addr'].split('/')[0]
         g1.local('gobgp n add {0} as 65000'.format(n))
         g1.add_peer(e1, reload_config=False)
 
         g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=e1)
 
-    def test_20_check_withdrawal_2(self):
+    def test_20_check_grpc_del_neighbor(self):
+        g1 = self.gobgp
+        e1 = self.quaggas['e1']
+        n = e1.peers[g1]['local_addr'].split('/')[0]
+        g1.local('gobgp n del {0}'.format(n))
+        g1.del_peer(e1, reload_config=False)
+
+    def test_21_check_withdrawal_2(self):
         g1 = self.gobgp
         g2 = self.quaggas['g2']
 
@@ -380,7 +388,7 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertTrue(ret[0]['nlri']['prefix'] == prefix)
         self.assertTrue('withdrawal' in ret[0])
 
-    def test_21_check_cli_sorted(self):
+    def test_22_check_cli_sorted(self):
         g1 = self.gobgp
         cnt = 0
 
@@ -406,7 +414,7 @@ class GoBGPTestBase(unittest.TestCase):
 
         self.assertTrue(cnt == cnt2)
 
-    def test_22_check_withdrawal3(self):
+    def test_23_check_withdrawal3(self):
         gobgp_ctn_image_name = parser_option.gobgp_image
         g1 = self.gobgp
         g3 = GoBGPContainer(name='g3', asn=65006, router_id='192.168.0.8',


### PR DESCRIPTION
cleaning outgoing channel while fsm handler is running may cause crash

Dec  2 06:14:36 g2 gobgpd[6955]: {"Topic":"Peer","level":"info","msg":"Delete a peer configuration for:10.173.176.211","time":"2016-12-02T06:14:36Z"}
Dec  2 06:14:36 g2 gobgpd[6955]: {"Data":"","Key":"10.173.176.211","Topic":"Peer","level":"warning","msg":"sent notification","time":"2016-12-02T06:14:36Z"}
Dec  2 06:14:36 g2 gobgpd[6955]: {"Key":"10.173.176.211","Reason":"notification-sent code 6(cease) subcode 3(peer deconfigured)","State":"BGP_FSM_ESTABLISHED","Topic":"Peer","level":"info","msg":"Peer Down","time":"2016-12-02T06:14:36Z"}
Dec  2 06:14:36 g2 gobgpd[6955]: panic: interface conversion: interface {} is nil, not *server.FsmOutgoingMsg
Dec  2 06:14:36 g2 gobgpd[6955]: goroutine 69 [running]:
Dec  2 06:14:36 g2 gobgpd[6955]: panic(0xd26200, 0xc82030c4c0)
Dec  2 06:14:36 g2 gobgpd[6955]: /usr/local/go/src/runtime/panic.go:481 +0x3e6
Dec  2 06:14:36 g2 gobgpd[6955]: github.com/osrg/gobgp/server.(*FSMHandler).sendMessageloop(0xc8201a66e0, 0x0, 0x0)
Dec  2 06:14:36 g2 gobgpd[6955]: /usr/local/opt/gopath/src/github.com/osrg/gobgp/server/fsm.go:1136 +0x3c3
Dec  2 06:14:36 g2 gobgpd[6955]: github.com/osrg/gobgp/server.(*FSMHandler).(github.com/osrg/gobgp/server.sendMessageloop)-fm(0x0, 0x0)
Dec  2 06:14:36 g2 gobgpd[6955]: /usr/local/opt/gopath/src/github.com/osrg/gobgp/server/fsm.go:1175 +0x2e
Dec  2 06:14:36 g2 gobgpd[6955]: gopkg.in/tomb%2ev2.(*Tomb).run(0xc8201a66e0, 0xc820278140)
Dec  2 06:14:36 g2 gobgpd[6955]: /usr/local/opt/gopath/src/gopkg.in/tomb.v2/tomb.go:163 +0x21
Dec  2 06:14:36 g2 gobgpd[6955]: created by gopkg.in/tomb%2ev2.(*Tomb).Go
Dec  2 06:14:36 g2 gobgpd[6955]: /usr/local/opt/gopath/src/gopkg.in/tomb.v2/tomb.go:159 +0x131

Signed-off-by: Wataru Ishida <ishida.wataru@lab.ntt.co.jp>