### PR TITLE
config: Introduce RouteFamily into AfiSafiState

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -3769,6 +3769,10 @@ type AfiSafiState struct {
 	// original -> bgp-op:total-prefixes
 	// .
 	TotalPrefixes uint32 `mapstructure:"total-prefixes" json:"total-prefixes,omitempty"`
+	// original -> gobgp:family
+	// gobgp:family's original type is route-family.
+	// Address family value of AFI-SAFI pair translated from afi-safi-name.
+	Family bgp.RouteFamily `mapstructure:"family" json:"family,omitempty"`
 }
 
 // struct for container bgp-mp:config.

--- a/config/default.go
+++ b/config/default.go
@@ -38,6 +38,7 @@ func defaultAfiSafi(typ AfiSafiType, enable bool) AfiSafi {
 		},
 		State: AfiSafiState{
 			AfiSafiName: typ,
+			Family:      bgp.AddressFamilyValueMap[string(typ)],
 		},
 	}
 }
@@ -210,8 +211,10 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn ui
 			if len(afs) > i {
 				vv.Set("afi-safi", afs[i])
 			}
-			if _, err := bgp.GetRouteFamily(string(n.AfiSafis[i].Config.AfiSafiName)); err != nil {
+			if rf, err := bgp.GetRouteFamily(string(n.AfiSafis[i].Config.AfiSafiName)); err != nil {
 				return err
+			} else {
+				n.AfiSafis[i].State.Family = rf
 			}
 			n.AfiSafis[i].State.AfiSafiName = n.AfiSafis[i].Config.AfiSafiName
 			if !vv.IsSet("afi-safi.config.enabled") {

--- a/config/util.go
+++ b/config/util.go
@@ -59,12 +59,8 @@ type AfiSafis []AfiSafi
 
 func (c AfiSafis) ToRfList() ([]bgp.RouteFamily, error) {
 	rfs := make([]bgp.RouteFamily, 0, len(c))
-	for _, rf := range c {
-		k, err := bgp.GetRouteFamily(string(rf.Config.AfiSafiName))
-		if err != nil {
-			return nil, fmt.Errorf("invalid address family: %s", rf.Config.AfiSafiName)
-		}
-		rfs = append(rfs, k)
+	for _, af := range c {
+		rfs = append(rfs, af.State.Family)
 	}
 	return rfs, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1009,7 +1009,7 @@ func (server *BgpServer) handleFSMMessage(peer *Peer, e *FsmMsg) {
 						rtc = true
 					}
 					for i, a := range peer.fsm.pConf.AfiSafis {
-						if g, _ := bgp.GetRouteFamily(string(a.Config.AfiSafiName)); f == g {
+						if a.State.Family == f {
 							peer.fsm.pConf.AfiSafis[i].MpGracefulRestart.State.EndOfRibReceived = true
 						}
 					}

--- a/tools/pyang_plugins/bgpyang2golang.py
+++ b/tools/pyang_plugins/bgpyang2golang.py
@@ -721,6 +721,7 @@ _type_translation_map = {
     'yang:timeticks': 'int64',
     'ptypes:install-protocol-type': 'string',
     'binary': '[]byte',
+    'route-family': 'bgp.RouteFamily',
     'bgp-capability': 'bgp.ParameterCapabilityInterface',
     'bgp-open-message': '*bgp.BGPMessage',
 }

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -1227,6 +1227,18 @@ module gobgp {
       }
   }
 
+  grouping afi-safi-state {
+    leaf family {
+      description
+        "Address family value of AFI-SAFI pair translated from afi-safi-name.";
+      type route-family;
+    }
+  }
+
+  augment "/bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:state" {
+      uses afi-safi-state;
+  }
+
   augment "/bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi" {
     container route-target-membership {
       container config {


### PR DESCRIPTION
To reduce the translations of "AfiSafiName" into "bgp.RouteFamily", this patch introduces "RouteFamily" field into "AfiSafiState" and stores the translated value.

Currently, this translations of "AfiSafiName" is not critical for the performance, but "AfiSafiName" will be translated at many place and many time, so this patch reduces the complication of handling translations (error checks or so).