### PR TITLE
BMP: Fix behavior for specifying pre-policy

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -338,6 +338,9 @@ func setDefaultConfigValuesWithViper(v *viper.Viper, b *BgpConfigSet) error {
 		if server.Config.Port == 0 {
 			server.Config.Port = bmp.BMP_DEFAULT_PORT
 		}
+		if server.Config.RouteMonitoringPolicy == "" {
+			server.Config.RouteMonitoringPolicy = BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY
+		}
 		// statistics-timeout is uint16 value and implicitly less than 65536
 		if server.Config.StatisticsTimeout != 0 && server.Config.StatisticsTimeout < 15 {
 			return fmt.Errorf("too small statistics-timeout value: %d", server.Config.StatisticsTimeout)

--- a/gobgp/cmd/bmp.go
+++ b/gobgp/cmd/bmp.go
@@ -49,6 +49,7 @@ func modBmpServer(cmdType string, args []string) error {
 		policyType := config.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY
 		if len(args) > 1 {
 			switch args[1] {
+			case "pre":
 			case "post":
 				policyType = config.BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY
 			case "both":

--- a/gobgp/cmd/bmp.go
+++ b/gobgp/cmd/bmp.go
@@ -17,11 +17,12 @@ package cmd
 
 import (
 	"fmt"
+	"net"
+	"strconv"
+
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bmp"
 	"github.com/spf13/cobra"
-	"net"
-	"strconv"
 )
 
 func modBmpServer(cmdType string, args []string) error {


### PR DESCRIPTION
- In the document, it says `route-monitoring policy` is `pre-policy` by default. However it doesn't work unless specifying `route-monitoring policy = "pre-policy"` in the config explicitly.
- When type `gobgp bmp add x.x.x.x:xxxx`, it works fine for pre-policy. But when type it with `pre`, it returns error.

This PR will fix those 2 issues.