### PR TITLE
table: avoid unnecessary memory allocation about generating radix key

### DIFF
--- a/table/destination.go
+++ b/table/destination.go
@@ -53,7 +53,7 @@ const (
 func IpToRadixkey(b []byte, max uint8) string {
 	var buffer bytes.Buffer
 	for i := 0; i < len(b) && i < int(max); i++ {
-		buffer.WriteString(fmt.Sprintf("%08b", b[i]))
+		fmt.Fprintf(&buffer, "%08b", b[i])
 	}
 	return buffer.String()[:max]
 }


### PR DESCRIPTION
Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>