### PR TITLE
bmp: Enable to specify all route monitoring policies

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -859,6 +859,7 @@ const (
 	BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY BmpRouteMonitoringPolicyType = "post-policy"
 	BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH        BmpRouteMonitoringPolicyType = "both"
 	BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB   BmpRouteMonitoringPolicyType = "local-rib"
+	BMP_ROUTE_MONITORING_POLICY_TYPE_ALL         BmpRouteMonitoringPolicyType = "all"
 )
 
 var BmpRouteMonitoringPolicyTypeToIntMap = map[BmpRouteMonitoringPolicyType]int{
@@ -866,6 +867,7 @@ var BmpRouteMonitoringPolicyTypeToIntMap = map[BmpRouteMonitoringPolicyType]int{
 	BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY: 1,
 	BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH:        2,
 	BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB:   3,
+	BMP_ROUTE_MONITORING_POLICY_TYPE_ALL:         4,
 }
 
 func (v BmpRouteMonitoringPolicyType) ToInt() int {
@@ -881,6 +883,7 @@ var IntToBmpRouteMonitoringPolicyTypeMap = map[int]BmpRouteMonitoringPolicyType{
 	1: BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY,
 	2: BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH,
 	3: BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB,
+	4: BMP_ROUTE_MONITORING_POLICY_TYPE_ALL,
 }
 
 func (v BmpRouteMonitoringPolicyType) Validate() error {

--- a/docs/sources/bmp.md
+++ b/docs/sources/bmp.md
@@ -25,7 +25,12 @@ Add `[bmp-servers]` session to enable BMP.
     port=11019
 ```
 
-Flows can be post-policy, pre-policy, or both. Pre-policy flows are the default. 
+The supported route monitoring policy types are:
+- pre-policy (Default)
+- post-policy
+- both (Obsoleted)
+- local-rib
+- all
 
 Enable post-policy support as follows:
 
@@ -37,14 +42,14 @@ Enable post-policy support as follows:
     route-monitoring-policy = "post-policy"
 ```
 
-Enable both pre-policy and post-policy support as follows:
+Enable all policies support as follows:
 
 ```toml
 [[bmp-servers]]
   [bmp-servers.config]
     address = "127.0.0.1"
     port=11019
-    route-monitoring-policy = "both"
+    route-monitoring-policy = "all"
 ```
 
 

--- a/server/bmp.go
+++ b/server/bmp.go
@@ -167,11 +167,16 @@ func (b *bmpClient) loop() {
 							}
 						}
 					case *WatchEventBestPath:
+						info := &table.PeerInfo{
+							Address: net.ParseIP("0.0.0.0").To4(),
+							AS:      b.s.bgpConfig.Global.Config.As,
+							ID:      net.ParseIP(b.s.bgpConfig.Global.Config.RouterId).To4(),
+						}
 						for _, p := range msg.PathList {
 							u := table.CreateUpdateMsgFromPaths([]*table.Path{p})[0]
 							if payload, err := u.Serialize(); err != nil {
 								return false
-							} else if err = write(bmpPeerRoute(bmp.BMP_PEER_TYPE_LOCAL_RIB, false, 0, p.GetSource(), p.GetTimestamp().Unix(), payload)); err != nil {
+							} else if err = write(bmpPeerRoute(bmp.BMP_PEER_TYPE_LOCAL_RIB, false, 0, info, p.GetTimestamp().Unix(), payload)); err != nil {
 								return false
 							}
 						}

--- a/server/bmp.go
+++ b/server/bmp.go
@@ -113,11 +113,13 @@ func (b *bmpClient) loop() {
 
 		if func() bool {
 			ops := []WatchOption{WatchPeerState(true)}
-			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH {
+			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH {
 				ops = append(ops, WatchUpdate(true))
-			} else if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH {
+			}
+			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH {
 				ops = append(ops, WatchPostUpdate(true))
-			} else if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB {
+			}
+			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
 				ops = append(ops, WatchBestPath(true))
 			}
 			w := b.s.Watch(ops...)

--- a/server/bmp.go
+++ b/server/bmp.go
@@ -113,10 +113,15 @@ func (b *bmpClient) loop() {
 
 		if func() bool {
 			ops := []WatchOption{WatchPeerState(true)}
-			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH {
+			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH {
+				log.WithFields(
+					log.Fields{"Topic": "bmp"},
+				).Warn("both option for route-monitoring-policy is obsoleted")
+			}
+			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
 				ops = append(ops, WatchUpdate(true))
 			}
-			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH {
+			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
 				ops = append(ops, WatchPostUpdate(true))
 			}
 			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -46,7 +46,7 @@ module gobgp {
       }
       enum BOTH {
         value 2;
-        description "send both pre and post-policy routes";
+        description "!OBSOLETED! send both pre and post-policy routes";
       }
       enum LOCAL-RIB {
         value 3;

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -52,6 +52,10 @@ module gobgp {
         value 3;
         description "send local rib routes";
       }
+      enum ALL {
+        value 4;
+        description "send pre-policy, post-policy, and local rib routes";
+      }
     }
   }
 


### PR DESCRIPTION
This patch adds the new key "all" for specifying the all BMP route monitoring policies.

Configuration Example:
```
  [[bmp-servers]]
    [bmp-servers.config]
      address = "127.0.0.1"
      port=11019
      route-monitoring-policy = "all"
```
Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>