### PR TITLE
Fix rpki server status

### DIFF
--- a/server/rpki.go
+++ b/server/rpki.go
@@ -251,6 +251,7 @@ func (m *roaManager) HandleROAEvent(ev *ROAEvent) {
 		log.WithFields(log.Fields{"Topic": "rpki"}).Infof("ROA server %s is connected", ev.Src)
 		client.conn = ev.conn
 		client.state.Uptime = time.Now().Unix()
+		client.state.Up = true
 		client.t = tomb.Tomb{}
 		client.t.Go(client.established)
 	case RTR:


### PR DESCRIPTION
`gobgp rpki servers` command for the first time after gobgpd started seems to return "Down" even though the RTR session has been established. From the second time on, it seems to work correctly. I guess `client.state.Up = true` is missing in the case of `CONNECTED` in `HandleROAEvent()`.
