### PR TITLE
config/default: Set treat-as-withdraw to true as default

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -143,6 +143,10 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn ui
 	n.State.PeerAs = n.Config.PeerAs
 	n.AsPathOptions.State.AllowOwnAs = n.AsPathOptions.Config.AllowOwnAs
 
+	if !v.IsSet("neighbor.error-handling.config.treat-as-withdraw") {
+		n.ErrorHandling.Config.TreatAsWithdraw = true
+	}
+
 	if !v.IsSet("neighbor.timers.config.connect-retry") && n.Timers.Config.ConnectRetry == 0 {
 		n.Timers.Config.ConnectRetry = float64(DEFAULT_CONNECT_RETRY)
 	}


### PR DESCRIPTION
RFC7606 updates some other RFC and says that BGP speakers
should not send NOTIFICATION for some errors in received UPDATE.
Thus, treat-as-withdraw should be true as a default value.

Signed-off-by: Satoshi Fujimoto <satoshi.fujimoto7@gmail.com>