### PR TITLE
docs: Update config example

### DIFF
--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -17,9 +17,6 @@
         default-import-policy = "reject-route"
         export-policy-list = ["policy2"]
         default-export-policy = "accept-route"
-    [global.mpls-label-range]
-        min-label = 1000
-        max-label = 2000
 
 [[rpki-servers]]
     [rpki-servers.config]

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -31,9 +31,10 @@
         statistics-timeout = 3600
 
 [[mrt-dump]]
-    dump-type = "updates"
-    file-name = "/tmp/log/2006/01/02.1504.dump"
-    interval = 180
+    [mrt-dump.config]
+        dump-type = "updates"
+        file-name = "/tmp/log/2006/01/02.1504.dump"
+        dump-interval = 180
 
 [zebra]
     [zebra.config]
@@ -123,6 +124,7 @@
         [neighbors.afi-safis.config]
         afi-safi-name = "ipv6-flowspec"
     [[neighbors.afi-safis]]
+        [neighbors.afi-safis.config]
         afi-safi-name = "opaque"
     [neighbors.apply-policy.config]
         import-policy-list = ["policy1"]
@@ -187,7 +189,7 @@
             community-set = "cs0"
             match-set-options = "all"
         [policy-definitions.statements.conditions.bgp-conditions.match-large-community-set]
-            community-set = "ls0"
+            large-community-set = "ls0"
             match-set-options = "all"
         [policy-definitions.statements.actions.bgp-actions.set-as-path-prepend]
             as = "last-as"
@@ -246,7 +248,7 @@
 [[policy-definitions]]
     name = "route-type-policy"
     [[policy-definitions.statements]]
-        # this statement matches with locally generated routes 
+        # this statement matches with locally generated routes
         [policy-definitions.statements.conditions.bgp-conditions]
             route-type = "local"
         [policy-definitions.statements.actions]


### PR DESCRIPTION
Currently, "docs/sources/configuration.md" has some obsoleted config parameters and some syntax errors.
This PR fixes these problems and introduces UT for validating syntax of the configuration example.