### PR TITLE
gobgpd: Support for forwarding logs to fluentd

### DIFF
--- a/gobgpd/util.go
+++ b/gobgpd/util.go
@@ -19,15 +19,18 @@ package main
 
 import (
 	"log/syslog"
+	"net"
 	"os"
 	"os/signal"
 	"runtime"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"syscall"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/Sirupsen/logrus/hooks/syslog"
+	"github.com/evalphobia/logrus_fluent"
 )
 
 func init() {
@@ -98,6 +101,28 @@ func addSyslogHook(host, facility string) error {
 	if err != nil {
 		return err
 	}
+	log.AddHook(hook)
+	return nil
+}
+
+func addFluentHook(hostport, tag string) error {
+	var err error
+	host := "127.0.0.1"
+	port := "24244"
+	host, port, err = net.SplitHostPort(hostport)
+	if err != nil {
+		return err
+	}
+	var p int
+	p, err = strconv.Atoi(port)
+	if err != nil {
+		return err
+	}
+	hook, err := logrus_fluent.New(host, p)
+	if err != nil {
+		return err
+	}
+	hook.SetTag(tag)
 	log.AddHook(hook)
 	return nil
 }


### PR DESCRIPTION
Command line options:
 --fluent `host:port` enables to forward logs to fluentd
 --fluent-tag `tag` sets `tag` on forwarded logs (Default tag is `gobgpd`)

Ex.)
gobgpd command
```bash
gobgpd -f gobgpd.conf --fluent :24224
```

fluentd config
```bash
<source>
  @type forward
  port 24224
</source>

<match gobgpd>
  @type stdout
</match>
```