### PR TITLE
zebra/zapi: Fix offset calculation in IPRouteBody

### DIFF
--- a/zebra/zapi.go
+++ b/zebra/zapi.go
@@ -850,14 +850,15 @@ func (b *IPRouteBody) DecodeFromBytes(data []byte, version uint8) error {
 
 	if b.Message&MESSAGE_DISTANCE > 0 {
 		b.Distance = data[pos]
+		pos += 1
 	}
 	if b.Message&MESSAGE_METRIC > 0 {
-		pos += 1
 		b.Metric = binary.BigEndian.Uint32(data[pos : pos+4])
+		pos += 4
 	}
 	if b.Message&MESSAGE_MTU > 0 {
-		pos += 4
 		b.Mtu = binary.BigEndian.Uint32(data[pos : pos+4])
+		pos += 4
 	}
 
 	return nil


### PR DESCRIPTION
Currently, if the received IP route message has not Distance field, zebra/zapi will fail to parse message, because "offset" is incremented *before* parsing each field and it cases index error.
("offset" should be incremented *after* parsing each field.)
This patch fixes this problem.

Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>