### PR TITLE
config/default: Avoid doubly setting

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -106,12 +106,18 @@ func SetDefaultNeighborConfigValues(n *Neighbor, asn uint32) error {
 
 func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn uint32) error {
 	if v == nil {
+		// Determines this function is called against the same Neighbor struct,
+		// and if already called, returns immediately.
+		if n.State.LocalAs != 0 {
+			return nil
+		}
 		v = viper.New()
 	}
 
 	if n.Config.LocalAs == 0 {
 		n.Config.LocalAs = asn
 	}
+	n.State.LocalAs = n.Config.LocalAs
 
 	if n.Config.PeerAs != n.Config.LocalAs {
 		n.Config.PeerType = PEER_TYPE_EXTERNAL

--- a/config/default.go
+++ b/config/default.go
@@ -205,17 +205,19 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn ui
 		if err != nil {
 			return err
 		}
-		for i, af := range n.AfiSafis {
+		for i := range n.AfiSafis {
 			vv := viper.New()
 			if len(afs) > i {
 				vv.Set("afi-safi", afs[i])
 			}
-			af.State.AfiSafiName = af.Config.AfiSafiName
-			if !vv.IsSet("afi-safi.config.enabled") {
-				af.Config.Enabled = true
+			if _, err := bgp.GetRouteFamily(string(n.AfiSafis[i].Config.AfiSafiName)); err != nil {
+				return err
 			}
-			af.MpGracefulRestart.State.Enabled = af.MpGracefulRestart.Config.Enabled
-			n.AfiSafis[i] = af
+			n.AfiSafis[i].State.AfiSafiName = n.AfiSafis[i].Config.AfiSafiName
+			if !vv.IsSet("afi-safi.config.enabled") {
+				n.AfiSafis[i].Config.Enabled = true
+			}
+			n.AfiSafis[i].MpGracefulRestart.State.Enabled = n.AfiSafis[i].MpGracefulRestart.Config.Enabled
 		}
 	}
 

--- a/config/default.go
+++ b/config/default.go
@@ -205,7 +205,7 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn ui
 				vv.Set("afi-safi", afs[i])
 			}
 			af.State.AfiSafiName = af.Config.AfiSafiName
-			if !vv.IsSet("afi-safi.config") {
+			if !vv.IsSet("afi-safi.config.enabled") {
 				af.Config.Enabled = true
 			}
 			af.MpGracefulRestart.State.Enabled = af.MpGracefulRestart.Config.Enabled


### PR DESCRIPTION
Currently, GoBGP miss-compares the loaded neighbor configs from file with the current neighbor configs when called to reload configuration with SIGHUP.

For example, GoBGP has one neighbor ("10.0.0.2") in config file:
```
$ cat gobgpd.toml 
[global.config]
  as = 65001
  router-id = "10.0.0.1"

[[neighbors]]
  [neighbors.config]
    neighbor-address = "10.0.0.2"
    peer-as = 65002
  [[neighbors.afi-safis]]
    [neighbors.afi-safis.config]
      afi-safi-name = "ipv4-unicast"
  [[neighbors.afi-safis]]
    [neighbors.afi-safis.config]
      afi-safi-name = "ipv6-unicast"
```
Just one neighbor will be added at the startup:
```
$ gobgpd -f gobgpd.toml 
{"level":"info","msg":"gobgpd started","time":"2017-08-04T13:17:43+09:00"}
{"Topic":"Config","level":"info","msg":"Finished reading the config file","time":"2017-08-04T13:17:43+09:00"}
{"level":"info","msg":"Peer 10.0.0.2 is added","time":"2017-08-04T13:17:43+09:00"}
{"Topic":"Peer","level":"info","msg":"Add a peer configuration for:10.0.0.2","time":"2017-08-04T13:17:43+09:00"}
```
If one more neighbor ("10.0.0.3") is added and with no change for the existing neighbor ("10.0.0.2"):
```
$ cat gobgpd.toml 
[global.config]
  as = 65001
  router-id = "10.0.0.1"

[[neighbors]]
  [neighbors.config]
    neighbor-address = "10.0.0.2"
    peer-as = 65002
  [[neighbors.afi-safis]]
    [neighbors.afi-safis.config]
      afi-safi-name = "ipv4-unicast"
  [[neighbors.afi-safis]]
    [neighbors.afi-safis.config]
      afi-safi-name = "ipv6-unicast"

[[neighbors]]
  [neighbors.config]
    neighbor-address = "10.0.0.3"
    peer-as = 65003
  [[neighbors.afi-safis]]
    [neighbors.afi-safis.config]
      afi-safi-name = "ipv4-unicast"
  [[neighbors.afi-safis]]
    [neighbors.afi-safis.config]
      afi-safi-name = "ipv6-unicast"
```
And send SIGHUP to GoBGP:
```
$ sudo pkill -HUP gobgpd
```
Then, the new neighbor ("10.0.0.3") is added, but unexpectedly the existing neighbor ("10.0.0.2") is updated:
```
{"Topic":"Config","level":"info","msg":"Reload the config file","time":"2017-08-04T13:18:13+09:00"}
{"level":"info","msg":"Peer 10.0.0.3 is added","time":"2017-08-04T13:18:13+09:00"}
{"Topic":"Peer","level":"info","msg":"Add a peer configuration for:10.0.0.3","time":"2017-08-04T13:18:13+09:00"}
{"level":"info","msg":"Peer 10.0.0.2 is updated","time":"2017-08-04T13:18:13+09:00"}  # <-- "10.0.0.2" should NOT be updated
```

This problem occurs because `setDefaultNeighborConfigValuesWithViper()` in `config/default.go` is called "twice" when the configuration is loaded from the files.
The first call is from "config/serve.go" and the second is from AddNeighbor() in "server/server.go".
Especially, the second one is called with `v *viper.Viper = nil`, so the unexpected (if config from file, not form gRPC or other APIs) default value will be set.

This PR fixes this problem.