### PR TITLE
server: fix in-policy bug

### DIFF
--- a/server/peer.go
+++ b/server/peer.go
@@ -475,6 +475,8 @@ func (peer *Peer) handleUpdate(e *FsmMsg) ([]*table.Path, []bgp.RouteFamily, *bg
 			}
 			if path.Filtered(peer.ID()) != table.POLICY_DIRECTION_IN {
 				paths = append(paths, path)
+			} else {
+				paths = append(paths, path.Clone(true))
 			}
 		}
 		return paths, eor, nil

--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -17,8 +17,10 @@ from fabric.api import local, lcd
 from fabric import colors
 from fabric.utils import indent
 from fabric.state import env, output
-from docker import Client
-
+try:
+    from docker import Client
+except ImportError:
+    from docker import APIClient as Client
 import netaddr
 import os
 import time


### PR DESCRIPTION
When a path is rejected by in-policy, the prefix must be withdrawn
since it might already exist in the rib.

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>