### PR TITLE
scenario tests: Use local GoBGP executables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ script: test/scenario_test/ci-scripts/travis-build-script.sh
 
 env:
   global:
-    - DOCKER_IMAGE=gobgp
-    - FROM_IMAGE=osrg/quagga
+    - DOCKER_IMAGE=osrg/quagga
 
 matrix:
   allow_failures:
@@ -69,7 +68,7 @@ matrix:
       services:
         - docker
     - env:
-        - TEST=bgp_zebra_nht_test.py FROM_IMAGE=osrg/quagga:v1.0
+        - TEST=bgp_zebra_nht_test.py DOCKER_IMAGE=osrg/quagga:v1.0
       sudo: required
       services:
         - docker
@@ -144,7 +143,7 @@ matrix:
       services:
         - docker
     - env:
-        - TEST=zapi_v3_test.py FROM_IMAGE=osrg/quagga:v1.0
+        - TEST=zapi_v3_test.py DOCKER_IMAGE=osrg/quagga:v1.0
       sudo: required
       services:
         - docker

--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -97,29 +97,6 @@ class CmdBuffer(list):
         return self.delim.join(self)
 
 
-def make_gobgp_ctn(tag='gobgp', local_gobgp_path='', from_image='osrg/quagga'):
-    if local_gobgp_path == '':
-        local_gobgp_path = os.getcwd()
-
-    c = CmdBuffer()
-    c << 'FROM {0}'.format(from_image)
-    c << 'ADD gobgp /go/src/github.com/osrg/gobgp/'
-    c << 'RUN go get github.com/osrg/gobgp/gobgpd'
-    c << 'RUN go install github.com/osrg/gobgp/gobgpd'
-    c << 'RUN go get github.com/osrg/gobgp/gobgp'
-    c << 'RUN go install github.com/osrg/gobgp/gobgp'
-
-    rindex = local_gobgp_path.rindex('gobgp')
-    if rindex < 0:
-        raise Exception('{0} seems not gobgp dir'.format(local_gobgp_path))
-
-    workdir = local_gobgp_path[:rindex]
-    with lcd(workdir):
-        local('echo \'{0}\' > Dockerfile'.format(str(c)))
-        local('docker build -t {0} .'.format(tag))
-        local('rm Dockerfile')
-
-
 class Bridge(object):
     def __init__(self, name, subnet='', with_ip=True, self_ip=False):
         self.name = name

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -47,7 +47,8 @@ def extract_path_attribute(path, typ):
 
 
 class GoBGPContainer(BGPContainer):
-
+    LOCAL_GOPATH = os.environ['GOPATH']
+    CONTAINER_GOPATH = '/go'
     SHARED_VOLUME = '/root/shared_volume'
     QUAGGA_VOLUME = '/etc/quagga'
 
@@ -56,6 +57,11 @@ class GoBGPContainer(BGPContainer):
                  zapi_version=2, ospfd_config=None):
         super(GoBGPContainer, self).__init__(name, asn, router_id,
                                              ctn_image_name)
+        # Add volume to export local GoBGP executables into container.
+        self.shared_volumes.append(
+            (self.LOCAL_GOPATH + '/bin/', self.CONTAINER_GOPATH + '/bin/'))
+
+        # Add volume to export config files into container.
         self.shared_volumes.append((self.config_dir, self.SHARED_VOLUME))
 
         self.log_level = log_level

--- a/test/scenario_test/README.md
+++ b/test/scenario_test/README.md
@@ -56,9 +56,11 @@ Execute the following commands inside the VM to install the dependencies:
  Download docker images pertaining to GoBGP testing.
 
  ```shell
- $ sudo docker pull golang:1.5
- $ sudo docker pull osrg/quagga
+ $ sudo docker pull golang:1.7
  $ sudo docker pull osrg/gobgp
+ $ sudo docker pull osrg/quagga
+ $ sudo docker pull osrg/quagga:v1.0
+ $ sudo docker pull osrg/exabgp
  ```
  <br>
 

--- a/test/scenario_test/README.md
+++ b/test/scenario_test/README.md
@@ -77,7 +77,8 @@ You also need this operation at every modification to the source code.
 
 ```shell
 $ cd $GOPATH/src/github.com/osrg/gobgp
-$ sudo fab -f ./test/lib/base.py make_gobgp_ctn --set tag=gobgp
+$ go install ./gobgp/
+$ go install ./gobgpd/
 ```
 
 ## <a name="section3"> Run test

