### PR TITLE
policy: send a withdrawal if export policy blocks an existing route

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -101,8 +101,10 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn ui
 
 	if n.Config.PeerAs != n.Config.LocalAs {
 		n.Config.PeerType = PEER_TYPE_EXTERNAL
+		n.State.PeerType = PEER_TYPE_EXTERNAL
 	} else {
 		n.Config.PeerType = PEER_TYPE_INTERNAL
+		n.State.PeerType = PEER_TYPE_INTERNAL
 	}
 
 	n.State.PeerAs = n.Config.PeerAs

--- a/server/peer.go
+++ b/server/peer.go
@@ -278,6 +278,14 @@ func (peer *Peer) filterpath(path, old *table.Path) *table.Path {
 		Info: peer.fsm.peerInfo,
 	}
 	path = peer.policy.ApplyPolicy(peer.TableID(), table.POLICY_DIRECTION_EXPORT, path, options)
+	// When 'path' is filetered (path == nil), check 'old' has been sent to this peer.
+	// If it has, send withdrawal to the peer.
+	if path == nil && old != nil {
+		o := peer.policy.ApplyPolicy(peer.TableID(), table.POLICY_DIRECTION_EXPORT, old, options)
+		if o != nil {
+			path = old.Clone(true)
+		}
+	}
 
 	// draft-uttaro-idr-bgp-persistence-02
 	// 4.3.  Processing LLGR_STALE Routes

--- a/server/server.go
+++ b/server/server.go
@@ -367,7 +367,7 @@ func filterpath(peer *Peer, path, old *table.Path) *table.Path {
 		}
 
 		if ignore {
-			if path.IsWithdraw == false && old != nil {
+			if !path.IsWithdraw && old != nil && old.GetSource().Address.String() != peer.ID() {
 				// we advertise a route from ebgp,
 				// which is the old best. We got the
 				// new best from ibgp. We don't
@@ -400,7 +400,7 @@ func filterpath(peer *Peer, path, old *table.Path) *table.Path {
 			// the withdrawal path.
 			// Thing is same when peer A and we advertized prefix P (as local
 			// route), then, we withdraws the prefix.
-			if path.IsWithdraw == false && old != nil {
+			if !path.IsWithdraw && old != nil && old.GetSource().Address.String() != peer.ID() {
 				return old.Clone(true)
 			}
 		}


### PR DESCRIPTION
This patch fixes a bug of export policy and implicit withdrawal.

When a path is filtered by export policy, we need to check whether the
old path (implicit withdrawn path) was sent before the new path.
If it has been sent, we need to send a withdrawal message.

Signed-off-by: ISHIDA Wataru <ishida.wataru@lab.ntt.co.jp>