### PR TITLE
Use critbit instead of go-radix

### DIFF
--- a/server/rpki.go
+++ b/server/rpki.go
@@ -528,8 +528,7 @@ func ValidatePath(ownAs uint32, tree *radix.Tree, cidr string, asPath *bgp.PathA
 	_, n, _ := net.ParseCIDR(cidr)
 	ones, _ := n.Mask.Size()
 	prefixLen := uint8(ones)
-	key := table.IpToRadixkey(n.IP, prefixLen)
-	_, b, _ := tree.LongestPrefix(key)
+	_, b, _ := table.GetLongestPrefix(tree, n.IP, prefixLen)
 	if b == nil {
 		return validation
 	}

--- a/server/rpki_test.go
+++ b/server/rpki_test.go
@@ -23,8 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	radix "github.com/armon/go-radix"
-
+	"github.com/k-sone/critbitgo"
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
 	"github.com/osrg/gobgp/table"
@@ -56,8 +55,10 @@ func strToASParam(str string) *bgp.PathAttributeAsPath {
 	return bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(atype, as)})
 }
 
-func validateOne(tree *radix.Tree, cidr, aspathStr string) config.RpkiValidationResultType {
-	r := ValidatePath(65500, tree, cidr, strToASParam(aspathStr))
+func validateOne(tree *critbitgo.Trie, cidr string, aspathStr string) config.RpkiValidationResultType {
+	_, p, _ := net.ParseCIDR(cidr)
+	ones, _ := p.Mask.Size()
+	r := ValidatePath(65500, tree, p.IP, uint8(ones), strToASParam(aspathStr))
 	return r.Status
 }
 

--- a/table/policy.go
+++ b/table/policy.go
@@ -482,7 +482,7 @@ func NewPrefixSetFromApiStruct(name string, prefixes []*Prefix) (*PrefixSet, err
 		} else if family != x.AddressFamily {
 			return nil, fmt.Errorf("multiple families")
 		}
-		key := CidrToRadixkey(x.Prefix.String())
+		key := CidrToTrieKey(x.Prefix.String())
 		d, ok := tree.Get(key)
 		if ok {
 			ps := d.([]*Prefix)
@@ -518,7 +518,7 @@ func NewPrefixSet(c config.PrefixSet) (*PrefixSet, error) {
 		} else if family != y.AddressFamily {
 			return nil, fmt.Errorf("multiple families")
 		}
-		key := CidrToRadixkey(y.Prefix.String())
+		key := CidrToTrieKey(y.Prefix.String())
 		d, ok := tree.Get(key)
 		if ok {
 			ps := d.([]*Prefix)

--- a/table/table.go
+++ b/table/table.go
@@ -267,10 +267,10 @@ func (t *Table) GetLongerPrefixDestinations(key string) ([]*Destination, error) 
 		if err != nil {
 			return nil, err
 		}
-		k := CidrToRadixkey(prefix.String())
+		k := CidrToTrieKey(prefix.String())
 		r := radix.New()
 		for _, dst := range t.GetDestinations() {
-			r.Insert(dst.RadixKey, dst)
+			r.Insert(dst.TreeKey, dst)
 		}
 		r.WalkPrefix(k, func(s string, v interface{}) bool {
 			results = append(results, v.(*Destination))


### PR DESCRIPTION
As discussed in #1414, critbitgo reduces memory consumption and give some speedups.
This PR replaces go-radix with critbitgo.