### PR TITLE
table/policy: fix ReplacePolicy with preserve=true to remove old statements

### DIFF
--- a/table/policy.go
+++ b/table/policy.go
@@ -3482,9 +3482,10 @@ func (r *RoutingPolicy) ReplacePolicy(x *Policy, refer, preserve bool) (err erro
 		}
 	}
 
+	ys := y.Statements
 	err = y.Replace(x)
 	if err == nil && !preserve {
-		for _, st := range y.Statements {
+		for _, st := range ys {
 			if !r.statementInUse(st) {
 				log.WithFields(log.Fields{
 					"Topic": "Policy",


### PR DESCRIPTION
When policy is replaced, the **old** statements have to be checked for being still in use anywhere else, not the **new** ones