### PR TITLE
server: fix fd leak in DialTCP() on Linux

### DIFF
--- a/server/sockopt_linux_test.go
+++ b/server/sockopt_linux_test.go
@@ -18,8 +18,12 @@ package server
 
 import (
 	"bytes"
+	"fmt"
+	"net"
+	"os"
 	"syscall"
 	"testing"
+	"time"
 	"unsafe"
 )
 
@@ -62,5 +66,41 @@ func Test_buildTcpMD5Sigv6(t *testing.T) {
 		t.Log("OK")
 	} else {
 		t.Error("Something wrong v6")
+	}
+}
+
+func Test_DialTCP_FDleak(t *testing.T) {
+	openFds := func() int {
+		pid := os.Getpid()
+		f, err := os.OpenFile(fmt.Sprintf("/proc/%d/fdinfo", pid), os.O_RDONLY, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		names, err := f.Readdirnames(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(names)
+	}
+
+	before := openFds()
+
+	for i := 0; i < 10; i++ {
+		laddr, _ := net.ResolveTCPAddr("tcp", net.JoinHostPort("127.0.0.1", "0"))
+		d := TCPDialer{
+			Dialer: net.Dialer{
+				LocalAddr: laddr,
+				Timeout:   1 * time.Second,
+			},
+		}
+		if _, err := d.DialTCP("127.0.0.1", 1); err == nil {
+			t.Fatalf("should not succeed")
+		}
+
+	}
+
+	if after := openFds(); before != after {
+		t.Fatalf("could be fd leak, %d %d", before, after)
 	}
 }


### PR DESCRIPTION
A new socket was created so we must close it before this function
returns _either_ on failure or success. On success, net.FileConn() in
newTCPConn() increases the refcount of the socket so this fi.Close()
doesn't destroy the socket; the caller can use it (and needs to close
it later).

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>