### PR TITLE
server/zclient: Retry zebra message version negotiation

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -252,6 +252,9 @@ func setDefaultConfigValuesWithViper(v *viper.Viper, b *BgpConfigSet) error {
 	if b.Zebra.Config.Url == "" {
 		b.Zebra.Config.Url = "unix:/var/run/quagga/zserv.api"
 	}
+	if b.Zebra.Config.Version < 2 || 3 > b.Zebra.Config.Version {
+		b.Zebra.Config.Version = 2
+	}
 	if !v.IsSet("zebra.config.nexthop-trigger-enable") && !b.Zebra.Config.NexthopTriggerEnable && b.Zebra.Config.Version > 2 {
 		b.Zebra.Config.NexthopTriggerEnable = true
 	}


### PR DESCRIPTION
Currently, the Zebra message version used by ZClient is configurable (default 2), but if the given version is miss-matched with that of Zebra daemon, ZCient will fail to connect.

This patch fixes ZClient to retry the version negotiation.
For example, if failed with the version 2, retry with the version 3.

Note: In order to receive the first message from Zebra daemon when instantiating ZClient, this patch fixes ZClient to send HELLO and ROUTER_ID_ADD messages automatically.

Also the following fixes the default value for Zebra.Config.Version.