### PR TITLE
Tcpflags parser

### DIFF
--- a/docs/sources/flowspec.md
+++ b/docs/sources/flowspec.md
@@ -45,7 +45,7 @@ CLI syntax to add ipv4/ipv6 flowspec rule is
 ```shell
 % global rib add match <MATCH_EXPR> then <THEN_EXPR> -a [ipv4-flowspec|ipv6-flowspec]
    <MATCH_EXPR> : { destination <PREFIX> [<OFFSET>] | source <PREFIX> [<OFFSET>] |
-                    protocol <PROTO>... | fragment <FRAGMENT_TYPE> | tcp-flags [not] [match] <TCPFLAG>... |
+                    protocol <PROTO>... | fragment <FRAGMENT_TYPE> | tcp-flags [!] [=] <TCPFLAG>... |
                     { port | destination-port | source-port | icmp-type | icmp-code | packet-length | dscp | label } <ITEM>... }...
    <PROTO> : ospf, pim, igp, udp, igmp, tcp, egp, rsvp, gre, ipip, unknown, icmp, sctp, <VALUE>
    <FRAGMENT_TYPE> : dont-fragment, is-fragment, first-fragment, last-fragment, not-a-fragment

--- a/docs/sources/flowspec.md
+++ b/docs/sources/flowspec.md
@@ -49,7 +49,7 @@ CLI syntax to add ipv4/ipv6 flowspec rule is
                     { port | destination-port | source-port | icmp-type | icmp-code | packet-length | dscp | label } <ITEM>... }...
    <PROTO> : ospf, pim, igp, udp, igmp, tcp, egp, rsvp, gre, ipip, unknown, icmp, sctp, <VALUE>
    <FRAGMENT_TYPE> : dont-fragment, is-fragment, first-fragment, last-fragment, not-a-fragment
-   <TCPFLAG> : rst, push, ack, urgent, fin, syn
+   <TCPFLAG> : U, C, E, F, S, R, P, A
    <ITEM> : &?{<|>|=}<value>
    <THEN_EXPR> : { accept | discard | rate-limit <value> | redirect <RT> | mark <value> | action { sample | terminal | sample-terminal } | rt <RT>... }...
    <RT> : xxx:yyy, xx.xx.xx.xx:yyy, xxx.xxx:yyy
@@ -71,6 +71,9 @@ that for l2vpn flowspec rule is
 ```shell
 # add a flowspec rule which redirect flows with dst 10.0.0.0/24 and src 20.0.0.0/24 to VRF with RT 10:10
 % gobgp global rib -a ipv4-flowspec add match destination 10.0.0.0/24 source 20.0.0.0/24 then redirect 10:10
+
+# add a flowspec rule wich discard flows with dst 2001::2/128 and port equals 80 and with TCP flags not match SA (SYN/ACK) and not match U (URG)
+% gobgp global rib -a ipv6-flowspec add match destination 2001::2/128 port '=80' tcp-flags '=!SA&=!U' then discard
 
 # show flowspec table
 % gobgp global rib -a ipv4-flowspec

