### PR TITLE
*: Support BGP Confederations (RFC 5065) 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,6 +147,9 @@ matrix:
     - <<: *_docker
       env:
         - TEST=bgp_malformed_msg_handling_test.py
+    - <<: *_docker
+      env:
+        - TEST=bgp_confederation_test.py
 #
 # Spell Check
 #

--- a/config/default.go
+++ b/config/default.go
@@ -124,6 +124,11 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, g *Glo
 
 	if n.Config.LocalAs == 0 {
 		n.Config.LocalAs = g.Config.As
+		if !g.Confederation.Config.Enabled || n.IsConfederation(g) {
+			n.Config.LocalAs = g.Config.As
+		} else {
+			n.Config.LocalAs = g.Confederation.Config.Identifier
+		}
 	}
 	n.State.LocalAs = n.Config.LocalAs
 

--- a/config/default.go
+++ b/config/default.go
@@ -101,11 +101,18 @@ func isLocalLinkLocalAddress(ifindex int, addr net.IP) (bool, error) {
 	return false, nil
 }
 
-func SetDefaultNeighborConfigValues(n *Neighbor, asn uint32) error {
-	return setDefaultNeighborConfigValuesWithViper(nil, n, asn)
+func SetDefaultNeighborConfigValues(n *Neighbor, g *Global) error {
+	return setDefaultNeighborConfigValuesWithViper(nil, n, g)
 }
 
-func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn uint32) error {
+func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, g *Global) error {
+	if n == nil {
+		return fmt.Errorf("neighbor config is nil")
+	}
+	if g == nil {
+		return fmt.Errorf("global config is nil")
+	}
+
 	if v == nil {
 		// Determines this function is called against the same Neighbor struct,
 		// and if already called, returns immediately.
@@ -116,7 +123,7 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, asn ui
 	}
 
 	if n.Config.LocalAs == 0 {
-		n.Config.LocalAs = asn
+		n.Config.LocalAs = g.Config.As
 	}
 	n.State.LocalAs = n.Config.LocalAs
 
@@ -407,7 +414,7 @@ func setDefaultConfigValuesWithViper(v *viper.Viper, b *BgpConfigSet) error {
 		if len(list) > idx {
 			vv.Set("neighbor", list[idx])
 		}
-		if err := setDefaultNeighborConfigValuesWithViper(vv, &n, b.Global.Config.As); err != nil {
+		if err := setDefaultNeighborConfigValuesWithViper(vv, &n, &b.Global); err != nil {
 			return err
 		}
 		b.Neighbors[idx] = n

--- a/config/util.go
+++ b/config/util.go
@@ -40,19 +40,24 @@ func detectConfigFileType(path, def string) string {
 	}
 }
 
-func IsConfederationMember(g *Global, p *Neighbor) bool {
-	if p.Config.PeerAs != g.Config.As {
-		for _, member := range g.Confederation.Config.MemberAsList {
-			if member == p.Config.PeerAs {
-				return true
-			}
+func (n *Neighbor) IsConfederationMember(g *Global) bool {
+	for _, member := range g.Confederation.Config.MemberAsList {
+		if member == n.Config.PeerAs {
+			return true
 		}
 	}
 	return false
 }
 
-func IsEBGPPeer(g *Global, p *Neighbor) bool {
-	return p.Config.PeerAs != g.Config.As
+func (n *Neighbor) IsConfederation(g *Global) bool {
+	if n.Config.PeerAs == g.Config.As {
+		return true
+	}
+	return n.IsConfederationMember(g)
+}
+
+func (n *Neighbor) IsEBGPPeer(g *Global) bool {
+	return n.Config.PeerAs != g.Config.As
 }
 
 type AfiSafis []AfiSafi

--- a/packet/bgp/validate_test.go
+++ b/packet/bgp/validate_test.go
@@ -41,29 +41,29 @@ func bgpupdateV6() *BGPMessage {
 func Test_Validate_CapV4(t *testing.T) {
 	assert := assert.New(t)
 	message := bgpupdate().Body.(*BGPUpdate)
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv6_UC: BGP_ADD_PATH_BOTH}, false)
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv6_UC: BGP_ADD_PATH_BOTH}, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 
-	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false)
+	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
 	assert.Equal(true, res)
 }
 
 func Test_Validate_CapV6(t *testing.T) {
 	assert := assert.New(t)
 	message := bgpupdateV6().Body.(*BGPUpdate)
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv6_UC: BGP_ADD_PATH_BOTH}, false)
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv6_UC: BGP_ADD_PATH_BOTH}, false, false)
 	assert.Equal(true, res)
 	assert.NoError(err)
 
