### PR TITLE
table: fix DeletePolicyAssignment() crash with bogus input

### DIFF
--- a/table/policy.go
+++ b/table/policy.go
@@ -3526,7 +3526,12 @@ func (r *RoutingPolicy) DeletePolicyAssignment(id string, dir PolicyDirection, p
 		}
 		err = r.setDefaultPolicy(id, dir, ROUTE_TYPE_NONE)
 	} else {
-		n := make([]*Policy, 0, len(cur)-len(ps))
+		l := len(cur) - len(ps)
+		if l < 0 {
+			// try to remove more than the assigned policies...
+			l = len(cur)
+		}
+		n := make([]*Policy, 0, l)
 		for _, y := range cur {
 			found := false
 			for _, x := range ps {


### PR DESCRIPTION
len(cur)-len(ps) is negative if the caller tries to remove more than
currently assigned policies.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>