### PR TITLE
drop go1.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ matrix:
   allow_failures:
     - go: tip
   include:
-    - go: 1.5
-      before_install: true
-      install: go get -t ./...
-      script: go test ./...
     - go: 1.6
       before_install: true
       install: go get -t ./...


### PR DESCRIPTION
because gRPC drops go1.5 support.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>