### PR TITLE
Patch 1

### DIFF
--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -279,7 +279,7 @@ func main() {
 			}
 			for i, dn := range newConfig.DynamicNeighbors {
 				log.Infof("Dynamic Neighbor %s is added to PeerGroup %s", dn.Config.Prefix, dn.Config.PeerGroup)
-				if err := bgpServer.AddDynamicNeighbor(&newConfig.DynamicNeighors[i]); err != nil {
+				if err := bgpServer.AddDynamicNeighbor(&newConfig.DynamicNeighbors[i]); err != nil {
 					log.Warn(err)
 				}
 			}

--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -279,7 +279,7 @@ func main() {
 			}
 			for i, dn := range newConfig.DynamicNeighbors {
 				log.Infof("Dynamic Neighbor %s is added to PeerGroup %s", dn.Config.Prefix, dn.Config.PeerGroup)
-				if err := bgpServer.AddDynamicNeighbor(&newConfig.DynamicNeighors); err != nil {
+				if err := bgpServer.AddDynamicNeighbor(&newConfig.DynamicNeighors[i]); err != nil {
 					log.Warn(err)
 				}
 			}

--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -277,9 +277,9 @@ func main() {
 				}
 				updatePolicy = updatePolicy || u
 			}
-			for _, dn := range newConfig.DynamicNeighbors {
+			for i, dn := range newConfig.DynamicNeighbors {
 				log.Infof("Dynamic Neighbor %s is added to PeerGroup %s", dn.Config.Prefix, dn.Config.PeerGroup)
-				if err := bgpServer.AddDynamicNeighbor(&dn); err != nil {
+				if err := bgpServer.AddDynamicNeighbor(&newConfig.DynamicNeighors); err != nil {
 					log.Warn(err)
 				}
 			}


### PR DESCRIPTION
The temporary pointer from the range function is being passed to AddDynamicNeighbor which is the same for every iteration of the loop. So the PeerGroup.DynamicNeighbors all end up with the same config.DynamicNeighbor.

Fixes #1408