### PR TITLE
Fix RouteDistinguisher parsing and VPNV6 VRF rib parsing

### DIFF
--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -1271,7 +1271,7 @@ func ParseRouteDistinguisher(rd string) (RouteDistinguisherInterface, error) {
 	if err != nil {
 		return nil, err
 	}
-	assigned, _ := strconv.Atoi(elems[9])
+	assigned, _ := strconv.Atoi(elems[10])
 	ip := net.ParseIP(elems[1])
 	switch {
 	case ip.To4() != nil:

--- a/packet/bgp/bgp_test.go
+++ b/packet/bgp/bgp_test.go
@@ -840,6 +840,6 @@ func Test_ParseRouteDistingusher(t *testing.T) {
 		t.Fatal("Type of RD interface is not RouteDistinguisherFourOctetAS")
 	}
 
-	assert.Equal(uint32((100 << 16) | 1000), rdType2.Admin)
+	assert.Equal(uint32((100<<16)|1000), rdType2.Admin)
 	assert.Equal(uint16(10000), rdType2.Assigned)
 }

--- a/packet/bgp/bgp_test.go
+++ b/packet/bgp/bgp_test.go
@@ -812,3 +812,34 @@ func Test_MpReachNLRIWithIPv4PrefixWithIPv6Nexthop(t *testing.T) {
 	// Test serialised value
 	assert.Equal(bufin, bufout)
 }
+
+func Test_ParseRouteDistingusher(t *testing.T) {
+	assert := assert.New(t)
+
+	rd, _ := ParseRouteDistinguisher("100:1000")
+	rdType0, ok := rd.(*RouteDistinguisherTwoOctetAS)
+	if !ok {
+		t.Fatal("Type of RD interface is not RouteDistinguisherTwoOctetAS")
+	}
+
+	assert.Equal(uint16(100), rdType0.Admin)
+	assert.Equal(uint32(1000), rdType0.Assigned)
+
+	rd, _ = ParseRouteDistinguisher("10.0.0.0:100")
+	rdType1, ok := rd.(*RouteDistinguisherIPAddressAS)
+	if !ok {
+		t.Fatal("Type of RD interface is not RouteDistinguisherIPAddressAS")
+	}
+
+	assert.Equal("10.0.0.0", rdType1.Admin.String())
+	assert.Equal(uint16(100), rdType1.Assigned)
+
+	rd, _ = ParseRouteDistinguisher("100.1000:10000")
+	rdType2, ok := rd.(*RouteDistinguisherFourOctetAS)
+	if !ok {
+		t.Fatal("Type of RD interface is not RouteDistinguisherFourOctetAS")
+	}
+
+	assert.Equal(uint32((100 << 16) | 1000), rdType2.Admin)
+	assert.Equal(uint16(10000), rdType2.Assigned)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1123,6 +1123,9 @@ func (server *BgpServer) fixupApiPath(vrfId string, pathList []*table.Path) erro
 
 		if vrfId != "" {
 			vrf := server.globalRib.Vrfs[vrfId]
+			if vrf == nil {
+				return fmt.Errorf("vrf %s not found", vrfId)
+			}
 			if err := vrf.ToGlobalPath(path); err != nil {
 				return err
 			}

--- a/table/path.go
+++ b/table/path.go
@@ -1,4 +1,3 @@
-
 // Copyright (C) 2014 Nippon Telegraph and Telephone Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/table/path.go
+++ b/table/path.go
@@ -1,3 +1,4 @@
+
 // Copyright (C) 2014 Nippon Telegraph and Telephone Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -1105,12 +1106,13 @@ func (p *Path) ToLocal() *Path {
 		n := nlri.(*bgp.LabeledVPNIPv6AddrPrefix)
 		_, c, _ := net.ParseCIDR(n.IPPrefix())
 		ones, _ := c.Mask.Size()
-		nlri = bgp.NewIPAddrPrefix(uint8(ones), c.IP.String())
+		nlri = bgp.NewIPv6AddrPrefix(uint8(ones), c.IP.String())
 	default:
 		return p
 	}
 	path := NewPath(p.OriginInfo().source, nlri, p.IsWithdraw, p.GetPathAttrs(), p.OriginInfo().timestamp, false)
 	path.delPathAttr(bgp.BGP_ATTR_TYPE_EXTENDED_COMMUNITIES)
+
 	if f == bgp.RF_IPv4_VPN {
 		nh := path.GetNexthop()
 		path.delPathAttr(bgp.BGP_ATTR_TYPE_MP_REACH_NLRI)


### PR DESCRIPTION
RouteDistinguisher Parsing is off by 1 when examining the regular expression.

VPNV6 Path parsing is assigning to a v4 rather than a v6 structure.