### PR TITLE
scenario_test/addpath_test: Test cases with non add-path router

### DIFF
--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -382,18 +382,35 @@ class BGPContainer(Container):
                   local_pref=None, identifier=None, reload_config=True):
         if route not in self.routes:
             self.routes[route] = []
-        self.routes[route].append({'prefix': route,
-                              'rf': rf,
-                              'attr': attribute,
-                              'next-hop': nexthop,
-                              'as-path': aspath,
-                              'community': community,
-                              'med': med,
-                              'local-pref': local_pref,
-                              'extended-community': extendedcommunity,
-                              'identifier': identifier,
-                              'matchs': matchs,
-                              'thens': thens})
+        self.routes[route].append({
+            'prefix': route,
+            'rf': rf,
+            'attr': attribute,
+            'next-hop': nexthop,
+            'as-path': aspath,
+            'community': community,
+            'med': med,
+            'local-pref': local_pref,
+            'extended-community': extendedcommunity,
+            'identifier': identifier,
+            'matchs': matchs,
+            'thens': thens,
+        })
+        if self.is_running and reload_config:
+            self.create_config()
+            self.reload_config()
+
+    def del_route(self, route, identifier=None, reload_config=True):
+        if route not in self.routes:
+            return
+        if identifier:
+            new_paths = []
+            for path in self.routes[route]:
+                if path['identifier'] != identifier:
+                    new_paths.append(path)
+            self.routes[route] = new_paths
+        else:
+            self.routes[route] = []
         if self.is_running and reload_config:
             self.create_config()
             self.reload_config()

--- a/test/scenario_test/addpath_test.py
+++ b/test/scenario_test/addpath_test.py
@@ -37,9 +37,12 @@ class GoBGPTestBase(unittest.TestCase):
         g1 = GoBGPContainer(name='g1', asn=65000, router_id='192.168.0.1',
                             ctn_image_name=gobgp_ctn_image_name,
                             log_level=parser_option.gobgp_log_level)
-        e1 = ExaBGPContainer(name='e1', asn=65000, router_id='192.168.0.2')
+        g2 = GoBGPContainer(name='g2', asn=65000, router_id='192.168.0.2',
+                            ctn_image_name=gobgp_ctn_image_name,
+                            log_level=parser_option.gobgp_log_level)
+        e1 = ExaBGPContainer(name='e1', asn=65000, router_id='192.168.0.3')
 
-        ctns = [g1, e1]
+        ctns = [g1, g2, e1]
 
         e1.add_route(route='192.168.100.0/24', identifier=10, aspath=[100, 200, 300])
         e1.add_route(route='192.168.100.0/24', identifier=20, aspath=[100, 200])
@@ -51,18 +54,46 @@ class GoBGPTestBase(unittest.TestCase):
 
         g1.add_peer(e1, addpath=True)
         e1.add_peer(g1, addpath=True)
+
+        g1.add_peer(g2, addpath=False, is_rr_client=True)
+        g2.add_peer(g1, addpath=False)
+
         cls.g1 = g1
+        cls.g2 = g2
         cls.e1 = e1
 
     # test each neighbor state is turned establish
     def test_01_neighbor_established(self):
+        self.g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g2)
         self.g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.e1)
 
     # test three routes are installed to the rib due to add-path feature
     def test_02_check_g1_global_rib(self):
         rib = self.g1.get_global_rib()
-        self.assertTrue(len(rib) == 1)
-        self.assertTrue(len(rib[0]['paths']) == 3)
+        self.assertEqual(len(rib), 1)
+        self.assertEqual(len(rib[0]['paths']), 3)
+
+    # test only the best path is advertised to g2
+    def test_03_check_g2_global_rib(self):
+        rib = self.g2.get_global_rib()
+        self.assertEqual(len(rib), 1)
+        self.assertEqual(len(rib[0]['paths']), 1)
+        self.assertEqual(rib[0]['paths'][0]["aspath"], [100])
+
+    # test a withdraw route with path_id is removed from the rib
+    def test_04_withdraw_route_with_path_id(self):
+        self.e1.del_route(route='192.168.100.0/24', identifier=30)
+
+        rib = self.g1.get_global_rib()
+        self.assertEqual(len(rib), 1)
+        self.assertEqual(len(rib[0]['paths']), 2)
+
+    # test the best path is replaced due to the removal from g1 rib
+    def test_05_check_g2_global_rib(self):
+        rib = self.g2.get_global_rib()
+        self.assertEqual(len(rib), 1)
+        self.assertEqual(len(rib[0]['paths']), 1)
+        self.assertEqual(rib[0]['paths'][0]["aspath"], [100, 200])
 
 
 if __name__ == '__main__':

--- a/test/scenario_test/addpath_test.py
+++ b/test/scenario_test/addpath_test.py
@@ -13,18 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+import time
 import unittest
+
+import nose
 from fabric.api import local
+
 from lib import base
 from lib.base import BGP_FSM_ESTABLISHED
-from lib.gobgp import *
-from lib.exabgp import *
-import sys
-import os
-import time
-import nose
+from lib.gobgp import GoBGPContainer
+from lib.exabgp import ExaBGPContainer
 from lib.noseplugin import OptionParser, parser_option
-from itertools import combinations
 
 
 class GoBGPTestBase(unittest.TestCase):
@@ -64,10 +64,8 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertTrue(len(rib) == 1)
         self.assertTrue(len(rib[0]['paths']) == 3)
 
+
 if __name__ == '__main__':
-    if os.geteuid() is not 0:
-        print "you are not root."
-        sys.exit(1)
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
         print "docker not found"


### PR DESCRIPTION
This patch adds the test cases for the mixed situation of add-path enabled routers and non add-path enabled routers and advertising/withdrawing routes in such situation.