### PR TITLE
table: Advertise local-pref set by import policy

### DIFF
--- a/table/path.go
+++ b/table/path.go
@@ -215,7 +215,7 @@ func UpdatePathAttrs(global *config.Global, peer *config.Neighbor, info *PeerInf
 		// For iBGP peers we are required to send local-pref attribute
 		// for connected or local prefixes.
 		// We set default local-pref 100.
-		if pref := path.getPathAttr(bgp.BGP_ATTR_TYPE_LOCAL_PREF); pref == nil || !path.IsLocal() {
+		if pref := path.getPathAttr(bgp.BGP_ATTR_TYPE_LOCAL_PREF); pref == nil {
 			path.setPathAttr(bgp.NewPathAttributeLocalPref(DEFAULT_LOCAL_PREF))
 		}
 


### PR DESCRIPTION
At importing a path from an external peer, LOCAL_PREF can be set by an
import policy but at exporting a best path to an internal peer, this
learned, calculated LOCAL_PREF is never used and every time overwritten
by a default value 100.

According to RFC 4271 "5.1.5. LOCAL_PREF" and "9.1.1. Phase 1:
Calculation of Degree of Preference", the learned value should be
advertised to other internal peers.

This fixes it by just removing resetting a non-local path's LOCAL_PREF
by the default value.

(commit message ends here)

The current behavior is introduced at 2db916a before introducing local-pref action at 0dbf1d8 so I guess kind of stub behavior survives.

It works in my test environment but if there is something wrong, misunderstanding, any feedback is welcome.