### PR TITLE
bmp: Support number of withdraw updates and prefixes

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -2168,6 +2168,10 @@ type Received struct {
 	Keepalive uint64 `mapstructure:"keepalive" json:"keepalive,omitempty"`
 	// original -> gobgp:DYNAMIC-CAP
 	DynamicCap uint64 `mapstructure:"dynamic-cap" json:"dynamic-cap,omitempty"`
+	// original -> gobgp:WITHDRAW-UPDATE
+	WithdrawUpdate uint32 `mapstructure:"withdraw-update" json:"withdraw-update,omitempty"`
+	// original -> gobgp:WITHDRAW-PREFIX
+	WithdrawPrefix uint32 `mapstructure:"withdraw-prefix" json:"withdraw-prefix,omitempty"`
 	// original -> gobgp:DISCARDED
 	Discarded uint64 `mapstructure:"discarded" json:"discarded,omitempty"`
 	// original -> gobgp:TOTAL
@@ -2196,6 +2200,12 @@ func (lhs *Received) Equal(rhs *Received) bool {
 	if lhs.DynamicCap != rhs.DynamicCap {
 		return false
 	}
+	if lhs.WithdrawUpdate != rhs.WithdrawUpdate {
+		return false
+	}
+	if lhs.WithdrawPrefix != rhs.WithdrawPrefix {
+		return false
+	}
 	if lhs.Discarded != rhs.Discarded {
 		return false
 	}
@@ -2219,6 +2229,10 @@ type Sent struct {
 	Keepalive uint64 `mapstructure:"keepalive" json:"keepalive,omitempty"`
 	// original -> gobgp:DYNAMIC-CAP
 	DynamicCap uint64 `mapstructure:"dynamic-cap" json:"dynamic-cap,omitempty"`
+	// original -> gobgp:WITHDRAW-UPDATE
+	WithdrawUpdate uint32 `mapstructure:"withdraw-update" json:"withdraw-update,omitempty"`
+	// original -> gobgp:WITHDRAW-PREFIX
+	WithdrawPrefix uint32 `mapstructure:"withdraw-prefix" json:"withdraw-prefix,omitempty"`
 	// original -> gobgp:DISCARDED
 	Discarded uint64 `mapstructure:"discarded" json:"discarded,omitempty"`
 	// original -> gobgp:TOTAL
@@ -2245,6 +2259,12 @@ func (lhs *Sent) Equal(rhs *Sent) bool {
 		return false
 	}
 	if lhs.DynamicCap != rhs.DynamicCap {
+		return false
+	}
+	if lhs.WithdrawUpdate != rhs.WithdrawUpdate {
+		return false
+	}
+	if lhs.WithdrawPrefix != rhs.WithdrawPrefix {
 		return false
 	}
 	if lhs.Discarded != rhs.Discarded {

--- a/server/bmp.go
+++ b/server/bmp.go
@@ -295,6 +295,8 @@ func bmpPeerStats(peerType uint8, peerDist uint64, timestamp int64, neighConf *c
 		[]bmp.BMPStatsTLVInterface{
 			bmp.NewBMPStatsTLV64(bmp.BMP_STAT_TYPE_ADJ_RIB_IN, uint64(neighConf.State.AdjTable.Accepted)),
 			bmp.NewBMPStatsTLV64(bmp.BMP_STAT_TYPE_LOC_RIB, uint64(neighConf.State.AdjTable.Advertised+neighConf.State.AdjTable.Filtered)),
+			bmp.NewBMPStatsTLV32(bmp.BMP_STAT_TYPE_WITHDRAW_UPDATE, neighConf.State.Messages.Received.WithdrawUpdate),
+			bmp.NewBMPStatsTLV32(bmp.BMP_STAT_TYPE_WITHDRAW_PREFIX, neighConf.State.Messages.Received.WithdrawPrefix),
 		},
 	)
 }

--- a/server/fsm.go
+++ b/server/fsm.go
@@ -20,6 +20,7 @@ import (
 	"github.com/eapache/channels"
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
+	"github.com/osrg/gobgp/packet/bmp"
 	"github.com/osrg/gobgp/table"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/tomb.v2"
@@ -179,6 +180,18 @@ func (fsm *FSM) bgpMessageStateUpdate(MessageType uint8, isIn bool) {
 		} else {
 			state.Sent.Discarded++
 		}
+	}
+}
+
+func (fsm *FSM) bmpStatsUpdate(statType uint16, increment int) {
+	stats := &fsm.pConf.State.Messages.Received
+	switch statType {
+	// TODO
+	// Support other stat types.
+	case bmp.BMP_STAT_TYPE_WITHDRAW_UPDATE:
+		stats.WithdrawUpdate += uint32(increment)
+	case bmp.BMP_STAT_TYPE_WITHDRAW_PREFIX:
+		stats.WithdrawPrefix += uint32(increment)
 	}
 }
 
@@ -710,6 +723,17 @@ func (h *FSMHandler) recvMessageWithError() (*FsmMsg, error) {
 					}).Warn("malformed BGP update message")
 					fmsg.MsgData = err
 					return fmsg, err
+				}
+
+				if routes := len(body.WithdrawnRoutes); routes > 0 {
+					h.fsm.bmpStatsUpdate(bmp.BMP_STAT_TYPE_WITHDRAW_UPDATE, 1)
+					h.fsm.bmpStatsUpdate(bmp.BMP_STAT_TYPE_WITHDRAW_PREFIX, routes)
+				} else if attr := getPathAttrFromBGPUpdate(body, bgp.BGP_ATTR_TYPE_MP_UNREACH_NLRI); attr != nil {
+					mpUnreach := attr.(*bgp.PathAttributeMpUnreachNLRI)
+					if routes = len(mpUnreach.Value); routes > 0 {
+						h.fsm.bmpStatsUpdate(bmp.BMP_STAT_TYPE_WITHDRAW_UPDATE, 1)
+						h.fsm.bmpStatsUpdate(bmp.BMP_STAT_TYPE_WITHDRAW_PREFIX, routes)
+					}
 				}
 
 				table.UpdatePathAttrs4ByteAs(body)

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -180,6 +180,18 @@ module gobgp {
         error condition has occurred exchanged.";
     }
 
+    leaf WITHDRAW-UPDATE {
+      type uint32;
+      description
+        "Number of updates subjected to treat-as-withdraw treatment.";
+    }
+
+    leaf WITHDRAW-PREFIX {
+      type uint32;
+      description
+        "Number of prefixes subjected to treat-as-withdraw treatment.";
+    }
+
     leaf DISCARDED {
       type uint64;
       description
@@ -194,7 +206,6 @@ module gobgp {
         error condition has occurred exchanged.";
     }
   }
-
 
   grouping gobgp-adjacent-table {
     container adj-table {


### PR DESCRIPTION
This PR enables to send BMP statistics reports for the following types;
- Stat Type = 11: (32-bit Counter) Number of updates subjected to treat-as-withdraw treatment.
- Stat Type = 12: (32-bit Counter) Number of prefixes subjected to treat-as-withdraw treatment.

Note: Currently, this implementation considers only updates or prefixes received from neighbors, but not enough to follow the handling process described in RFC7606.