### PR TITLE
bmp: Enable to send BMP Route Mirroring messages

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -1171,6 +1171,9 @@ type BmpServerConfig struct {
 	RouteMonitoringPolicy BmpRouteMonitoringPolicyType `mapstructure:"route-monitoring-policy" json:"route-monitoring-policy,omitempty"`
 	// original -> gobgp:statistics-timeout
 	StatisticsTimeout uint16 `mapstructure:"statistics-timeout" json:"statistics-timeout,omitempty"`
+	// original -> gobgp:route-mirroring-enabled
+	//gobgp:route-mirroring-enabled's original type is boolean
+	RouteMirroringEnabled bool `mapstructure:"route-mirroring-enabled" json:"route-mirroring-enabled,omitempty"`
 }
 
 func (lhs *BmpServerConfig) Equal(rhs *BmpServerConfig) bool {
@@ -1187,6 +1190,9 @@ func (lhs *BmpServerConfig) Equal(rhs *BmpServerConfig) bool {
 		return false
 	}
 	if lhs.StatisticsTimeout != rhs.StatisticsTimeout {
+		return false
+	}
+	if lhs.RouteMirroringEnabled != rhs.RouteMirroringEnabled {
 		return false
 	}
 	return true

--- a/docs/sources/bmp.md
+++ b/docs/sources/bmp.md
@@ -64,6 +64,17 @@ Please note the range of this interval is 15 though 65535 seconds.
     statistics-timeout = 3600
 ```
 
+To enable route mirroring feature, specify `true` for `route-mirroring-enabled` option.
+Please note this option is mainly for debugging purpose.
+
+```toml
+[[bmp-servers]]
+  [bmp-servers.config]
+    address = "127.0.0.1"
+    port=11019
+    route-mirroring-enabled = true
+```
+
 ## <a name="verify"> Verification
 
 Let's check if BMP works with a bmp server. GoBGP also supports BMP server (currently, just shows received BMP messages in the json format).

--- a/packet/bmp/bmp_test.go
+++ b/packet/bmp/bmp_test.go
@@ -92,6 +92,20 @@ func Test_StatisticsReport(t *testing.T) {
 	verify(t, s0)
 }
 
+func Test_RouteMirroring(t *testing.T) {
+	p0 := NewBMPPeerHeader(0, 0, 1000, "10.0.0.1", 70000, "10.0.0.2", 1)
+	s0 := NewBMPRouteMirroring(
+		*p0,
+		[]BMPRouteMirrTLVInterface{
+			NewBMPRouteMirrTLV16(BMP_ROUTE_MIRRORING_TLV_TYPE_INFO, BMP_ROUTE_MIRRORING_INFO_MSG_LOST),
+			NewBMPRouteMirrTLVUnknown(0xff, []byte{0x01, 0x02, 0x03, 0x04}),
+			// RFC7854: BGP Message TLV MUST occur last in the list of TLVs
+			NewBMPRouteMirrTLVBGPMsg(BMP_ROUTE_MIRRORING_TLV_TYPE_BGP_MSG, bgp.NewTestBGPOpenMessage()),
+		},
+	)
+	verify(t, s0)
+}
+
 func Test_BogusHeader(t *testing.T) {
 	h, err := ParseBMPMessage(make([]byte, 10))
 	assert.Nil(t, h)

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -548,19 +548,29 @@ module gobgp {
         "Reference to the address of the BMP server used as
          a key in the BMP server list";
     }
+
     leaf port {
       type uint32;
       description
         "Reference to the port of the BMP server";
     }
+
     leaf route-monitoring-policy {
       type bmp-route-monitoring-policy-type;
       default PRE-POLICY;
     }
+
     leaf statistics-timeout {
       type uint16;
       description
         "Interval seconds of statistics messages sent to BMP server";
+    }
+
+    leaf route-mirroring-enabled {
+      type boolean;
+      description
+        "Enable feature for mirroring of received BGP messages
+         mainly for debugging purpose";
     }
   }
 


### PR DESCRIPTION
This PR enables to sent BMP Route Mirroring messages which described in [RFC7854](https://tools.ietf.org/html/rfc7854).
With these commits, it is possible to monitor all received UPDATE messages before the BGP state comparison.

Note: Currently, this feature notifies UPDATE message only, please refer to the note of the first commit `server: Implement event for BGP message watcher` for this constraint.