### PR TITLE
Support Dynamic Neighbor

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -862,7 +862,6 @@ func (s *Server) DeleteVrf(ctx context.Context, arg *DeleteVrfRequest) (*DeleteV
 func NewNeighborFromAPIStruct(a *Peer) (*config.Neighbor, error) {
 	pconf := &config.Neighbor{}
 	if a.Conf != nil {
-		pconf.Config.NeighborAddress = a.Conf.NeighborAddress
 		pconf.Config.PeerAs = a.Conf.PeerAs
 		pconf.Config.LocalAs = a.Conf.LocalAs
 		pconf.Config.AuthPassword = a.Conf.AuthPassword
@@ -993,6 +992,7 @@ func NewNeighborFromAPIStruct(a *Peer) (*config.Neighbor, error) {
 		pconf.State.AdjTable.Advertised = a.Info.Advertised
 		pconf.State.PeerAs = a.Info.PeerAs
 		pconf.State.PeerType = config.IntToPeerTypeMap[int(a.Info.PeerType)]
+		pconf.State.NeighborAddress = a.Info.NeighborAddress
 
 		if a.Info.Messages != nil {
 			if a.Info.Messages.Sent != nil {

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -197,11 +197,12 @@ func NewPeerFromConfigStruct(pconf *config.Neighbor) *Peer {
 					TOTAL:        s.Messages.Sent.Total,
 				},
 			},
-			Received:   s.AdjTable.Received,
-			Accepted:   s.AdjTable.Accepted,
-			Advertised: s.AdjTable.Advertised,
-			PeerAs:     s.PeerAs,
-			PeerType:   uint32(s.PeerType.ToInt()),
+			Received:        s.AdjTable.Received,
+			Accepted:        s.AdjTable.Accepted,
+			Advertised:      s.AdjTable.Advertised,
+			PeerAs:          s.PeerAs,
+			PeerType:        uint32(s.PeerType.ToInt()),
+			NeighborAddress: pconf.State.NeighborAddress,
 		},
 		Timers: &Timers{
 			Config: &TimersConfig{

--- a/client/client.go
+++ b/client/client.go
@@ -136,14 +136,14 @@ func (cli *Client) getNeighbor(name string, afi int, vrf string, enableAdvertise
 	neighbors := make([]*config.Neighbor, 0, len(ret.Peers))
 
 	for _, p := range ret.Peers {
-		if name != "" && name != p.Conf.NeighborAddress && name != p.Conf.NeighborInterface {
+		if name != "" && name != p.Info.NeighborAddress && name != p.Conf.NeighborInterface {
 			continue
 		}
 		if vrf != "" && name != p.Conf.Vrf {
 			continue
 		}
 		if afi > 0 {
-			v6 := net.ParseIP(p.Conf.NeighborAddress).To4() == nil
+			v6 := net.ParseIP(p.Info.NeighborAddress).To4() == nil
 			if afi == bgp.AFI_IP && v6 || afi == bgp.AFI_IP6 && !v6 {
 				continue
 			}

--- a/config/default.go
+++ b/config/default.go
@@ -131,6 +131,7 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn ui
 	}
 
 	n.State.PeerAs = n.Config.PeerAs
+	n.State.NeighborAddress = n.Config.NeighborAddress
 	n.AsPathOptions.State.AllowOwnAs = n.AsPathOptions.Config.AllowOwnAs
 
 	if !v.IsSet("neighbor.timers.config.connect-retry") && n.Timers.Config.ConnectRetry == 0 {
@@ -154,14 +155,14 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn ui
 		if err != nil {
 			return err
 		}
-		n.Config.NeighborAddress = addr
+		n.State.NeighborAddress = addr
 	}
 
 	if n.Transport.Config.LocalAddress == "" {
-		if n.Config.NeighborAddress == "" {
+		if n.State.NeighborAddress == "" {
 			return fmt.Errorf("no neighbor address/interface specified")
 		}
-		ipAddr, err := net.ResolveIPAddr("ip", n.Config.NeighborAddress)
+		ipAddr, err := net.ResolveIPAddr("ip", n.State.NeighborAddress)
 		if err != nil {
 			return err
 		}
@@ -184,8 +185,8 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn ui
 				defaultAfiSafi(AFI_SAFI_TYPE_IPV4_UNICAST, true),
 				defaultAfiSafi(AFI_SAFI_TYPE_IPV6_UNICAST, true),
 			}
-		} else if ipAddr, err := net.ResolveIPAddr("ip", n.Config.NeighborAddress); err != nil {
-			return fmt.Errorf("invalid neighbor address: %s", n.Config.NeighborAddress)
+		} else if ipAddr, err := net.ResolveIPAddr("ip", n.State.NeighborAddress); err != nil {
+			return fmt.Errorf("invalid neighbor address: %s", n.State.NeighborAddress)
 		} else if ipAddr.IP.To4() != nil {
 			n.AfiSafis = []AfiSafi{defaultAfiSafi(AFI_SAFI_TYPE_IPV4_UNICAST, true)}
 		} else {

--- a/config/default.go
+++ b/config/default.go
@@ -276,15 +276,38 @@ func validatePeerGroupConfig(n *Neighbor, b *BgpConfigSet) error {
 	if name == "" {
 		return nil
 	}
+
+	pg, err := getPeerGroup(name, b)
+	if err != nil {
+		return err
+	}
+
+	if pg.Config.PeerAs != 0 && n.Config.PeerAs != 0 {
+		return fmt.Errorf("Cannot configure remote-as for members. PeerGroup AS %d.", pg.Config.PeerAs)
+	}
+	return nil
+}
+
+func getPeerGroup(n string, b *BgpConfigSet) (*PeerGroup, error) {
+	if n == "" {
+		return nil, fmt.Errorf("peer-group name is not configured")
+	}
 	for _, pg := range b.PeerGroups {
-		if name == pg.Config.PeerGroupName {
-			if pg.Config.PeerAs != 0 && n.Config.PeerAs != 0 {
-				return fmt.Errorf("Cannot configure remote-as for members. Peer-group AS %d.", pg.Config.PeerAs)
-			}
-			return nil
+		if n == pg.Config.PeerGroupName {
+			return &pg, nil
 		}
 	}
-	return fmt.Errorf("No such peer-group: %s", name)
+	return nil, fmt.Errorf("No such peer-group: %s", n)
+}
+
+func validateDynamicNeighborConfig(d *DynamicNeighborConfig, b *BgpConfigSet) error {
+	if _, err := getPeerGroup(d.PeerGroup, b); err != nil {
+		return err
+	}
+	if _, _, err := net.ParseCIDR(d.Prefix); err != nil {
+		return fmt.Errorf("Invalid Dynamic Neighbor prefix %s", d.Prefix)
+	}
+	return nil
 }
 
 func setDefaultConfigValuesWithViper(v *viper.Viper, b *BgpConfigSet) error {
@@ -344,6 +367,12 @@ func setDefaultConfigValuesWithViper(v *viper.Viper, b *BgpConfigSet) error {
 		}
 	}
 
+	for _, d := range b.DynamicNeighbors {
+		if err := validateDynamicNeighborConfig(&d.Config, b); err != nil {
+			return err
+		}
+	}
+
 	for idx, r := range b.RpkiServers {
 		if r.Config.Port == 0 {
 			b.RpkiServers[idx].Config.Port = rtr.RPKI_DEFAULT_PORT
@@ -372,11 +401,12 @@ func setDefaultConfigValuesWithViper(v *viper.Viper, b *BgpConfigSet) error {
 func OverwriteNeighborConfigWithPeerGroup(c *Neighbor, pg *PeerGroup) error {
 	v := viper.New()
 
-	val, ok := configuredFields[c.Config.NeighborAddress]
-	if !ok {
-		return fmt.Errorf("No such neighbor %s", c.Config.NeighborAddress)
+	val, ok := configuredFields[c.State.NeighborAddress]
+	if ok {
+		v.Set("neighbor", val)
+	} else {
+		v.Set("neighbor.config.peer-group", c.Config.PeerGroup)
 	}
-	v.Set("neighbor", val)
 
 	overwriteConfig(&c.Config, &pg.Config, "neighbor.config", v)
 	overwriteConfig(&c.Timers.Config, &pg.Timers.Config, "neighbor.timers.config", v)

--- a/config/serve.go
+++ b/config/serve.go
@@ -76,7 +76,7 @@ func ReadConfigfileServe(path, format string, configCh chan *BgpConfigSet) {
 
 func inSlice(n Neighbor, b []Neighbor) int {
 	for i, nb := range b {
-		if nb.Config.NeighborAddress == n.Config.NeighborAddress {
+		if nb.State.NeighborAddress == n.State.NeighborAddress {
 			return i
 		}
 	}

--- a/config/serve.go
+++ b/config/serve.go
@@ -19,6 +19,7 @@ type BgpConfigSet struct {
 	Collector         Collector          `mapstructure:"collector"`
 	DefinedSets       DefinedSets        `mapstructure:"defined-sets"`
 	PolicyDefinitions []PolicyDefinition `mapstructure:"policy-definitions"`
+	DynamicNeighbors  []DynamicNeighbor  `mapstructure:"dynamic-neighbors"`
 }
 
 func ReadConfigfileServe(path, format string, configCh chan *BgpConfigSet) {

--- a/config/util.go
+++ b/config/util.go
@@ -140,3 +140,14 @@ func ParseMaskLength(prefix, mask string) (int, int, error) {
 	}
 	return min, max, nil
 }
+
+func ExtractNeighborAddress(c *Neighbor) (string, error) {
+	addr := c.State.NeighborAddress
+	if addr == "" {
+		addr = c.Config.NeighborAddress
+		if addr == "" {
+			return "", fmt.Errorf("NeighborAddress is not configured")
+		}
+	}
+	return addr, nil
+}

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -140,6 +140,11 @@
     [peer-groups.afi-safis.config]
       afi-safi-name = "ipv4-unicast"
 
+[[dynamic-neighbors]]
+  [dynamic-neighbors.config]
+    prefix = "20.0.0.0/24"
+    peer-group = "my-peer-group"
+
 [[defined-sets.prefix-sets]]
     prefix-set-name = "ps0"
     [[defined-sets.prefix-sets.prefix-list]]

--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -178,8 +178,8 @@ func (n neighbors) Swap(i, j int) {
 }
 
 func (n neighbors) Less(i, j int) bool {
-	p1 := n[i].Config.NeighborAddress
-	p2 := n[j].Config.NeighborAddress
+	p1 := n[i].State.NeighborAddress
+	p2 := n[j].State.NeighborAddress
 	p1Isv4 := !strings.Contains(p1, ":")
 	p2Isv4 := !strings.Contains(p2, ":")
 	if p1Isv4 != p2Isv4 {

--- a/gobgp/cmd/monitor.go
+++ b/gobgp/cmd/monitor.go
@@ -89,7 +89,7 @@ func NewMonitorCmd() *cobra.Command {
 					j, _ := json.Marshal(s)
 					fmt.Println(string(j))
 				} else {
-					addr := s.Config.NeighborAddress
+					addr := s.State.NeighborAddress
 					if s.Config.NeighborInterface != "" {
 						addr = fmt.Sprintf("%s(%s)", addr, s.Config.NeighborInterface)
 					}

--- a/gobgp/cmd/neighbor.go
+++ b/gobgp/cmd/neighbor.go
@@ -77,7 +77,7 @@ func showNeighbors(vrf string) error {
 
 	if globalOpts.Quiet {
 		for _, p := range m {
-			fmt.Println(p.Config.NeighborAddress)
+			fmt.Println(p.State.NeighborAddress)
 		}
 		return nil
 	}
@@ -92,7 +92,7 @@ func showNeighbors(vrf string) error {
 	for _, n := range m {
 		if i := len(n.Config.NeighborInterface); i > maxaddrlen {
 			maxaddrlen = i
-		} else if j := len(n.Config.NeighborAddress); j > maxaddrlen {
+		} else if j := len(n.State.NeighborAddress); j > maxaddrlen {
 			maxaddrlen = j
 		}
 		if l := len(getASN(n)); l > maxaslen {
@@ -142,7 +142,7 @@ func showNeighbors(vrf string) error {
 	}
 
 	for i, n := range m {
-		neigh := n.Config.NeighborAddress
+		neigh := n.State.NeighborAddress
 		if n.Config.NeighborInterface != "" {
 			neigh = n.Config.NeighborInterface
 		}
@@ -163,7 +163,7 @@ func showNeighbor(args []string) error {
 		return nil
 	}
 
-	fmt.Printf("BGP neighbor is %s, remote AS %s", p.Config.NeighborAddress, getASN(p))
+	fmt.Printf("BGP neighbor is %s, remote AS %s", p.State.NeighborAddress, getASN(p))
 
 	if p.RouteReflector.Config.RouteReflectorClient {
 		fmt.Printf(", route-reflector-client\n")
@@ -854,6 +854,7 @@ func modNeighbor(cmdType string, args []string) error {
 			peer.Config.NeighborInterface = m["interface"][0]
 		} else {
 			peer.Config.NeighborAddress = m[""][0]
+			peer.State.NeighborAddress = m[""][0]
 		}
 		if len(m["vrf"]) == 1 {
 			peer.Config.Vrf = m["vrf"][0]
@@ -952,7 +953,7 @@ func NewNeighborCmd() *cobra.Command {
 						if err != nil {
 							exitWithError(err)
 						}
-						addr = peer.Config.NeighborAddress
+						addr = peer.State.NeighborAddress
 					}
 					err := f(cmd.Use, addr, args[:len(args)-1])
 					if err != nil {
@@ -983,7 +984,7 @@ func NewNeighborCmd() *cobra.Command {
 			if err != nil {
 				exitWithError(err)
 			}
-			remoteIP := peer.Config.NeighborAddress
+			remoteIP := peer.State.NeighborAddress
 			for _, v := range []string{CMD_IN, CMD_IMPORT, CMD_EXPORT} {
 				if err := showNeighborPolicy(remoteIP, v, 4); err != nil {
 					exitWithError(err)
@@ -1000,7 +1001,7 @@ func NewNeighborCmd() *cobra.Command {
 				if err != nil {
 					exitWithError(err)
 				}
-				remoteIP := peer.Config.NeighborAddress
+				remoteIP := peer.State.NeighborAddress
 				err = showNeighborPolicy(remoteIP, cmd.Use, 0)
 				if err != nil {
 					exitWithError(err)
@@ -1016,7 +1017,7 @@ func NewNeighborCmd() *cobra.Command {
 					if err != nil {
 						exitWithError(err)
 					}
-					remoteIP := peer.Config.NeighborAddress
+					remoteIP := peer.State.NeighborAddress
 					args = args[:len(args)-1]
 					if err = modNeighborPolicy(remoteIP, cmd.Use, subcmd.Use, args); err != nil {
 						exitWithError(err)

--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -267,19 +267,19 @@ func main() {
 				updatePolicy = updatePolicy || u
 			}
 			for i, p := range added {
-				log.Infof("Peer %v is added", p.Config.NeighborAddress)
+				log.Infof("Peer %v is added", p.State.NeighborAddress)
 				if err := bgpServer.AddNeighbor(&added[i]); err != nil {
 					log.Warn(err)
 				}
 			}
 			for i, p := range deleted {
-				log.Infof("Peer %v is deleted", p.Config.NeighborAddress)
+				log.Infof("Peer %v is deleted", p.State.NeighborAddress)
 				if err := bgpServer.DeleteNeighbor(&deleted[i]); err != nil {
 					log.Warn(err)
 				}
 			}
 			for i, p := range updated {
-				log.Infof("Peer %v is updated", p.Config.NeighborAddress)
+				log.Infof("Peer %v is updated", p.State.NeighborAddress)
 				u, err := bgpServer.UpdateNeighbor(&updated[i])
 				if err != nil {
 					log.Warn(err)

--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -266,6 +266,12 @@ func main() {
 				}
 				updatePolicy = updatePolicy || u
 			}
+			for _, dn := range newConfig.DynamicNeighbors {
+				log.Infof("Dynamic Neighbor %s is added to PeerGroup %s", dn.Config.Prefix, dn.Config.PeerGroup)
+				if err := bgpServer.AddDynamicNeighbor(&dn); err != nil {
+					log.Warn(err)
+				}
+			}
 			for i, p := range added {
 				log.Infof("Peer %v is added", p.State.NeighborAddress)
 				if err := bgpServer.AddNeighbor(&added[i]); err != nil {

--- a/server/bmp.go
+++ b/server/bmp.go
@@ -289,7 +289,7 @@ func bmpPeerRoute(t uint8, policy bool, pd uint64, peeri *table.PeerInfo, timest
 
 func bmpPeerStats(peerType uint8, peerDist uint64, timestamp int64, neighConf *config.Neighbor) *bmp.BMPMessage {
 	var peerFlags uint8 = 0
-	ph := bmp.NewBMPPeerHeader(peerType, peerFlags, peerDist, neighConf.Config.NeighborAddress, neighConf.State.PeerAs, neighConf.State.RemoteRouterId, float64(timestamp))
+	ph := bmp.NewBMPPeerHeader(peerType, peerFlags, peerDist, neighConf.State.NeighborAddress, neighConf.State.PeerAs, neighConf.State.RemoteRouterId, float64(timestamp))
 	return bmp.NewBMPStatisticsReport(
 		*ph,
 		[]bmp.BMPStatsTLVInterface{

--- a/server/mrt.go
+++ b/server/mrt.go
@@ -109,7 +109,7 @@ func (m *mrtWriter) loop() error {
 				t := uint32(time.Now().Unix())
 				peers := make([]*mrt.Peer, 0, len(m.Neighbor))
 				for _, pconf := range m.Neighbor {
-					peers = append(peers, mrt.NewPeer(pconf.State.RemoteRouterId, pconf.Config.NeighborAddress, pconf.Config.PeerAs, true))
+					peers = append(peers, mrt.NewPeer(pconf.State.RemoteRouterId, pconf.State.NeighborAddress, pconf.Config.PeerAs, true))
 				}
 				if bm, err := mrt.NewMRTMessage(t, mrt.TABLE_DUMPv2, mrt.PEER_INDEX_TABLE, mrt.NewPeerIndexTable(m.RouterId, "", peers)); err != nil {
 					break
@@ -119,7 +119,7 @@ func (m *mrtWriter) loop() error {
 
 				idx := func(p *table.Path) uint16 {
 					for i, pconf := range m.Neighbor {
-						if p.GetSource().Address.String() == pconf.Config.NeighborAddress {
+						if p.GetSource().Address.String() == pconf.State.NeighborAddress {
 							return uint16(i)
 						}
 					}

--- a/server/peer.go
+++ b/server/peer.go
@@ -44,11 +44,11 @@ func NewPeerGroup(c *config.PeerGroup) *PeerGroup {
 }
 
 func (pg *PeerGroup) AddMember(c config.Neighbor) {
-	pg.members[c.Config.NeighborAddress] = c
+	pg.members[c.State.NeighborAddress] = c
 }
 
 func (pg *PeerGroup) DeleteMember(c config.Neighbor) {
-	delete(pg.members, c.Config.NeighborAddress)
+	delete(pg.members, c.State.NeighborAddress)
 }
 
 type Peer struct {
@@ -71,7 +71,7 @@ func NewPeer(g *config.Global, conf *config.Neighbor, loc *table.TableManager, p
 		prefixLimitWarned: make(map[bgp.RouteFamily]bool),
 	}
 	if peer.isRouteServerClient() {
-		peer.tableId = conf.Config.NeighborAddress
+		peer.tableId = conf.State.NeighborAddress
 	} else {
 		peer.tableId = table.GLOBAL_RIB_NAME
 	}
@@ -81,7 +81,7 @@ func NewPeer(g *config.Global, conf *config.Neighbor, loc *table.TableManager, p
 }
 
 func (peer *Peer) ID() string {
-	return peer.fsm.pConf.Config.NeighborAddress
+	return peer.fsm.pConf.State.NeighborAddress
 }
 
 func (peer *Peer) TableID() string {
@@ -360,7 +360,7 @@ func (peer *Peer) processOutgoingPaths(paths, olds []*table.Path) []*table.Path 
 	if peer.fsm.pConf.GracefulRestart.State.LocalRestarting {
 		log.WithFields(log.Fields{
 			"Topic": "Peer",
-			"Key":   peer.fsm.pConf.Config.NeighborAddress,
+			"Key":   peer.fsm.pConf.State.NeighborAddress,
 		}).Debug("now syncing, suppress sending updates")
 		return nil
 	}
@@ -478,7 +478,7 @@ func (peer *Peer) handleUpdate(e *FsmMsg) ([]*table.Path, []bgp.RouteFamily, *bg
 	update := m.Body.(*bgp.BGPUpdate)
 	log.WithFields(log.Fields{
 		"Topic":       "Peer",
-		"Key":         peer.fsm.pConf.Config.NeighborAddress,
+		"Key":         peer.fsm.pConf.State.NeighborAddress,
 		"nlri":        update.NLRI,
 		"withdrawals": update.WithdrawnRoutes,
 		"attributes":  update.PathAttributes,

--- a/table/destination.go
+++ b/table/destination.go
@@ -127,7 +127,7 @@ func (i *PeerInfo) String() string {
 func NewPeerInfo(g *config.Global, p *config.Neighbor) *PeerInfo {
 	id := net.ParseIP(string(p.RouteReflector.Config.RouteReflectorClusterId)).To4()
 	// exclude zone info
-	naddr, _ := net.ResolveIPAddr("ip", p.Config.NeighborAddress)
+	naddr, _ := net.ResolveIPAddr("ip", p.State.NeighborAddress)
 	return &PeerInfo{
 		AS:                      p.Config.PeerAs,
 		LocalAS:                 g.Config.As,

--- a/table/path.go
+++ b/table/path.go
@@ -258,7 +258,7 @@ func UpdatePathAttrs(global *config.Global, peer *config.Neighbor, info *PeerInf
 	} else {
 		log.WithFields(log.Fields{
 			"Topic": "Peer",
-			"Key":   peer.Config.NeighborAddress,
+			"Key":   peer.State.NeighborAddress,
 		}).Warnf("invalid peer type: %d", peer.State.PeerType)
 	}
 	return path

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -1126,6 +1126,45 @@ module gobgp {
       uses listen-config;
   }
 
+  grouping dynamic-neighbors {
+    container dynamic-neighbors {
+      list dynamic-neighbor {
+        key "prefix";
+
+        leaf prefix {
+          type leafref {
+            path "../config/prefix";
+          }
+        }
+
+        container config {
+          uses bgp-global-dynamic-neighbor-config;
+        }
+
+        container state {
+          config false;
+          uses bgp-global-dynamic-neighbor-config;
+        }
+      }
+    }
+  }
+
+  grouping bgp-global-dynamic-neighbor-config {
+    description "A dynamic neighbor belongs to a peer group.
+     This configuration structure was taken from the latest openconfig.";
+
+    leaf prefix {
+      type string;
+    }
+    leaf peer-group {
+      type string;
+    }
+  }
+
+  augment "/bgp:bgp" {
+    uses dynamic-neighbors;
+  }
+
   augment "/bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi" {
       uses bgp-mp:all-afi-safi-common;
   }


### PR DESCRIPTION
This patch adds the Dynamic Neighbor feature.
The configuration syntax is like following:
```
[[dynamic-neighbors]]
  [dynamic-neighbors.config]
    prefix = "10.0.0.0/24"
    peer-group = "my-peer-group"
```


(This patch updates #1289)