### PR TITLE
flowspec: Comply with RFC 5575 for TCP Flags and Fragment

### DIFF
--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -881,7 +881,7 @@ usage: %s rib %s%%smatch <MATCH_EXPR> then <THEN_EXPR> -a %%s
 			ExtCommNameMap[RATE], ExtCommNameMap[REDIRECT],
 			ExtCommNameMap[MARK], ExtCommNameMap[ACTION], ExtCommNameMap[RT])
 		ipFsMatchExpr := fmt.Sprintf(`   <MATCH_EXPR> : { %s <PREFIX> [<OFFSET>] | %s <PREFIX> [<OFFSET>] |
-                    %s <PROTO>... | %s <FRAGMENT_TYPE> | %s [!] [=] <TCPFLAG>... |
+                    %s <PROTO>... | %s [!] [=] <FRAGMENT_TYPE> | %s [!] [=] <TCPFLAG>... |
                     { %s | %s | %s | %s | %s | %s | %s | %s } <ITEM>... }...
    <PROTO> : %s
    <FRAGMENT_TYPE> : dont-fragment, is-fragment, first-fragment, last-fragment, not-a-fragment

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -2613,9 +2613,8 @@ func parseTcpFlagCmd(myCmd string) ([][2]int, error) {
 			}
 		case TCPFlagOpNameMap[TCP_FLAG_OP_AND], TCPFlagOpNameMap[TCP_FLAG_OP_OR]:
 			if bit := TCPFlagOpValueMap[myCmdChar]; bit&TCPFlagOp(operatorValue[0]) == 0 {
-				operatorValue[0] |= int(bit)
 				tcpOperatorsFlagsValues = append(tcpOperatorsFlagsValues, operatorValue)
-				operatorValue[0] = 0
+				operatorValue[0] = int(bit)
 				operatorValue[1] = 0
 				index++
 			} else {
@@ -3311,9 +3310,9 @@ func formatFlag(op int, value int) string {
 		}
 	}
 	if op&TCP_FLAG_OP_AND > 0 {
-		retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_AND])
+		retString = fmt.Sprintf("%s%s", TCPFlagOpNameMap[TCP_FLAG_OP_AND], retString)
 	} else { // default is or
-		retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_OR])
+		retString = fmt.Sprintf("%s%s", TCPFlagOpNameMap[TCP_FLAG_OP_OR], retString)
 	}
 	return retString
 }

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -2595,24 +2595,24 @@ func parseTcpFlagCmd(myCmd string) ([][2]int, error) {
 	for index < len(myCmd) {
 		myCmdChar := myCmd[index : index+1]
 		switch myCmdChar {
-		case TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]:
-			if bit := TCPFlagOpValueMap[myCmdChar]; bit&TCPFlagOp(operatorValue[0]) == 0 {
+		case BitmaskFlagOpNameMap[BITMASK_FLAG_OP_MATCH]:
+			if bit := BitmaskFlagOpValueMap[myCmdChar]; bit&BitmaskFlagOp(operatorValue[0]) == 0 {
 				operatorValue[0] |= int(bit)
 				index++
 			} else {
 				err := fmt.Errorf("Match flag appears multiple time")
 				return nil, err
 			}
-		case TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:
-			if bit := TCPFlagOpValueMap[myCmdChar]; bit&TCPFlagOp(operatorValue[0]) == 0 {
+		case BitmaskFlagOpNameMap[BITMASK_FLAG_OP_NOT]:
+			if bit := BitmaskFlagOpValueMap[myCmdChar]; bit&BitmaskFlagOp(operatorValue[0]) == 0 {
 				operatorValue[0] |= int(bit)
 				index++
 			} else {
 				err := fmt.Errorf("Not flag appears multiple time")
 				return nil, err
 			}
-		case TCPFlagOpNameMap[TCP_FLAG_OP_AND], TCPFlagOpNameMap[TCP_FLAG_OP_OR]:
-			if bit := TCPFlagOpValueMap[myCmdChar]; bit&TCPFlagOp(operatorValue[0]) == 0 {
+		case BitmaskFlagOpNameMap[BITMASK_FLAG_OP_AND], BitmaskFlagOpNameMap[BITMASK_FLAG_OP_OR]:
+			if bit := BitmaskFlagOpValueMap[myCmdChar]; bit&BitmaskFlagOp(operatorValue[0]) == 0 {
 				tcpOperatorsFlagsValues = append(tcpOperatorsFlagsValues, operatorValue)
 				operatorValue[0] = int(bit)
 				operatorValue[1] = 0
@@ -2629,7 +2629,7 @@ func parseTcpFlagCmd(myCmd string) ([][2]int, error) {
 			// we loop till we reach the end of TCP flags description
 			// exit conditions : we reach the end of tcp flags (we find & or ' ') or we reach the end of the line
 			for loopIndex < len(myCmd) &&
-				(myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_AND] && myLoopChar != TCPFlagOpNameMap[TCP_FLAG_OP_OR]) {
+				(myLoopChar != BitmaskFlagOpNameMap[BITMASK_FLAG_OP_AND] && myLoopChar != BitmaskFlagOpNameMap[BITMASK_FLAG_OP_OR]) {
 				// we check if inspected charater is a well known tcp flag and if it doesn't appear twice
 				if bit, isPresent := TCPFlagValueMap[myLoopChar]; isPresent && (bit&TCPFlag(operatorValue[1]) == 0) {
 					operatorValue[1] |= int(bit) // we set this flag
@@ -2649,7 +2649,7 @@ func parseTcpFlagCmd(myCmd string) ([][2]int, error) {
 			return nil, err
 		}
 	}
-	operatorValue[0] |= int(TCPFlagOpValueMap["E"])
+	operatorValue[0] |= int(BitmaskFlagOpValueMap["E"])
 	tcpOperatorsFlagsValues = append(tcpOperatorsFlagsValues, operatorValue)
 	return tcpOperatorsFlagsValues, nil
 }
@@ -3298,21 +3298,21 @@ func formatProto(op int, value int) string {
 
 func formatFlag(op int, value int) string {
 	var retString string
-	if op&TCP_FLAG_OP_MATCH > 0 {
-		retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_MATCH])
+	if op&BITMASK_FLAG_OP_MATCH > 0 {
+		retString = fmt.Sprintf("%s%s", retString, BitmaskFlagOpNameMap[BITMASK_FLAG_OP_MATCH])
 	}
-	if op&TCP_FLAG_OP_NOT > 0 {
-		retString = fmt.Sprintf("%s%s", retString, TCPFlagOpNameMap[TCP_FLAG_OP_NOT])
+	if op&BITMASK_FLAG_OP_NOT > 0 {
+		retString = fmt.Sprintf("%s%s", retString, BitmaskFlagOpNameMap[BITMASK_FLAG_OP_NOT])
 	}
 	for flag, valueFlag := range TCPFlagValueMap {
 		if value&int(valueFlag) > 0 {
 			retString = fmt.Sprintf("%s%s", retString, flag)
 		}
 	}
-	if op&TCP_FLAG_OP_AND > 0 {
-		retString = fmt.Sprintf("%s%s", TCPFlagOpNameMap[TCP_FLAG_OP_AND], retString)
+	if op&BITMASK_FLAG_OP_AND > 0 {
+		retString = fmt.Sprintf("%s%s", BitmaskFlagOpNameMap[BITMASK_FLAG_OP_AND], retString)
 	} else { // default is or
-		retString = fmt.Sprintf("%s%s", TCPFlagOpNameMap[TCP_FLAG_OP_OR], retString)
+		retString = fmt.Sprintf("%s%s", BitmaskFlagOpNameMap[BITMASK_FLAG_OP_OR], retString)
 	}
 	return retString
 }

--- a/packet/bgp/bgp_test.go
+++ b/packet/bgp/bgp_test.go
@@ -305,11 +305,14 @@ func Test_FlowSpecNlri(t *testing.T) {
 	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_PKT_LEN, []*FlowSpecComponentItem{item2, item3, item4}))
 	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_DSCP, []*FlowSpecComponentItem{item2, item3, item4}))
 	isFlagment := 0x02
-	item5 := NewFlowSpecComponentItem(isFlagment, 0)
-	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_FRAGMENT, []*FlowSpecComponentItem{item5}))
-	item6 := NewFlowSpecComponentItem(0, TCP_FLAG_ACK)
-	item7 := NewFlowSpecComponentItem(and|not, TCP_FLAG_URGENT)
-	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_TCP_FLAG, []*FlowSpecComponentItem{item6, item7}))
+	lastFlagment := 0x08
+	match := 0x1
+	item5 := NewFlowSpecComponentItem(match, isFlagment)
+	item6 := NewFlowSpecComponentItem(and, lastFlagment)
+	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_FRAGMENT, []*FlowSpecComponentItem{item5, item6}))
+	item7 := NewFlowSpecComponentItem(0, TCP_FLAG_ACK)
+	item8 := NewFlowSpecComponentItem(and|not, TCP_FLAG_URGENT)
+	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_TCP_FLAG, []*FlowSpecComponentItem{item7, item8}))
 	n1 := NewFlowSpecIPv4Unicast(cmp)
 	buf1, err := n1.Serialize()
 	assert.Nil(err)

--- a/packet/bgp/constant.go
+++ b/packet/bgp/constant.go
@@ -154,6 +154,32 @@ var BitmaskFlagOpValueMap = map[string]BitmaskFlagOp{
 	BitmaskFlagOpNameMap[BITMASK_FLAG_OP_MATCH]: BITMASK_FLAG_OP_MATCH,
 }
 
+type FragmentFlag int
+
+const (
+	FRAG_FLAG_NOT   = 0x00
+	FRAG_FLAG_DONT  = 0x01
+	FRAG_FLAG_IS    = 0x02
+	FRAG_FLAG_FIRST = 0x04
+	FRAG_FLAG_LAST  = 0x08
+)
+
+var FragmentFlagNameMap = map[FragmentFlag]string{
+	FRAG_FLAG_NOT:   "not-a-fragment",
+	FRAG_FLAG_DONT:  "dont-fragment",
+	FRAG_FLAG_IS:    "is-fragment",
+	FRAG_FLAG_FIRST: "first-fragment",
+	FRAG_FLAG_LAST:  "last-fragment",
+}
+
+var FragmentFlagValueMap = map[string]FragmentFlag{
+	FragmentFlagNameMap[FRAG_FLAG_NOT]:   FRAG_FLAG_NOT,
+	FragmentFlagNameMap[FRAG_FLAG_DONT]:  FRAG_FLAG_DONT,
+	FragmentFlagNameMap[FRAG_FLAG_IS]:    FRAG_FLAG_IS,
+	FragmentFlagNameMap[FRAG_FLAG_FIRST]: FRAG_FLAG_FIRST,
+	FragmentFlagNameMap[FRAG_FLAG_LAST]:  FRAG_FLAG_LAST,
+}
+
 type DECNumOp int
 
 const (

--- a/packet/bgp/constant.go
+++ b/packet/bgp/constant.go
@@ -128,30 +128,30 @@ var TCPFlagValueMap = map[string]TCPFlag{
 	TCPFlagNameMap[TCP_FLAG_ECE]:    TCP_FLAG_ECE,
 }
 
-type TCPFlagOp int
+type BitmaskFlagOp int
 
 const (
-	TCP_FLAG_OP_OR    = 0x00
-	TCP_FLAG_OP_AND   = 0x40
-	TCP_FLAG_OP_END   = 0x80
-	TCP_FLAG_OP_NOT   = 0x02
-	TCP_FLAG_OP_MATCH = 0x01
+	BITMASK_FLAG_OP_OR    = 0x00
+	BITMASK_FLAG_OP_AND   = 0x40
+	BITMASK_FLAG_OP_END   = 0x80
+	BITMASK_FLAG_OP_NOT   = 0x02
+	BITMASK_FLAG_OP_MATCH = 0x01
 )
 
-var TCPFlagOpNameMap = map[TCPFlagOp]string{
-	TCP_FLAG_OP_OR:    " ",
-	TCP_FLAG_OP_AND:   "&",
-	TCP_FLAG_OP_END:   "E",
-	TCP_FLAG_OP_NOT:   "!",
-	TCP_FLAG_OP_MATCH: "=",
+var BitmaskFlagOpNameMap = map[BitmaskFlagOp]string{
+	BITMASK_FLAG_OP_OR:    " ",
+	BITMASK_FLAG_OP_AND:   "&",
+	BITMASK_FLAG_OP_END:   "E",
+	BITMASK_FLAG_OP_NOT:   "!",
+	BITMASK_FLAG_OP_MATCH: "=",
 }
 
-var TCPFlagOpValueMap = map[string]TCPFlagOp{
-	TCPFlagOpNameMap[TCP_FLAG_OP_OR]:    TCP_FLAG_OP_OR,
-	TCPFlagOpNameMap[TCP_FLAG_OP_AND]:   TCP_FLAG_OP_AND,
-	TCPFlagOpNameMap[TCP_FLAG_OP_END]:   TCP_FLAG_OP_END,
-	TCPFlagOpNameMap[TCP_FLAG_OP_NOT]:   TCP_FLAG_OP_NOT,
-	TCPFlagOpNameMap[TCP_FLAG_OP_MATCH]: TCP_FLAG_OP_MATCH,
+var BitmaskFlagOpValueMap = map[string]BitmaskFlagOp{
+	BitmaskFlagOpNameMap[BITMASK_FLAG_OP_OR]:    BITMASK_FLAG_OP_OR,
+	BitmaskFlagOpNameMap[BITMASK_FLAG_OP_AND]:   BITMASK_FLAG_OP_AND,
+	BitmaskFlagOpNameMap[BITMASK_FLAG_OP_END]:   BITMASK_FLAG_OP_END,
+	BitmaskFlagOpNameMap[BITMASK_FLAG_OP_NOT]:   BITMASK_FLAG_OP_NOT,
+	BitmaskFlagOpNameMap[BITMASK_FLAG_OP_MATCH]: BITMASK_FLAG_OP_MATCH,
 }
 
 type DECNumOp int


### PR DESCRIPTION
For "fragment" field,  RFC 5575 suggests using "bitmask operand format", but GoBGP does not have an interface to configure it.
This PR introduces the way to configure bitmask operands for"fragment" field.
(This fixes the problem which was pointed out in #1361.)

And for "tcp-flags" field, if the field is specified from CLI command, GoBGP sets 'AND' bit to the invalid operand.
This PR also fixes this problem to comply with RFC 5575.