-	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false)
+	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
 	assert.Equal(false, res)
 }
 
 func Test_Validate_OK(t *testing.T) {
 	assert := assert.New(t)
 	message := bgpupdate().Body.(*BGPUpdate)
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false)
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
 	assert.Equal(true, res)
 	assert.NoError(err)
 
@@ -151,7 +151,7 @@ func Test_Validate_duplicate_attribute(t *testing.T) {
 	origin.DecodeFromBytes(originBytes)
 	message.PathAttributes = append(message.PathAttributes, origin)
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false)
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -165,7 +165,7 @@ func Test_Validate_mandatory_missing(t *testing.T) {
 	assert := assert.New(t)
 	message := bgpupdate().Body.(*BGPUpdate)
 	message.PathAttributes = message.PathAttributes[1:]
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false)
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -182,7 +182,7 @@ func Test_Validate_mandatory_missing_nocheck(t *testing.T) {
 	message.PathAttributes = message.PathAttributes[1:]
 	message.NLRI = nil
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false)
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
 	assert.Equal(true, res)
 	assert.NoError(err)
 }
@@ -196,7 +196,7 @@ func Test_Validate_invalid_origin(t *testing.T) {
 	origin.DecodeFromBytes(originBytes)
 	message.PathAttributes[0] = origin
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false)
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -218,7 +218,7 @@ func Test_Validate_invalid_nexthop_zero(t *testing.T) {
 	nexthop.DecodeFromBytes(nexthopBytes)
 	message.PathAttributes[2] = nexthop
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false)
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -240,7 +240,7 @@ func Test_Validate_invalid_nexthop_lo(t *testing.T) {
 	nexthop.DecodeFromBytes(nexthopBytes)
 	message.PathAttributes[2] = nexthop
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false)
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -262,7 +262,7 @@ func Test_Validate_invalid_nexthop_de(t *testing.T) {
 	nexthop.DecodeFromBytes(nexthopBytes)
 	message.PathAttributes[2] = nexthop
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false)
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -283,7 +283,7 @@ func Test_Validate_unrecognized_well_known(t *testing.T) {
 	unknown.DecodeFromBytes(unknownBytes)
 	message.PathAttributes = append(message.PathAttributes, unknown)
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false)
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -299,7 +299,7 @@ func Test_Validate_aspath(t *testing.T) {
 	message := bgpupdate().Body.(*BGPUpdate)
 
 	// VALID AS_PATH
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true)
+	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, false)
 	assert.Equal(true, res)
 
 	// CONFED_SET
@@ -317,13 +317,21 @@ func Test_Validate_aspath(t *testing.T) {
 	}
 
 	message.PathAttributes = newAttrs
-	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true)
+	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
 	assert.Equal(uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR), e.TypeCode)
 	assert.Equal(uint8(BGP_ERROR_SUB_MALFORMED_AS_PATH), e.SubTypeCode)
 	assert.Equal(ERROR_HANDLING_TREAT_AS_WITHDRAW, e.ErrorHandling)
+	assert.Nil(e.Data)
+
+	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, true)
+	assert.Equal(false, res)
+	assert.Error(err)
+	e = err.(*MessageError)
+	assert.Equal(uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR), e.TypeCode)
+	assert.Equal(uint8(BGP_ERROR_SUB_MALFORMED_AS_PATH), e.SubTypeCode)
 	assert.Nil(e.Data)
 
 	// CONFED_SEQ
@@ -341,7 +349,7 @@ func Test_Validate_aspath(t *testing.T) {
 	}
 
 	message.PathAttributes = newAttrs
