### PR TITLE
introduce dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.pyc
 gobgp/gobgp
 gobgpd/gobgpd
+vendor/
 
 # Folders
 _obj

--- a/lock.json
+++ b/lock.json
@@ -1,0 +1,290 @@
+{
+    "memo": "38a99c3238c2fdf550bd24d8058d4bdb735ce26720d3e7f0113e7cf7d4da1d6f",
+    "projects": [
+        {
+            "name": "github.com/BurntSushi/toml",
+            "branch": "master",
+            "revision": "99064174e013895bbd9b025c31100bd1d9b590ca",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/Sirupsen/logrus",
+            "branch": "master",
+            "revision": "61e43dc76f7ee59a82bdf3d71033dc12bea4c77d",
+            "packages": [
+                ".",
+                "hooks/syslog"
+            ]
+        },
+        {
+            "name": "github.com/armon/go-radix",
+            "branch": "master",
+            "revision": "4239b77079c7b5d1243b7b4736304ce8ddb6f0f2",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/davecgh/go-spew",
+            "version": "v1.1.0",
+            "revision": "346938d642f2ec3594ed81d874461961cd0faa76",
+            "packages": [
+                "spew"
+            ]
+        },
+        {
+            "name": "github.com/eapache/channels",
+            "branch": "master",
+            "revision": "47238d5aae8c0fefd518ef2bee46290909cf8263",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/eapache/queue",
+            "branch": "master",
+            "revision": "44cc805cf13205b55f69e14bcb69867d1ae92f98",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/fsnotify/fsnotify",
+            "branch": "master",
+            "revision": "a904159b9206978bb6d53fcc7a769e5cd726c737",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/golang/protobuf",
+            "branch": "master",
+            "revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+            "packages": [
+                "proto"
+            ]
+        },
+        {
+            "name": "github.com/hashicorp/hcl",
+            "branch": "master",
+            "revision": "372e8ddaa16fd67e371e9323807d056b799360af",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/inconshreveable/mousetrap",
+            "branch": "master",
+            "revision": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/influxdata/influxdb",
+            "branch": "master",
+            "revision": "2fe8ed308439a98a9b01943939b44048ed952c90",
+            "packages": [
+                "client/v2"
+            ]
+        },
+        {
+            "name": "github.com/jessevdk/go-flags",
+            "branch": "master",
+            "revision": "4e64e4a4e2552194cf594243e23aa9baf3b4297e",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/kr/pretty",
+            "branch": "master",
+            "revision": "cfb55aafdaf3ec08f0db22699ab822c50091b1c4",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/kr/text",
+            "branch": "main",
+            "revision": "7cafcd837844e784b526369c9bce262804aebc60",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/magiconair/properties",
+            "branch": "master",
+            "revision": "b3b15ef068fd0b17ddf408a23669f20811d194d2",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/mitchellh/mapstructure",
+            "branch": "master",
+            "revision": "db1efb556f84b25a0a13a04aad883943538ad2e0",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/pelletier/go-buffruneio",
+            "branch": "master",
+            "revision": "df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/pelletier/go-toml",
+            "branch": "master",
+            "revision": "a1f048ba24490f9b0674a67e1ce995d685cddf4a",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/pmezard/go-difflib",
+            "version": "v1.0.0",
+            "revision": "792786c7400a136282c1664665ae0a8db921c6c2",
+            "packages": [
+                "difflib"
+            ]
+        },
+        {
+            "name": "github.com/satori/go.uuid",
+            "branch": "master",
+            "revision": "b061729afc07e77a8aa4fad0a2fd840958f1942a",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/spf13/afero",
+            "branch": "master",
+            "revision": "72b31426848c6ef12a7a8e216708cb0d1530f074",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/spf13/cast",
+            "branch": "master",
+            "revision": "d1139bab1c07d5ad390a65e7305876b3c1a8370b",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/spf13/cobra",
+            "branch": "master",
+            "revision": "35136c09d8da66b901337c6e86fd8e88a1a255bd",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/spf13/jwalterweatherman",
+            "branch": "master",
+            "revision": "fa7ca7e836cf3a8bb4ebf799f472c12d7e903d66",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/spf13/pflag",
+            "branch": "master",
+            "revision": "9ff6c6923cfffbcd502984b8e0c80539a94968b7",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/spf13/viper",
+            "branch": "master",
+            "revision": "5ed0fc31f7f453625df314d8e66b9791e8d13003",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/stretchr/testify",
+            "version": "v1.1.4",
+            "revision": "69483b4bd14f5845b5a1e55bca19e954e827f1d0",
+            "packages": [
+                "assert"
+            ]
+        },
+        {
+            "name": "github.com/vishvananda/netlink",
+            "branch": "master",
+            "revision": "ebdfb7402004b397e6573c71132160d8e23cc12a",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "github.com/vishvananda/netns",
+            "branch": "master",
+            "revision": "2c9454e4fc6e2edc1a1c84e64ed3d6e662fb6991",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "golang.org/x/net",
+            "branch": "master",
+            "revision": "007e530097ad7f954752df63046b4036f98ba6a6",
+            "packages": [
+                "context",
+                "http2",
+                "http2/hpack",
+                "trace"
+            ]
+        },
+        {
+            "name": "golang.org/x/sys",
+            "branch": "master",
+            "revision": "7a6e5648d140666db5d920909e082ca00a87ba2c",
+            "packages": [
+                "unix"
+            ]
+        },
+        {
+            "name": "golang.org/x/text",
+            "branch": "master",
+            "revision": "506f9d5c962f284575e88337e7d9296d27e729d3",
+            "packages": [
+                "transform",
+                "unicode/norm"
+            ]
+        },
+        {
+            "name": "google.golang.org/grpc",
+            "branch": "master",
+            "revision": "21f8ed309495401e6fd79b3a9fd549582aed1b4c",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "gopkg.in/tomb.v2",
+            "branch": "v2",
+            "revision": "d5d1b5820637886def9eef33e03a27a9f166942c",
+            "packages": [
+                "."
+            ]
+        },
+        {
+            "name": "gopkg.in/yaml.v2",
+            "branch": "v2",
+            "revision": "4c78c975fe7c825c6d1466c42be594d1d6f3aba6",
+            "packages": [
+                "."
+            ]
+        }
+    ]
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,49 @@
+{
+    "dependencies": {
+        "github.com/BurntSushi/toml": {
+            "branch": "master"
+        },
+        "github.com/Sirupsen/logrus": {
+            "branch": "master"
+        },
+        "github.com/armon/go-radix": {
+            "branch": "master"
+        },
+        "github.com/eapache/channels": {
+            "branch": "master"
+        },
+        "github.com/golang/protobuf": {
+            "branch": "master"
+        },
+        "github.com/influxdata/influxdb": {
+            "branch": "master"
+        },
+        "github.com/jessevdk/go-flags": {
+            "branch": "master"
+        },
+        "github.com/kr/pretty": {
+            "branch": "master"
+        },
+        "github.com/satori/go.uuid": {
+            "branch": "master"
+        },
+        "github.com/spf13/cobra": {
+            "branch": "master"
+        },
+        "github.com/spf13/viper": {
+            "branch": "master"
+        },
+        "github.com/vishvananda/netlink": {
+            "branch": "master"
+        },
+        "golang.org/x/net": {
+            "branch": "master"
+        },
+        "google.golang.org/grpc": {
+            "branch": "master"
+        },
+        "gopkg.in/tomb.v2": {
+            "branch": "v2"
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/golang/dep

Not official yet but looks like it would in the future.

If you don't like it (for example, if you use gobgp as a package for
your own program), then just ignore lock.json and manifest.json.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>