### PR TITLE
policy: avoid crash when getting ext-community information

### DIFF
--- a/gobgp/cmd/policy.go
+++ b/gobgp/cmd/policy.go
@@ -58,7 +58,7 @@ func formatDefinedSet(head bool, typ string, indent int, list []table.DefinedSet
 		}
 		for i, x := range l {
 			if typ == "COMMUNITY" || typ == "EXT-COMMUNITY" || typ == "LARGE-COMMUNITY" {
-				exp := regexp.MustCompile("\\^(\\S+)\\$")
+				exp := regexp.MustCompile("\\^\\^(\\S+)\\$\\$")
 				x = exp.ReplaceAllString(x, "$1")
 			}
 			if i == 0 {

--- a/table/policy.go
+++ b/table/policy.go
@@ -1091,7 +1091,10 @@ func NewExtCommunitySet(c config.ExtCommunitySet) (*ExtCommunitySet, error) {
 }
 
 func (s *ExtCommunitySet) Append(arg DefinedSet) error {
-	s.regExpSet.Append(arg)
+	err := s.regExpSet.Append(arg)
+	if err != nil {
+		return err
+	}
 	sList := arg.(*ExtCommunitySet).subtypeList
 	s.subtypeList = append(s.subtypeList, sList...)
 	return nil

--- a/table/policy.go
+++ b/table/policy.go
@@ -1090,6 +1090,13 @@ func NewExtCommunitySet(c config.ExtCommunitySet) (*ExtCommunitySet, error) {
 	}, nil
 }
 
+func (s *ExtCommunitySet) Append(arg DefinedSet) error {
+	s.regExpSet.Append(arg)
+	sList := arg.(*ExtCommunitySet).subtypeList
+	s.subtypeList = append(s.subtypeList, sList...)
+	return nil
+}
+
 type LargeCommunitySet struct {
 	regExpSet
 }


### PR DESCRIPTION
GoBGP goes down when showing ext-community policy after ext-community value is added multiple times.

- cli side
```
% gobgp global as 65000 router-id 10.10.0.1
% gobgp policy ext-community add ecs1 RT:100:100
% gobgp policy ext-community add ecs1 RT:101:100
% gobgp policy ext-community
2016/12/06 13:16:51 transport: http2Client.notifyError got notified that the client transport was broken EOF.
rpc error: code = 13 desc = transport is closing
```

- gobgpd log
```
% sudo gobgpd
{"level":"info","msg":"gobgpd started","time":"2016-12-06T13:16:20-08:00"}
panic: runtime error: index out of range

goroutine 20 [running]:
panic(0x667420, 0xc42000c110)
  /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/osrg/gobgp/table.(*ExtCommunitySet).List.func1(0x1, 0xc4202743d0, 0xb, 0xc420274650, 0xe)
  /Users/yokoi-h/workspace/go/src/github.com/osrg/gobgp/table/policy.go:1033 +0x362
github.com/osrg/gobgp/table.(*ExtCommunitySet).List(0xc420212410, 0xe6d1, 0xc420045c10, 0x15803)
  /Users/yokoi-h/workspace/go/src/github.com/osrg/gobgp/table/policy.go:1045 +0x11d
github.com/osrg/gobgp/table.(*ExtCommunitySet).ToConfig(0xc420212410, 0xc42014b4a0)
  /Users/yokoi-h/workspace/go/src/github.com/osrg/gobgp/table/policy.go:1053 +0x2f
github.com/osrg/gobgp/table.(*RoutingPolicy).GetDefinedSet(0xc42011ad00, 0x5, 0x0, 0x0, 0x0)
  /Users/yokoi-h/workspace/go/src/github.com/osrg/gobgp/table/policy.go:3144 +0x8e0
github.com/osrg/gobgp/server.(*BgpServer).GetDefinedSet.func2()
  /Users/yokoi-h/workspace/go/src/github.com/osrg/gobgp/server/server.go:1992 +0x8d
github.com/osrg/gobgp/server.(*BgpServer).Serve(0xc4201c8800)
  /Users/yokoi-h/workspace/go/src/github.com/osrg/gobgp/server/server.go:239 +0x376
created by main.main
  /Users/yokoi-h/workspace/go/src/github.com/osrg/gobgp/gobgpd/main.go:179 +0x43b
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xabbf4]

```

This patch fixes the issue.
Could you review this patch?