### PR TITLE
server: export addROA()/delROA() for library usage

### DIFF
--- a/server/rpki.go
+++ b/server/rpki.go
@@ -303,6 +303,10 @@ func (m *roaManager) deleteROA(roa *table.ROA) {
 	}).Info("Can't withdraw a ROA")
 }
 
+func (m *roaManager) DeleteROA(roa *table.ROA) {
+	m.deleteROA(roa)
+}
+
 func (m *roaManager) addROA(roa *table.ROA) {
 	tree, key := m.roa2tree(roa)
 	b, _ := tree.Get(key)
@@ -323,6 +327,10 @@ func (m *roaManager) addROA(roa *table.ROA) {
 		}
 	}
 	bucket.entries = append(bucket.entries, roa)
+}
+
+func (m *roaManager) AddROA(roa *table.ROA) {
+	m.addROA(roa)
 }
 
 func (c *roaManager) handleRTRMsg(client *roaClient, state *config.RpkiServerState, buf []byte) {


### PR DESCRIPTION
I'd like to use addROA()/delROA() in my code as library. But currently they are not exportable.
I am happy if you could merge this. 