### PR TITLE
config: Detect config file type automatically

### DIFF
--- a/config/serve.go
+++ b/config/serve.go
@@ -25,6 +25,9 @@ func ReadConfigfileServe(path, format string, configCh chan *BgpConfigSet) {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGHUP)
 
+	// Update config file type, if detectable
+	format = detectConfigFileType(path, format)
+
 	cnt := 0
 	for {
 		c := &BgpConfigSet{}

--- a/config/util.go
+++ b/config/util.go
@@ -18,11 +18,27 @@ package config
 import (
 	"fmt"
 	"net"
+	"path/filepath"
 	"regexp"
 	"strconv"
 
 	"github.com/osrg/gobgp/packet/bgp"
 )
+
+// Returns config file type by retrieving extension from the given path.
+// If no corresponding type found, returns the given def as the default value.
+func detectConfigFileType(path, def string) string {
+	switch ext := filepath.Ext(path); ext {
+	case ".toml":
+		return "toml"
+	case ".yaml", ".yml":
+		return "yaml"
+	case ".json":
+		return "json"
+	default:
+		return def
+	}
+}
 
 func IsConfederationMember(g *Global, p *Neighbor) bool {
 	if p.Config.PeerAs != g.Config.As {

--- a/config/util_test.go
+++ b/config/util_test.go
@@ -1,0 +1,31 @@
+// Copyright (C) 2017 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestdetectConfigFileType(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal("toml", detectConfigFileType("bgpd.conf", "toml"))
+	assert.Equal("toml", detectConfigFileType("bgpd.toml", "xxx"))
+	assert.Equal("yaml", detectConfigFileType("bgpd.yaml", "xxx"))
+	assert.Equal("yaml", detectConfigFileType("bgpd.yml", "xxx"))
+	assert.Equal("json", detectConfigFileType("bgpd.json", "xxx"))
+}


### PR DESCRIPTION
This patch enables to automatically detect the type of config file
by retrieving the extension from the config file name.
e.g.) "gobgpd.toml" will be assumed as TOML formatted file.

Note: This feature will override the format specified with the cli
"--config-type" option.

Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>