### PR TITLE
mrt: fix bug of general address family rib serialization

### DIFF
--- a/packet/mrt/mrt.go
+++ b/packet/mrt/mrt.go
@@ -465,7 +465,7 @@ func (u *Rib) Serialize() ([]byte, error) {
 	switch rf {
 	case bgp.RF_IPv4_UC, bgp.RF_IPv4_MC, bgp.RF_IPv6_UC, bgp.RF_IPv6_MC:
 	default:
-		bbuf := make([]byte, 0, 2)
+		bbuf := make([]byte, 2)
 		binary.BigEndian.PutUint16(bbuf, u.Prefix.AFI())
 		buf = append(buf, bbuf...)
 		buf = append(buf, u.Prefix.SAFI())


### PR DESCRIPTION
allocate a slice with 2 byte length (not 2 byte capacity) for
PutUint16()

fixes #1313

Signed-off-by: Wataru Ishida <ishida.wataru@lab.ntt.co.jp>