### PR TITLE
bmp: Implement Information TLV on Initiation and Termination messages

### DIFF
--- a/packet/bmp/bmp.go
+++ b/packet/bmp/bmp.go
@@ -338,18 +338,15 @@ func (body *BMPStatisticsReport) ParseBody(msg *BMPMessage, data []byte) error {
 			return fmt.Errorf("value lengh is not enough: %d bytes (%d bytes expected)", len(data), tl.Length)
 		}
 		var s BMPStatsTLVInterface
-		var err error = nil
-		if tl.Type == BMP_STAT_TYPE_ADJ_RIB_IN || tl.Type == BMP_STAT_TYPE_LOC_RIB {
+		switch tl.Type {
+		case BMP_STAT_TYPE_ADJ_RIB_IN, BMP_STAT_TYPE_LOC_RIB:
 			s = &BMPStatsTLV64{BMPStatsTLV: tl}
-			err = s.ParseValue(data)
-		} else if tl.Type == BMP_STAT_TYPE_PER_AFI_SAFI_ADJ_RIB_IN || tl.Type == BMP_STAT_TYPE_PER_AFI_SAFI_LOC_RIB {
+		case BMP_STAT_TYPE_PER_AFI_SAFI_ADJ_RIB_IN, BMP_STAT_TYPE_PER_AFI_SAFI_LOC_RIB:
 			s = &BMPStatsTLVPerAfiSafi64{BMPStatsTLV: tl}
-			err = s.ParseValue(data)
-		} else {
+		default:
 			s = &BMPStatsTLV32{BMPStatsTLV: tl}
-			err = s.ParseValue(data)
 		}
-		if err != nil {
+		if err := s.ParseValue(data); err != nil {
 			return err
 		}
 		body.Stats = append(body.Stats, s)

--- a/packet/bmp/bmp_test.go
+++ b/packet/bmp/bmp_test.go
@@ -41,8 +41,10 @@ func verify(t *testing.T, m1 *BMPMessage) {
 
 func Test_Initiation(t *testing.T) {
 	verify(t, NewBMPInitiation(nil))
-	tlv := NewBMPTLV(1, []byte{0x3, 0xb, 0x0, 0x0, 0x0, 0xf, 0x42, 0x40})
-	m := NewBMPInitiation([]BMPTLV{*tlv})
+	m := NewBMPInitiation([]BMPInfoTLVInterface{
+		NewBMPInfoTLVString(BMP_INIT_TLV_TYPE_STRING, "free-form UTF-8 string"),
+		NewBMPInfoTLVUnknown(0xff, []byte{0x01, 0x02, 0x03, 0x04}),
+	})
 	verify(t, m)
 }
 

--- a/packet/bmp/bmp_test.go
+++ b/packet/bmp/bmp_test.go
@@ -48,6 +48,16 @@ func Test_Initiation(t *testing.T) {
 	verify(t, m)
 }
 
+func Test_Termination(t *testing.T) {
+	verify(t, NewBMPTermination(nil))
+	m := NewBMPTermination([]BMPTermTLVInterface{
+		NewBMPTermTLVString(BMP_TERM_TLV_TYPE_STRING, "free-form UTF-8 string"),
+		NewBMPTermTLV16(BMP_TERM_TLV_TYPE_REASON, BMP_TERM_REASON_ADMIN),
+		NewBMPTermTLVUnknown(0xff, []byte{0x01, 0x02, 0x03, 0x04}),
+	})
+	verify(t, m)
+}
+
 func Test_PeerUpNotification(t *testing.T) {
 	m := bgp.NewTestBGPOpenMessage()
 	p0 := NewBMPPeerHeader(0, 0, 1000, "10.0.0.1", 70000, "10.0.0.2", 1)

--- a/server/bmp.go
+++ b/server/bmp.go
@@ -148,7 +148,7 @@ func (b *bmpClient) loop() {
 				return err
 			}
 
-			if err := write(bmp.NewBMPInitiation([]bmp.BMPTLV{})); err != nil {
+			if err := write(bmp.NewBMPInitiation([]bmp.BMPInfoTLVInterface{})); err != nil {
 				return false
 			}
 

--- a/server/bmp.go
+++ b/server/bmp.go
@@ -221,6 +221,12 @@ func (b *bmpClient) loop() {
 						}
 					}
 				case <-b.dead:
+					term := bmp.NewBMPTermination([]bmp.BMPTermTLVInterface{
+						bmp.NewBMPTermTLV16(bmp.BMP_TERM_TLV_TYPE_REASON, bmp.BMP_TERM_REASON_PERMANENTLY_ADMIN),
+					})
+					if err := write(term); err != nil {
+						return false
+					}
 					conn.Close()
 					return true
 				}


### PR DESCRIPTION
Currently, the Information TLV fields are implemented as BMPTLV, but not enough decoded and required to be constructed in binary format.

This PR introduces BMPInfoTLV/BMPTermTLV and makes easy to handle these TLV fields.