### PR TITLE
bmp: Stats reports for Adj-RIBs-In and Loc-RIB routes

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -1169,6 +1169,8 @@ type BmpServerConfig struct {
 	Port uint32 `mapstructure:"port" json:"port,omitempty"`
 	// original -> gobgp:route-monitoring-policy
 	RouteMonitoringPolicy BmpRouteMonitoringPolicyType `mapstructure:"route-monitoring-policy" json:"route-monitoring-policy,omitempty"`
+	// original -> gobgp:statistics-timeout
+	StatisticsTimeout uint16 `mapstructure:"statistics-timeout" json:"statistics-timeout,omitempty"`
 }
 
 func (lhs *BmpServerConfig) Equal(rhs *BmpServerConfig) bool {
@@ -1182,6 +1184,9 @@ func (lhs *BmpServerConfig) Equal(rhs *BmpServerConfig) bool {
 		return false
 	}
 	if lhs.RouteMonitoringPolicy != rhs.RouteMonitoringPolicy {
+		return false
+	}
+	if lhs.StatisticsTimeout != rhs.StatisticsTimeout {
 		return false
 	}
 	return true

--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -2100,6 +2100,8 @@ func (lhs *Timers) Equal(rhs *Timers) bool {
 type AdjTable struct {
 	// original -> gobgp:ADVERTISED
 	Advertised uint32 `mapstructure:"advertised" json:"advertised,omitempty"`
+	// original -> gobgp:FILTERED
+	Filtered uint32 `mapstructure:"filtered" json:"filtered,omitempty"`
 	// original -> gobgp:RECEIVED
 	Received uint32 `mapstructure:"received" json:"received,omitempty"`
 	// original -> gobgp:ACCEPTED
@@ -2111,6 +2113,9 @@ func (lhs *AdjTable) Equal(rhs *AdjTable) bool {
 		return false
 	}
 	if lhs.Advertised != rhs.Advertised {
+		return false
+	}
+	if lhs.Filtered != rhs.Filtered {
 		return false
 	}
 	if lhs.Received != rhs.Received {

--- a/config/default.go
+++ b/config/default.go
@@ -267,6 +267,10 @@ func setDefaultConfigValuesWithViper(v *viper.Viper, b *BgpConfigSet) error {
 		if server.Config.Port == 0 {
 			server.Config.Port = bmp.BMP_DEFAULT_PORT
 		}
+		// statistics-timeout is uint16 value and implicitly less than 65536
+		if server.Config.StatisticsTimeout != 0 && server.Config.StatisticsTimeout < 15 {
+			return fmt.Errorf("too small statistics-timeout value: %d", server.Config.StatisticsTimeout)
+		}
 		b.BmpServers[idx] = server
 	}
 

--- a/docs/sources/bmp.md
+++ b/docs/sources/bmp.md
@@ -52,6 +52,17 @@ Enable all policies support as follows:
     route-monitoring-policy = "all"
 ```
 
+To enable BMP stats reports, specify the interval seconds to send statistics messages.
+The default value is 0 and no statistics messages are sent.
+Please note the range of this interval is 15 though 65535 seconds.
+
+```toml
+[[bmp-servers]]
+  [bmp-servers.config]
+    address = "127.0.0.1"
+    port=11019
+    statistics-timeout = 3600
+```
 
 ## <a name="verify"> Verification
 

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -30,6 +30,8 @@
     [bmp-servers.config]
         address = "127.0.0.1"
         port = 11019
+        route-monitoring-policy = "pre-policy"
+        statistics-timeout = 3600
 
 [[mrt-dump]]
     dump-type = "updates"

--- a/packet/bmp/bmp_test.go
+++ b/packet/bmp/bmp_test.go
@@ -67,6 +67,19 @@ func Test_RouteMonitoring(t *testing.T) {
 	verify(t, NewBMPRouteMonitoring(*p0, m))
 }
 
+func Test_StatisticsReport(t *testing.T) {
+	p0 := NewBMPPeerHeader(0, 0, 1000, "10.0.0.1", 70000, "10.0.0.2", 1)
+	s0 := NewBMPStatisticsReport(
+		*p0,
+		[]BMPStatsTLVInterface{
+			NewBMPStatsTLV32(BMP_STAT_TYPE_REJECTED, 100),
+			NewBMPStatsTLV64(BMP_STAT_TYPE_ADJ_RIB_IN, 200),
+			NewBMPStatsTLVPerAfiSafi64(BMP_STAT_TYPE_PER_AFI_SAFI_LOC_RIB, bgp.AFI_IP, bgp.SAFI_UNICAST, 300),
+		},
+	)
+	verify(t, s0)
+}
+
 func Test_BogusHeader(t *testing.T) {
 	h, err := ParseBMPMessage(make([]byte, 10))
 	assert.Nil(t, h)

--- a/server/bmp.go
+++ b/server/bmp.go
@@ -113,22 +113,31 @@ func (b *bmpClient) loop() {
 
 		if func() bool {
 			ops := []WatchOption{WatchPeerState(true)}
-			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH {
+			if b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH {
 				log.WithFields(
 					log.Fields{"Topic": "bmp"},
 				).Warn("both option for route-monitoring-policy is obsoleted")
 			}
-			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
+			if b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY || b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
 				ops = append(ops, WatchUpdate(true))
 			}
-			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
+			if b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY || b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
 				ops = append(ops, WatchPostUpdate(true))
 			}
-			if b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB || b.typ == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
+			if b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB || b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
 				ops = append(ops, WatchBestPath(true))
 			}
 			w := b.s.Watch(ops...)
 			defer w.Stop()
+
+			var tickerCh <-chan time.Time
+			if b.c.StatisticsTimeout == 0 {
+				log.WithFields(log.Fields{"Topic": "bmp"}).Debug("statistics reports disabled")
+			} else {
+				t := time.NewTicker(time.Duration(b.c.StatisticsTimeout) * time.Second)
+				defer t.Stop()
+				tickerCh = t.C
+			}
 
 			write := func(msg *bmp.BMPMessage) error {
 				buf, _ := msg.Serialize()
@@ -201,6 +210,16 @@ func (b *bmpClient) loop() {
 							}
 						}
 					}
+				case <-tickerCh:
+					neighborList := b.s.GetNeighbor("", true)
+					for _, n := range neighborList {
+						if n.State.SessionState != config.SESSION_STATE_ESTABLISHED {
+							continue
+						}
+						if err := write(bmpPeerStats(bmp.BMP_PEER_TYPE_GLOBAL, 0, 0, n)); err != nil {
+							return false
+						}
+					}
 				case <-b.dead:
 					conn.Close()
 					return true
@@ -216,7 +235,7 @@ type bmpClient struct {
 	s      *BgpServer
 	dead   chan struct{}
 	host   string
-	typ    config.BmpRouteMonitoringPolicyType
+	c      *config.BmpServerConfig
 	ribout ribout
 }
 
@@ -250,6 +269,18 @@ func bmpPeerRoute(t uint8, policy bool, pd uint64, peeri *table.PeerInfo, timest
 	return m
 }
 
+func bmpPeerStats(peerType uint8, peerDist uint64, timestamp int64, neighConf *config.Neighbor) *bmp.BMPMessage {
+	var peerFlags uint8 = 0
+	ph := bmp.NewBMPPeerHeader(peerType, peerFlags, peerDist, neighConf.Config.NeighborAddress, neighConf.State.PeerAs, neighConf.State.RemoteRouterId, float64(timestamp))
+	return bmp.NewBMPStatisticsReport(
+		*ph,
+		[]bmp.BMPStatsTLVInterface{
+			bmp.NewBMPStatsTLV64(bmp.BMP_STAT_TYPE_ADJ_RIB_IN, uint64(neighConf.State.AdjTable.Accepted)),
+			bmp.NewBMPStatsTLV64(bmp.BMP_STAT_TYPE_LOC_RIB, uint64(neighConf.State.AdjTable.Advertised+neighConf.State.AdjTable.Filtered)),
+		},
+	)
+}
+
 func (b *bmpClientManager) addServer(c *config.BmpServerConfig) error {
 	host := net.JoinHostPort(c.Address, strconv.Itoa(int(c.Port)))
 	if _, y := b.clientMap[host]; y {
@@ -259,7 +290,7 @@ func (b *bmpClientManager) addServer(c *config.BmpServerConfig) error {
 		s:      b.s,
 		dead:   make(chan struct{}),
 		host:   host,
-		typ:    c.RouteMonitoringPolicy,
+		c:      c,
 		ribout: newribout(),
 	}
 	go b.clientMap[host].loop()

--- a/server/peer.go
+++ b/server/peer.go
@@ -543,8 +543,9 @@ func (peer *Peer) ToConfig(getAdvertised bool) *config.Neighbor {
 	if peer.fsm.state == bgp.BGP_FSM_ESTABLISHED {
 		rfList := peer.configuredRFlist()
 		if getAdvertised {
-			pathList, _ := peer.getBestFromLocal(rfList)
+			pathList, filtered := peer.getBestFromLocal(rfList)
 			conf.State.AdjTable.Advertised = uint32(len(pathList))
+			conf.State.AdjTable.Filtered = uint32(len(filtered))
 		} else {
 			conf.State.AdjTable.Advertised = 0
 		}

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -553,6 +553,11 @@ module gobgp {
       type bmp-route-monitoring-policy-type;
       default PRE-POLICY;
     }
+    leaf statistics-timeout {
+      type uint16;
+      description
+        "Interval seconds of statistics messages sent to BMP server";
+    }
   }
 
   grouping gobgp-bmp-server-state {

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -202,6 +202,10 @@ module gobgp {
         type uint32;
       }
 
+      leaf FILTERED {
+        type uint32;
+      }
+
       leaf RECEIVED {
         type uint32;
       }


### PR DESCRIPTION
This PR enables to send BMP statistics reports for the number of routes in Adj-RIBs-In and Loc-RIB.
Also includes the improvements of BMP statistics reports serializer and the updates of documents for BMP configurations.