--- a/test/scenario_test/README.md
+++ b/test/scenario_test/README.md
@@ -36,7 +36,6 @@ Server:
  Git commit:   76d6bc9
  Built:        Tue Nov  3 17:43:42 UTC 2015
  OS/Arch:      linux/amd64
-
 ```
 
 ## <a name="section1"> Set up dependencies
@@ -44,73 +43,67 @@ Execute the following commands inside the VM to install the dependencies:
 
 1. Install pip and [pipework](https://github.com/jpetazzo/pipework).
 
- ```shell
- $ sudo apt-get update
- $ sudo apt-get install git python-pip python-dev iputils-arping bridge-utils lv
- $ sudo wget https://raw.github.com/jpetazzo/pipework/master/pipework -O /usr/local/bin/pipework
- $ sudo chmod 755 /usr/local/bin/pipework
- ```
- <br>
+```shell
+$ sudo apt-get update
+$ sudo apt-get install git python-pip python-dev iputils-arping bridge-utils lv
+$ sudo wget https://raw.github.com/jpetazzo/pipework/master/pipework -O /usr/local/bin/pipework
+$ sudo chmod 755 /usr/local/bin/pipework
+```
 
-1. Get docker images.
+2. Get docker images.
  Download docker images pertaining to GoBGP testing.
 
- ```shell
- $ sudo docker pull golang:1.7
- $ sudo docker pull osrg/gobgp
- $ sudo docker pull osrg/quagga
- $ sudo docker pull osrg/quagga:v1.0
- $ sudo docker pull osrg/exabgp
- ```
- <br>
+```shell
+$ sudo docker pull golang:1.7
+$ sudo docker pull osrg/gobgp
+$ sudo docker pull osrg/quagga
+$ sudo docker pull osrg/quagga:v1.0
+$ sudo docker pull osrg/exabgp
+```
 
-1. Clone gobgp and install python libraries.
+3. Clone GoBGP and install python libraries.
 
- ```shell
- $ mkdir -p $GOPATH/src/github.com/osrg
- $ cd $GOPATH/src/github.com/osrg
- $ git clone https://github.com/osrg/gobgp.git
- $ cd ./gobgp/test
- $ sudo pip install -r pip-requires.txt
- ```
-<br>
+```shell
+$ mkdir -p $GOPATH/src/github.com/osrg
+$ cd $GOPATH/src/github.com/osrg
+$ git clone https://github.com/osrg/gobgp.git
+$ cd ./gobgp/test
+$ sudo pip install -r pip-requires.txt
+```
 
 ## <a name="section2"> Install local source code
-You need to install local source code into gobgp docker container.
+You need to install local source code into GoBGP docker container.
 You also need this operation at every modification to the source code.
 
-```
+```shell
 $ cd $GOPATH/src/github.com/osrg/gobgp
 $ sudo fab -f ./test/lib/base.py make_gobgp_ctn --set tag=gobgp
 ```
 
-
 ## <a name="section3"> Run test
 
-1. Run all test
-
+1. Run all test.
  You can run all scenario tests with run_all_tests.sh.
  If all tests passed, you can see "all tests passed successfully" at the end of the test.
 
- ```shell
- $ cd $GOPATH/src/github.com/osrg/gobgp/test/scenario_test
- $ ./run_all_tests.sh
- ...
- OK
- all tests passed successfully
- ```
- <br>
-2. Run each test
+```shell
+$ cd $GOPATH/src/github.com/osrg/gobgp/test/scenario_test
+$ ./run_all_tests.sh
+...
+OK
+all tests passed successfully
+```
 
+2. Run each test.
  Gobgp have a scenario test shown in the following.
  You can run scenario tests individually with each test file.
 
- ```shell
- $ cd $GOPATH/src/github.com/osrg/gobgp/test/scenario_test
- $ sudo -E PYTHONPATH=$GOBGP/test python <scenario test name>.py
- ...
- OK
- ```
+```shell
+$ cd $GOPATH/src/github.com/osrg/gobgp/test/scenario_test
+$ sudo -E PYTHONPATH=$GOBGP/test python <scenario test name>.py
+...
+OK
+```
 
  what kind of scenaio tests:
  - bgp_router_test
