### PR TITLE
server: fix a bug of error handling

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -993,7 +993,7 @@ func (s *BgpServer) AddBmp(c *config.BmpServerConfig) error {
 	}, true)
 }
 
-func (s *BgpServer) DeleteBmp(c *config.BmpServerConfig) (err error) {
+func (s *BgpServer) DeleteBmp(c *config.BmpServerConfig) error {
 	return s.mgmtOperation(func() error {
 		return s.bmpManager.deleteServer(c)
 	}, true)
@@ -1133,7 +1133,7 @@ func (server *BgpServer) fixupApiPath(vrfId string, pathList []*table.Path) erro
 }
 
 func (s *BgpServer) AddPath(vrfId string, pathList []*table.Path) (uuidBytes []byte, err error) {
-	s.mgmtOperation(func() error {
+	err = s.mgmtOperation(func() error {
 		if err := s.fixupApiPath(vrfId, pathList); err != nil {
 			return err
 		}
@@ -1401,7 +1401,7 @@ func (s *BgpServer) SoftReset(addr string, family bgp.RouteFamily) error {
 }
 
 func (s *BgpServer) GetRib(addr string, family bgp.RouteFamily, prefixes []*table.LookupPrefix) (rib *table.Table, err error) {
-	s.mgmtOperation(func() error {
+	err = s.mgmtOperation(func() error {
 		m := s.globalRib
 		id := table.GLOBAL_RIB_NAME
 		if len(addr) > 0 {
@@ -1426,7 +1426,7 @@ func (s *BgpServer) GetRib(addr string, family bgp.RouteFamily, prefixes []*tabl
 }
 
 func (s *BgpServer) GetVrfRib(name string, family bgp.RouteFamily, prefixes []*table.LookupPrefix) (rib *table.Table, err error) {
-	s.mgmtOperation(func() error {
+	err = s.mgmtOperation(func() error {
 		m := s.globalRib
 		vrfs := m.Vrfs
 		if _, ok := vrfs[name]; !ok {
@@ -1452,7 +1452,7 @@ func (s *BgpServer) GetVrfRib(name string, family bgp.RouteFamily, prefixes []*t
 }
 
 func (s *BgpServer) GetAdjRib(addr string, family bgp.RouteFamily, in bool, prefixes []*table.LookupPrefix) (rib *table.Table, err error) {
-	s.mgmtOperation(func() error {
+	err = s.mgmtOperation(func() error {
 		peer, ok := s.neighborMap[addr]
 		if !ok {
 			return fmt.Errorf("Neighbor that has %v doesn't exist.", addr)
@@ -1474,7 +1474,7 @@ func (s *BgpServer) GetAdjRib(addr string, family bgp.RouteFamily, in bool, pref
 }
 
 func (s *BgpServer) GetRibInfo(addr string, family bgp.RouteFamily) (info *table.TableInfo, err error) {
-	s.mgmtOperation(func() error {
+	err = s.mgmtOperation(func() error {
 		m := s.globalRib
 		id := table.GLOBAL_RIB_NAME
 		if len(addr) > 0 {
@@ -1494,7 +1494,7 @@ func (s *BgpServer) GetRibInfo(addr string, family bgp.RouteFamily) (info *table
 }
 
 func (s *BgpServer) GetAdjRibInfo(addr string, family bgp.RouteFamily, in bool) (info *table.TableInfo, err error) {
-	s.mgmtOperation(func() error {
+	err = s.mgmtOperation(func() error {
 		peer, ok := s.neighborMap[addr]
 		if !ok {
 			return fmt.Errorf("Neighbor that has %v doesn't exist.", addr)
@@ -1680,7 +1680,7 @@ func (s *BgpServer) DeleteNeighbor(c *config.Neighbor) error {
 }
 
 func (s *BgpServer) UpdateNeighbor(c *config.Neighbor) (policyUpdated bool, err error) {
-	s.mgmtOperation(func() error {
+	err = s.mgmtOperation(func() error {
 		addr := c.Config.NeighborAddress
 		peer, ok := s.neighborMap[addr]
 		if !ok {
@@ -1842,7 +1842,7 @@ func (s *BgpServer) DisableNeighbor(addr string) error {
 }
 
 func (s *BgpServer) GetDefinedSet(typ table.DefinedType) (sets *config.DefinedSets, err error) {
-	s.mgmtOperation(func() error {
+	err = s.mgmtOperation(func() error {
 		sets, err = s.policy.GetDefinedSet(typ)
 		return nil
 	}, false)
@@ -1945,7 +1945,7 @@ func (server *BgpServer) toPolicyInfo(name string, dir table.PolicyDirection) (s
 }
 
 func (s *BgpServer) GetPolicyAssignment(name string, dir table.PolicyDirection) (rt table.RouteType, l []*config.PolicyDefinition, err error) {
-	s.mgmtOperation(func() error {
+	err = s.mgmtOperation(func() error {
 		var id string
 		id, err = s.toPolicyInfo(name, dir)
 		if err != nil {
@@ -2021,7 +2021,7 @@ func (s *BgpServer) ValidateRib(prefix string) error {
 }
 
 func (s *BgpServer) GetRpki() (l []*config.RpkiServer, err error) {
-	s.mgmtOperation(func() error {
+	err = s.mgmtOperation(func() error {
 		l = s.roaManager.GetServers()
 		return nil
 	}, false)


### PR DESCRIPTION
when using named return for management operations, we need to substitute
the return value of (*BgpServer).mgmtOperation() to a valiable 'err' for
proper error propagation.

close #1215

Signed-off-by: Wataru Ishida <ishida.wataru@lab.ntt.co.jp>