### PR TITLE
server: fix table query with shorter-prefixes option

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -371,13 +371,13 @@ func (t *Table) Select(option ...TableSelectOption) (*Table, error) {
 						}
 					}
 				case LOOKUP_SHORTER:
-					_, prefix, err := net.ParseCIDR(key)
+					addr, prefix, err := net.ParseCIDR(key)
 					if err != nil {
 						return nil, err
 					}
-					ones, bits := prefix.Mask.Size()
+					ones, _ := prefix.Mask.Size()
 					for i := ones; i > 0; i-- {
-						prefix.Mask = net.CIDRMask(i, bits)
+						_, prefix, _ := net.ParseCIDR(fmt.Sprintf("%s/%d", addr.String(), i))
 						f(prefix.String())
 					}
 				default:


### PR DESCRIPTION
$ gobgp g r 168.181.21.128/25 shorter-prefixes
Network not in table
$ gobgp g r 168.181.21.0/25 shorter-prefixes
   Network             Next Hop             AS_PATH              Age       Attrs
*> 168.181.21.0/24     187.16.221.202       61580                04:17:41  [{Origin: i}]

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>