### PR TITLE
packet/mrt: BGP with Geo-Location Extensions (RFC6397)

### DIFF
--- a/gobgp/cmd/mrt.go
+++ b/gobgp/cmd/mrt.go
@@ -80,6 +80,8 @@ func injectMrt(filename string, count int, skip int, onlyBest bool) error {
 					peers = msg.Body.(*mrt.PeerIndexTable).Peers
 					continue
 				case mrt.RIB_IPV4_UNICAST, mrt.RIB_IPV6_UNICAST:
+				case mrt.GEO_PEER_TABLE:
+					fmt.Printf("WARNING: Skipping GEO_PEER_TABLE: %s", msg.Body.(*mrt.GeoPeerTable))
 				default:
 					exitWithError(fmt.Errorf("unsupported subType: %v", subType))
 				}

--- a/packet/mrt/mrt_test.go
+++ b/packet/mrt/mrt_test.go
@@ -227,6 +227,22 @@ func TestMrtRibWithAddPath(t *testing.T) {
 	assert.Equal(t, reflect.DeepEqual(r1, r2), true)
 }
 
+func TestMrtGeoPeerTable(t *testing.T) {
+	p1 := NewGeoPeer("192.168.0.1", 28.031157, 86.899684)
+	p2 := NewGeoPeer("192.168.0.1", 35.360556, 138.727778)
+	pt1 := NewGeoPeerTable("192.168.0.1", 12.345678, 98.765432, []*GeoPeer{p1, p2})
+	b1, err := pt1.Serialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pt2 := &GeoPeerTable{}
+	err = pt2.DecodeFromBytes(b1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, reflect.DeepEqual(pt1, pt2), true)
+}
+
 func TestMrtBgp4mpStateChange(t *testing.T) {
 	c1 := NewBGP4MPStateChange(65000, 65001, 1, "192.168.0.1", "192.168.0.2", false, ACTIVE, ESTABLISHED)
 	b1, err := c1.Serialize()


### PR DESCRIPTION
This patch enables to decode/encode MRT format with BGP routing information including the geographical location which described in RFC6397.

Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>