### PR TITLE
gobgpd: Avoid name collision

### DIFF
--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -25,15 +25,16 @@ import (
 	"syscall"
 
 	"github.com/jessevdk/go-flags"
-	p "github.com/kr/pretty"
+	"github.com/kr/pretty"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
 	api "github.com/osrg/gobgp/api"
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
 	"github.com/osrg/gobgp/server"
 	"github.com/osrg/gobgp/table"
-	log "github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 func main() {
@@ -115,7 +116,7 @@ func main() {
 		go config.ReadConfigfileServe(opts.ConfigFile, opts.ConfigType, configCh)
 		c := <-configCh
 		if opts.LogLevel == "debug" {
-			p.Println(c)
+			pretty.Println(c)
 		}
 		os.Exit(0)
 	}


### PR DESCRIPTION
alias "p" for "github.com/kr/pretty" collides the local variable "p" for Peer structure.
This patch fixes to avoid this name collision and also sorts the import order with goimports.
  e.g.) goimports -w -local github.com/osrg/gobgp gobgpd/main.go

Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>