### PR TITLE
*: Enhancement for "Remove Duplicate Large Communities"

### DIFF
--- a/packet/bgp/validate.go
+++ b/packet/bgp/validate.go
@@ -191,22 +191,6 @@ func ValidateAttribute(a PathAttributeInterface, rfs map[RouteFamily]BGPAddPathM
 				}
 			}
 		}
-	case *PathAttributeLargeCommunities:
-		uniq := make([]*LargeCommunity, 0, len(p.Values))
-		for _, x := range p.Values {
-			found := false
-			for _, y := range uniq {
-				if x.String() == y.String() {
-					found = true
-					break
-				}
-			}
-			if !found {
-				uniq = append(uniq, x)
-			}
-		}
-		p.Values = uniq
-
 	case *PathAttributeUnknown:
 		if p.GetFlags()&BGP_ATTR_FLAG_OPTIONAL == 0 {
 			eMsg := fmt.Sprintf("unrecognized well-known attribute %s", p.GetType())

--- a/packet/bgp/validate_test.go
+++ b/packet/bgp/validate_test.go
@@ -393,18 +393,3 @@ func Test_Validate_flowspec(t *testing.T) {
 	_, err = ValidateAttribute(a, m, false)
 	assert.NotNil(err)
 }
-
-func TestValidateLargeCommunities(t *testing.T) {
-	assert := assert.New(t)
-	c1, err := ParseLargeCommunity("10:10:10")
-	assert.Nil(err)
-	c2, err := ParseLargeCommunity("10:10:10")
-	assert.Nil(err)
-	c3, err := ParseLargeCommunity("10:10:20")
-	assert.Nil(err)
-	a := NewPathAttributeLargeCommunities([]*LargeCommunity{c1, c2, c3})
-	assert.True(len(a.Values) == 3)
-	_, err = ValidateAttribute(a, nil, false)
-	assert.Nil(err)
-	assert.True(len(a.Values) == 2)
-}

--- a/table/path_test.go
+++ b/table/path_test.go
@@ -367,3 +367,21 @@ func TestReplaceAS(t *testing.T) {
 	assert.Equal(t, list[2], uint32(10))
 	assert.Equal(t, list[3], uint32(2))
 }
+
+func TestValidateLargeCommunities(t *testing.T) {
+	assert := assert.New(t)
+	c1, err := bgp.ParseLargeCommunity("10:10:10")
+	assert.Nil(err)
+	c2, err := bgp.ParseLargeCommunity("10:10:10")
+	assert.Nil(err)
+	c3, err := bgp.ParseLargeCommunity("10:10:20")
+	assert.Nil(err)
+	nlri := bgp.NewIPAddrPrefix(24, "30.30.30.0")
+
+	a := bgp.NewPathAttributeLargeCommunities([]*bgp.LargeCommunity{c1, c2, c3})
+	path := NewPath(nil, nlri, false, []bgp.PathAttributeInterface{a}, time.Now(), false)
+
+	assert.True(len(path.getPathAttr(bgp.BGP_ATTR_TYPE_LARGE_COMMUNITY).(*bgp.PathAttributeLargeCommunities).Values) == 3)
+	path.RemoveDuplicateLargeCommunities()
+	assert.True(len(path.getPathAttr(bgp.BGP_ATTR_TYPE_LARGE_COMMUNITY).(*bgp.PathAttributeLargeCommunities).Values) == 2)
+}

--- a/table/table_manager.go
+++ b/table/table_manager.go
@@ -227,6 +227,8 @@ func (manager *TableManager) ProcessPaths(pathList []*Path) []*Destination {
 		}
 		rf := path.GetRouteFamily()
 		if t, ok := manager.Tables[rf]; ok {
+			path.FixupAttributes()
+
 			dst := t.insert(path)
 			key := dst.GetNlri().String()
 			if !m[key] {


### PR DESCRIPTION
Currently, GoBGP does not remove duplicate large communities values
if it is instructed via CLI.
And the removal logic is written in packet/bgp/validate.go,
but it is not validation (RFC 8092 says that the packet which has
duplicate values shall not be considered as malformed).

This commit moves the removal logic to table/path.go,
and removes duplicate values even if it is instructed via CLI.

Signed-off-by: Satoshi Fujimoto <satoshi.fujimoto7@gmail.com>