### PR TITLE
config: Initialize Graceful Restart State

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -190,6 +190,7 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn ui
 			if !vv.IsSet("afi-safi.config") {
 				af.Config.Enabled = true
 			}
+			af.MpGracefulRestart.State.Enabled = af.MpGracefulRestart.Config.Enabled
 			n.AfiSafis[i] = af
 		}
 	}


### PR DESCRIPTION
Currently, the restarting speaker ends restarting procedure
before receiving End-of-Rib markers from all helper speakers.
It is because `MpGracefulRestart.State.Enabled` is not initialized,
always evalueted to false, so the restarting speaker misunderstands
as there is no helper speaker.

This patch adds code to initialize `MpGracefulRestart.State.Enabled`.
This fixes #1296.

Signed-off-by: Satoshi Fujimoto <satoshi.fujimoto7@gmail.com>