### PR TITLE
table: allocate bitmap for path id dynamically

### DIFF
--- a/api/util.go
+++ b/api/util.go
@@ -82,7 +82,7 @@ func (d *Destination) ToNativeDestination(option ...ToNativeOption) (*table.Dest
 		}
 		paths = append(paths, path)
 	}
-	return table.NewDestination(nlri, paths...), nil
+	return table.NewDestination(nlri, 0, paths...), nil
 }
 
 func (p *Path) ToNativePath(option ...ToNativeOption) (*table.Path, error) {

--- a/gobgp/cmd/mrt.go
+++ b/gobgp/cmd/mrt.go
@@ -108,7 +108,7 @@ func injectMrt(filename string, count int, skip int, onlyBest bool) error {
 				}
 
 				if onlyBest {
-					dst := table.NewDestination(nlri)
+					dst := table.NewDestination(nlri, 0)
 					for _, p := range paths {
 						dst.AddNewPath(p)
 					}

--- a/table/adj.go
+++ b/table/adj.go
@@ -178,7 +178,7 @@ func (adj *AdjRib) Select(family bgp.RouteFamily, accepted bool, option ...Table
 		if d, y := dsts[path.GetNlri().String()]; y {
 			d.knownPathList = append(d.knownPathList, path)
 		} else {
-			dst := NewDestination(path.GetNlri())
+			dst := NewDestination(path.GetNlri(), 0)
 			dsts[path.GetNlri().String()] = dst
 			dst.knownPathList = append(dst.knownPathList, path)
 		}

--- a/table/table.go
+++ b/table/table.go
@@ -217,10 +217,7 @@ func (t *Table) getOrCreateDest(nlri bgp.AddrPrefixInterface) *Destination {
 			"Topic": "Table",
 			"Key":   tableKey,
 		}).Debugf("create Destination")
-		dest = NewDestination(nlri)
-		dest.localIdMap = NewBitmap(2048)
-		// the id zero means id is not allocated yet.
-		dest.localIdMap.Flag(0)
+		dest = NewDestination(nlri, 64)
 		t.setDestination(tableKey, dest)
 	}
 	return dest

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -28,7 +28,7 @@ func TestTableDeleteDestByNlri(t *testing.T) {
 	ipv4t := NewTable(bgp.RF_IPv4_UC)
 	for _, path := range pathT {
 		tableKey := ipv4t.tableKey(path.GetNlri())
-		dest := NewDestination(path.GetNlri())
+		dest := NewDestination(path.GetNlri(), 0)
 		ipv4t.setDestination(tableKey, dest)
 	}
 	tableKey := ipv4t.tableKey(pathT[0].GetNlri())
@@ -43,11 +43,11 @@ func TestTableDeleteDest(t *testing.T) {
 	ipv4t := NewTable(bgp.RF_IPv4_UC)
 	for _, path := range pathT {
 		tableKey := ipv4t.tableKey(path.GetNlri())
-		dest := NewDestination(path.GetNlri())
+		dest := NewDestination(path.GetNlri(), 0)
 		ipv4t.setDestination(tableKey, dest)
 	}
 	tableKey := ipv4t.tableKey(pathT[0].GetNlri())
-	dest := NewDestination(pathT[0].GetNlri())
+	dest := NewDestination(pathT[0].GetNlri(), 0)
 	ipv4t.setDestination(tableKey, dest)
 	ipv4t.deleteDest(dest)
 	gdest := ipv4t.GetDestination(tableKey)
@@ -67,7 +67,7 @@ func TestTableSetDestinations(t *testing.T) {
 	destinations := make(map[string]*Destination)
 	for _, path := range pathT {
 		tableKey := ipv4t.tableKey(path.GetNlri())
-		dest := NewDestination(path.GetNlri())
+		dest := NewDestination(path.GetNlri(), 0)
 		destinations[tableKey] = dest
 	}
 	ipv4t.setDestinations(destinations)
@@ -81,7 +81,7 @@ func TestTableGetDestinations(t *testing.T) {
 	destinations := make(map[string]*Destination)
 	for _, path := range pathT {
 		tableKey := ipv4t.tableKey(path.GetNlri())
-		dest := NewDestination(path.GetNlri())
+		dest := NewDestination(path.GetNlri(), 0)
 		destinations[tableKey] = dest
 	}
 	ipv4t.setDestinations(destinations)


### PR DESCRIPTION
allocating 256 bytes per prefix isn't a good idea. Let's allocate 8
bytes by default and expand dynamically if necessary.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>