### PR TITLE
Fix incorrect validation

### DIFF
--- a/server/rpki_test.go
+++ b/server/rpki_test.go
@@ -221,3 +221,35 @@ func TestValidate8(t *testing.T) {
 	r = validateOne(tree, "10.0.0.0/24", "65001")
 	assert.Equal(r, config.RPKI_VALIDATION_RESULT_TYPE_INVALID)
 }
+
+func TestValidate9(t *testing.T) {
+	assert := assert.New(t)
+
+	manager, _ := NewROAManager(0)
+	manager.addROA(table.NewROA(bgp.AFI_IP, net.ParseIP("10.0.0.0").To4(), 24, 24, 65000, ""))
+	manager.addROA(table.NewROA(bgp.AFI_IP, net.ParseIP("10.0.0.0").To4(), 16, 24, 65001, ""))
+
+	var r config.RpkiValidationResultType
+	tree := manager.Roas[bgp.RF_IPv4_UC]
+	r = validateOne(tree, "10.0.0.0/24", "65000")
+	assert.Equal(r, config.RPKI_VALIDATION_RESULT_TYPE_VALID)
+
+	r = validateOne(tree, "10.0.0.0/24", "65001")
+	assert.Equal(r, config.RPKI_VALIDATION_RESULT_TYPE_VALID)
+}
+
+func TestValidate10(t *testing.T) {
+	assert := assert.New(t)
+
+	manager, _ := NewROAManager(0)
+	manager.addROA(table.NewROA(bgp.AFI_IP, net.ParseIP("10.0.0.0").To4(), 24, 24, 0, ""))
+	manager.addROA(table.NewROA(bgp.AFI_IP, net.ParseIP("10.0.0.0").To4(), 16, 24, 65001, ""))
+
+	var r config.RpkiValidationResultType
+	tree := manager.Roas[bgp.RF_IPv4_UC]
+	r = validateOne(tree, "10.0.0.0/24", "65000")
+	assert.Equal(r, config.RPKI_VALIDATION_RESULT_TYPE_INVALID)
+
+	r = validateOne(tree, "10.0.0.0/24", "65001")
+	assert.Equal(r, config.RPKI_VALIDATION_RESULT_TYPE_VALID)
+}


### PR DESCRIPTION
The pseudo code in RFC6811 says:
```
   result = BGP_PFXV_STATE_NOT_FOUND;

   //Iterate through all the Covering entries in the local VRP
   //database, pfx_validate_table.
   entry = next_lookup_result(pfx_validate_table, route_prefix);

   while (entry != NULL) {
     prefix_exists = TRUE;

     if (route_prefix_length <= entry->max_length) {
       if (route_origin_as != NONE
           && entry->origin_as != 0
           && route_origin_as == entry->origin_as) {
         result = BGP_PFXV_STATE_VALID;
         return (result);
       }
     }
     entry = next_lookup_result(pfx_validate_table, input.prefix);
   }

   //If one or more VRP entries Covered the route prefix, but
   //none Matched, return "Invalid" validation state.
   if (prefix_exists == TRUE) {
     result = BGP_PFXV_STATE_INVALID;
   }

   return (result);
```

It means that it looks up the received route with ROA table recursively.
On the otherhand,  It looks validatePath() validates  only once.

Let's say, ROA table has:
```
10.0.0.0/24-24 AS65000
10.0.0.0/16-24 AS65001
```
and received:
```
10.0.0.0/24 AS65001
```

In this case, the current gobgp code should determine "Invalid".
But I believe that it should determine "Valid".
(I've confirmed with RIPE RPKI Validator in the similar situation.)

I've added the examples and fixed code.
What do you think?