### PR TITLE
Packet bgp confirm IPv4 to IPv6 nexthop address conversion when AFI_IP6

### DIFF
--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -3787,9 +3787,9 @@ func NewPrefixFromRouteFamily(afi uint16, safi uint8) (prefix AddrPrefixInterfac
 	case RF_OPAQUE:
 		prefix = &OpaqueNLRI{}
 	default:
-		return nil, fmt.Errorf("unknown route family. AFI: %d, SAFI: %d", afi, safi)
+		err = fmt.Errorf("unknown route family. AFI: %d, SAFI: %d", afi, safi)
 	}
-	return prefix, nil
+	return prefix, err
 }
 
 type BGPAttrFlag uint8

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -7346,7 +7346,7 @@ func (msg *BGPHeader) DecodeFromBytes(data []byte) error {
 
 func (msg *BGPHeader) Serialize() ([]byte, error) {
 	buf := make([]byte, 19)
-	for i, _ := range buf[:16] {
+	for i := range buf[:16] {
 		buf[i] = 0xff
 	}
 	binary.BigEndian.PutUint16(buf[16:18], msg.Len)

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -44,7 +44,7 @@ const (
 	SAFI_EVPN                     = 70
 	SAFI_MPLS_VPN                 = 128
 	SAFI_MPLS_VPN_MULTICAST       = 129
-	SAFI_ROUTE_TARGET_CONSTRTAINS = 132
+	SAFI_ROUTE_TARGET_CONSTRAINTS = 132
 	SAFI_FLOW_SPEC_UNICAST        = 133
 	SAFI_FLOW_SPEC_VPN            = 134
 	SAFI_KEY_VALUE                = 241
@@ -64,7 +64,7 @@ const (
 )
 
 // RFC7153 5.1. Registries for the "Type" Field
-// RANGE	REGISTRACTION PROCEDURES
+// RANGE	REGISTRATION PROCEDURES
 // 0x00-0x3F	Transitive First Come First Served
 // 0x40-0x7F	Non-Transitive First Come First Served
 // 0x80-0x8F	Transitive Experimental Use
@@ -92,8 +92,8 @@ const (
 	EC_TYPE_GENERIC_TRANSITIVE_EXPERIMENTAL3      ExtendedCommunityAttrType = 0x82 // RFC7674
 )
 
-// RFC7153 5.2. Registraction for the "Sub-Type" Field
-// RANGE	REGISTRACTION PROCEDURES
+// RFC7153 5.2. Registries for the "Sub-Type" Field
+// RANGE	REGISTRATION PROCEDURES
 // 0x00-0xBF	First Come First Served
 // 0xC0-0xFF	IETF Review
 type ExtendedCommunityAttrSubType uint8
@@ -1586,7 +1586,7 @@ func (n *RouteTargetMembershipNLRI) AFI() uint16 {
 }
 
 func (n *RouteTargetMembershipNLRI) SAFI() uint8 {
-	return SAFI_ROUTE_TARGET_CONSTRTAINS
+	return SAFI_ROUTE_TARGET_CONSTRAINTS
 }
 
 func (n *RouteTargetMembershipNLRI) Len() int {
@@ -3686,7 +3686,7 @@ const (
 	RF_IPv6_MPLS   RouteFamily = AFI_IP6<<16 | SAFI_MPLS_LABEL
 	RF_VPLS        RouteFamily = AFI_L2VPN<<16 | SAFI_VPLS
 	RF_EVPN        RouteFamily = AFI_L2VPN<<16 | SAFI_EVPN
-	RF_RTC_UC      RouteFamily = AFI_IP<<16 | SAFI_ROUTE_TARGET_CONSTRTAINS
+	RF_RTC_UC      RouteFamily = AFI_IP<<16 | SAFI_ROUTE_TARGET_CONSTRAINTS
 	RF_IPv4_ENCAP  RouteFamily = AFI_IP<<16 | SAFI_ENCAPSULATION
 	RF_IPv6_ENCAP  RouteFamily = AFI_IP6<<16 | SAFI_ENCAPSULATION
 	RF_FS_IPv4_UC  RouteFamily = AFI_IP<<16 | SAFI_FLOW_SPEC_UNICAST
@@ -6417,12 +6417,12 @@ func (t *TunnelEncapSubTLVDefault) Serialize() ([]byte, error) {
 	return t.Value, nil
 }
 
-type TunnelEncapSubTLVEncapuslation struct {
+type TunnelEncapSubTLVEncapsulation struct {
 	Key    uint32 // this represent both SessionID for L2TPv3 case and GRE-key for GRE case (RFC5512 4.)
 	Cookie []byte
 }
 
-func (t *TunnelEncapSubTLVEncapuslation) Serialize() ([]byte, error) {
+func (t *TunnelEncapSubTLVEncapsulation) Serialize() ([]byte, error) {
 	buf := make([]byte, 4)
 	binary.BigEndian.PutUint32(buf, t.Key)
 	return append(buf, t.Cookie...), nil
@@ -6476,7 +6476,7 @@ func (p *TunnelEncapSubTLV) DecodeFromBytes(data []byte) error {
 			return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLV bytes available")
 		}
 		key := binary.BigEndian.Uint32(data[:4])
-		p.Value = &TunnelEncapSubTLVEncapuslation{
+		p.Value = &TunnelEncapSubTLVEncapsulation{
 			Key:    key,
 			Cookie: data[4:],
 		}

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -2427,7 +2427,7 @@ func flowSpecPrefixParser(rf RouteFamily, args []string) (FlowSpecComponentInter
 		return nil, fmt.Errorf("invalid flowspec dst/src prefix")
 	}
 	typ := args[0]
-	ip, net, err := net.ParseCIDR(args[1])
+	ip, nw, err := net.ParseCIDR(args[1])
 	if err != nil {
 		return nil, fmt.Errorf("invalid ip prefix")
 	}
@@ -2437,7 +2437,7 @@ func flowSpecPrefixParser(rf RouteFamily, args []string) (FlowSpecComponentInter
 	} else if afi == AFI_IP6 && !strings.Contains(ip.String(), ":") {
 		return nil, fmt.Errorf("invalid ipv6 prefix")
 	}
-	ones, _ := net.Mask.Size()
+	ones, _ := nw.Mask.Size()
 	var offset uint8
 	if len(args) > 2 {
 		o, err := strconv.Atoi(args[2])

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -4194,10 +4194,10 @@ type AsPathParamFormat struct {
 }
 
 var asPathParamFormatMap = map[uint8]*AsPathParamFormat{
-	BGP_ASPATH_ATTR_TYPE_SET:        &AsPathParamFormat{"{", "}", ","},
-	BGP_ASPATH_ATTR_TYPE_SEQ:        &AsPathParamFormat{"", "", " "},
-	BGP_ASPATH_ATTR_TYPE_CONFED_SET: &AsPathParamFormat{"(", ")", " "},
-	BGP_ASPATH_ATTR_TYPE_CONFED_SEQ: &AsPathParamFormat{"[", "]", ","},
+	BGP_ASPATH_ATTR_TYPE_SET:        {"{", "}", ","},
+	BGP_ASPATH_ATTR_TYPE_SEQ:        {"", "", " "},
+	BGP_ASPATH_ATTR_TYPE_CONFED_SET: {"(", ")", " "},
+	BGP_ASPATH_ATTR_TYPE_CONFED_SEQ: {"[", "]", ","},
 }
 
 type AsPathParamInterface interface {


### PR DESCRIPTION
Currently, GoBGP will miss-convert IPv4 nexthop address to IPv6
address when advertising AFI_IP6 routes with IPv4 peering.
For example, if the local address of GoBGP is "172.20.0.1", the
advertised nexthop will be miss-converted into "AC14:1::".
In this case, the nexthop address should be "::ffff:172.20.0.1".
The following patches fix this problem.

Also, including some improvements detected by code inspection
tools (e.g., IDE, golint, ...).