### PR TITLE
table: handle IPv4-Mapped IPv6 Address as v6

### DIFF
--- a/table/policy.go
+++ b/table/policy.go
@@ -286,13 +286,13 @@ func (lhs *Prefix) Equal(rhs *Prefix) bool {
 }
 
 func NewPrefix(c config.Prefix) (*Prefix, error) {
-	addr, prefix, err := net.ParseCIDR(c.IpPrefix)
+	_, prefix, err := net.ParseCIDR(c.IpPrefix)
 	if err != nil {
 		return nil, err
 	}
 
 	rf := bgp.RF_IPv4_UC
-	if addr.To4() == nil {
+	if strings.Contains(c.IpPrefix, ":") {
 		rf = bgp.RF_IPv6_UC
 	}
 	p := &Prefix{


### PR DESCRIPTION
Currently, Prefix wrongly handles IPv4-Mapped IPv6 Address as v4.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>