### PR TITLE
server: Implement TTL security

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -2073,6 +2073,8 @@ type TransportConfig struct {
 	// original -> gobgp:remote-port
 	//gobgp:remote-port's original type is inet:port-number
 	RemotePort uint16 `mapstructure:"remote-port" json:"remote-port,omitempty"`
+	// original -> gobgp:ttl
+	Ttl uint8 `mapstructure:"ttl" json:"ttl,omitempty"`
 }
 
 func (lhs *TransportConfig) Equal(rhs *TransportConfig) bool {
@@ -2092,6 +2094,9 @@ func (lhs *TransportConfig) Equal(rhs *TransportConfig) bool {
 		return false
 	}
 	if lhs.RemotePort != rhs.RemotePort {
+		return false
+	}
+	if lhs.Ttl != rhs.Ttl {
 		return false
 	}
 	return true

--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -1565,6 +1565,8 @@ type PeerGroup struct {
 	UseMultiplePaths UseMultiplePaths `mapstructure:"use-multiple-paths" json:"use-multiple-paths,omitempty"`
 	// original -> gobgp:route-server
 	RouteServer RouteServer `mapstructure:"route-server" json:"route-server,omitempty"`
+	// original -> gobgp:ttl-security
+	TtlSecurity TtlSecurity `mapstructure:"ttl-security" json:"ttl-security,omitempty"`
 }
 
 func (lhs *PeerGroup) Equal(rhs *PeerGroup) bool {
@@ -1624,6 +1626,58 @@ func (lhs *PeerGroup) Equal(rhs *PeerGroup) bool {
 		return false
 	}
 	if !lhs.RouteServer.Equal(&(rhs.RouteServer)) {
+		return false
+	}
+	if !lhs.TtlSecurity.Equal(&(rhs.TtlSecurity)) {
+		return false
+	}
+	return true
+}
+
+//struct for container gobgp:state
+type TtlSecurityState struct {
+	// original -> gobgp:enabled
+	//gobgp:enabled's original type is boolean
+	Enabled bool `mapstructure:"enabled" json:"enabled,omitempty"`
+	// original -> gobgp:ttl-min
+	TtlMin uint8 `mapstructure:"ttl-min" json:"ttl-min,omitempty"`
+}
+
+//struct for container gobgp:config
+type TtlSecurityConfig struct {
+	// original -> gobgp:enabled
+	//gobgp:enabled's original type is boolean
+	Enabled bool `mapstructure:"enabled" json:"enabled,omitempty"`
+	// original -> gobgp:ttl-min
+	TtlMin uint8 `mapstructure:"ttl-min" json:"ttl-min,omitempty"`
+}
+
+func (lhs *TtlSecurityConfig) Equal(rhs *TtlSecurityConfig) bool {
+	if lhs == nil || rhs == nil {
+		return false
+	}
+	if lhs.Enabled != rhs.Enabled {
+		return false
+	}
+	if lhs.TtlMin != rhs.TtlMin {
+		return false
+	}
+	return true
+}
+
+//struct for container gobgp:ttl-security
+type TtlSecurity struct {
+	// original -> gobgp:ttl-security-config
+	Config TtlSecurityConfig `mapstructure:"config" json:"config,omitempty"`
+	// original -> gobgp:ttl-security-state
+	State TtlSecurityState `mapstructure:"state" json:"state,omitempty"`
+}
+
+func (lhs *TtlSecurity) Equal(rhs *TtlSecurity) bool {
+	if lhs == nil || rhs == nil {
+		return false
+	}
+	if !lhs.Config.Equal(&(rhs.Config)) {
 		return false
 	}
 	return true
@@ -2521,6 +2575,8 @@ type Neighbor struct {
 	UseMultiplePaths UseMultiplePaths `mapstructure:"use-multiple-paths" json:"use-multiple-paths,omitempty"`
 	// original -> gobgp:route-server
 	RouteServer RouteServer `mapstructure:"route-server" json:"route-server,omitempty"`
+	// original -> gobgp:ttl-security
+	TtlSecurity TtlSecurity `mapstructure:"ttl-security" json:"ttl-security,omitempty"`
 }
 
 func (lhs *Neighbor) Equal(rhs *Neighbor) bool {
@@ -2580,6 +2636,9 @@ func (lhs *Neighbor) Equal(rhs *Neighbor) bool {
 		return false
 	}
 	if !lhs.RouteServer.Equal(&(rhs.RouteServer)) {
+		return false
+	}
+	if !lhs.TtlSecurity.Equal(&(rhs.TtlSecurity)) {
 		return false
 	}
 	return true

--- a/config/default.go
+++ b/config/default.go
@@ -232,6 +232,11 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn ui
 			n.GracefulRestart.Config.DeferralTime = uint16(360)
 		}
 	}
+
+	if n.EbgpMultihop.Config.Enabled && n.TtlSecurity.Config.Enabled {
+		return fmt.Errorf("ebgp-multihop and ttl-security are mututally exclusive")
+	}
+
 	return nil
 }
 
