### PR TITLE
table: Fixed bug when looking up prefixes with a default route.

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -376,7 +376,7 @@ func (t *Table) Select(option ...TableSelectOption) (*Table, error) {
 						return nil, err
 					}
 					ones, _ := prefix.Mask.Size()
-					for i := ones; i > 0; i-- {
+					for i := ones; i >= 0; i-- {
 						_, prefix, _ := net.ParseCIDR(fmt.Sprintf("%s/%d", addr.String(), i))
 						f(prefix.String())
 					}
@@ -386,7 +386,7 @@ func (t *Table) Select(option ...TableSelectOption) (*Table, error) {
 						if t.routeFamily == bgp.RF_IPv6_UC {
 							masklen = 128
 						}
-						for i := masklen; i > 0; i-- {
+						for i := masklen; i >= 0; i-- {
 							_, prefix, err := net.ParseCIDR(fmt.Sprintf("%s/%d", key, i))
 							if err != nil {
 								return nil, err


### PR DESCRIPTION
For issue [1301](https://github.com/osrg/gobgp/issues/1301).
The last iteration of the loop was 1 so the mask calculation stopped at /1 thus leaving blank any lookup of a prefix when a default route is present.