### PR TITLE
table: reduce allocations in destination selection by an additional factor of 5

### DIFF
--- a/table/destination.go
+++ b/table/destination.go
@@ -51,22 +51,11 @@ const (
 )
 
 func IpToRadixkey(b []byte, max uint8) string {
-	var backing [128]byte
-	buf := backing[:max]
-	for y, i := 8, 0; y <= len(buf); y, i = y+8, i+1 {
-		n, byt, cur := 8, b[i], buf[y-8:y]
-		for byt > 0 {
-			n--
-			cur[n] = byte('0' + byt&1)
-			byt >>= 1
-		}
+	var buffer bytes.Buffer
+	for i := 0; i < len(b) && i < int(max); i++ {
+		fmt.Fprintf(&buffer, "%08b", b[i])
 	}
-	for i := 0; i < len(buf); i++ {
-		if buf[i] == 0 {
-			buf[i] = '0'
-		}
-	}
-	return string(buf)
+	return buffer.String()[:max]
 }
 
 func CidrToRadixkey(cidr string) string {

--- a/table/destination_test.go
+++ b/table/destination_test.go
@@ -17,11 +17,13 @@ package table
 
 import (
 	//"fmt"
-	"github.com/osrg/gobgp/packet/bgp"
-	"github.com/stretchr/testify/assert"
+	"fmt"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/osrg/gobgp/packet/bgp"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDestinationNewIPv4(t *testing.T) {
@@ -400,6 +402,28 @@ func TestRadixkey(t *testing.T) {
 	assert.Equal(t, "000010100000001100100000", IpToRadixkey(net.ParseIP("10.3.32.0").To4(), 24))
 	assert.Equal(t, "000010100000001100100000", IpToRadixkey(net.ParseIP("10.3.32.0").To4(), 24))
 	assert.Equal(t, CidrToRadixkey("::ffff:0.0.0.0/96")+"000010100000001100100000", CidrToRadixkey("::ffff:10.3.32.0/120"))
+}
+
+func TestIpToRadixkey(t *testing.T) {
+	for i := byte(0); i < 255; i += 3 {
+		for y := byte(1); y < 128; y *= 2 {
+			ip := net.IPv4(i, i+2, i+3, i-y)
+			for n := uint8(16); n <= 32; n += 2 {
+				exp := CidrToRadixkey(fmt.Sprintf("%v/%d", ip.To4(), n))
+				got := IpToRadixkey(ip.To4(), n)
+				if exp != got {
+					t.Fatalf(`exp %v; got %v`, exp, got)
+				}
+			}
+			for n := uint8(116); n <= 128; n += 2 {
+				exp := CidrToRadixkey(fmt.Sprintf("::ffff:%v/%d", ip.To16(), n))
+				got := IpToRadixkey(ip.To16(), n)
+				if exp != got {
+					t.Fatalf(`exp %v; got %v`, exp, got)
+				}
+			}
+		}
+	}
 }
 
 func TestMultipath(t *testing.T) {

--- a/table/path.go
+++ b/table/path.go
@@ -92,6 +92,28 @@ type Path struct {
 	IsNexthopInvalid bool
 }
 
+// reset is just like Clone except it reuses the same backing slices and map for
+// use in places where a copy isn't needed, but rather a derivative that leaves
+// the original discarded.
+func (path *Path) reset(isWithdraw bool) {
+	vrfIds := path.VrfIds[0:0]
+	pathAttrs := path.pathAttrs[0:0]
+	filtered := path.filtered
+	if filtered != nil {
+		for k := range filtered {
+			delete(filtered, k)
+		}
+	}
+	*path = Path{
+		parent:           path,
+		IsWithdraw:       isWithdraw,
+		IsNexthopInvalid: path.IsNexthopInvalid,
+		pathAttrs:        pathAttrs,
+		VrfIds:           vrfIds,
+		filtered:         filtered,
+	}
+}
+
 func NewPath(source *PeerInfo, nlri bgp.AddrPrefixInterface, isWithdraw bool, pattrs []bgp.PathAttributeInterface, timestamp time.Time, noImplicitWithdraw bool) *Path {
 	if !isWithdraw && pattrs == nil {
 		log.WithFields(log.Fields{

--- a/table/path.go
+++ b/table/path.go
@@ -92,28 +92,6 @@ type Path struct {
 	IsNexthopInvalid bool
 }
 
-// reset is just like Clone except it reuses the same backing slices and map for
-// use in places where a copy isn't needed, but rather a derivative that leaves
-// the original discarded.
-func (path *Path) reset(isWithdraw bool) {
-	vrfIds := path.VrfIds[0:0]
-	pathAttrs := path.pathAttrs[0:0]
-	filtered := path.filtered
-	if filtered != nil {
-		for k := range filtered {
-			delete(filtered, k)
-		}
-	}
-	*path = Path{
-		parent:           path,
-		IsWithdraw:       isWithdraw,
-		IsNexthopInvalid: path.IsNexthopInvalid,
-		pathAttrs:        pathAttrs,
-		VrfIds:           vrfIds,
-		filtered:         filtered,
-	}
-}
-
 func NewPath(source *PeerInfo, nlri bgp.AddrPrefixInterface, isWithdraw bool, pattrs []bgp.PathAttributeInterface, timestamp time.Time, noImplicitWithdraw bool) *Path {
 	if !isWithdraw && pattrs == nil {
 		log.WithFields(log.Fields{


### PR DESCRIPTION
This round of changes is slightly more aggressive than the last but
provides a flat reduction in allocations for the Select paths by an
additional factor of 5.

In table/path.go we provide a new reset method akin to clone, see
inline comments.
In table/destination.go we recalculate the RadixKey we can now derive
our new route destinations with the prior changeset in place to prevent
from the previous, skipping this expensive step. We then reuse the
existing paths at line 1012 that have already been created calling the
newly added reset() method mentioned above. **note:** it's unclear
if applying a empty filter is actually necessary, because it returns the
zero value in all the cases I saw resulting in the same behavior. If this
skip can be skipped it should, since it surprisingly accounts for around
25-35% of the cpu time.

This brings us to 2x allocs per row, which is fair. Anything beyond this will come down to rules around ownership of memory, we could reduce this to 1x allocation in some cases but would forbid callers from mutating the results. It could be technically be reduced to 0 allocations if a separate path was provided specifically for serving requests but I think from 220k to 8k is a good start :- )


```Go
BenchmarkBasic/IPv4-8         	     300	   3923225 ns/op	  959523 B/op	    8249 allocs/op
BenchmarkBasic/IPv6-8         	     500	   3697597 ns/op	  959641 B/op	    8250 allocs/op
PASS
```