@@ -424,6 +429,7 @@ func OverwriteNeighborConfigWithPeerGroup(c *Neighbor, pg *PeerGroup) error {
 	overwriteConfig(&c.ApplyPolicy.Config, &pg.ApplyPolicy.Config, "neighbor.apply-policy.config", v)
 	overwriteConfig(&c.UseMultiplePaths.Config, &pg.UseMultiplePaths.Config, "neighbor.use-multiple-paths.config", v)
 	overwriteConfig(&c.RouteServer.Config, &pg.RouteServer.Config, "neighbor.route-server.config", v)
+	overwriteConfig(&c.TtlSecurity.Config, &pg.TtlSecurity.Config, "neighbor.ttl-security.config", v)
 
 	if !v.IsSet("neighbor.afi-safis") {
 		c.AfiSafis = pg.AfiSafis

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -131,6 +131,12 @@
         default-in-policy = "reject-route"
     [neighbors.route-server.config]
         route-server-client = true
+    # To enable TTL Security, uncomment the following.
+    # Please note that this feature is mututally exclusive with
+    # "neighbors.ebgp-multihop.config".
+    #[neighbors.ttl-security.config]
+    #    enabled = true
+    #    ttl-min = 255  # 255 means directly connected
 
 [[peer-groups]]
   [peer-groups.config]

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -65,6 +65,7 @@
         passive-mode = true
         local-address = "192.168.10.1"
         remote-port = 2016
+        ttl = 64  # default value on Linux
     [neighbors.ebgp-multihop.config]
         enabled = true
         multihop-ttl = 100

--- a/server/fsm.go
+++ b/server/fsm.go
@@ -493,10 +493,15 @@ func (h *FSMHandler) active() (bgp.FSMState, FsmStateReason) {
 				ttl = 255
 				ttlMin = int(fsm.pConf.TtlSecurity.Config.TtlMin)
 			} else if fsm.pConf.Config.PeerAs != 0 && fsm.pConf.Config.PeerType == config.PEER_TYPE_EXTERNAL {
-				ttl = 1
 				if fsm.pConf.EbgpMultihop.Config.Enabled {
 					ttl = int(fsm.pConf.EbgpMultihop.Config.MultihopTtl)
+				} else if fsm.pConf.Transport.Config.Ttl != 0 {
+					ttl = int(fsm.pConf.Transport.Config.Ttl)
+				} else {
+					ttl = 1
 				}
+			} else if fsm.pConf.Transport.Config.Ttl != 0 {
+				ttl = int(fsm.pConf.Transport.Config.Ttl)
 			}
 			if ttl != 0 {
 				if err := SetTcpTTLSockopts(conn.(*net.TCPConn), ttl); err != nil {

--- a/server/sockopt.go
+++ b/server/sockopt.go
@@ -29,6 +29,10 @@ func SetTcpTTLSockopts(conn *net.TCPConn, ttl int) error {
 	return fmt.Errorf("setting ttl is not supported")
 }
 
+func SetTcpMinTTLSockopts(conn *net.TCPConn, ttl int) error {
+	return fmt.Errorf("setting min ttl is not supported")
+}
+
 func DialTCPTimeoutWithMD5Sig(host string, port int, localAddr, key string, msec int) (*net.TCPConn, error) {
 	return nil, fmt.Errorf("md5 active connection unsupported")
 }

--- a/server/sockopt_linux.go
+++ b/server/sockopt_linux.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	TCP_MD5SIG = 14
+	TCP_MD5SIG       = 14 // TCP MD5 Signature (RFC2385)
+	IPV6_MINHOPCOUNT = 73 // Generalized TTL Security Mechanism (RFC5082)
 )
 
 type tcpmd5sig struct {
@@ -74,13 +75,7 @@ func SetTcpMD5SigSockopts(l *net.TCPListener, address string, key string) error 
 	return nil
 }
 
-func SetTcpTTLSockopts(conn *net.TCPConn, ttl int) error {
-	level := syscall.IPPROTO_IP
-	name := syscall.IP_TTL
-	if strings.Contains(conn.RemoteAddr().String(), "[") {
-		level = syscall.IPPROTO_IPV6
-		name = syscall.IPV6_UNICAST_HOPS
-	}
+func setTcpSockoptInt(conn *net.TCPConn, level int, name int, value int) error {
 	fi, err := conn.File()
 	defer fi.Close()
 	if err != nil {
@@ -89,7 +84,27 @@ func SetTcpTTLSockopts(conn *net.TCPConn, ttl int) error {
 	if conn, err := net.FileConn(fi); err == nil {
 		defer conn.Close()
 	}
-	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(int(fi.Fd()), level, name, ttl))
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(int(fi.Fd()), level, name, value))
+}
+
+func SetTcpTTLSockopts(conn *net.TCPConn, ttl int) error {
+	level := syscall.IPPROTO_IP
+	name := syscall.IP_TTL
+	if strings.Contains(conn.RemoteAddr().String(), "[") {
+		level = syscall.IPPROTO_IPV6
+		name = syscall.IPV6_UNICAST_HOPS
+	}
+	return setTcpSockoptInt(conn, level, name, ttl)
+}
+
+func SetTcpMinTTLSockopts(conn *net.TCPConn, ttl int) error {
+	level := syscall.IPPROTO_IP
+	name := syscall.IP_MINTTL
+	if strings.Contains(conn.RemoteAddr().String(), "[") {
+		level = syscall.IPPROTO_IPV6
+		name = IPV6_MINHOPCOUNT
+	}
+	return setTcpSockoptInt(conn, level, name, ttl)
 }
 
 func DialTCPTimeoutWithMD5Sig(host string, port int, localAddr, key string, msec int) (*net.TCPConn, error) {

--- a/server/sockopt_openbsd.go
+++ b/server/sockopt_openbsd.go
@@ -348,7 +348,8 @@ func saDelete(address string) error {
 }
 
 const (
-	TCP_MD5SIG = 0x4
+	TCP_MD5SIG       = 0x4 // TCP MD5 Signature (RFC2385)
+	IPV6_MINHOPCOUNT = 73  // Generalized TTL Security Mechanism (RFC5082)
 )
 
 func SetTcpMD5SigSockopts(l *net.TCPListener, address string, key string) error {
@@ -373,13 +374,7 @@ func SetTcpMD5SigSockopts(l *net.TCPListener, address string, key string) error 
 	return saDelete(address)
 }
 
-func SetTcpTTLSockopts(conn *net.TCPConn, ttl int) error {
-	level := syscall.IPPROTO_IP
-	name := syscall.IP_TTL
-	if strings.Contains(conn.RemoteAddr().String(), "[") {
-		level = syscall.IPPROTO_IPV6
-		name = syscall.IPV6_UNICAST_HOPS
-	}
+func setTcpSockoptInt(conn *net.TCPConn, level int, name int, value int) error {
 	fi, err := conn.File()
 	defer fi.Close()
 	if err != nil {
@@ -388,7 +383,27 @@ func SetTcpTTLSockopts(conn *net.TCPConn, ttl int) error {
 	if conn, err := net.FileConn(fi); err == nil {
 		defer conn.Close()
 	}
-	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(int(fi.Fd()), level, name, ttl))
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(int(fi.Fd()), level, name, value))
+}
+
+func SetTcpTTLSockopts(conn *net.TCPConn, ttl int) error {
+	level := syscall.IPPROTO_IP
+	name := syscall.IP_TTL
+	if strings.Contains(conn.RemoteAddr().String(), "[") {
+		level = syscall.IPPROTO_IPV6
+		name = syscall.IPV6_UNICAST_HOPS
+	}
+	return setTcpSockoptInt(conn, level, name, ttl)
+}
+
+func SetTcpMinTTLSockopts(conn *net.TCPConn, ttl int) error {
+	level := syscall.IPPROTO_IP
+	name := syscall.IP_MINTTL
+	if strings.Contains(conn.RemoteAddr().String(), "[") {
+		level = syscall.IPPROTO_IPV6
+		name = IPV6_MINHOPCOUNT
+	}
+	return setTcpSockoptInt(conn, level, name, ttl)
 }
 
 func DialTCPTimeoutWithMD5Sig(host string, port int, localAddr, key string, msec int) (*net.TCPConn, error) {

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -807,6 +807,11 @@ module gobgp {
     leaf remote-port {
       type inet:port-number;
     }
+
+    leaf ttl {
+      description "TTL value for BGP packets";
+      type uint8;
+    }
   }
 
   augment "/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:timers/bgp:config" {

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -653,6 +653,47 @@ module gobgp {
       }
   }
 
+  grouping gobgp-ttl-security-config {
+    description
+      "Configuration parameters for TTL Security";
+
+    leaf enabled {
+      type boolean;
+      default "false";
+      description
+        "Enable features for TTL Security";
+    }
+
+    leaf ttl-min {
+      type uint8;
+      description
+        "Reference to the port of the BMP server";
+    }
+  }
+
+  grouping gobgp-ttl-security-config-set {
+    description
+      "set of configurations for Generalized TTL Security Mechanism (GTSM)";
+
+    container ttl-security {
+      description
+        "Configure TTL Security feature";
+
+      container config {
+        description
+          "Configuration parameters for TTL Security";
+        uses gobgp-ttl-security-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State information for TTL Security";
+        uses gobgp-ttl-security-config;
+      }
+    }
+  }
+
   // augment statements
   augment "/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:state/bgp:messages/bgp:sent" {
     description "additional counters";
@@ -824,6 +865,16 @@ module gobgp {
     description "route server configuration for neighbor";
     uses gobgp-route-server-config-set;
   }
+
+  augment "/bgp:bgp/bgp:peer-groups/bgp:peer-group" {
+    description "TTL Security configuration for peer-group";
+    uses gobgp-ttl-security-config-set;
+  }
+
+  augment "/bgp:bgp/bgp:neighbors/bgp:neighbor" {
+    description "TTL Security configuration for neighbor";
+    uses gobgp-ttl-security-config-set;
+   }
 
   augment "/bgp:bgp/bgp:global/bgp:apply-policy/bgp:config" {
     description "addtional policy";


### PR DESCRIPTION
This patch enable to configure Generalized TTL Security Mechanism (GTSM).

TTL security enables to specify the minimum TTL(IPv4)/HOPLIMIT(IPv6) which can be accepted.
For example, "ttl-min = 255" means that only directly connected peer is acceptable.

Note: TTL Security feature is mututally exclusive with "neighbors.ebgp-multihop.config".

fixes https://github.com/osrg/gobgp/issues/1268