### PR TITLE
zebra: Process per-route MTU zebra message

### DIFF
--- a/server/zclient.go
+++ b/server/zclient.go
@@ -138,6 +138,7 @@ func createPathFromIPRouteMessage(m *zebra.Message) *table.Path {
 		"IfIndex":      body.Ifindexs,
 		"Metric":       body.Metric,
 		"Distance":     body.Distance,
+		"Mtu":          body.Mtu,
 		"api":          header.Command.String(),
 	}).Debugf("create path from ip route message.")
 

--- a/server/zclient_test.go
+++ b/server/zclient_test.go
@@ -38,7 +38,7 @@ func Test_createRequestFromIPRouteMessage(t *testing.T) {
 	b := &zebra.IPRouteBody{
 		Type:         zebra.ROUTE_TYPE(zebra.ROUTE_STATIC),
 		Flags:        zebra.FLAG(zebra.FLAG_SELECTED),
-		Message:      zebra.MESSAGE_NEXTHOP | zebra.MESSAGE_DISTANCE | zebra.MESSAGE_METRIC,
+		Message:      zebra.MESSAGE_NEXTHOP | zebra.MESSAGE_DISTANCE | zebra.MESSAGE_METRIC | zebra.MESSAGE_MTU,
 		SAFI:         zebra.SAFI(zebra.SAFI_UNICAST),
 		Prefix:       net.ParseIP("192.168.100.0"),
 		PrefixLength: uint8(24),
@@ -46,6 +46,7 @@ func Test_createRequestFromIPRouteMessage(t *testing.T) {
 		Ifindexs:     []uint32{1},
 		Distance:     uint8(0),
 		Metric:       uint32(100),
+		Mtu:          uint32(0),
 		Api:          zebra.API_TYPE(zebra.IPV4_ROUTE_ADD),
 	}
 


### PR DESCRIPTION
Since Quagga 1.0.20160309, it implements per-route MTU handling which
adds MTU attribute to every ZEBRA_IPV4_ROUTE_ADD and
ZEBRA_IPV6_ROUTE_ADD messages. It causes "message length invalid" error
when GoBGP receives messages from Zebra and as the result, routes from
Zebra are no longer added to GoBGP.

This fixes the issue by decoding/encoding MTU attribute properly.

Now parsed MTU attribute is not used anywhere, just kept in an internal
structure.