### PR TITLE
bgp: Advertise IPv4 routes with IPv6 Next Hop

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -568,7 +568,7 @@ func (s *Server) api2PathList(resource Resource, ApiPathList []*Path) ([]*table.
 			return nil, fmt.Errorf("not found nlri or nexthop")
 		}
 
-		if resource != Resource_VRF && bgp.RouteFamily(path.Family) == bgp.RF_IPv4_UC {
+		if resource != Resource_VRF && bgp.RouteFamily(path.Family) == bgp.RF_IPv4_UC && net.ParseIP(nexthop).To4() != nil {
 			pattr = append(pattr, bgp.NewPathAttributeNextHop(nexthop))
 		} else {
 			pattr = append(pattr, bgp.NewPathAttributeMpReachNLRI(nexthop, []bgp.AddrPrefixInterface{nlri}))

--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -797,7 +797,7 @@ func ParsePath(rf bgp.RouteFamily, args []string) (*table.Path, error) {
 		return nil, err
 	}
 
-	if rf == bgp.RF_IPv4_UC {
+	if rf == bgp.RF_IPv4_UC && net.ParseIP(nexthop).To4() != nil {
 		attrs = append(attrs, bgp.NewPathAttributeNextHop(nexthop))
 	} else {
 		mpreach := bgp.NewPathAttributeMpReachNLRI(nexthop, []bgp.AddrPrefixInterface{nlri})


### PR DESCRIPTION
RFC5549 allows IPv6 Next Hop address for the advertisement of IPv4 related NLRIs for <AFI/SAFI> of <1/1>, <1/2>, <1/4> and <1/128>.
Currently, the advertisement using the MP_REACH_NLRI is supported, but IPv4 routes with IPv6 Next Hop is not enough.

This patch enable to advertise IPv4 routes for <AFI/SAFI> of <1/1> through GoBGP CLI command.
e.g.)
  $ gobgp global rib add -a ipv4 10.2.1.0/24 nexthop 2001:2::1

Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>