### PR TITLE
table: handle IPv4-Mapped IPv6 Address as v6

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -1001,12 +1001,12 @@ func (s *Server) DeleteNeighbor(ctx context.Context, arg *DeleteNeighborRequest)
 }
 
 func NewPrefixFromApiStruct(a *Prefix) (*table.Prefix, error) {
-	addr, prefix, err := net.ParseCIDR(a.IpPrefix)
+	_, prefix, err := net.ParseCIDR(a.IpPrefix)
 	if err != nil {
 		return nil, err
 	}
 	rf := bgp.RF_IPv4_UC
-	if addr.To4() == nil {
+	if strings.Contains(a.IpPrefix, ":") {
 		rf = bgp.RF_IPv6_UC
 	}
 	return &table.Prefix{


### PR DESCRIPTION
Currently, Prefix structure wrongly handles IPv4-Mapped IPv6 Address
as v4.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>