### PR TITLE
GetVrf() cause gobgpd panic if it is not started

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1256,7 +1256,10 @@ func (s *BgpServer) GetVrf() (l []*table.Vrf) {
 
 	s.mgmtCh <- func() {
 		defer close(ch)
-
+		if err := s.active(); err != nil {
+			log.Errorf("get vrf failed: %v", err)
+			return
+		}
 		l = make([]*table.Vrf, 0, len(s.globalRib.Vrfs))
 		for _, vrf := range s.globalRib.Vrfs {
 			l = append(l, vrf.Clone())


### PR DESCRIPTION
**Issue:**

GetVrf() cause gobgpd panic if it is not started.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x176c0a]

goroutine 20 [running]:
panic(0x6680e0, 0xc4200120a0)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/osrg/gobgp/server.(*BgpServer).GetVrf.func2()
	/Users/kaitoY/code/go/src/github.com/osrg/gobgp/server/server.go:1260 +0xda
github.com/osrg/gobgp/server.(*BgpServer).Serve(0xc420058400)
	/Users/kaitoY/code/go/src/github.com/osrg/gobgp/server/server.go:239 +0x376
created by main.main
	/Users/kaitoY/code/go/src/github.com/osrg/gobgp/gobgpd/main.go:179 +0x43b
```

**Step to reproduce:**

1. Start gobgpd without configuration file: 
`gobgpd`
2. Use command line tool to get vrf:
`gobgp vrf`

**Cause**

This is because of below two reasons:

1. In bgpd package, it won't call bgpServer.Start() utill a configuration is received, and the globalRib is initialized in the Start() call.
2. In server package, GetVrf() call does not check if server is started.

Please review PR for a simple fix.