### PR TITLE
Fix Fails in Initializing Dynamic Peer

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -130,8 +130,11 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn ui
 		}
 	}
 
+	if n.State.NeighborAddress == "" {
+		n.State.NeighborAddress = n.Config.NeighborAddress
+	}
+
 	n.State.PeerAs = n.Config.PeerAs
-	n.State.NeighborAddress = n.Config.NeighborAddress
 	n.AsPathOptions.State.AllowOwnAs = n.AsPathOptions.Config.AllowOwnAs
 
 	if !v.IsSet("neighbor.timers.config.connect-retry") && n.Timers.Config.ConnectRetry == 0 {

--- a/server/peer.go
+++ b/server/peer.go
@@ -62,6 +62,9 @@ func newDynamicPeer(g *config.Global, neighborAddress string, pg *config.PeerGro
 		Config: config.NeighborConfig{
 			PeerGroup: pg.Config.PeerGroupName,
 		},
+		State: config.NeighborState{
+			NeighborAddress: neighborAddress,
+		},
 		Transport: config.Transport{
 			Config: config.TransportConfig{
 				PassiveMode: true,
@@ -82,7 +85,6 @@ func newDynamicPeer(g *config.Global, neighborAddress string, pg *config.PeerGro
 		}).Debugf("Can't set default config: %s", err)
 		return nil
 	}
-	conf.State.NeighborAddress = neighborAddress
 	peer := NewPeer(g, &conf, loc, policy)
 	peer.fsm.state = bgp.BGP_FSM_ACTIVE
 	return peer

--- a/server/peer.go
+++ b/server/peer.go
@@ -68,8 +68,20 @@ func newDynamicPeer(g *config.Global, neighborAddress string, pg *config.PeerGro
 			},
 		},
 	}
-	config.OverwriteNeighborConfigWithPeerGroup(&conf, pg)
-	config.SetDefaultNeighborConfigValues(&conf, g.Config.As)
+	if err := config.OverwriteNeighborConfigWithPeerGroup(&conf, pg); err != nil {
+		log.WithFields(log.Fields{
+			"Topic": "Peer",
+			"Key":   neighborAddress,
+		}).Debugf("Can't overwrite neighbor config: %s", err)
+		return nil
+	}
+	if err := config.SetDefaultNeighborConfigValues(&conf, g.Config.As); err != nil {
+		log.WithFields(log.Fields{
+			"Topic": "Peer",
+			"Key":   neighborAddress,
+		}).Debugf("Can't set default config: %s", err)
+		return nil
+	}
 	conf.State.NeighborAddress = neighborAddress
 	peer := NewPeer(g, &conf, loc, policy)
 	peer.fsm.state = bgp.BGP_FSM_ACTIVE

--- a/server/server.go
+++ b/server/server.go
@@ -241,6 +241,14 @@ func (server *BgpServer) Serve() {
 					"Topic": "Peer",
 				}).Debugf("Accepted a new dynamic neighbor from:%s", remoteAddr)
 				peer := newDynamicPeer(&server.bgpConfig.Global, remoteAddr, pg.Conf, server.globalRib, server.policy)
+				if peer == nil {
+					log.WithFields(log.Fields{
+						"Topic": "Peer",
+						"Key":   remoteAddr,
+					}).Infof("Can't create new Dynamic Peer")
+					conn.Close()
+					return
+				}
 				server.policy.Reset(nil, map[string]config.ApplyPolicy{peer.ID(): peer.fsm.pConf.ApplyPolicy})
 				server.neighborMap[remoteAddr] = peer
 				peer.startFSMHandler(server.fsmincomingCh, server.fsmStateCh)


### PR DESCRIPTION
If State.NeighborAddress is not set, setting default configs
for the dynamic peers will fail. This patch sets State.NeighborAddress
before setting default configs.
And this avoids overwriting State.NeighborAddress if it is set.

This fixes #1283.