### PR TITLE
BMP: Support for "bmp-draft-evens-grow-bmp-local-rib"

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -858,12 +858,14 @@ const (
 	BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY  BmpRouteMonitoringPolicyType = "pre-policy"
 	BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY BmpRouteMonitoringPolicyType = "post-policy"
 	BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH        BmpRouteMonitoringPolicyType = "both"
+	BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB   BmpRouteMonitoringPolicyType = "local-rib"
 )
 
 var BmpRouteMonitoringPolicyTypeToIntMap = map[BmpRouteMonitoringPolicyType]int{
 	BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY:  0,
 	BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY: 1,
 	BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH:        2,
+	BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB:   3,
 }
 
 func (v BmpRouteMonitoringPolicyType) ToInt() int {
@@ -878,6 +880,7 @@ var IntToBmpRouteMonitoringPolicyTypeMap = map[int]BmpRouteMonitoringPolicyType{
 	0: BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY,
 	1: BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY,
 	2: BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH,
+	3: BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB,
 }
 
 func (v BmpRouteMonitoringPolicyType) Validate() error {

--- a/packet/bmp/bmp.go
+++ b/packet/bmp/bmp.go
@@ -43,12 +43,14 @@ const (
 	BMP_PEER_TYPE_GLOBAL uint8 = iota
 	BMP_PEER_TYPE_L3VPN
 	BMP_PEER_TYPE_LOCAL
+	BMP_PEER_TYPE_LOCAL_RIB
 )
 
 const (
 	BMP_PEER_FLAG_IPV6        = 1 << 7
 	BMP_PEER_FLAG_POST_POLICY = 1 << 6
 	BMP_PEER_FLAG_TWO_AS      = 1 << 5
+	BMP_PEER_FLAG_FILTERED    = 1 << 6
 )
 
 func (h *BMPHeader) DecodeFromBytes(data []byte) error {

--- a/packet/bmp/bmp_test.go
+++ b/packet/bmp/bmp_test.go
@@ -48,14 +48,14 @@ func Test_Initiation(t *testing.T) {
 
 func Test_PeerUpNotification(t *testing.T) {
 	m := bgp.NewTestBGPOpenMessage()
-	p0 := NewBMPPeerHeader(0, false, 1000, "10.0.0.1", 70000, "10.0.0.2", 1)
+	p0 := NewBMPPeerHeader(0, 0, 1000, "10.0.0.1", 70000, "10.0.0.2", 1)
 	verify(t, NewBMPPeerUpNotification(*p0, "10.0.0.3", 10, 100, m, m))
-	p1 := NewBMPPeerHeader(0, false, 1000, "fe80::6e40:8ff:feab:2c2a", 70000, "10.0.0.2", 1)
+	p1 := NewBMPPeerHeader(0, 0, 1000, "fe80::6e40:8ff:feab:2c2a", 70000, "10.0.0.2", 1)
 	verify(t, NewBMPPeerUpNotification(*p1, "fe80::6e40:8ff:feab:2c2a", 10, 100, m, m))
 }
 
 func Test_PeerDownNotification(t *testing.T) {
-	p0 := NewBMPPeerHeader(0, false, 1000, "10.0.0.1", 70000, "10.0.0.2", 1)
+	p0 := NewBMPPeerHeader(0, 0, 1000, "10.0.0.1", 70000, "10.0.0.2", 1)
 	verify(t, NewBMPPeerDownNotification(*p0, BMP_PEER_DOWN_REASON_UNKNOWN, nil, []byte{0x3, 0xb}))
 	m := bgp.NewBGPNotificationMessage(1, 2, nil)
 	verify(t, NewBMPPeerDownNotification(*p0, BMP_PEER_DOWN_REASON_LOCAL_BGP_NOTIFICATION, m, nil))
@@ -63,7 +63,7 @@ func Test_PeerDownNotification(t *testing.T) {
 
 func Test_RouteMonitoring(t *testing.T) {
 	m := bgp.NewTestBGPUpdateMessage()
-	p0 := NewBMPPeerHeader(0, false, 1000, "fe80::6e40:8ff:feab:2c2a", 70000, "10.0.0.2", 1)
+	p0 := NewBMPPeerHeader(0, 0, 1000, "fe80::6e40:8ff:feab:2c2a", 70000, "10.0.0.2", 1)
 	verify(t, NewBMPRouteMonitoring(*p0, m))
 }
 

--- a/server/bmp.go
+++ b/server/bmp.go
@@ -198,17 +198,29 @@ type bmpClient struct {
 }
 
 func bmpPeerUp(laddr string, lport, rport uint16, sent, recv *bgp.BGPMessage, t uint8, policy bool, pd uint64, peeri *table.PeerInfo, timestamp int64) *bmp.BMPMessage {
-	ph := bmp.NewBMPPeerHeader(t, policy, pd, peeri.Address.String(), peeri.AS, peeri.ID.String(), float64(timestamp))
+	var flags uint8 = 0
+	if policy {
+		flags |= bmp.BMP_PEER_FLAG_POST_POLICY
+	}
+	ph := bmp.NewBMPPeerHeader(t, flags, pd, peeri.Address.String(), peeri.AS, peeri.ID.String(), float64(timestamp))
 	return bmp.NewBMPPeerUpNotification(*ph, laddr, lport, rport, sent, recv)
 }
 
 func bmpPeerDown(reason uint8, t uint8, policy bool, pd uint64, peeri *table.PeerInfo, timestamp int64) *bmp.BMPMessage {
-	ph := bmp.NewBMPPeerHeader(t, policy, pd, peeri.Address.String(), peeri.AS, peeri.ID.String(), float64(timestamp))
+	var flags uint8 = 0
+	if policy {
+		flags |= bmp.BMP_PEER_FLAG_POST_POLICY
+	}
+	ph := bmp.NewBMPPeerHeader(t, flags, pd, peeri.Address.String(), peeri.AS, peeri.ID.String(), float64(timestamp))
 	return bmp.NewBMPPeerDownNotification(*ph, reason, nil, []byte{})
 }
 
 func bmpPeerRoute(t uint8, policy bool, pd uint64, peeri *table.PeerInfo, timestamp int64, payload []byte) *bmp.BMPMessage {
-	ph := bmp.NewBMPPeerHeader(t, policy, pd, peeri.Address.String(), peeri.AS, peeri.ID.String(), float64(timestamp))
+	var flags uint8 = 0
+	if policy {
+		flags |= bmp.BMP_PEER_FLAG_POST_POLICY
+	}
+	ph := bmp.NewBMPPeerHeader(t, flags, pd, peeri.Address.String(), peeri.AS, peeri.ID.String(), float64(timestamp))
 	m := bmp.NewBMPRouteMonitoring(*ph, nil)
 	body := m.Body.(*bmp.BMPRouteMonitoring)
 	body.BGPUpdatePayload = payload

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -48,6 +48,10 @@ module gobgp {
         value 2;
         description "send both pre and post-policy routes";
       }
+      enum LOCAL-RIB {
+        value 3;
+        description "send local rib routes";
+      }
     }
   }
 


### PR DESCRIPTION
These patches enable to send BMP Route Monitoring message for Local RIB routes described in "bmp-draft-evens-grow-bmp-local-rib".

Configuration Example: gobgpd.toml
  ...
  [[bmp-servers]]
    [bmp-servers.config]
      address = "127.0.0.1"
      port=11019
      route-monitoring-policy = "local-rib"
  ...

issues #1281

Note: As @mstrother said, I guess we should have "route-monitoring-policy" to be configurable as a list of the interesting route types, but currently we need to configure it as a string value.
Could we accept the both types (list or string) as route-monitoring-policy"? How to implement it?
Or, should we have a new key like "route-monitoring-**policies**" or so?