### PR TITLE
table: fix handling of update msg which has both mpreach and mpunreach

### DIFF
--- a/table/message.go
+++ b/table/message.go
@@ -315,11 +315,12 @@ func createUpdateMsgFromPath(path *Path, msg *bgp.BGPMessage) *bgp.BGPMessage {
 				}
 			} else {
 				attrs := make([]bgp.PathAttributeInterface, 0, 8)
-
 				for _, p := range path.GetPathAttrs() {
-					if p.GetType() == bgp.BGP_ATTR_TYPE_MP_REACH_NLRI {
+					switch p.GetType() {
+					case bgp.BGP_ATTR_TYPE_MP_REACH_NLRI:
 						attrs = append(attrs, bgp.NewPathAttributeMpReachNLRI(path.GetNexthop().String(), []bgp.AddrPrefixInterface{path.GetNlri()}))
-					} else {
+					case bgp.BGP_ATTR_TYPE_MP_UNREACH_NLRI:
+					default:
 						attrs = append(attrs, p)
 					}
 				}

--- a/table/message.go
+++ b/table/message.go
@@ -278,8 +278,16 @@ func createUpdateMsgFromPath(path *Path, msg *bgp.BGPMessage) *bgp.BGPMessage {
 				u := msg.Body.(*bgp.BGPUpdate)
 				u.NLRI = append(u.NLRI, nlri)
 			} else {
-				pathAttrs := path.GetPathAttrs()
-				return bgp.NewBGPUpdateMessage(nil, pathAttrs, []*bgp.IPAddrPrefix{nlri})
+				attrs := make([]bgp.PathAttributeInterface, 0, 8)
+				for _, p := range path.GetPathAttrs() {
+					switch p.GetType() {
+					case bgp.BGP_ATTR_TYPE_MP_REACH_NLRI:
+					case bgp.BGP_ATTR_TYPE_MP_UNREACH_NLRI:
+					default:
+						attrs = append(attrs, p)
+					}
+				}
+				return bgp.NewBGPUpdateMessage(nil, attrs, []*bgp.IPAddrPrefix{nlri})
 			}
 		}
 	} else {

--- a/table/message_test.go
+++ b/table/message_test.go
@@ -432,3 +432,29 @@ func TestBMP(t *testing.T) {
 	pList := ProcessMessage(msg, peerR1(), time.Now())
 	CreateUpdateMsgFromPaths(pList)
 }
+
+func TestMixedMPReachMPUnreach(t *testing.T) {
+	aspath1 := []bgp.AsPathParamInterface{
+		bgp.NewAs4PathParam(2, []uint32{100}),
+	}
+	nlri1 := []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(32, "2222::")}
+	nlri2 := []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(32, "1111::")}
+
+	p := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		bgp.NewPathAttributeAsPath(aspath1),
+		bgp.NewPathAttributeMpReachNLRI("1::1", nlri1),
+		bgp.NewPathAttributeMpUnreachNLRI(nlri2),
+	}
+	msg := bgp.NewBGPUpdateMessage(nil, p, nil)
+	pList := ProcessMessage(msg, peerR1(), time.Now())
+	assert.Equal(t, len(pList), 2)
+	assert.Equal(t, pList[0].IsWithdraw, false)
+	assert.Equal(t, pList[1].IsWithdraw, true)
+	msgs := CreateUpdateMsgFromPaths(pList)
+	assert.Equal(t, len(msgs), 2)
+	attrs := msgs[0].Body.(*bgp.BGPUpdate).PathAttributes
+	assert.Equal(t, len(attrs), 3)
+	attrs = msgs[1].Body.(*bgp.BGPUpdate).PathAttributes
+	assert.Equal(t, len(attrs), 1)
+}


### PR DESCRIPTION
don't put a mpunreach attribute in a path whose NLRI is taken from a mpreach
attribute.
also, don't put a mpreach attribute in a withdrawal path whose NLRI is
taken from a mpunreach attribute.

Signed-off-by: Wataru Ishida <ishida.wataru@lab.ntt.co.jp>