-	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true)
+	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e = err.(*MessageError)
@@ -349,6 +357,9 @@ func Test_Validate_aspath(t *testing.T) {
 	assert.Equal(uint8(BGP_ERROR_SUB_MALFORMED_AS_PATH), e.SubTypeCode)
 	assert.Equal(ERROR_HANDLING_TREAT_AS_WITHDRAW, e.ErrorHandling)
 	assert.Nil(e.Data)
+
+	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, true)
+	assert.Equal(true, res)
 }
 
 func Test_Validate_flowspec(t *testing.T) {
@@ -382,7 +393,7 @@ func Test_Validate_flowspec(t *testing.T) {
 	n1 := NewFlowSpecIPv4Unicast(cmp)
 	a := NewPathAttributeMpReachNLRI("", []AddrPrefixInterface{n1})
 	m := map[RouteFamily]BGPAddPathMode{RF_FS_IPv4_UC: BGP_ADD_PATH_NONE}
-	_, err := ValidateAttribute(a, m, false)
+	_, err := ValidateAttribute(a, m, false, false)
 	assert.Nil(err)
 
 	cmp = make([]FlowSpecComponentInterface, 0)
@@ -390,7 +401,7 @@ func Test_Validate_flowspec(t *testing.T) {
 	cmp = append(cmp, NewFlowSpecDestinationPrefix(NewIPAddrPrefix(24, "10.0.0.0")))
 	n1 = NewFlowSpecIPv4Unicast(cmp)
 	a = NewPathAttributeMpReachNLRI("", []AddrPrefixInterface{n1})
-	_, err = ValidateAttribute(a, m, false)
+	_, err = ValidateAttribute(a, m, false, false)
 	assert.NotNil(err)
 }
 
@@ -404,7 +415,7 @@ func TestValidateLargeCommunities(t *testing.T) {
 	assert.Nil(err)
 	a := NewPathAttributeLargeCommunities([]*LargeCommunity{c1, c2, c3})
 	assert.True(len(a.Values) == 3)
-	_, err = ValidateAttribute(a, nil, false)
+	_, err = ValidateAttribute(a, nil, false, false)
 	assert.Nil(err)
 	assert.True(len(a.Values) == 2)
 }

--- a/server/peer.go
+++ b/server/peer.go
@@ -79,7 +79,7 @@ func newDynamicPeer(g *config.Global, neighborAddress string, pg *config.PeerGro
 		}).Debugf("Can't overwrite neighbor config: %s", err)
 		return nil
 	}
