### PR TITLE
Similar changes as for TCP flags parser and provide support of RFC 5575Bis

### DIFF
--- a/docs/sources/flowspec.md
+++ b/docs/sources/flowspec.md
@@ -66,6 +66,26 @@ that for l2vpn flowspec rule is
    <RT> : xxx:yyy, xx.xx.xx.xx:yyy, xxx.xxx:yyy
 ```
 
+### Manage operators and decimal values
+
+Gobgp supports operators as defined by the following standard draft https://tools.ietf.org/html/draft-hr-idr-rfc5575bis-03
+
+As such it provides the following capabilties and operators:
+
+```
+            +----+----+----+----------------------------------+
+            | lt | gt | eq | Resulting operation              |
+            +----+----+----+----------------------------------+
+            | 0  | 0  | 0  | true (independent of the value)  |
+            | 0  | 0  | 1  | == (equal)                       |
+            | 0  | 1  | 0  | > (greater than)                 |
+            | 0  | 1  | 1  | >= (greater than or equal)       |
+            | 1  | 0  | 0  | < (less than)                    |
+            | 1  | 0  | 1  | <= (less than or equal)          |
+            | 1  | 1  | 0  | != (not equal value)             |
+            | 1  | 1  | 1  | false (independent of the value) |
+            +----+----+----+----------------------------------+
+```
 ### Examples
 
 ```shell
@@ -73,7 +93,7 @@ that for l2vpn flowspec rule is
 % gobgp global rib -a ipv4-flowspec add match destination 10.0.0.0/24 source 20.0.0.0/24 then redirect 10:10
 
 # add a flowspec rule wich discard flows with dst 2001::2/128 and port equals 80 and with TCP flags not match SA (SYN/ACK) and not match U (URG)
-% gobgp global rib -a ipv6-flowspec add match destination 2001::2/128 port '=80' tcp-flags '=!SA&=!U' then discard
+% gobgp global rib -a ipv6-flowspec add match destination 2001::2/128 port '==80' tcp-flags '=!SA&=!U' then discard
 
 # show flowspec table
 % gobgp global rib -a ipv4-flowspec
@@ -81,17 +101,17 @@ that for l2vpn flowspec rule is
 *> [destination:10.0.0.0/24][source:20.0.0.0/24] 0.0.0.0                                   00:00:04   [{Origin: i} {Extcomms: [redirect: 10:10]}]
 
 # add another flowspec rule which discard flows whose ip protocol is tcp and destination port is 80 or greater than or equal to 8080 and lesser than or equal to 8888
-% gobgp global rib -a ipv4-flowspec add match protocol tcp destination-port '=80' '>=8080&<=8888' then discard
+% gobgp global rib -a ipv4-flowspec add match protocol tcp destination-port '==80' '>=8080&<=8888' then discard
 
 % gobgp global rib -a ipv4-flowspec
    Network                                              Next Hop             AS_PATH              Age        Attrs
 *> [destination:10.0.0.0/24][source:20.0.0.0/24]        0.0.0.0                                   00:03:19   [{Origin: i} {Extcomms: [redirect: 10:10]}]
-*> [protocol: tcp][destination-port: =80 >=8080&<=8888] 0.0.0.0                                   00:00:03   [{Origin: i} {Extcomms: [discard]}]
+*> [protocol: tcp][destination-port: ==80 >=8080&<=8888] 0.0.0.0                                   00:00:03   [{Origin: i} {Extcomms: [discard]}]
 
 # delete a flowspec rule
 % gobgp global rib -a ipv4-flowspec del match destination 10.0.0.0/24 source 20.0.0.0/24 then redirect 10:10
 
 % gobgp global rib -a ipv4-flowspec
    Network                                              Next Hop             AS_PATH              Age        Attrs
-*> [protocol: tcp][destination-port: =80 >=8080&<=8888] 0.0.0.0                                   00:00:03   [{Origin: i} {Extcomms: [discard]}]
+*> [protocol: tcp][destination-port: ==80 >=8080&<=8888] 0.0.0.0                                   00:00:03   [{Origin: i} {Extcomms: [discard]}]
 ```


### PR DESCRIPTION
This pull request propose a new version of decimal parser in order to fully support https://tools.ietf.org/html/draft-hr-idr-rfc5575bis-03

It adds an important feature for filter use case (DDoS or security) with the not equal operator (!=).

As an example the following command is now supported: 
```
gobgp global rib -a ipv4-flowspec add match destination 2.2.2.2/32 destination-port '!=80&!=443&!=22' then discard
```
Usefull in case of web site with remote management.

Let me know your thoughts ...

Thanks Matt.