### PR TITLE
server: Set TTL before dialing for interoperability of TTL security

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -75,9 +75,8 @@ func getIPv6LinkLocalAddress(ifname string) (string, error) {
 		return "", err
 	}
 	for _, addr := range addrs {
-		if ip, _, err := net.ParseCIDR(addr.String()); err != nil {
-			return "", err
-		} else if ip.To4() == nil && ip.IsLinkLocalUnicast() {
+		ip := addr.(*net.IPNet).IP
+		if ip.To4() == nil && ip.IsLinkLocalUnicast() {
 			return fmt.Sprintf("%s%%%s", ip.String(), ifname), nil
 		}
 	}

--- a/server/fsm.go
+++ b/server/fsm.go
@@ -329,28 +329,32 @@ func (fsm *FSM) connectLoop() error {
 		if fsm.pConf.Transport.Config.RemotePort != 0 {
 			port = int(fsm.pConf.Transport.Config.RemotePort)
 		}
-		host := net.JoinHostPort(addr, strconv.Itoa(port))
-		// check if LocalAddress has been configured
-		laddr := fsm.pConf.Transport.Config.LocalAddress
-		var conn net.Conn
-		var err error
-		if fsm.pConf.Config.AuthPassword != "" {
-			deadline := (MIN_CONNECT_RETRY - 1) * 1000 // msec
-			conn, err = DialTCPTimeoutWithMD5Sig(addr, port, laddr, fsm.pConf.Config.AuthPassword, deadline)
-		} else {
-			lhost := net.JoinHostPort(laddr, "0")
-			ltcpaddr, e := net.ResolveTCPAddr("tcp", lhost)
-			if e != nil {
-				log.WithFields(log.Fields{
-					"Topic": "Peer",
-					"Key":   fsm.pConf.State.NeighborAddress,
-				}).Warnf("failed to resolve ltcpaddr: %s", e)
-				return
-			}
-			d := net.Dialer{LocalAddr: ltcpaddr, Timeout: time.Duration(MIN_CONNECT_RETRY-1) * time.Second}
-			conn, err = d.Dial("tcp", host)
+		laddr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(fsm.pConf.Transport.Config.LocalAddress, "0"))
+		if err != nil {
+			log.WithFields(log.Fields{
+				"Topic": "Peer",
+				"Key":   fsm.pConf.State.NeighborAddress,
+			}).Warn("failed to resolve local address: %s", err)
+			return
 		}
-
+		var conn net.Conn
+		d := TCPDialer{
+			Dialer: net.Dialer{
+				LocalAddr: laddr,
+				Timeout:   time.Duration(MIN_CONNECT_RETRY-1) * time.Second,
+			},
+			AuthPassword: fsm.pConf.Config.AuthPassword,
+		}
+		if fsm.pConf.TtlSecurity.Config.Enabled {
+			d.Ttl = 255
+			d.TtlMin = fsm.pConf.TtlSecurity.Config.TtlMin
+		} else if fsm.pConf.Config.PeerAs != 0 && fsm.pConf.Config.PeerType == config.PEER_TYPE_EXTERNAL {
+			d.Ttl = 1
+			if fsm.pConf.EbgpMultihop.Config.Enabled {
+				d.Ttl = fsm.pConf.EbgpMultihop.Config.MultihopTtl
+			}
+		}
+		conn, err = d.DialTCP(addr, port)
 		if err == nil {
 			select {
 			case fsm.connCh <- conn:
@@ -505,7 +509,7 @@ func (h *FSMHandler) active() (bgp.FSMState, FsmStateReason) {
 				ttl = int(fsm.pConf.Transport.Config.Ttl)
 			}
 			if ttl != 0 {
-				if err := SetTcpTTLSockopts(conn.(*net.TCPConn), ttl); err != nil {
+				if err := SetTcpTTLSockopt(conn.(*net.TCPConn), ttl); err != nil {
 					log.WithFields(log.Fields{
 						"Topic": "Peer",
 						"Key":   fsm.pConf.Config.NeighborAddress,
@@ -514,7 +518,7 @@ func (h *FSMHandler) active() (bgp.FSMState, FsmStateReason) {
 				}
 			}
 			if ttlMin != 0 {
-				if err := SetTcpMinTTLSockopts(conn.(*net.TCPConn), ttlMin); err != nil {
+				if err := SetTcpMinTTLSockopt(conn.(*net.TCPConn), ttlMin); err != nil {
 					log.WithFields(log.Fields{
 						"Topic": "Peer",
 						"Key":   fsm.pConf.Config.NeighborAddress,

--- a/server/server.go
+++ b/server/server.go
@@ -1723,7 +1723,7 @@ func (server *BgpServer) addNeighbor(c *config.Neighbor) error {
 	if server.bgpConfig.Global.Config.Port > 0 {
 		for _, l := range server.Listeners(addr) {
 			if c.Config.AuthPassword != "" {
-				if err := SetTcpMD5SigSockopts(l, addr, c.Config.AuthPassword); err != nil {
+				if err := SetTcpMD5SigSockopt(l, addr, c.Config.AuthPassword); err != nil {
 					log.WithFields(log.Fields{
 						"Topic": "Peer",
 						"Key":   addr,
@@ -1825,7 +1825,7 @@ func (server *BgpServer) deleteNeighbor(c *config.Neighbor, code, subcode uint8)
 		return fmt.Errorf("Can't delete a peer configuration for %s", addr)
 	}
 	for _, l := range server.Listeners(addr) {
-		if err := SetTcpMD5SigSockopts(l, addr, ""); err != nil {
+		if err := SetTcpMD5SigSockopt(l, addr, ""); err != nil {
 			log.WithFields(log.Fields{
 				"Topic": "Peer",
 				"Key":   addr,

--- a/server/sockopt.go
+++ b/server/sockopt.go
@@ -19,20 +19,68 @@ package server
 import (
 	"fmt"
 	"net"
+
+	log "github.com/sirupsen/logrus"
 )
 
-func SetTcpMD5SigSockopts(l *net.TCPListener, address string, key string) error {
-	return fmt.Errorf("md5 not supported")
+func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+	return fmt.Errorf("setting md5 is not supported")
 }
 
-func SetTcpTTLSockopts(conn *net.TCPConn, ttl int) error {
+func SetTcpTTLSockopt(conn *net.TCPConn, ttl int) error {
 	return fmt.Errorf("setting ttl is not supported")
 }
 
-func SetTcpMinTTLSockopts(conn *net.TCPConn, ttl int) error {
+func SetTcpMinTTLSockopt(conn *net.TCPConn, ttl int) error {
 	return fmt.Errorf("setting min ttl is not supported")
 }
 
-func DialTCPTimeoutWithMD5Sig(host string, port int, localAddr, key string, msec int) (*net.TCPConn, error) {
-	return nil, fmt.Errorf("md5 active connection unsupported")
+type TCPDialer struct {
+	net.Dialer
+
+	// MD5 authentication password.
+	AuthPassword string
+
+	// The TTL value to set outgoing connection.
+	Ttl uint8
+
+	// The minimum TTL value for incoming packets.
+	TtlMin uint8
+}
+
+func (d *TCPDialer) DialTCP(addr string, port int) (*net.TCPConn, error) {
+	if d.AuthPassword != "" {
+		log.WithFields(log.Fields{
+			"Topic": "Peer",
+			"Key":   addr,
+		}).Warn("setting md5 for active connection is not supported")
+	}
+	if d.Ttl != 0 {
+		log.WithFields(log.Fields{
+			"Topic": "Peer",
+			"Key":   addr,
+		}).Warn("setting ttl for active connection is not supported")
+	}
+	if d.TtlMin != 0 {
+		log.WithFields(log.Fields{
+			"Topic": "Peer",
+			"Key":   addr,
+		}).Warn("setting min ttl for active connection is not supported")
+	}
+
+	raddr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(addr, fmt.Sprintf("%d", port)))
+	if err != nil {
+		return nil, fmt.Errorf("invalid remote address: %s", err)
+	}
+	laddr, err := net.ResolveTCPAddr("tcp", d.LocalAddr.String())
+	if err != nil {
+		return nil, fmt.Errorf("invalid local address: %s", err)
+	}
+
+	dialer := net.Dialer{LocalAddr: laddr, Timeout: d.Timeout}
+	conn, err := dialer.Dial("tcp", raddr.String())
+	if err != nil {
+		return nil, err
+	}
+	return conn.(*net.TCPConn), nil
 }

--- a/server/sockopt.go
+++ b/server/sockopt.go
@@ -27,6 +27,10 @@ func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
 	return fmt.Errorf("setting md5 is not supported")
 }
 
+func SetListenTcpTTLSockopt(l *net.TCPListener, ttl int) error {
+	return fmt.Errorf("setting ttl is not supported")
+}
+
 func SetTcpTTLSockopt(conn *net.TCPConn, ttl int) error {
 	return fmt.Errorf("setting ttl is not supported")
 }

--- a/server/sockopt_bsd.go
+++ b/server/sockopt_bsd.go
@@ -36,13 +36,8 @@ func setsockoptTcpMD5Sig(fd int, address string, key string) error {
 }
 
 func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
-	fi, err := l.File()
+	fi, _, err := extractFileAndFamilyFromTCPListener(l)
 	defer fi.Close()
-	if err != nil {
-		return err
-	}
-	fl, err := net.FileListener(fi)
-	defer fl.Close()
 	if err != nil {
 		return err
 	}
@@ -57,6 +52,15 @@ func setsockoptIpTtl(fd int, family int, value int) error {
 		name = syscall.IPV6_UNICAST_HOPS
 	}
 	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, level, name, value))
+}
+
+func SetListenTcpTTLSockopt(l *net.TCPListener, ttl int) error {
+	fi, family, err := extractFileAndFamilyFromTCPListener(l)
+	defer fi.Close()
+	if err != nil {
+		return err
+	}
+	return setsockoptIpTtl(int(fi.Fd()), family, ttl)
 }
 
 func SetTcpTTLSockopt(conn *net.TCPConn, ttl int) error {

--- a/server/sockopt_linux.go
+++ b/server/sockopt_linux.go
@@ -65,13 +65,8 @@ func setsockoptTcpMD5Sig(fd int, address string, key string) error {
 }
 
 func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
-	fi, err := l.File()
+	fi, _, err := extractFileAndFamilyFromTCPListener(l)
 	defer fi.Close()
-	if err != nil {
-		return err
-	}
-	fl, err := net.FileListener(fi)
-	defer fl.Close()
 	if err != nil {
 		return err
 	}
@@ -86,6 +81,15 @@ func setsockoptIpTtl(fd int, family int, value int) error {
 		name = syscall.IPV6_UNICAST_HOPS
 	}
 	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, level, name, value))
+}
+
+func SetListenTcpTTLSockopt(l *net.TCPListener, ttl int) error {
+	fi, family, err := extractFileAndFamilyFromTCPListener(l)
+	defer fi.Close()
+	if err != nil {
+		return err
+	}
+	return setsockoptIpTtl(int(fi.Fd()), family, ttl)
 }
 
 func SetTcpTTLSockopt(conn *net.TCPConn, ttl int) error {

--- a/server/sockopt_openbsd.go
+++ b/server/sockopt_openbsd.go
@@ -363,13 +363,8 @@ func setsockoptTcpMD5Sig(fd int, address string, key string) error {
 }
 
 func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
-	fi, err := l.File()
+	fi, _, err := extractFileAndFamilyFromTCPListener(l)
 	defer fi.Close()
-	if err != nil {
-		return err
-	}
-	fl, err := net.FileListener(fi)
-	defer fl.Close()
 	if err != nil {
 		return err
 	}
@@ -384,6 +379,15 @@ func setsockoptIpTtl(fd int, family int, value int) error {
 		name = syscall.IPV6_UNICAST_HOPS
 	}
 	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, level, name, value))
+}
+
+func SetListenTcpTTLSockopt(l *net.TCPListener, ttl int) error {
+	fi, family, err := extractFileAndFamilyFromTCPListener(l)
+	defer fi.Close()
+	if err != nil {
+		return err
+	}
+	return setsockoptIpTtl(int(fi.Fd()), family, ttl)
 }
 
 func SetTcpTTLSockopt(conn *net.TCPConn, ttl int) error {

--- a/server/sockopt_openbsd.go
+++ b/server/sockopt_openbsd.go
@@ -19,12 +19,12 @@ package server
 import (
 	"encoding/binary"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net"
 	"os"
-	"strings"
 	"syscall"
 	"unsafe"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -352,21 +352,9 @@ const (
 	IPV6_MINHOPCOUNT = 73  // Generalized TTL Security Mechanism (RFC5082)
 )
 
-func SetTcpMD5SigSockopts(l *net.TCPListener, address string, key string) error {
-	fi, err := l.File()
-	defer fi.Close()
-
-	if err != nil {
-		return err
-	}
-
-	if l, err := net.FileListener(fi); err == nil {
-		defer l.Close()
-	}
-
-	t := int(1)
-	if e := syscall.SetsockoptInt(int(fi.Fd()), syscall.IPPROTO_TCP, TCP_MD5SIG, t); e != nil {
-		return e
+func setsockoptTcpMD5Sig(fd int, address string, key string) error {
+	if err := syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, TCP_MD5SIG, 1); err != nil {
+		return os.NewSyscallError("setsockopt", err)
 	}
 	if len(key) > 0 {
 		return saAdd(address, key)
@@ -374,38 +362,104 @@ func SetTcpMD5SigSockopts(l *net.TCPListener, address string, key string) error 
 	return saDelete(address)
 }
 
-func setTcpSockoptInt(conn *net.TCPConn, level int, name int, value int) error {
-	fi, err := conn.File()
+func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+	fi, err := l.File()
 	defer fi.Close()
 	if err != nil {
 		return err
 	}
-	if conn, err := net.FileConn(fi); err == nil {
-		defer conn.Close()
+	fl, err := net.FileListener(fi)
+	defer fl.Close()
+	if err != nil {
+		return err
 	}
-	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(int(fi.Fd()), level, name, value))
+	return setsockoptTcpMD5Sig(int(fi.Fd()), address, key)
 }
 
-func SetTcpTTLSockopts(conn *net.TCPConn, ttl int) error {
+func setsockoptIpTtl(fd int, family int, value int) error {
 	level := syscall.IPPROTO_IP
 	name := syscall.IP_TTL
-	if strings.Contains(conn.RemoteAddr().String(), "[") {
+	if family == syscall.AF_INET6 {
 		level = syscall.IPPROTO_IPV6
 		name = syscall.IPV6_UNICAST_HOPS
 	}
-	return setTcpSockoptInt(conn, level, name, ttl)
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, level, name, value))
 }
 
-func SetTcpMinTTLSockopts(conn *net.TCPConn, ttl int) error {
+func SetTcpTTLSockopt(conn *net.TCPConn, ttl int) error {
+	fi, family, err := extractFileAndFamilyFromTCPConn(conn)
+	defer fi.Close()
+	if err != nil {
+		return err
+	}
+	return setsockoptIpTtl(int(fi.Fd()), family, ttl)
+}
+
+func setsockoptIpMinTtl(fd int, family int, value int) error {
 	level := syscall.IPPROTO_IP
 	name := syscall.IP_MINTTL
-	if strings.Contains(conn.RemoteAddr().String(), "[") {
+	if family == syscall.AF_INET6 {
 		level = syscall.IPPROTO_IPV6
 		name = IPV6_MINHOPCOUNT
 	}
-	return setTcpSockoptInt(conn, level, name, ttl)
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, level, name, value))
 }
 
-func DialTCPTimeoutWithMD5Sig(host string, port int, localAddr, key string, msec int) (*net.TCPConn, error) {
-	return nil, fmt.Errorf("md5 active connection unsupported")
+func SetTcpMinTTLSockopt(conn *net.TCPConn, ttl int) error {
+	fi, family, err := extractFileAndFamilyFromTCPConn(conn)
+	defer fi.Close()
+	if err != nil {
+		return err
+	}
+	return setsockoptIpMinTtl(int(fi.Fd()), family, ttl)
+}
+
+type TCPDialer struct {
+	net.Dialer
+
+	// MD5 authentication password.
+	AuthPassword string
+
+	// The TTL value to set outgoing connection.
+	Ttl uint8
+
+	// The minimum TTL value for incoming packets.
+	TtlMin uint8
+}
+
+func (d *TCPDialer) DialTCP(addr string, port int) (*net.TCPConn, error) {
+	if d.AuthPassword != "" {
+		log.WithFields(log.Fields{
+			"Topic": "Peer",
+			"Key":   addr,
+		}).Warn("setting md5 for active connection is not supported")
+	}
+	if d.Ttl != 0 {
+		log.WithFields(log.Fields{
+			"Topic": "Peer",
+			"Key":   addr,
+		}).Warn("setting ttl for active connection is not supported")
+	}
+	if d.TtlMin != 0 {
+		log.WithFields(log.Fields{
+			"Topic": "Peer",
+			"Key":   addr,
+		}).Warn("setting min ttl for active connection is not supported")
+	}
+
+	raddr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(addr, fmt.Sprintf("%d", port)))
+	if err != nil {
+		return nil, fmt.Errorf("invalid remote address: %s", err)
+	}
+	laddr, err := net.ResolveTCPAddr("tcp", d.LocalAddr.String())
+	if err != nil {
+		return nil, fmt.Errorf("invalid local address: %s", err)
+	}
+
+	dialer := net.Dialer{LocalAddr: laddr, Timeout: d.Timeout}
+	conn, err := dialer.Dial("tcp", raddr.String())
+	if err != nil {
+		return nil, err
+	}
+	return conn.(*net.TCPConn), nil
 }

--- a/server/util.go
+++ b/server/util.go
@@ -66,6 +66,31 @@ func decodeAdministrativeCommunication(data []byte) (string, []byte) {
 	return string(data[1 : communicationLen+1]), data[communicationLen+1:]
 }
 
+func extractFileAndFamilyFromTCPListener(l *net.TCPListener) (*os.File, int, error) {
+	// Note #1: TCPListener.File() has the unexpected side-effect of putting
+	// the original socket into blocking mode. See Note #2.
+	fi, err := l.File()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Note #2: Call net.FileListener() to put the original socket back into
+	// non-blocking mode.
+	fl, err := net.FileListener(fi)
+	if err != nil {
+		fi.Close()
+		return nil, 0, err
+	}
+	fl.Close()
+
+	family := syscall.AF_INET
+	if strings.Contains(l.Addr().String(), "[") {
+		family = syscall.AF_INET6
+	}
+
+	return fi, family, nil
+}
+
 func extractFileAndFamilyFromTCPConn(conn *net.TCPConn) (*os.File, int, error) {
 	// Note #1: TCPConn.File() has the unexpected side-effect of putting
 	// the original socket into blocking mode. See Note #2.


### PR DESCRIPTION
For the interoperability of TTL security, we need to set TTL before dialing and accepting connection to/from neighbors.
This patch fixes to set the default TTL(=255) for incoming connection, and set the given TTL for outgoing connection.