### PR TITLE
flowspec: comply with RFC 5575 about TCP flags rules

### DIFF
--- a/docs/sources/flowspec.md
+++ b/docs/sources/flowspec.md
@@ -45,11 +45,11 @@ CLI syntax to add ipv4/ipv6 flowspec rule is
 ```shell
 % global rib add match <MATCH_EXPR> then <THEN_EXPR> -a [ipv4-flowspec|ipv6-flowspec]
    <MATCH_EXPR> : { destination <PREFIX> [<OFFSET>] | source <PREFIX> [<OFFSET>] |
-                    protocol <PROTO>... | fragment <FRAGMENT_TYPE> | tcp-flags [not] [match] <TCPFLAG>... |
+                    protocol <PROTO>... | fragment <FRAGMENT_TYPE> | tcp-flags [!] [=] <TCPFLAG>... |
                     { port | destination-port | source-port | icmp-type | icmp-code | packet-length | dscp | label } <ITEM>... }...
    <PROTO> : ospf, pim, igp, udp, igmp, tcp, egp, rsvp, gre, ipip, unknown, icmp, sctp, <VALUE>
    <FRAGMENT_TYPE> : dont-fragment, is-fragment, first-fragment, last-fragment, not-a-fragment
-   <TCPFLAG> : rst, push, ack, urgent, fin, syn
+   <TCPFLAG> : U, C, E, F, S, R, P, A
    <ITEM> : &?{<|>|=}<value>
    <THEN_EXPR> : { accept | discard | rate-limit <value> | redirect <RT> | mark <value> | action { sample | terminal | sample-terminal } | rt <RT>... }...
    <RT> : xxx:yyy, xx.xx.xx.xx:yyy, xxx.xxx:yyy
@@ -71,6 +71,9 @@ that for l2vpn flowspec rule is
 ```shell
 # add a flowspec rule which redirect flows with dst 10.0.0.0/24 and src 20.0.0.0/24 to VRF with RT 10:10
 % gobgp global rib -a ipv4-flowspec add match destination 10.0.0.0/24 source 20.0.0.0/24 then redirect 10:10
+
+# add a flowspec rule wich discard flows with dst 2001::2/128 and port equals 80 and with TCP flags not match SA (SYN/ACK) and not match U (URG)
+% gobgp global rib -a ipv6-flowspec add match destination 2001::2/128 port '=80' tcp-flags '=!SA&=!U' then discard
 
 # show flowspec table
 % gobgp global rib -a ipv4-flowspec