--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -863,7 +863,7 @@ usage: %s rib %s%%smatch <MATCH_EXPR> then <THEN_EXPR> -a %%s
 			ExtCommNameMap[RATE], ExtCommNameMap[REDIRECT],
 			ExtCommNameMap[MARK], ExtCommNameMap[ACTION], ExtCommNameMap[RT])
 		ipFsMatchExpr := fmt.Sprintf(`   <MATCH_EXPR> : { %s <PREFIX> [<OFFSET>] | %s <PREFIX> [<OFFSET>] |
-                    %s <PROTO>... | %s <FRAGMENT_TYPE> | %s [not] [match] <TCPFLAG>... |
+                    %s <PROTO>... | %s <FRAGMENT_TYPE> | %s [!] [=] <TCPFLAG>... |
                     { %s | %s | %s | %s | %s | %s | %s | %s } <ITEM>... }...
    <PROTO> : %s
    <FRAGMENT_TYPE> : dont-fragment, is-fragment, first-fragment, last-fragment, not-a-fragment

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -2531,7 +2531,6 @@ func parseTcpFlagCmd(myCmd string) ([][2]int, error) {
 				tcpOperatorsFlagsValues = append(tcpOperatorsFlagsValues, operatorValue)
 				operatorValue[0] = 0
 				operatorValue[1] = 0
-				// resetAllFlagsToFalse(tcpFlagBitMap, tcpFlagOpBitMap)
 				index++
 			} else {
 				err := fmt.Errorf("AND or OR (space) operator appears multiple time")
@@ -2543,7 +2542,7 @@ func parseTcpFlagCmd(myCmd string) ([][2]int, error) {
 			myLoopChar := myCmdChar
 			loopIndex := index
 			// we loop till we reach the end of TCP flags description
-			// exit conditions : we reach the end of tcp flags (we found & or ' ') or we reach the end of the line
+			// exit conditions : we reach the end of tcp flags (we find & or ' ') or we reach the end of the line
 			for loopIndex < len(myCmd) &&
 				(myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_AND] && myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_OR]) {
 				// we check if inspected charater is a well known tcp flag and if it doesn't appear twice

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -2488,34 +2488,171 @@ func flowSpecIpProtoParser(rf RouteFamily, args []string) (FlowSpecComponentInte
 	return doFlowSpecNumericParser(0, args, validationFunc)
 }
 
+// func flowSpecTcpFlagParser(rf RouteFamily, args []string) (FlowSpecComponentInterface, error) {
+// 	ss := make([]string, 0, len(TCPFlagNameMap))
+// 	for _, v := range TCPFlagNameMap {
+// 		ss = append(ss, v)
+// 	}
+// 	protos := strings.Join(ss, "|")
+// 	exp := regexp.MustCompile(fmt.Sprintf("^%s (not )?(match )?((((%s)\\&)*(%s) )*(((%s)\\&)*(%s)))$", FlowSpecNameMap[FLOW_SPEC_TYPE_TCP_FLAG], protos, protos, protos, protos))
+// 	elems := exp.FindStringSubmatch(strings.Join(args, " "))
+// 	if len(elems) < 1 {
+// 		return nil, fmt.Errorf("invalid flag format")
+// 	}
+// 	items := make([]*FlowSpecComponentItem, 0)
+// 	op := 0
+// 	if elems[2] != "" {
+// 		op |= 0x1
+// 	}
+// 	if elems[1] != "" {
+// 		op |= 0x2
+// 	}
+// 	for _, v := range strings.Split(elems[3], " ") {
+// 		flag := 0
+// 		for _, e := range strings.Split(v, "&") {
+// 			flag |= int(TCPFlagValueMap[e])
+// 		}
+// 		items = append(items, NewFlowSpecComponentItem(op, flag))
+// 	}
+// 	return NewFlowSpecComponent(FLOW_SPEC_TYPE_TCP_FLAG, items), nil
+// }
+
 func flowSpecTcpFlagParser(rf RouteFamily, args []string) (FlowSpecComponentInterface, error) {
-	ss := make([]string, 0, len(TCPFlagNameMap))
-	for _, v := range TCPFlagNameMap {
-		ss = append(ss, v)
-	}
-	protos := strings.Join(ss, "|")
-	exp := regexp.MustCompile(fmt.Sprintf("^%s (not )?(match )?((((%s)\\&)*(%s) )*(((%s)\\&)*(%s)))$", FlowSpecNameMap[FLOW_SPEC_TYPE_TCP_FLAG], protos, protos, protos, protos))
-	elems := exp.FindStringSubmatch(strings.Join(args, " "))
-	if len(elems) < 1 {
-		return nil, fmt.Errorf("invalid flag format")
-	}
-	items := make([]*FlowSpecComponentItem, 0)
-	op := 0
-	if elems[2] != "" {
-		op |= 0x1
-	}
-	if elems[1] != "" {
-		op |= 0x2
-	}
-	for _, v := range strings.Split(elems[3], " ") {
-		flag := 0
-		for _, e := range strings.Split(v, "&") {
-			flag |= int(TCPFlagValueMap[e])
-		}
-		items = append(items, NewFlowSpecComponentItem(op, flag))
-	}
-	return NewFlowSpecComponent(FLOW_SPEC_TYPE_TCP_FLAG, items), nil
+	args = append(args[:0], args[1:]...) // removing tcp-flags string
+	fullCmd := strings.Join(args, " ") // rebuiling tcp filters
+    err, flags, ops := parseTcpFlagCmd(fullCmd)
+    if (err != nil) {
+        return nil, err
+    }
+    items := make([]*FlowSpecComponentItem, 0)
+    for index := 0; index < len(flags); index++ {
+        items = append(items, NewFlowSpecComponentItem(ops[index], flags[index]))
+    }
+    return NewFlowSpecComponent(FLOW_SPEC_TYPE_TCP_FLAG, items), nil
 }
+
+func parseTcpFlagCmd(myCmd string) (error, []int, []int) {
+    var tcpFlagBitMap = map[string]bool{
+        TCPFlagNameMap[TCP_FLAG_FIN]:    false,
+        TCPFlagNameMap[TCP_FLAG_SYN]:    false,
+        TCPFlagNameMap[TCP_FLAG_RST]:    false,
+        TCPFlagNameMap[TCP_FLAG_PUSH]:   false,
+        TCPFlagNameMap[TCP_FLAG_ACK]:    false,
+        TCPFlagNameMap[TCP_FLAG_URGENT]: false,
+        TCPFlagNameMap[TCP_FLAG_CWR]:    false,
+        TCPFlagNameMap[TCP_FLAG_ECE]:    false,
+    }
+    var tcpFlagOpBitMap = map[string]bool{
+        TCPFlagOpNameMap[TCP_FLAG_OP_OR]:    false,
+        TCPFlagOpNameMap[TCP_FLAG_OP_AND]:   false,
+        TCPFlagOpNameMap[TCP_FLAG_OP_END]:   false,
+        TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:   false,
+        TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]: false,
+    }
+    var index int = 0
+    var tcpFlagsValues []int
+    var tcpFlowSpecOps []int
+    var tcpFlagsValue int = 0
+    var tcpFlowSpecOp int = 0
+    for index < len(myCmd) {
+        myCmdChar := myCmd[index:index+1]
+        switch myCmdChar {
+        case TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]:
+            if(tcpFlagOpBitMap[myCmdChar] == false) {
+                tcpFlagOpBitMap[myCmdChar] = true
+                index++
+            } else {
+                err := fmt.Errorf("Match flag appears multiple time")
+                return err, tcpFlagsValues, tcpFlowSpecOps
+            }
+        case TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:
+            if(tcpFlagOpBitMap[myCmdChar] == false) {
+                tcpFlagOpBitMap[myCmdChar] = true
+                index++
+            } else {
+                err := fmt.Errorf("Not flag appears multiple time")
+                return err, tcpFlagsValues, tcpFlowSpecOps
+            }
+        case TCPFlagOpNameMap[TCP_FLAG_OP_AND], TCPFlagOpNameMap[TCP_FLAG_OP_OR]:
+            if(tcpFlagOpBitMap[myCmdChar] == false) {
+                tcpFlagOpBitMap[myCmdChar] = true
+                tcpFlagsValue, tcpFlowSpecOp = setTcpOpsBitmapWithMap(tcpFlagBitMap, tcpFlagOpBitMap)
+                tcpFlagsValues = append(tcpFlagsValues, tcpFlagsValue)
+                tcpFlowSpecOps = append(tcpFlowSpecOps, tcpFlowSpecOp)
+                resetAllFlagsToFalse(tcpFlagBitMap, tcpFlagOpBitMap)
+                index++
+            } else {
+                err := fmt.Errorf("AND or OR (space) operator appears multiple time")
+                return err, tcpFlagsValues, tcpFlowSpecOps
+            }
+        case TCPFlagNameMap[TCP_FLAG_ACK], TCPFlagNameMap[TCP_FLAG_SYN], TCPFlagNameMap[TCP_FLAG_FIN],
+        TCPFlagNameMap[TCP_FLAG_URGENT], TCPFlagNameMap[TCP_FLAG_ECE], TCPFlagNameMap[TCP_FLAG_RST],
+        TCPFlagNameMap[TCP_FLAG_CWR], TCPFlagNameMap[TCP_FLAG_PUSH]:
+            myLoopChar := myCmdChar
+            loopIndex := index
+            // we loop till we reach the end of TCP flags description
+            // exit conditions : we reach the end of tcp flags (we found & or ' ') or we reach the end of the line
+            for (loopIndex < len(myCmd) &&
+                (myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_AND] && myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_OR])) {
+                // we check if inspected charater is a well known tcp flag and if it doesn't appear twice
+                if (TCPFlagValueMap[myLoopChar]!= 0 && tcpFlagBitMap[myLoopChar] == false) {
+                    tcpFlagBitMap[myLoopChar] = true            // we set this flag to true
+                    loopIndex++                                 // we move to next character
+                    if(loopIndex < len(myCmd)) {
+                        myLoopChar = myCmd[loopIndex:loopIndex+1]   // we move to the next character only if we didn't reach the end of cmd
+                    }
+                } else {
+                    err := fmt.Errorf("flag %s appears multiple time or is not part of TCP flags", myLoopChar)
+                    return err, tcpFlagsValues, tcpFlowSpecOps
+                }
+            }
+            // we are done with flags, we give back the next cooming charater to the main loop
+            index = loopIndex
+        default:
+            err := fmt.Errorf("flag %s not part of tcp flags", myCmdChar)
+            return err, tcpFlagsValues, tcpFlowSpecOps
+        }
+    }
+    tcpFlagOpBitMap["E"] = true
+    tcpFlagsValue, tcpFlowSpecOp = setTcpOpsBitmapWithMap(tcpFlagBitMap, tcpFlagOpBitMap)
+    tcpFlagsValues = append(tcpFlagsValues, tcpFlagsValue)
+    tcpFlowSpecOps = append(tcpFlowSpecOps, tcpFlowSpecOp)
+    resetAllFlagsToFalse(tcpFlagBitMap, tcpFlagOpBitMap)
+    return nil, tcpFlagsValues, tcpFlowSpecOps
+}
+
+func resetAllFlagsToFalse(myTcpFlagBitMap map[string]bool, myTcpFlagOpBitMap map[string]bool) {
+    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_FIN]]     = false
+    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_SYN]]     = false
+    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_RST]]     = false
+    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_PUSH]]    = false
+    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_ACK]]     = false
+    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_URGENT]]  = false
+    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_CWR]]     = false
+    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_ECE]]     = false
+    myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_AND]]   = false
+    myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_OR]]    = false
+    myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_END]]   = false
+    myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_NOT]]   = false
+    myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]] = false
+}
+
+func setTcpOpsBitmapWithMap(myTcpFlagBitMap map[string]bool, myTcpFlagOpBitMap map[string]bool) (int, int) {
+    var myFlags int = 0
+    var myOps int = 0
+    for flagString, flagSetUnset := range myTcpFlagBitMap {
+        if (flagSetUnset) {
+            myFlags |= int(TCPFlagValueMap[flagString])
+        }
+    }
+    for opString, opSetUnset := range myTcpFlagOpBitMap {
+        if (opSetUnset) {
+            myOps |= int(TCPFlagOpValueMap[opString])
+        }
+    }
+    return myFlags, myOps
+}
+
 
 func flowSpecEtherTypeParser(rf RouteFamily, args []string) (FlowSpecComponentInterface, error) {
 	if len(args) < 2 || args[0] != FlowSpecNameMap[FLOW_SPEC_TYPE_ETHERNET_TYPE] {
@@ -3084,21 +3221,24 @@ func formatProto(op int, value int) string {
 }
 
 func formatFlag(op int, value int) string {
-	and := " "
-	ss := make([]string, 0, 2)
-	if op&0x40 > 0 {
-		and = "&"
-	}
-	if op&0x1 > 0 {
-		ss = append(ss, "match")
-	}
-	if op&0x2 > 0 {
-		ss = append(ss, "not")
-	}
-	if len(ss) > 0 {
-		return fmt.Sprintf("%s(%s)%s", and, strings.Join(ss, "|"), TCPFlag(value).String())
-	}
-	return fmt.Sprintf("%s%s", and, TCPFlag(value).String())
+    var retString string
+    if op&TCP_FLAG_OP_MATCH > 0 {
+        retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_MATCH])
+    }
+    if op&TCP_FLAG_OP_NOT > 0 {
+        retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_NOT])
+    }
+    for flag, valueFlag := range TCPFlagValueMap {
+        if value&int(valueFlag) > 0 {
+            retString = fmt.Sprintf("%s%s", retString, flag)
+        }
+    }
+    if op&TCP_FLAG_OP_AND > 0 {
+        retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_AND])
+    } else { // default is or
+        retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_OR])
+    }
+    return retString
 }
 
 func formatFragment(op int, value int) string {

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -2490,140 +2490,139 @@ func flowSpecIpProtoParser(rf RouteFamily, args []string) (FlowSpecComponentInte
 
 func flowSpecTcpFlagParser(rf RouteFamily, args []string) (FlowSpecComponentInterface, error) {
 	args = append(args[:0], args[1:]...) // removing tcp-flags string
-	fullCmd := strings.Join(args, " ") // rebuiling tcp filters
-    err, flags, ops := parseTcpFlagCmd(fullCmd)
-    if (err != nil) {
-        return nil, err
-    }
-    items := make([]*FlowSpecComponentItem, 0)
-    for index := 0; index < len(flags); index++ {
-        items = append(items, NewFlowSpecComponentItem(ops[index], flags[index]))
-    }
-    return NewFlowSpecComponent(FLOW_SPEC_TYPE_TCP_FLAG, items), nil
+	fullCmd := strings.Join(args, " ")   // rebuiling tcp filters
+	err, flags, ops := parseTcpFlagCmd(fullCmd)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]*FlowSpecComponentItem, 0)
+	for index := 0; index < len(flags); index++ {
+		items = append(items, NewFlowSpecComponentItem(ops[index], flags[index]))
+	}
+	return NewFlowSpecComponent(FLOW_SPEC_TYPE_TCP_FLAG, items), nil
 }
 
 func parseTcpFlagCmd(myCmd string) (error, []int, []int) {
-    var tcpFlagBitMap = map[string]bool{
-        TCPFlagNameMap[TCP_FLAG_FIN]:    false,
-        TCPFlagNameMap[TCP_FLAG_SYN]:    false,
-        TCPFlagNameMap[TCP_FLAG_RST]:    false,
-        TCPFlagNameMap[TCP_FLAG_PUSH]:   false,
-        TCPFlagNameMap[TCP_FLAG_ACK]:    false,
-        TCPFlagNameMap[TCP_FLAG_URGENT]: false,
-        TCPFlagNameMap[TCP_FLAG_CWR]:    false,
-        TCPFlagNameMap[TCP_FLAG_ECE]:    false,
-    }
-    var tcpFlagOpBitMap = map[string]bool{
-        TCPFlagOpNameMap[TCP_FLAG_OP_OR]:    false,
-        TCPFlagOpNameMap[TCP_FLAG_OP_AND]:   false,
-        TCPFlagOpNameMap[TCP_FLAG_OP_END]:   false,
-        TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:   false,
-        TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]: false,
-    }
-    var index int = 0
-    var tcpFlagsValues []int
-    var tcpFlowSpecOps []int
-    var tcpFlagsValue int = 0
-    var tcpFlowSpecOp int = 0
-    for index < len(myCmd) {
-        myCmdChar := myCmd[index:index+1]
-        switch myCmdChar {
-        case TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]:
-            if(tcpFlagOpBitMap[myCmdChar] == false) {
-                tcpFlagOpBitMap[myCmdChar] = true
-                index++
-            } else {
-                err := fmt.Errorf("Match flag appears multiple time")
-                return err, tcpFlagsValues, tcpFlowSpecOps
-            }
-        case TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:
-            if(tcpFlagOpBitMap[myCmdChar] == false) {
-                tcpFlagOpBitMap[myCmdChar] = true
-                index++
-            } else {
-                err := fmt.Errorf("Not flag appears multiple time")
-                return err, tcpFlagsValues, tcpFlowSpecOps
-            }
-        case TCPFlagOpNameMap[TCP_FLAG_OP_AND], TCPFlagOpNameMap[TCP_FLAG_OP_OR]:
-            if(tcpFlagOpBitMap[myCmdChar] == false) {
-                tcpFlagOpBitMap[myCmdChar] = true
-                tcpFlagsValue, tcpFlowSpecOp = setTcpOpsBitmapWithMap(tcpFlagBitMap, tcpFlagOpBitMap)
-                tcpFlagsValues = append(tcpFlagsValues, tcpFlagsValue)
-                tcpFlowSpecOps = append(tcpFlowSpecOps, tcpFlowSpecOp)
-                resetAllFlagsToFalse(tcpFlagBitMap, tcpFlagOpBitMap)
-                index++
-            } else {
-                err := fmt.Errorf("AND or OR (space) operator appears multiple time")
-                return err, tcpFlagsValues, tcpFlowSpecOps
-            }
-        case TCPFlagNameMap[TCP_FLAG_ACK], TCPFlagNameMap[TCP_FLAG_SYN], TCPFlagNameMap[TCP_FLAG_FIN],
-        TCPFlagNameMap[TCP_FLAG_URGENT], TCPFlagNameMap[TCP_FLAG_ECE], TCPFlagNameMap[TCP_FLAG_RST],
-        TCPFlagNameMap[TCP_FLAG_CWR], TCPFlagNameMap[TCP_FLAG_PUSH]:
-            myLoopChar := myCmdChar
-            loopIndex := index
-            // we loop till we reach the end of TCP flags description
-            // exit conditions : we reach the end of tcp flags (we found & or ' ') or we reach the end of the line
-            for (loopIndex < len(myCmd) &&
-                (myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_AND] && myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_OR])) {
-                // we check if inspected charater is a well known tcp flag and if it doesn't appear twice
-                if (TCPFlagValueMap[myLoopChar]!= 0 && tcpFlagBitMap[myLoopChar] == false) {
-                    tcpFlagBitMap[myLoopChar] = true            // we set this flag to true
-                    loopIndex++                                 // we move to next character
-                    if(loopIndex < len(myCmd)) {
-                        myLoopChar = myCmd[loopIndex:loopIndex+1]   // we move to the next character only if we didn't reach the end of cmd
-                    }
-                } else {
-                    err := fmt.Errorf("flag %s appears multiple time or is not part of TCP flags", myLoopChar)
-                    return err, tcpFlagsValues, tcpFlowSpecOps
-                }
-            }
-            // we are done with flags, we give back the next cooming charater to the main loop
-            index = loopIndex
-        default:
-            err := fmt.Errorf("flag %s not part of tcp flags", myCmdChar)
-            return err, tcpFlagsValues, tcpFlowSpecOps
-        }
-    }
-    tcpFlagOpBitMap["E"] = true
-    tcpFlagsValue, tcpFlowSpecOp = setTcpOpsBitmapWithMap(tcpFlagBitMap, tcpFlagOpBitMap)
-    tcpFlagsValues = append(tcpFlagsValues, tcpFlagsValue)
-    tcpFlowSpecOps = append(tcpFlowSpecOps, tcpFlowSpecOp)
-    resetAllFlagsToFalse(tcpFlagBitMap, tcpFlagOpBitMap)
-    return nil, tcpFlagsValues, tcpFlowSpecOps
+	var tcpFlagBitMap = map[string]bool{
+		TCPFlagNameMap[TCP_FLAG_FIN]:    false,
+		TCPFlagNameMap[TCP_FLAG_SYN]:    false,
+		TCPFlagNameMap[TCP_FLAG_RST]:    false,
+		TCPFlagNameMap[TCP_FLAG_PUSH]:   false,
+		TCPFlagNameMap[TCP_FLAG_ACK]:    false,
+		TCPFlagNameMap[TCP_FLAG_URGENT]: false,
+		TCPFlagNameMap[TCP_FLAG_CWR]:    false,
+		TCPFlagNameMap[TCP_FLAG_ECE]:    false,
+	}
+	var tcpFlagOpBitMap = map[string]bool{
+		TCPFlagOpNameMap[TCP_FLAG_OP_OR]:    false,
+		TCPFlagOpNameMap[TCP_FLAG_OP_AND]:   false,
+		TCPFlagOpNameMap[TCP_FLAG_OP_END]:   false,
+		TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:   false,
+		TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]: false,
+	}
+	var index int = 0
+	var tcpFlagsValues []int
+	var tcpFlowSpecOps []int
+	var tcpFlagsValue int = 0
+	var tcpFlowSpecOp int = 0
+	for index < len(myCmd) {
+		myCmdChar := myCmd[index : index+1]
+		switch myCmdChar {
+		case TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]:
+			if tcpFlagOpBitMap[myCmdChar] == false {
+				tcpFlagOpBitMap[myCmdChar] = true
+				index++
+			} else {
+				err := fmt.Errorf("Match flag appears multiple time")
+				return err, tcpFlagsValues, tcpFlowSpecOps
+			}
+		case TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:
+			if tcpFlagOpBitMap[myCmdChar] == false {
+				tcpFlagOpBitMap[myCmdChar] = true
+				index++
+			} else {
+				err := fmt.Errorf("Not flag appears multiple time")
+				return err, tcpFlagsValues, tcpFlowSpecOps
+			}
+		case TCPFlagOpNameMap[TCP_FLAG_OP_AND], TCPFlagOpNameMap[TCP_FLAG_OP_OR]:
+			if tcpFlagOpBitMap[myCmdChar] == false {
+				tcpFlagOpBitMap[myCmdChar] = true
+				tcpFlagsValue, tcpFlowSpecOp = setTcpOpsBitmapWithMap(tcpFlagBitMap, tcpFlagOpBitMap)
+				tcpFlagsValues = append(tcpFlagsValues, tcpFlagsValue)
+				tcpFlowSpecOps = append(tcpFlowSpecOps, tcpFlowSpecOp)
+				resetAllFlagsToFalse(tcpFlagBitMap, tcpFlagOpBitMap)
+				index++
+			} else {
+				err := fmt.Errorf("AND or OR (space) operator appears multiple time")
+				return err, tcpFlagsValues, tcpFlowSpecOps
+			}
+		case TCPFlagNameMap[TCP_FLAG_ACK], TCPFlagNameMap[TCP_FLAG_SYN], TCPFlagNameMap[TCP_FLAG_FIN],
+			TCPFlagNameMap[TCP_FLAG_URGENT], TCPFlagNameMap[TCP_FLAG_ECE], TCPFlagNameMap[TCP_FLAG_RST],
+			TCPFlagNameMap[TCP_FLAG_CWR], TCPFlagNameMap[TCP_FLAG_PUSH]:
+			myLoopChar := myCmdChar
+			loopIndex := index
+			// we loop till we reach the end of TCP flags description
+			// exit conditions : we reach the end of tcp flags (we found & or ' ') or we reach the end of the line
+			for loopIndex < len(myCmd) &&
+				(myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_AND] && myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_OR]) {
+				// we check if inspected charater is a well known tcp flag and if it doesn't appear twice
+				if TCPFlagValueMap[myLoopChar] != 0 && tcpFlagBitMap[myLoopChar] == false {
+					tcpFlagBitMap[myLoopChar] = true // we set this flag to true
+					loopIndex++                      // we move to next character
+					if loopIndex < len(myCmd) {
+						myLoopChar = myCmd[loopIndex : loopIndex+1] // we move to the next character only if we didn't reach the end of cmd
+					}
+				} else {
+					err := fmt.Errorf("flag %s appears multiple time or is not part of TCP flags", myLoopChar)
+					return err, tcpFlagsValues, tcpFlowSpecOps
+				}
+			}
+			// we are done with flags, we give back the next cooming charater to the main loop
+			index = loopIndex
+		default:
+			err := fmt.Errorf("flag %s not part of tcp flags", myCmdChar)
+			return err, tcpFlagsValues, tcpFlowSpecOps
+		}
+	}
+	tcpFlagOpBitMap["E"] = true
+	tcpFlagsValue, tcpFlowSpecOp = setTcpOpsBitmapWithMap(tcpFlagBitMap, tcpFlagOpBitMap)
+	tcpFlagsValues = append(tcpFlagsValues, tcpFlagsValue)
+	tcpFlowSpecOps = append(tcpFlowSpecOps, tcpFlowSpecOp)
+	resetAllFlagsToFalse(tcpFlagBitMap, tcpFlagOpBitMap)
+	return nil, tcpFlagsValues, tcpFlowSpecOps
 }
 
 func resetAllFlagsToFalse(myTcpFlagBitMap map[string]bool, myTcpFlagOpBitMap map[string]bool) {
-    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_FIN]]     = false
-    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_SYN]]     = false
-    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_RST]]     = false
-    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_PUSH]]    = false
-    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_ACK]]     = false
-    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_URGENT]]  = false
-    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_CWR]]     = false
-    myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_ECE]]     = false
-    myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_AND]]   = false
-    myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_OR]]    = false
-    myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_END]]   = false
-    myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_NOT]]   = false
-    myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]] = false
+	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_FIN]] = false
+	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_SYN]] = false
+	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_RST]] = false
+	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_PUSH]] = false
+	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_ACK]] = false
+	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_URGENT]] = false
+	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_CWR]] = false
+	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_ECE]] = false
+	myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_AND]] = false
+	myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_OR]] = false
+	myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_END]] = false
+	myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_NOT]] = false
+	myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]] = false
 }
 
 func setTcpOpsBitmapWithMap(myTcpFlagBitMap map[string]bool, myTcpFlagOpBitMap map[string]bool) (int, int) {
-    var myFlags int = 0
-    var myOps int = 0
-    for flagString, flagSetUnset := range myTcpFlagBitMap {
-        if (flagSetUnset) {
-            myFlags |= int(TCPFlagValueMap[flagString])
-        }
-    }
-    for opString, opSetUnset := range myTcpFlagOpBitMap {
-        if (opSetUnset) {
-            myOps |= int(TCPFlagOpValueMap[opString])
-        }
-    }
-    return myFlags, myOps
+	var myFlags int = 0
+	var myOps int = 0
+	for flagString, flagSetUnset := range myTcpFlagBitMap {
+		if flagSetUnset {
+			myFlags |= int(TCPFlagValueMap[flagString])
+		}
+	}
+	for opString, opSetUnset := range myTcpFlagOpBitMap {
+		if opSetUnset {
+			myOps |= int(TCPFlagOpValueMap[opString])
+		}
+	}
+	return myFlags, myOps
 }
-
 
 func flowSpecEtherTypeParser(rf RouteFamily, args []string) (FlowSpecComponentInterface, error) {
 	if len(args) < 2 || args[0] != FlowSpecNameMap[FLOW_SPEC_TYPE_ETHERNET_TYPE] {
@@ -3192,24 +3191,24 @@ func formatProto(op int, value int) string {
 }
 
 func formatFlag(op int, value int) string {
-    var retString string
-    if op&TCP_FLAG_OP_MATCH > 0 {
-        retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_MATCH])
-    }
-    if op&TCP_FLAG_OP_NOT > 0 {
-        retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_NOT])
-    }
-    for flag, valueFlag := range TCPFlagValueMap {
-        if value&int(valueFlag) > 0 {
-            retString = fmt.Sprintf("%s%s", retString, flag)
-        }
-    }
-    if op&TCP_FLAG_OP_AND > 0 {
-        retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_AND])
-    } else { // default is or
-        retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_OR])
-    }
-    return retString
+	var retString string
+	if op&TCP_FLAG_OP_MATCH > 0 {
+		retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_MATCH])
+	}
+	if op&TCP_FLAG_OP_NOT > 0 {
+		retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_NOT])
+	}
+	for flag, valueFlag := range TCPFlagValueMap {
+		if value&int(valueFlag) > 0 {
+			retString = fmt.Sprintf("%s%s", retString, flag)
+		}
+	}
+	if op&TCP_FLAG_OP_AND > 0 {
+		retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_AND])
+	} else { // default is or
+		retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_OR])
+	}
+	return retString
 }
 
 func formatFragment(op int, value int) string {

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -2491,138 +2491,85 @@ func flowSpecIpProtoParser(rf RouteFamily, args []string) (FlowSpecComponentInte
 func flowSpecTcpFlagParser(rf RouteFamily, args []string) (FlowSpecComponentInterface, error) {
 	args = append(args[:0], args[1:]...) // removing tcp-flags string
 	fullCmd := strings.Join(args, " ")   // rebuiling tcp filters
-	err, flags, ops := parseTcpFlagCmd(fullCmd)
+	opsFlags, err := parseTcpFlagCmd(fullCmd)
 	if err != nil {
 		return nil, err
 	}
 	items := make([]*FlowSpecComponentItem, 0)
-	for index := 0; index < len(flags); index++ {
-		items = append(items, NewFlowSpecComponentItem(ops[index], flags[index]))
+	for _, opFlag := range(opsFlags) {
+		items = append(items, NewFlowSpecComponentItem(opFlag[0], opFlag[1]))
 	}
 	return NewFlowSpecComponent(FLOW_SPEC_TYPE_TCP_FLAG, items), nil
 }
 
-func parseTcpFlagCmd(myCmd string) (error, []int, []int) {
-	var tcpFlagBitMap = map[string]bool{
-		TCPFlagNameMap[TCP_FLAG_FIN]:    false,
-		TCPFlagNameMap[TCP_FLAG_SYN]:    false,
-		TCPFlagNameMap[TCP_FLAG_RST]:    false,
-		TCPFlagNameMap[TCP_FLAG_PUSH]:   false,
-		TCPFlagNameMap[TCP_FLAG_ACK]:    false,
-		TCPFlagNameMap[TCP_FLAG_URGENT]: false,
-		TCPFlagNameMap[TCP_FLAG_CWR]:    false,
-		TCPFlagNameMap[TCP_FLAG_ECE]:    false,
-	}
-	var tcpFlagOpBitMap = map[string]bool{
-		TCPFlagOpNameMap[TCP_FLAG_OP_OR]:    false,
-		TCPFlagOpNameMap[TCP_FLAG_OP_AND]:   false,
-		TCPFlagOpNameMap[TCP_FLAG_OP_END]:   false,
-		TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:   false,
-		TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]: false,
-	}
-	var index int = 0
-	var tcpFlagsValues []int
-	var tcpFlowSpecOps []int
-	var tcpFlagsValue int = 0
-	var tcpFlowSpecOp int = 0
-	for index < len(myCmd) {
-		myCmdChar := myCmd[index : index+1]
-		switch myCmdChar {
-		case TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]:
-			if tcpFlagOpBitMap[myCmdChar] == false {
-				tcpFlagOpBitMap[myCmdChar] = true
-				index++
-			} else {
-				err := fmt.Errorf("Match flag appears multiple time")
-				return err, tcpFlagsValues, tcpFlowSpecOps
-			}
-		case TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:
-			if tcpFlagOpBitMap[myCmdChar] == false {
-				tcpFlagOpBitMap[myCmdChar] = true
-				index++
-			} else {
-				err := fmt.Errorf("Not flag appears multiple time")
-				return err, tcpFlagsValues, tcpFlowSpecOps
-			}
-		case TCPFlagOpNameMap[TCP_FLAG_OP_AND], TCPFlagOpNameMap[TCP_FLAG_OP_OR]:
-			if tcpFlagOpBitMap[myCmdChar] == false {
-				tcpFlagOpBitMap[myCmdChar] = true
-				tcpFlagsValue, tcpFlowSpecOp = setTcpOpsBitmapWithMap(tcpFlagBitMap, tcpFlagOpBitMap)
-				tcpFlagsValues = append(tcpFlagsValues, tcpFlagsValue)
-				tcpFlowSpecOps = append(tcpFlowSpecOps, tcpFlowSpecOp)
-				resetAllFlagsToFalse(tcpFlagBitMap, tcpFlagOpBitMap)
-				index++
-			} else {
-				err := fmt.Errorf("AND or OR (space) operator appears multiple time")
-				return err, tcpFlagsValues, tcpFlowSpecOps
-			}
-		case TCPFlagNameMap[TCP_FLAG_ACK], TCPFlagNameMap[TCP_FLAG_SYN], TCPFlagNameMap[TCP_FLAG_FIN],
-			TCPFlagNameMap[TCP_FLAG_URGENT], TCPFlagNameMap[TCP_FLAG_ECE], TCPFlagNameMap[TCP_FLAG_RST],
-			TCPFlagNameMap[TCP_FLAG_CWR], TCPFlagNameMap[TCP_FLAG_PUSH]:
-			myLoopChar := myCmdChar
-			loopIndex := index
-			// we loop till we reach the end of TCP flags description
-			// exit conditions : we reach the end of tcp flags (we found & or ' ') or we reach the end of the line
-			for loopIndex < len(myCmd) &&
-				(myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_AND] && myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_OR]) {
-				// we check if inspected charater is a well known tcp flag and if it doesn't appear twice
-				if TCPFlagValueMap[myLoopChar] != 0 && tcpFlagBitMap[myLoopChar] == false {
-					tcpFlagBitMap[myLoopChar] = true // we set this flag to true
-					loopIndex++                      // we move to next character
-					if loopIndex < len(myCmd) {
-						myLoopChar = myCmd[loopIndex : loopIndex+1] // we move to the next character only if we didn't reach the end of cmd
-					}
-				} else {
-					err := fmt.Errorf("flag %s appears multiple time or is not part of TCP flags", myLoopChar)
-					return err, tcpFlagsValues, tcpFlowSpecOps
-				}
-			}
-			// we are done with flags, we give back the next cooming charater to the main loop
-			index = loopIndex
-		default:
-			err := fmt.Errorf("flag %s not part of tcp flags", myCmdChar)
-			return err, tcpFlagsValues, tcpFlowSpecOps
-		}
-	}
-	tcpFlagOpBitMap["E"] = true
-	tcpFlagsValue, tcpFlowSpecOp = setTcpOpsBitmapWithMap(tcpFlagBitMap, tcpFlagOpBitMap)
-	tcpFlagsValues = append(tcpFlagsValues, tcpFlagsValue)
-	tcpFlowSpecOps = append(tcpFlowSpecOps, tcpFlowSpecOp)
-	resetAllFlagsToFalse(tcpFlagBitMap, tcpFlagOpBitMap)
-	return nil, tcpFlagsValues, tcpFlowSpecOps
+func parseTcpFlagCmd(myCmd string) ( [][2]int, error) {
+    var index int = 0
+    var tcpOperatorsFlagsValues [][2]int
+    var operatorValue [2]int
+    for index < len(myCmd) {
+        myCmdChar := myCmd[index:index+1]
+        switch myCmdChar {
+        case TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]:
+            if bit := TCPFlagOpValueMap[myCmdChar]; bit & TCPFlagOp(operatorValue[0]) == 0 {
+                operatorValue[0] |= int(bit)
+                index++
+            } else {
+                err := fmt.Errorf("Match flag appears multiple time")
+                return nil, err
+            }
+        case TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:
+            if bit := TCPFlagOpValueMap[myCmdChar]; bit & TCPFlagOp(operatorValue[0]) == 0 {
+                operatorValue[0] |= int(bit)
+                index++
+            } else {
+                err := fmt.Errorf("Not flag appears multiple time")
+                return nil, err
+            }
+        case TCPFlagOpNameMap[TCP_FLAG_OP_AND], TCPFlagOpNameMap[TCP_FLAG_OP_OR]:
+            if bit := TCPFlagOpValueMap[myCmdChar]; bit & TCPFlagOp(operatorValue[0]) == 0 {
+                operatorValue[0] |= int(bit)
+                tcpOperatorsFlagsValues = append(tcpOperatorsFlagsValues, operatorValue)
+                operatorValue[0] = 0
+                operatorValue[1] = 0
+                // resetAllFlagsToFalse(tcpFlagBitMap, tcpFlagOpBitMap)
+                index++
+            } else {
+                err := fmt.Errorf("AND or OR (space) operator appears multiple time")
+                return nil, err
+            }
+        case TCPFlagNameMap[TCP_FLAG_ACK], TCPFlagNameMap[TCP_FLAG_SYN], TCPFlagNameMap[TCP_FLAG_FIN],
+        TCPFlagNameMap[TCP_FLAG_URGENT], TCPFlagNameMap[TCP_FLAG_ECE], TCPFlagNameMap[TCP_FLAG_RST],
+        TCPFlagNameMap[TCP_FLAG_CWR], TCPFlagNameMap[TCP_FLAG_PUSH]:
+            myLoopChar := myCmdChar
+            loopIndex := index
+            // we loop till we reach the end of TCP flags description
+            // exit conditions : we reach the end of tcp flags (we found & or ' ') or we reach the end of the line
+            for (loopIndex < len(myCmd) &&
+                (myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_AND] && myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_OR])) {
+                // we check if inspected charater is a well known tcp flag and if it doesn't appear twice
+                if bit, isPresent := TCPFlagValueMap[myLoopChar]; isPresent && (bit & TCPFlag(operatorValue[1]) == 0) {
+                    operatorValue[1] |= int(bit)            // we set this flag
+                    loopIndex++                                 // we move to next character
+                    if(loopIndex < len(myCmd)) {
+                        myLoopChar = myCmd[loopIndex:loopIndex+1]   // we move to the next character only if we didn't reach the end of cmd
+                    }
+                } else {
+                    err := fmt.Errorf("flag %s appears multiple time or is not part of TCP flags", myLoopChar)
+                    return nil, err
+                }
+            }
+            // we are done with flags, we give back the next cooming charater to the main loop
+            index = loopIndex
+        default:
+            err := fmt.Errorf("flag %s not part of tcp flags", myCmdChar)
+            return nil, err
+        }
+    }
+    operatorValue[0] |= int(TCPFlagOpValueMap["E"])
+    tcpOperatorsFlagsValues = append(tcpOperatorsFlagsValues, operatorValue)
+    return tcpOperatorsFlagsValues, nil
 }
 
-func resetAllFlagsToFalse(myTcpFlagBitMap map[string]bool, myTcpFlagOpBitMap map[string]bool) {
-	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_FIN]] = false
-	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_SYN]] = false
-	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_RST]] = false
-	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_PUSH]] = false
-	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_ACK]] = false
-	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_URGENT]] = false
-	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_CWR]] = false
-	myTcpFlagBitMap[TCPFlagNameMap[TCP_FLAG_ECE]] = false
-	myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_AND]] = false
-	myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_OR]] = false
-	myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_END]] = false
-	myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_NOT]] = false
-	myTcpFlagOpBitMap[TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]] = false
-}
-
-func setTcpOpsBitmapWithMap(myTcpFlagBitMap map[string]bool, myTcpFlagOpBitMap map[string]bool) (int, int) {
-	var myFlags int = 0
-	var myOps int = 0
-	for flagString, flagSetUnset := range myTcpFlagBitMap {
-		if flagSetUnset {
-			myFlags |= int(TCPFlagValueMap[flagString])
-		}
-	}
-	for opString, opSetUnset := range myTcpFlagOpBitMap {
-		if opSetUnset {
-			myOps |= int(TCPFlagOpValueMap[opString])
-		}
-	}
-	return myFlags, myOps
-}
 
 func flowSpecEtherTypeParser(rf RouteFamily, args []string) (FlowSpecComponentInterface, error) {
 	if len(args) < 2 || args[0] != FlowSpecNameMap[FLOW_SPEC_TYPE_ETHERNET_TYPE] {

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -2488,35 +2488,6 @@ func flowSpecIpProtoParser(rf RouteFamily, args []string) (FlowSpecComponentInte
 	return doFlowSpecNumericParser(0, args, validationFunc)
 }
 
-// func flowSpecTcpFlagParser(rf RouteFamily, args []string) (FlowSpecComponentInterface, error) {
-// 	ss := make([]string, 0, len(TCPFlagNameMap))
-// 	for _, v := range TCPFlagNameMap {
-// 		ss = append(ss, v)
-// 	}
-// 	protos := strings.Join(ss, "|")
-// 	exp := regexp.MustCompile(fmt.Sprintf("^%s (not )?(match )?((((%s)\\&)*(%s) )*(((%s)\\&)*(%s)))$", FlowSpecNameMap[FLOW_SPEC_TYPE_TCP_FLAG], protos, protos, protos, protos))
-// 	elems := exp.FindStringSubmatch(strings.Join(args, " "))
-// 	if len(elems) < 1 {
-// 		return nil, fmt.Errorf("invalid flag format")
-// 	}
-// 	items := make([]*FlowSpecComponentItem, 0)
-// 	op := 0
-// 	if elems[2] != "" {
-// 		op |= 0x1
-// 	}
-// 	if elems[1] != "" {
-// 		op |= 0x2
-// 	}
-// 	for _, v := range strings.Split(elems[3], " ") {
-// 		flag := 0
-// 		for _, e := range strings.Split(v, "&") {
-// 			flag |= int(TCPFlagValueMap[e])
-// 		}
-// 		items = append(items, NewFlowSpecComponentItem(op, flag))
-// 	}
-// 	return NewFlowSpecComponent(FLOW_SPEC_TYPE_TCP_FLAG, items), nil
-// }
-
 func flowSpecTcpFlagParser(rf RouteFamily, args []string) (FlowSpecComponentInterface, error) {
 	args = append(args[:0], args[1:]...) // removing tcp-flags string
 	fullCmd := strings.Join(args, " ") // rebuiling tcp filters

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -2496,80 +2496,79 @@ func flowSpecTcpFlagParser(rf RouteFamily, args []string) (FlowSpecComponentInte
 		return nil, err
 	}
 	items := make([]*FlowSpecComponentItem, 0)
-	for _, opFlag := range(opsFlags) {
+	for _, opFlag := range opsFlags {
 		items = append(items, NewFlowSpecComponentItem(opFlag[0], opFlag[1]))
 	}
 	return NewFlowSpecComponent(FLOW_SPEC_TYPE_TCP_FLAG, items), nil
 }
 
-func parseTcpFlagCmd(myCmd string) ( [][2]int, error) {
-    var index int = 0
-    var tcpOperatorsFlagsValues [][2]int
-    var operatorValue [2]int
-    for index < len(myCmd) {
-        myCmdChar := myCmd[index:index+1]
-        switch myCmdChar {
-        case TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]:
-            if bit := TCPFlagOpValueMap[myCmdChar]; bit & TCPFlagOp(operatorValue[0]) == 0 {
-                operatorValue[0] |= int(bit)
-                index++
-            } else {
-                err := fmt.Errorf("Match flag appears multiple time")
-                return nil, err
-            }
-        case TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:
-            if bit := TCPFlagOpValueMap[myCmdChar]; bit & TCPFlagOp(operatorValue[0]) == 0 {
-                operatorValue[0] |= int(bit)
-                index++
-            } else {
-                err := fmt.Errorf("Not flag appears multiple time")
-                return nil, err
-            }
-        case TCPFlagOpNameMap[TCP_FLAG_OP_AND], TCPFlagOpNameMap[TCP_FLAG_OP_OR]:
-            if bit := TCPFlagOpValueMap[myCmdChar]; bit & TCPFlagOp(operatorValue[0]) == 0 {
-                operatorValue[0] |= int(bit)
-                tcpOperatorsFlagsValues = append(tcpOperatorsFlagsValues, operatorValue)
-                operatorValue[0] = 0
-                operatorValue[1] = 0
-                // resetAllFlagsToFalse(tcpFlagBitMap, tcpFlagOpBitMap)
-                index++
-            } else {
-                err := fmt.Errorf("AND or OR (space) operator appears multiple time")
-                return nil, err
-            }
-        case TCPFlagNameMap[TCP_FLAG_ACK], TCPFlagNameMap[TCP_FLAG_SYN], TCPFlagNameMap[TCP_FLAG_FIN],
-        TCPFlagNameMap[TCP_FLAG_URGENT], TCPFlagNameMap[TCP_FLAG_ECE], TCPFlagNameMap[TCP_FLAG_RST],
-        TCPFlagNameMap[TCP_FLAG_CWR], TCPFlagNameMap[TCP_FLAG_PUSH]:
-            myLoopChar := myCmdChar
-            loopIndex := index
-            // we loop till we reach the end of TCP flags description
-            // exit conditions : we reach the end of tcp flags (we found & or ' ') or we reach the end of the line
-            for (loopIndex < len(myCmd) &&
-                (myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_AND] && myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_OR])) {
-                // we check if inspected charater is a well known tcp flag and if it doesn't appear twice
-                if bit, isPresent := TCPFlagValueMap[myLoopChar]; isPresent && (bit & TCPFlag(operatorValue[1]) == 0) {
-                    operatorValue[1] |= int(bit)            // we set this flag
-                    loopIndex++                                 // we move to next character
-                    if(loopIndex < len(myCmd)) {
-                        myLoopChar = myCmd[loopIndex:loopIndex+1]   // we move to the next character only if we didn't reach the end of cmd
-                    }
-                } else {
-                    err := fmt.Errorf("flag %s appears multiple time or is not part of TCP flags", myLoopChar)
-                    return nil, err
-                }
-            }
-            // we are done with flags, we give back the next cooming charater to the main loop
-            index = loopIndex
-        default:
-            err := fmt.Errorf("flag %s not part of tcp flags", myCmdChar)
-            return nil, err
-        }
-    }
-    operatorValue[0] |= int(TCPFlagOpValueMap["E"])
-    tcpOperatorsFlagsValues = append(tcpOperatorsFlagsValues, operatorValue)
-    return tcpOperatorsFlagsValues, nil
+func parseTcpFlagCmd(myCmd string) ([][2]int, error) {
+	var index int = 0
+	var tcpOperatorsFlagsValues [][2]int
+	var operatorValue [2]int
+	for index < len(myCmd) {
+		myCmdChar := myCmd[index : index+1]
+		switch myCmdChar {
+		case TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]:
+			if bit := TCPFlagOpValueMap[myCmdChar]; bit&TCPFlagOp(operatorValue[0]) == 0 {
+				operatorValue[0] |= int(bit)
+				index++
+			} else {
+				err := fmt.Errorf("Match flag appears multiple time")
+				return nil, err
+			}
+		case TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:
+			if bit := TCPFlagOpValueMap[myCmdChar]; bit&TCPFlagOp(operatorValue[0]) == 0 {
+				operatorValue[0] |= int(bit)
+				index++
+			} else {
+				err := fmt.Errorf("Not flag appears multiple time")
+				return nil, err
+			}
+		case TCPFlagOpNameMap[TCP_FLAG_OP_AND], TCPFlagOpNameMap[TCP_FLAG_OP_OR]:
+			if bit := TCPFlagOpValueMap[myCmdChar]; bit&TCPFlagOp(operatorValue[0]) == 0 {
+				operatorValue[0] |= int(bit)
+				tcpOperatorsFlagsValues = append(tcpOperatorsFlagsValues, operatorValue)
+				operatorValue[0] = 0
+				operatorValue[1] = 0
+				// resetAllFlagsToFalse(tcpFlagBitMap, tcpFlagOpBitMap)
+				index++
+			} else {
+				err := fmt.Errorf("AND or OR (space) operator appears multiple time")
+				return nil, err
+			}
+		case TCPFlagNameMap[TCP_FLAG_ACK], TCPFlagNameMap[TCP_FLAG_SYN], TCPFlagNameMap[TCP_FLAG_FIN],
+			TCPFlagNameMap[TCP_FLAG_URGENT], TCPFlagNameMap[TCP_FLAG_ECE], TCPFlagNameMap[TCP_FLAG_RST],
+			TCPFlagNameMap[TCP_FLAG_CWR], TCPFlagNameMap[TCP_FLAG_PUSH]:
+			myLoopChar := myCmdChar
+			loopIndex := index
+			// we loop till we reach the end of TCP flags description
+			// exit conditions : we reach the end of tcp flags (we found & or ' ') or we reach the end of the line
+			for loopIndex < len(myCmd) &&
+				(myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_AND] && myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_OR]) {
+				// we check if inspected charater is a well known tcp flag and if it doesn't appear twice
+				if bit, isPresent := TCPFlagValueMap[myLoopChar]; isPresent && (bit&TCPFlag(operatorValue[1]) == 0) {
+					operatorValue[1] |= int(bit) // we set this flag
+					loopIndex++                  // we move to next character
+					if loopIndex < len(myCmd) {
+						myLoopChar = myCmd[loopIndex : loopIndex+1] // we move to the next character only if we didn't reach the end of cmd
+					}
+				} else {
+					err := fmt.Errorf("flag %s appears multiple time or is not part of TCP flags", myLoopChar)
+					return nil, err
+				}
+			}
+			// we are done with flags, we give back the next cooming charater to the main loop
+			index = loopIndex
+		default:
+			err := fmt.Errorf("flag %s not part of tcp flags", myCmdChar)
+			return nil, err
+		}
+	}
+	operatorValue[0] |= int(TCPFlagOpValueMap["E"])
+	tcpOperatorsFlagsValues = append(tcpOperatorsFlagsValues, operatorValue)
+	return tcpOperatorsFlagsValues, nil
 }
-
 
 func flowSpecEtherTypeParser(rf RouteFamily, args []string) (FlowSpecComponentInterface, error) {
 	if len(args) < 2 || args[0] != FlowSpecNameMap[FLOW_SPEC_TYPE_ETHERNET_TYPE] {

--- a/packet/bgp/constant.go
+++ b/packet/bgp/constant.go
@@ -96,67 +96,67 @@ func (p Protocol) String() string {
 type TCPFlag int
 
 const (
-    TCP_FLAG_FIN    = 0x01
-    TCP_FLAG_SYN    = 0x02
-    TCP_FLAG_RST    = 0x04
-    TCP_FLAG_PUSH   = 0x08
-    TCP_FLAG_ACK    = 0x10
-    TCP_FLAG_URGENT = 0x20
-    TCP_FLAG_CWR    = 0x40
-    TCP_FLAG_ECE    = 0x80
+	TCP_FLAG_FIN    = 0x01
+	TCP_FLAG_SYN    = 0x02
+	TCP_FLAG_RST    = 0x04
+	TCP_FLAG_PUSH   = 0x08
+	TCP_FLAG_ACK    = 0x10
+	TCP_FLAG_URGENT = 0x20
+	TCP_FLAG_CWR    = 0x40
+	TCP_FLAG_ECE    = 0x80
 )
 
 var TCPFlagNameMap = map[TCPFlag]string{
-    TCP_FLAG_FIN:    "F",
-    TCP_FLAG_SYN:    "S",
-    TCP_FLAG_RST:    "R",
-    TCP_FLAG_PUSH:   "P",
-    TCP_FLAG_ACK:    "A",
-    TCP_FLAG_URGENT: "U",
-    TCP_FLAG_CWR:    "C",
-    TCP_FLAG_ECE :   "E",
+	TCP_FLAG_FIN:    "F",
+	TCP_FLAG_SYN:    "S",
+	TCP_FLAG_RST:    "R",
+	TCP_FLAG_PUSH:   "P",
+	TCP_FLAG_ACK:    "A",
+	TCP_FLAG_URGENT: "U",
+	TCP_FLAG_CWR:    "C",
+	TCP_FLAG_ECE:    "E",
 }
 
 var TCPFlagValueMap = map[string]TCPFlag{
-    TCPFlagNameMap[TCP_FLAG_FIN]:    TCP_FLAG_FIN,
-    TCPFlagNameMap[TCP_FLAG_SYN]:    TCP_FLAG_SYN,
-    TCPFlagNameMap[TCP_FLAG_RST]:    TCP_FLAG_RST,
-    TCPFlagNameMap[TCP_FLAG_PUSH]:   TCP_FLAG_PUSH,
-    TCPFlagNameMap[TCP_FLAG_ACK]:    TCP_FLAG_ACK,
-    TCPFlagNameMap[TCP_FLAG_URGENT]: TCP_FLAG_URGENT,
-    TCPFlagNameMap[TCP_FLAG_CWR]:    TCP_FLAG_CWR,
-    TCPFlagNameMap[TCP_FLAG_ECE]:    TCP_FLAG_ECE,
+	TCPFlagNameMap[TCP_FLAG_FIN]:    TCP_FLAG_FIN,
+	TCPFlagNameMap[TCP_FLAG_SYN]:    TCP_FLAG_SYN,
+	TCPFlagNameMap[TCP_FLAG_RST]:    TCP_FLAG_RST,
+	TCPFlagNameMap[TCP_FLAG_PUSH]:   TCP_FLAG_PUSH,
+	TCPFlagNameMap[TCP_FLAG_ACK]:    TCP_FLAG_ACK,
+	TCPFlagNameMap[TCP_FLAG_URGENT]: TCP_FLAG_URGENT,
+	TCPFlagNameMap[TCP_FLAG_CWR]:    TCP_FLAG_CWR,
+	TCPFlagNameMap[TCP_FLAG_ECE]:    TCP_FLAG_ECE,
 }
 
 type TCPFlagOp int
 
 const (
-    TCP_FLAG_OP_OR      = 0x00
-    TCP_FLAG_OP_AND     = 0x40
-    TCP_FLAG_OP_END     = 0x80
-    TCP_FLAG_OP_NOT     = 0x02
-    TCP_FLAG_OP_MATCH   = 0x01
+	TCP_FLAG_OP_OR    = 0x00
+	TCP_FLAG_OP_AND   = 0x40
+	TCP_FLAG_OP_END   = 0x80
+	TCP_FLAG_OP_NOT   = 0x02
+	TCP_FLAG_OP_MATCH = 0x01
 )
 
 var TCPFlagOpNameMap = map[TCPFlagOp]string{
-    TCP_FLAG_OP_OR:     " ",
-    TCP_FLAG_OP_AND:    "&",
-    TCP_FLAG_OP_END:    "E",
-    TCP_FLAG_OP_NOT:    "!",
-    TCP_FLAG_OP_MATCH:  "=",
+	TCP_FLAG_OP_OR:    " ",
+	TCP_FLAG_OP_AND:   "&",
+	TCP_FLAG_OP_END:   "E",
+	TCP_FLAG_OP_NOT:   "!",
+	TCP_FLAG_OP_MATCH: "=",
 }
 
 var TCPFlagOpValueMap = map[string]TCPFlagOp{
-    TCPFlagOpNameMap[TCP_FLAG_OP_OR]:       TCP_FLAG_OP_OR,
-    TCPFlagOpNameMap[TCP_FLAG_OP_AND]:      TCP_FLAG_OP_AND,
-    TCPFlagOpNameMap[TCP_FLAG_OP_END]:      TCP_FLAG_OP_END,
-    TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:      TCP_FLAG_OP_NOT,
-    TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]:    TCP_FLAG_OP_MATCH,
+	TCPFlagOpNameMap[TCP_FLAG_OP_OR]:    TCP_FLAG_OP_OR,
+	TCPFlagOpNameMap[TCP_FLAG_OP_AND]:   TCP_FLAG_OP_AND,
+	TCPFlagOpNameMap[TCP_FLAG_OP_END]:   TCP_FLAG_OP_END,
+	TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:   TCP_FLAG_OP_NOT,
+	TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]: TCP_FLAG_OP_MATCH,
 }
 
 func (f TCPFlag) String() string {
 	ss := make([]string, 0, 6)
-	for _, v := range []TCPFlag{TCP_FLAG_FIN, TCP_FLAG_SYN, TCP_FLAG_RST, TCP_FLAG_PUSH, TCP_FLAG_ACK, TCP_FLAG_URGENT, TCP_FLAG_CWR, TCP_FLAG_ECE, } {
+	for _, v := range []TCPFlag{TCP_FLAG_FIN, TCP_FLAG_SYN, TCP_FLAG_RST, TCP_FLAG_PUSH, TCP_FLAG_ACK, TCP_FLAG_URGENT, TCP_FLAG_CWR, TCP_FLAG_ECE} {
 		if f&v > 0 {
 			ss = append(ss, TCPFlagNameMap[v])
 		}

--- a/packet/bgp/constant.go
+++ b/packet/bgp/constant.go
@@ -96,35 +96,67 @@ func (p Protocol) String() string {
 type TCPFlag int
 
 const (
-	TCP_FLAG_FIN    = 0x01
-	TCP_FLAG_SYN    = 0x02
-	TCP_FLAG_RST    = 0x04
-	TCP_FLAG_PUSH   = 0x08
-	TCP_FLAG_ACK    = 0x10
-	TCP_FLAG_URGENT = 0x20
+    TCP_FLAG_FIN    = 0x01
+    TCP_FLAG_SYN    = 0x02
+    TCP_FLAG_RST    = 0x04
+    TCP_FLAG_PUSH   = 0x08
+    TCP_FLAG_ACK    = 0x10
+    TCP_FLAG_URGENT = 0x20
+    TCP_FLAG_CWR    = 0x40
+    TCP_FLAG_ECE    = 0x80
 )
 
 var TCPFlagNameMap = map[TCPFlag]string{
-	TCP_FLAG_FIN:    "fin",
-	TCP_FLAG_SYN:    "syn",
-	TCP_FLAG_RST:    "rst",
-	TCP_FLAG_PUSH:   "push",
-	TCP_FLAG_ACK:    "ack",
-	TCP_FLAG_URGENT: "urgent",
+    TCP_FLAG_FIN:    "F",
+    TCP_FLAG_SYN:    "S",
+    TCP_FLAG_RST:    "R",
+    TCP_FLAG_PUSH:   "P",
+    TCP_FLAG_ACK:    "A",
+    TCP_FLAG_URGENT: "U",
+    TCP_FLAG_CWR:    "C",
+    TCP_FLAG_ECE :   "E",
 }
 
 var TCPFlagValueMap = map[string]TCPFlag{
-	TCPFlagNameMap[TCP_FLAG_FIN]:    TCP_FLAG_FIN,
-	TCPFlagNameMap[TCP_FLAG_SYN]:    TCP_FLAG_SYN,
-	TCPFlagNameMap[TCP_FLAG_RST]:    TCP_FLAG_RST,
-	TCPFlagNameMap[TCP_FLAG_PUSH]:   TCP_FLAG_PUSH,
-	TCPFlagNameMap[TCP_FLAG_ACK]:    TCP_FLAG_ACK,
-	TCPFlagNameMap[TCP_FLAG_URGENT]: TCP_FLAG_URGENT,
+    TCPFlagNameMap[TCP_FLAG_FIN]:    TCP_FLAG_FIN,
+    TCPFlagNameMap[TCP_FLAG_SYN]:    TCP_FLAG_SYN,
+    TCPFlagNameMap[TCP_FLAG_RST]:    TCP_FLAG_RST,
+    TCPFlagNameMap[TCP_FLAG_PUSH]:   TCP_FLAG_PUSH,
+    TCPFlagNameMap[TCP_FLAG_ACK]:    TCP_FLAG_ACK,
+    TCPFlagNameMap[TCP_FLAG_URGENT]: TCP_FLAG_URGENT,
+    TCPFlagNameMap[TCP_FLAG_CWR]:    TCP_FLAG_CWR,
+    TCPFlagNameMap[TCP_FLAG_ECE]:    TCP_FLAG_ECE,
+}
+
+type TCPFlagOp int
+
+const (
+    TCP_FLAG_OP_OR      = 0x00
+    TCP_FLAG_OP_AND     = 0x40
+    TCP_FLAG_OP_END     = 0x80
+    TCP_FLAG_OP_NOT     = 0x02
+    TCP_FLAG_OP_MATCH   = 0x01
+)
+
+var TCPFlagOpNameMap = map[TCPFlagOp]string{
+    TCP_FLAG_OP_OR:     " ",
+    TCP_FLAG_OP_AND:    "&",
+    TCP_FLAG_OP_END:    "E",
+    TCP_FLAG_OP_NOT:    "!",
+    TCP_FLAG_OP_MATCH:  "=",
+}
+
+var TCPFlagOpValueMap = map[string]TCPFlagOp{
+    TCPFlagOpNameMap[TCP_FLAG_OP_OR]:       TCP_FLAG_OP_OR,
+    TCPFlagOpNameMap[TCP_FLAG_OP_AND]:      TCP_FLAG_OP_AND,
+    TCPFlagOpNameMap[TCP_FLAG_OP_END]:      TCP_FLAG_OP_END,
+    TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:      TCP_FLAG_OP_NOT,
+    TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]:    TCP_FLAG_OP_MATCH,
 }
 
 func (f TCPFlag) String() string {
 	ss := make([]string, 0, 6)
-	for _, v := range []TCPFlag{TCP_FLAG_FIN, TCP_FLAG_SYN, TCP_FLAG_RST, TCP_FLAG_PUSH, TCP_FLAG_ACK, TCP_FLAG_URGENT} {
+	for _, v := range []TCPFlag{TCP_FLAG_FIN, TCP_FLAG_SYN, TCP_FLAG_RST, TCP_FLAG_PUSH, TCP_FLAG_ACK, TCP_FLAG_URGENT, TCP_FLAG_CWR, TCP_FLAG_ECE, } {
 		if f&v > 0 {
 			ss = append(ss, TCPFlagNameMap[v])
 		}

--- a/packet/bgp/constant.go
+++ b/packet/bgp/constant.go
@@ -102,8 +102,8 @@ const (
 	TCP_FLAG_PUSH   = 0x08
 	TCP_FLAG_ACK    = 0x10
 	TCP_FLAG_URGENT = 0x20
-	TCP_FLAG_CWR    = 0x40
-	TCP_FLAG_ECE    = 0x80
+	TCP_FLAG_ECE    = 0x40
+	TCP_FLAG_CWR    = 0x80
 )
 
 var TCPFlagNameMap = map[TCPFlag]string{

--- a/test/scenario_test/flow_spec_test.py
+++ b/test/scenario_test/flow_spec_test.py
@@ -44,7 +44,7 @@ class GoBGPTestBase(unittest.TestCase):
         matchs = ['destination 10.0.0.0/24', 'source 20.0.0.0/24']
         thens = ['discard']
         e1.add_route(route='flow1', rf='ipv4-flowspec', matchs=matchs, thens=thens)
-        matchs2 = ['tcp-flags syn', 'protocol tcp udp', "packet-length '>1000&<2000'"]
+        matchs2 = ['tcp-flags S', 'protocol tcp udp', "packet-length '>1000&<2000'"]
         thens2 = ['rate-limit 9600', 'redirect 0.10:100', 'mark 20', 'action sample']
         g1.add_route(route='flow1', rf='ipv4-flowspec', matchs=matchs2, thens=thens2)
         matchs3 = ['destination 2001::/24/10', 'source 2002::/24/15']


### PR DESCRIPTION
This patch proposes a new way to configure BGP flowspec TCP flags rules

It allows to comply with RFC 5575 by defining flags like this '=SA =A' or '!SA' or '=SA&=!U'
= means match, ! means not, & means and, all TCP flags are identified by their first charater S for SYN A for Ack ...

I did my own parser as using regexp was not an easy task considering the various lexical possibilities.

If you have a look at this draft: https://tools.ietf.org/html/draft-hr-idr-rfc5575bis-02, this patch comply with it.

Thanks Matt.

here under a couple of examples:

```
root@matt-dev-box:/home/matthieu# /home/matthieu/go-work/bin/gobgp global rib -a ipv6-flowspec add match destination 2001::1/128 port '=80' tcp-flags CEUAPRSF then discard
root@matt-dev-box:/home/matthieu# /home/matthieu/go-work/bin/gobgp global rib -a ipv6-flowspec
    Network                                                    Next Hop             AS_PATH              Age        Attrs
*>  [destination:2001::1/128/0][port: =80][tcp-flags:FSRPAUCE ]fictitious                                00:00:03   [{Origin: ?} {Extcomms: [discard]}]
root@matt-dev-box:/home/matthieu# /home/matthieu/go-work/bin/gobgp global rib -a ipv6-flowspec add match destination 2001::2/128 port '=80' tcp-flags =!SA&=!U then discard
bash: !SA: event not found
root@matt-dev-box:/home/matthieu# /home/matthieu/go-work/bin/gobgp global rib -a ipv6-flowspec add match destination 2001::2/128 port '=80' tcp-flags '=!SA&=!U' then discard
root@matt-dev-box:/home/matthieu# /home/matthieu/go-work/bin/gobgp global rib -a ipv6-flowspec
    Network                                                    Next Hop             AS_PATH              Age        Attrs
*>  [destination:2001::2/128/0][port: =80][tcp-flags:=!SA&=!U ]fictitious                                00:00:04   [{Origin: ?} {Extcomms: [discard]}]
*>  [destination:2001::1/128/0][port: =80][tcp-flags:UCEFSRPA ]fictitious                                00:02:02   [{Origin: ?} {Extcomms: [discard]}]
```


