### PR TITLE
policy: allow using invert condition in statement

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -1209,14 +1209,16 @@ func NewAPIStatementFromTableStruct(t *table.Statement) *Statement {
 func toStatementApi(s *config.Statement) *Statement {
 	cs := &Conditions{}
 	if s.Conditions.MatchPrefixSet.PrefixSet != "" {
+		o, _ := table.NewMatchOption(s.Conditions.MatchPrefixSet.MatchSetOptions)
 		cs.PrefixSet = &MatchSet{
-			Type: MatchType(s.Conditions.MatchPrefixSet.MatchSetOptions.ToInt()),
+			Type: MatchType(o),
 			Name: s.Conditions.MatchPrefixSet.PrefixSet,
 		}
 	}
 	if s.Conditions.MatchNeighborSet.NeighborSet != "" {
+		o, _ := table.NewMatchOption(s.Conditions.MatchNeighborSet.MatchSetOptions)
 		cs.NeighborSet = &MatchSet{
-			Type: MatchType(s.Conditions.MatchNeighborSet.MatchSetOptions.ToInt()),
+			Type: MatchType(o),
 			Name: s.Conditions.MatchNeighborSet.NeighborSet,
 		}
 	}

--- a/table/policy.go
+++ b/table/policy.go
@@ -110,6 +110,16 @@ func (o MatchOption) String() string {
 	}
 }
 
+func (o MatchOption) ConvertToMatchSetOptionsRestrictedType() config.MatchSetOptionsRestrictedType {
+	switch o {
+	case MATCH_OPTION_ANY:
+		return config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY
+	case MATCH_OPTION_INVERT:
+		return config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_INVERT
+	}
+	return "unknown"
+}
+
 type MedActionType int
 
 const (
@@ -2363,10 +2373,10 @@ func (s *Statement) ToConfig() *config.Statement {
 				switch c.(type) {
 				case *PrefixCondition:
 					v := c.(*PrefixCondition)
-					cond.MatchPrefixSet = config.MatchPrefixSet{PrefixSet: v.set.Name(), MatchSetOptions: config.IntToMatchSetOptionsRestrictedTypeMap[int(v.option)]}
+					cond.MatchPrefixSet = config.MatchPrefixSet{PrefixSet: v.set.Name(), MatchSetOptions: v.option.ConvertToMatchSetOptionsRestrictedType()}
 				case *NeighborCondition:
 					v := c.(*NeighborCondition)
-					cond.MatchNeighborSet = config.MatchNeighborSet{NeighborSet: v.set.Name(), MatchSetOptions: config.IntToMatchSetOptionsRestrictedTypeMap[int(v.option)]}
+					cond.MatchNeighborSet = config.MatchNeighborSet{NeighborSet: v.set.Name(), MatchSetOptions: v.option.ConvertToMatchSetOptionsRestrictedType()}
 				case *AsPathLengthCondition:
 					v := c.(*AsPathLengthCondition)
 					cond.BgpConditions.AsPathLength = config.AsPathLength{Operator: config.IntToAttributeComparisonMap[int(v.operator)], Value: v.length}


### PR DESCRIPTION
Currently we get error when we use "invert" in statement condition like below.

```
% gobgp global as 65000 router-id 10.10.0.1
% gobgp policy neighbor add n1 172.16.132.11
% gobgp policy statement add statement1
% gobgp policy statement statement1 add condition neighbor n1 invert
rpc error: code = 2 desc = invalid match type
```

This patch fixes the issue.

Signed-off-by: Hiroshi Yokoi <yokoi.hiroshi@po.ntts.co.jp>