--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -863,7 +863,7 @@ usage: %s rib %s%%smatch <MATCH_EXPR> then <THEN_EXPR> -a %%s
 			ExtCommNameMap[RATE], ExtCommNameMap[REDIRECT],
 			ExtCommNameMap[MARK], ExtCommNameMap[ACTION], ExtCommNameMap[RT])
 		ipFsMatchExpr := fmt.Sprintf(`   <MATCH_EXPR> : { %s <PREFIX> [<OFFSET>] | %s <PREFIX> [<OFFSET>] |
-                    %s <PROTO>... | %s <FRAGMENT_TYPE> | %s [not] [match] <TCPFLAG>... |
+                    %s <PROTO>... | %s <FRAGMENT_TYPE> | %s [!] [=] <TCPFLAG>... |
                     { %s | %s | %s | %s | %s | %s | %s | %s } <ITEM>... }...
    <PROTO> : %s
    <FRAGMENT_TYPE> : dont-fragment, is-fragment, first-fragment, last-fragment, not-a-fragment

--- a/packet/bgp/constant.go
+++ b/packet/bgp/constant.go
@@ -102,15 +102,19 @@ const (
 	TCP_FLAG_PUSH   = 0x08
 	TCP_FLAG_ACK    = 0x10
 	TCP_FLAG_URGENT = 0x20
+	TCP_FLAG_ECE    = 0x40
+	TCP_FLAG_CWR    = 0x80
 )
 
 var TCPFlagNameMap = map[TCPFlag]string{
-	TCP_FLAG_FIN:    "fin",
-	TCP_FLAG_SYN:    "syn",
-	TCP_FLAG_RST:    "rst",
-	TCP_FLAG_PUSH:   "push",
-	TCP_FLAG_ACK:    "ack",
-	TCP_FLAG_URGENT: "urgent",
+	TCP_FLAG_FIN:    "F",
+	TCP_FLAG_SYN:    "S",
+	TCP_FLAG_RST:    "R",
+	TCP_FLAG_PUSH:   "P",
+	TCP_FLAG_ACK:    "A",
+	TCP_FLAG_URGENT: "U",
+	TCP_FLAG_CWR:    "C",
+	TCP_FLAG_ECE:    "E",
 }
 
 var TCPFlagValueMap = map[string]TCPFlag{
@@ -120,11 +124,39 @@ var TCPFlagValueMap = map[string]TCPFlag{
 	TCPFlagNameMap[TCP_FLAG_PUSH]:   TCP_FLAG_PUSH,
 	TCPFlagNameMap[TCP_FLAG_ACK]:    TCP_FLAG_ACK,
 	TCPFlagNameMap[TCP_FLAG_URGENT]: TCP_FLAG_URGENT,
+	TCPFlagNameMap[TCP_FLAG_CWR]:    TCP_FLAG_CWR,
+	TCPFlagNameMap[TCP_FLAG_ECE]:    TCP_FLAG_ECE,
+}
+
+type TCPFlagOp int
+
+const (
+	TCP_FLAG_OP_OR    = 0x00
+	TCP_FLAG_OP_AND   = 0x40
+	TCP_FLAG_OP_END   = 0x80
+	TCP_FLAG_OP_NOT   = 0x02
+	TCP_FLAG_OP_MATCH = 0x01
+)
+
+var TCPFlagOpNameMap = map[TCPFlagOp]string{
+	TCP_FLAG_OP_OR:    " ",
+	TCP_FLAG_OP_AND:   "&",
+	TCP_FLAG_OP_END:   "E",
+	TCP_FLAG_OP_NOT:   "!",
+	TCP_FLAG_OP_MATCH: "=",
+}
+
+var TCPFlagOpValueMap = map[string]TCPFlagOp{
+	TCPFlagOpNameMap[TCP_FLAG_OP_OR]:    TCP_FLAG_OP_OR,
+	TCPFlagOpNameMap[TCP_FLAG_OP_AND]:   TCP_FLAG_OP_AND,
+	TCPFlagOpNameMap[TCP_FLAG_OP_END]:   TCP_FLAG_OP_END,
+	TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:   TCP_FLAG_OP_NOT,
+	TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]: TCP_FLAG_OP_MATCH,
 }
 
 func (f TCPFlag) String() string {
 	ss := make([]string, 0, 6)
-	for _, v := range []TCPFlag{TCP_FLAG_FIN, TCP_FLAG_SYN, TCP_FLAG_RST, TCP_FLAG_PUSH, TCP_FLAG_ACK, TCP_FLAG_URGENT} {
+	for _, v := range []TCPFlag{TCP_FLAG_FIN, TCP_FLAG_SYN, TCP_FLAG_RST, TCP_FLAG_PUSH, TCP_FLAG_ACK, TCP_FLAG_URGENT, TCP_FLAG_CWR, TCP_FLAG_ECE} {
 		if f&v > 0 {
 			ss = append(ss, TCPFlagNameMap[v])
 		}

--- a/test/scenario_test/flow_spec_test.py
+++ b/test/scenario_test/flow_spec_test.py
@@ -44,7 +44,7 @@ class GoBGPTestBase(unittest.TestCase):
         matchs = ['destination 10.0.0.0/24', 'source 20.0.0.0/24']
         thens = ['discard']
         e1.add_route(route='flow1', rf='ipv4-flowspec', matchs=matchs, thens=thens)
-        matchs2 = ['tcp-flags syn', 'protocol tcp udp', "packet-length '>1000&<2000'"]
+        matchs2 = ['tcp-flags S', 'protocol tcp udp', "packet-length '>1000&<2000'"]
         thens2 = ['rate-limit 9600', 'redirect 0.10:100', 'mark 20', 'action sample']
         g1.add_route(route='flow1', rf='ipv4-flowspec', matchs=matchs2, thens=thens2)
         matchs3 = ['destination 2001::/24/10', 'source 2002::/24/15']


### PR DESCRIPTION
This patch proposes a new way to configure BGP flowspec TCP flags
rules It allows to comply with RFC 5575 by defining flags like this
=SA =A / '!SA' / '=SA&=!U' = means match, ! means not, & means and,
all TCP flags are identified by their first charater S for SYN A for
Ack ...