### PR TITLE
server: fix bug when global import policy rejects a route

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -542,7 +542,11 @@ func (server *BgpServer) propagateUpdate(peer *Peer, pathList []*table.Path) []*
 		best, old, _ = rib.ProcessPaths(ids, append(pathList, moded...))
 	} else {
 		for idx, path := range pathList {
-			path = server.policy.ApplyPolicy(table.GLOBAL_RIB_NAME, table.POLICY_DIRECTION_IMPORT, path, nil)
+			if p := server.policy.ApplyPolicy(table.GLOBAL_RIB_NAME, table.POLICY_DIRECTION_IMPORT, path, nil); p != nil {
+				path = p
+			} else {
+				path = path.Clone(true)
+			}
 			pathList[idx] = path
 			// RFC4684 Constrained Route Distribution 6. Operation
 			//

--- a/test/scenario_test/global_policy_test.py
+++ b/test/scenario_test/global_policy_test.py
@@ -263,6 +263,17 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertTrue(path['med'] == 100)
         self.assertTrue(path['local-pref'] == 100)
 
+    def test_18_reject_policy(self):
+        self.gobgp.local('gobgp global policy import set default reject')
+        self.gobgp.local('gobgp neighbor all softresetin')
+
+        time.sleep(1)
+
+        # self-generated routes remain since softresetin doesn't re-evaluate
+        # them
+        for v in self.gobgp.get_global_rib():
+            for p in v['paths']:
+                self.assertTrue(p['nexthop'] == '0.0.0.0')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
routes rejected by global import policy was not deleted from RIB

Signed-off-by: Wataru Ishida <ishida.wataru@lab.ntt.co.jp>