### PR TITLE
Fix crash of "gobgp vrf" when no global config exists.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1257,9 +1257,11 @@ func (s *BgpServer) GetVrf() (l []*table.Vrf) {
 	s.mgmtCh <- func() {
 		defer close(ch)
 
-		l = make([]*table.Vrf, 0, len(s.globalRib.Vrfs))
-		for _, vrf := range s.globalRib.Vrfs {
-			l = append(l, vrf.Clone())
+		if s.globalRib != nil {
+			l = make([]*table.Vrf, 0, len(s.globalRib.Vrfs))
+			for _, vrf := range s.globalRib.Vrfs {
+				l = append(l, vrf.Clone())
+			}
 		}
 	}
 	return l

--- a/table/table_manager.go
+++ b/table/table_manager.go
@@ -164,6 +164,9 @@ func (manager *TableManager) AddVrf(name string, id uint32, rd bgp.RouteDistingu
 }
 
 func (manager *TableManager) DeleteVrf(name string) ([]*Path, error) {
+	if manager == nil {
+		return nil, fmt.Errorf("vrf %s not found", name)
+	}
 	if _, ok := manager.Vrfs[name]; !ok {
 		return nil, fmt.Errorf("vrf %s not found", name)
 	}


### PR DESCRIPTION
This also fix crash of "gobgp delete vrf XXX" when no global config exists.