-	if err := config.SetDefaultNeighborConfigValues(&conf, g.Config.As); err != nil {
+	if err := config.SetDefaultNeighborConfigValues(&conf, g); err != nil {
 		log.WithFields(log.Fields{
 			"Topic": "Peer",
 			"Key":   neighborAddress,

--- a/server/server.go
+++ b/server/server.go
@@ -714,7 +714,15 @@ func (server *BgpServer) propagateUpdate(peer *Peer, pathList []*table.Path) {
 		dsts = rib.ProcessPaths(append(pathList, moded...))
 	} else {
 		for idx, path := range pathList {
-			if p := server.policy.ApplyPolicy(table.GLOBAL_RIB_NAME, table.POLICY_DIRECTION_IMPORT, path, nil); p != nil {
+			var options *table.PolicyOptions
+			if peer != nil {
+				options = &table.PolicyOptions{
+					Info: peer.fsm.peerInfo,
+				}
+			} else {
+				options = nil
+			}
+			if p := server.policy.ApplyPolicy(table.GLOBAL_RIB_NAME, table.POLICY_DIRECTION_IMPORT, path, options); p != nil {
 				path = p
 			} else {
 				path = path.Clone(true)

--- a/server/server.go
+++ b/server/server.go
@@ -1754,7 +1754,7 @@ func (server *BgpServer) addNeighbor(c *config.Neighbor) error {
 		}
 	}
 
-	if err := config.SetDefaultNeighborConfigValues(c, server.bgpConfig.Global.Config.As); err != nil {
+	if err := config.SetDefaultNeighborConfigValues(c, &server.bgpConfig.Global); err != nil {
 		return err
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -200,7 +200,8 @@ func TestNumGoroutineWithAddDeleteNeighbor(t *testing.T) {
 
 func newPeerandInfo(myAs, as uint32, address string, rib *table.TableManager) (*Peer, *table.PeerInfo) {
 	nConf := &config.Neighbor{Config: config.NeighborConfig{PeerAs: as, NeighborAddress: address}}
-	config.SetDefaultNeighborConfigValues(nConf, myAs)
+	gConf := &config.Global{Config: config.GlobalConfig{As: myAs}}
+	config.SetDefaultNeighborConfigValues(nConf, gConf)
 	policy := table.NewRoutingPolicy()
 	policy.Reset(&config.RoutingPolicy{}, nil)
 	p := NewPeer(

--- a/table/path.go
+++ b/table/path.go
@@ -665,7 +665,12 @@ func (path *Path) GetAsString() string {
 
 			sep := " "
 			switch segment.Type {
-			case bgp.BGP_ASPATH_ATTR_TYPE_SET, bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET:
+			case bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
+				s.WriteString("(")
+			case bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET:
+				s.WriteString("[")
+				sep = ","
+			case bgp.BGP_ASPATH_ATTR_TYPE_SET:
 				s.WriteString("{")
 				sep = ","
 			}
@@ -676,7 +681,11 @@ func (path *Path) GetAsString() string {
 				}
 			}
 			switch segment.Type {
-			case bgp.BGP_ASPATH_ATTR_TYPE_SET, bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET:
+			case bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
+				s.WriteString(")")
+			case bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET:
+				s.WriteString("]")
+			case bgp.BGP_ASPATH_ATTR_TYPE_SET:
 				s.WriteString("}")
 			}
 		}

--- a/table/path_test.go
+++ b/table/path_test.go
@@ -116,7 +116,7 @@ func TestPathPrependAsnToExistingSeqAttr(t *testing.T) {
 	peer := PathCreatePeer()
 	p := NewPath(peer[0], update.NLRI[0], false, update.PathAttributes, time.Now(), false)
 
-	p.PrependAsn(65000, 1)
+	p.PrependAsn(65000, 1, false)
 	assert.Equal([]uint32{65000, 65001, 65002, 65003, 65004, 65005, 0, 0, 0}, p.GetAsSeqList())
 }
 
@@ -138,7 +138,7 @@ func TestPathPrependAsnToNewAsPathAttr(t *testing.T) {
 	p := NewPath(peer[0], update.NLRI[0], false, update.PathAttributes, time.Now(), false)
 
 	asn := uint32(65000)
-	p.PrependAsn(asn, 1)
+	p.PrependAsn(asn, 1, false)
 	assert.Equal([]uint32{asn}, p.GetAsSeqList())
 }
 
@@ -166,7 +166,7 @@ func TestPathPrependAsnToNewAsPathSeq(t *testing.T) {
 	p := NewPath(peer[0], update.NLRI[0], false, update.PathAttributes, time.Now(), false)
 
 	asn := uint32(65000)
-	p.PrependAsn(asn, 1)
+	p.PrependAsn(asn, 1, false)
 	assert.Equal([]uint32{asn, 0, 0, 0}, p.GetAsSeqList())
 }
 
@@ -195,7 +195,7 @@ func TestPathPrependAsnToEmptyAsPathAttr(t *testing.T) {
 	p := NewPath(peer[0], update.NLRI[0], false, update.PathAttributes, time.Now(), false)
 
 	asn := uint32(65000)
-	p.PrependAsn(asn, 1)
+	p.PrependAsn(asn, 1, false)
 	assert.Equal([]uint32{asn, 0, 0, 0}, p.GetAsSeqList())
 }
 
@@ -233,7 +233,7 @@ func TestPathPrependAsnToFullPathAttr(t *testing.T) {
 	for _, v := range asns {
 		expected = append(expected, uint32(v))
 	}
-	p.PrependAsn(65000, 2)
+	p.PrependAsn(65000, 2, false)
 	assert.Equal(append(expected, []uint32{0, 0, 0}...), p.GetAsSeqList())
 }
 

--- a/table/policy.go
+++ b/table/policy.go
@@ -2260,7 +2260,7 @@ func (a *AsPathPrependAction) Type() ActionType {
 	return ACTION_AS_PATH_PREPEND
 }
 
-func (a *AsPathPrependAction) Apply(path *Path, _ *PolicyOptions) *Path {
+func (a *AsPathPrependAction) Apply(path *Path, option *PolicyOptions) *Path {
 	var asn uint32
 	if a.useLeftMost {
 		aspath := path.GetAsSeqList()
@@ -2283,7 +2283,8 @@ func (a *AsPathPrependAction) Apply(path *Path, _ *PolicyOptions) *Path {
 		asn = a.asn
 	}
 
-	path.PrependAsn(asn, a.repeat)
+	confed := option != nil && option.Info.Confederation
+	path.PrependAsn(asn, a.repeat, confed)
 
 	return path
 }

--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -327,7 +327,7 @@ class BGPContainer(Container):
                  graceful_restart=None, local_as=None, prefix_limit=None,
                  v6=False, llgr=None, vrf='', interface='', allow_as_in=0,
                  remove_private_as=None, replace_peer_as=False, addpath=False,
-                 treat_as_withdraw=False):
+                 treat_as_withdraw=False, remote_as=None):
         neigh_addr = ''
         local_addr = ''
         it = itertools.product(self.ip_addrs, peer.ip_addrs)
@@ -373,7 +373,8 @@ class BGPContainer(Container):
                             'remove_private_as': remove_private_as,
                             'replace_peer_as': replace_peer_as,
                             'addpath': addpath,
-                            'treat_as_withdraw': treat_as_withdraw}
+                            'treat_as_withdraw': treat_as_withdraw,
+                            'remote_as': remote_as or peer.asn}
         if self.is_running and reload_config:
             self.create_config()
             self.reload_config()

--- a/test/scenario_test/bgp_confederation_test.py
+++ b/test/scenario_test/bgp_confederation_test.py
@@ -1,0 +1,157 @@
+# Copyright (C) 2017 Nippon Telegraph and Telephone Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import sys
+import time
+import unittest
+
+from fabric.api import local
+import nose
+
+from lib.noseplugin import OptionParser, parser_option
+
+from lib import base
+from lib.base import BGP_FSM_ESTABLISHED
+from lib.gobgp import GoBGPContainer
+from lib.quagga import QuaggaBGPContainer
+
+
+class GoBGPTestBase(unittest.TestCase):
+
+    def _check_global_rib_first(self, q, prefix, aspath):
+        route = q.get_global_rib(prefix)[0]
+        self.assertListEqual(aspath, route['aspath'])
+
+    @classmethod
+    def setUpClass(cls):
+        #                  +-----Confederation(AS30)-----+
+        #  AS21     AS20   | +-AS65002-+     +-AS65001-+ |   AS10
+        # +----+   +----+  | | +-----+ |     | +-----+ | |  +----+
+        # | q3 |---| q2 |--+-+-| g1  |-+-----+-| q11 |-+-+--| q1 |
+        # +----+   +----+  | | +-----+ |     | +-----+ | |  +----+
+        #                  | |    |    |     |    |    | |
+        #                  | |    |    |     |    |    | |
+        #                  | |    |    |     |    |    | |
+        #                  | | +-----+ |     | +-----+ | |
+        #                  | | | q22 | |     | | q12 | | |
+        #                  | | +-----+ |     | +-----+ | |
+        #                  | +---------+     +---------+ |
+        #                  +-----------------------------+
+        
+        gobgp_ctn_image_name = parser_option.gobgp_image
+        base.TEST_PREFIX = parser_option.test_prefix
+
+        bgp_conf_1 = {'global': {'confederation': {'config': {
+            'enabled': True, 'identifier': 30, 'member-as-list': [65002]}}}}
+        bgp_conf_2 = {'global': {'confederation': {'config': {
+            'enabled': True, 'identifier': 30, 'member-as-list': [65001]}}}}
+
+        g1 = GoBGPContainer(name='g1', asn=65002, router_id='192.168.2.1',
+                            ctn_image_name=gobgp_ctn_image_name,
+                            log_level=parser_option.gobgp_log_level,
+                            bgp_config=bgp_conf_2)
+
+        q1 = QuaggaBGPContainer(name='q1', asn=10, router_id='1.1.1.1')
+        q2 = QuaggaBGPContainer(name='q2', asn=20, router_id='2.2.2.2')
+        q3 = QuaggaBGPContainer(name='q3', asn=21, router_id='3.3.3.3')
+        q11 = QuaggaBGPContainer(name='q11', asn=65001, router_id='192.168.1.1', bgpd_config=bgp_conf_1)
+        q12 = QuaggaBGPContainer(name='q12', asn=65001, router_id='192.168.1.2', bgpd_config=bgp_conf_1)
+        q22 = QuaggaBGPContainer(name='q22', asn=65002, router_id='192.168.2.2', bgpd_config=bgp_conf_2)
+
+        ctns = [g1, q1, q2, q3, q11, q12, q22]
+
+        cls.initial_wait_time = max(ctn.run() for ctn in ctns)
+
+        time.sleep(cls.initial_wait_time)
+
+        q1.add_peer(q11, remote_as=30)
+        q11.add_peer(q1)
+        q11.add_peer(q12)
+        q12.add_peer(q11)
+        g1.add_peer(q11)
+        q11.add_peer(g1)
+        g1.add_peer(q22)
+        q22.add_peer(g1)
+        g1.add_peer(q2)
+        q2.add_peer(g1, remote_as=30)
+        q3.add_peer(q2)
+        q2.add_peer(q3)
+        cls.gobgp = g1
+        cls.quaggas = {'q1': q1, 'q2': q2, 'q3': q3, 'q11': q11, 'q12': q12, 'q22': q22}
+
+    # test each neighbor state is turned establish
+    def test_01_neighbor_established(self):
+        self.gobgp.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.quaggas['q11'])
+        self.gobgp.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.quaggas['q22'])
+        self.gobgp.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.quaggas['q2'])
+        self.quaggas['q11'].wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.quaggas['q1'])
+        self.quaggas['q11'].wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.quaggas['q12'])
+        self.quaggas['q2'].wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.quaggas['q3'])
+
+    def test_02_route_advertise(self):
+        self.quaggas['q3'].add_route('10.0.0.0/24')
+        time.sleep(self.initial_wait_time)
+
+        routes = []
+        for i in range(60):
+            routes = self.quaggas['q1'].get_global_rib('10.0.0.0/24')
+            if len(routes) > 0:
+                break
+            time.sleep(1)
+        self.failIf(len(routes) == 0)
+
+        # Confirm AS_PATH in confederation is removed
+        self._check_global_rib_first(self.quaggas['q1'], '10.0.0.0/24', [30, 20, 21])
+
+        # Confirm AS_PATH in confederation is not removed
+        self._check_global_rib_first(self.quaggas['q11'], '10.0.0.0/24', [65002, 20, 21])
+
+        self._check_global_rib_first(self.quaggas['q22'], '10.0.0.0/24', [20, 21])
+
+    def test_03_best_path(self):
+        self.quaggas['q1'].add_route('10.0.0.0/24')
+
+        routes = []
+        for i in range(60):
+            routes = self.gobgp.get_global_rib('10.0.0.0/24')
+            print(routes)
+            if len(routes) == 1:
+                if len(routes[0]['paths']) == 2:
+                    break
+            time.sleep(1)
+        self.failIf(len(routes) != 1)
+        self.failIf(len(routes[0]['paths']) != 2)
+
+        # In g1, there are two routes to 10.0.0.0/24
+        # confirm the route from q1 is selected as the best path
+        # because it has shorter AS_PATH.
+        # (AS_CONFED_* segments in AS_PATH is not counted)
+        paths = routes[0]['paths']
+        self.assertTrue(paths[0]['aspath'], [65001, 10])
+
+        # confirm the new best path is advertised
+        self._check_global_rib_first(self.quaggas['q22'], '10.0.0.0/24', [65001, 10])
+
+
+if __name__ == '__main__':
+    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
+    if int(output) is not 0:
+        print "docker not found"
+        sys.exit(1)
+
+    nose.main(argv=sys.argv, addplugins=[OptionParser()],
+              defaultTest=sys.argv[0])


### PR DESCRIPTION
This PR adds the BGP confederations feature.

The configuration syntax is as follows:
```
[global.confederation.config]
  enabled = true
  identifier = 30
  member-as-list = [65001, 65002]
```