@@ -129,6 +122,7 @@ $ sudo fab -f ./test/lib/base.py make_gobgp_ctn --set tag=gobgp
 ## <a name="section4"> Clean up
 A lot of containers are created during the test.
 Let's clean up.
-```
+
+```shell
 $ sudo docker rm -f $(sudo docker ps -a -q)
 ```

--- a/test/scenario_test/README.md
+++ b/test/scenario_test/README.md
@@ -96,8 +96,8 @@ all tests passed successfully
 ```
 
 2. Run each test.
- Gobgp have a scenario test shown in the following.
  You can run scenario tests individually with each test file.
+ See `test/scenario_test/*.py`, for the individual test files.
 
 ```shell
 $ cd $GOPATH/src/github.com/osrg/gobgp/test/scenario_test
@@ -105,20 +105,6 @@ $ sudo -E PYTHONPATH=$GOBGP/test python <scenario test name>.py
 ...
 OK
 ```
-
- what kind of scenaio tests:
- - bgp_router_test
- - bgp_zebra_test
- - evpn_test
- - flow_spec_test
- - global_policy_test
- - ibgp_router_test
- - route_reflector_test
- - route_server_ipv4_v6_test
- - route_server_malformed_test
- - route_server_policy_grpc_test
- - route_server_policy_test
- - route_server_test
 
 ## <a name="section4"> Clean up
 A lot of containers are created during the test.

--- a/test/scenario_test/README.md
+++ b/test/scenario_test/README.md
@@ -107,9 +107,11 @@ OK
 ```
 
 ## <a name="section4"> Clean up
-A lot of containers are created during the test.
+A lot of containers, networks temporary files are created during the test.
 Let's clean up.
 
 ```shell
 $ sudo docker rm -f $(sudo docker ps -a -q)
+$ sudo docker network prune -f
+$ sudo rm -rf /tmp/gobgp
 ```

--- a/test/scenario_test/ci-scripts/jenkins-build-script.sh
+++ b/test/scenario_test/ci-scripts/jenkins-build-script.sh
@@ -33,11 +33,10 @@ do
 done
 
 sudo docker rmi $GOBGP_IMAGE
-sudo fab -f $GOBGP/test/lib/base.py make_gobgp_ctn:tag=$GOBGP_IMAGE
-[ "$?" != 0 ] && exit "$?"
 
-cd $GOBGP/gobgpd
-$GOROOT/bin/go get -v
+cd $GOBGP
+$GOROOT/bin/go get -v ./gobgp/
+$GOROOT/bin/go get -v ./gobgpd/
 
 cd $GOBGP/test/scenario_test
 ./run_all_tests.sh

--- a/test/scenario_test/ci-scripts/travis-build-script.sh
+++ b/test/scenario_test/ci-scripts/travis-build-script.sh
@@ -2,4 +2,4 @@
 
 echo "travis-build-script.sh"
 
-sudo PYTHONPATH=test python test/scenario_test/$TEST --gobgp-image $DOCKER_IMAGE -x -s
+PYTHONPATH=test python test/scenario_test/$TEST --gobgp-image $DOCKER_IMAGE -x -s

--- a/test/scenario_test/ci-scripts/travis-install-script.sh
+++ b/test/scenario_test/ci-scripts/travis-install-script.sh
@@ -2,6 +2,7 @@
 
 echo "travis-install-script.sh"
 
-sudo -H pip --quiet install -r test/pip-requires.txt
+pip --quiet install -r test/pip-requires.txt
 
-sudo fab -f test/lib/base.py make_gobgp_ctn:tag=$DOCKER_IMAGE,from_image=$FROM_IMAGE
+go get -v ./gobgp/
+go get -v ./gobgpd/


### PR DESCRIPTION
Currently, to reflect the modification of the local source code or to switch the base image for GoBGP container, it is required to re-build the GoBGP container image, and this take a long time to test or debug with the scenario tests.

This patch fixes to use the local GoBGP executables (gobgp and gobgpd) in container, and enables to reflect the changes without re-building container image.

Note: according to this change, the following command is no longer required and removed, but it is required to build GoBGP executables before running the scenario tests.
Removed command: `$ sudo fab -f ./test/lib/base.py make_gobgp_ctn --set tag=gobgp`