### PR TITLE
Allow filtering MRT routes by IP version and overriding next-hop

### DIFF
--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -111,9 +111,10 @@ var actionOpts struct {
 type mrtOpts struct {
 	OutputDir  string
 	FileFormat string
-	Best       bool `long:"only-best" description:"only keep best path routes"`
-	SkipV4     bool `long:"no-ipv4" description:"Skip importing IPv4 routes"`
-	SkipV6     bool `long:"no-ipv4" description:"Skip importing IPv6 routes"`
+	Best       bool   `long:"only-best" description:"only keep best path routes"`
+	SkipV4     bool   `long:"no-ipv4" description:"Skip importing IPv4 routes"`
+	SkipV6     bool   `long:"no-ipv4" description:"Skip importing IPv6 routes"`
+	NextHop    net.IP `long:"nexthop" description:"Rewrite nexthop"`
 }
 
 func formatTimedelta(d int64) string {

--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -109,15 +109,16 @@ var actionOpts struct {
 }
 
 var mrtOpts struct {
-	OutputDir  string
-	FileFormat string
-	Filename   string `long:"filename" description:"MRT file name"`
+	OutputDir   string
+	FileFormat  string
+	Filename    string `long:"filename" description:"MRT file name"`
 	RecordCount int    `long:"count" description:"Number of records to inject"`
 	RecordSkip  int    `long:"skip" description:"Number of records to skip before injecting"`
-	Best       bool   `long:"only-best" description:"only keep best path routes"`
-	SkipV4     bool   `long:"no-ipv4" description:"Skip importing IPv4 routes"`
-	SkipV6     bool   `long:"no-ipv4" description:"Skip importing IPv6 routes"`
-	NextHop    net.IP `long:"nexthop" description:"Rewrite nexthop"`
+	QueueSize   int    `long:"batch-size" description:"Maximum number of updates to keep queued"`
+	Best        bool   `long:"only-best" description:"only keep best path routes"`
+	SkipV4      bool   `long:"no-ipv4" description:"Skip importing IPv4 routes"`
+	SkipV6      bool   `long:"no-ipv4" description:"Skip importing IPv6 routes"`
+	NextHop     net.IP `long:"nexthop" description:"Rewrite nexthop"`
 }
 
 func formatTimedelta(d int64) string {

--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -108,10 +108,12 @@ var actionOpts struct {
 	NexthopAction       string `long:"next-hop" description:"specifying a next-hop action of policy"`
 }
 
-var mrtOpts struct {
+type mrtOpts struct {
 	OutputDir  string
 	FileFormat string
 	Best       bool `long:"only-best" description:"only keep best path routes"`
+	SkipV4     bool `long:"no-ipv4" description:"Skip importing IPv4 routes"`
+	SkipV6     bool `long:"no-ipv4" description:"Skip importing IPv6 routes"`
 }
 
 func formatTimedelta(d int64) string {

--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -111,6 +111,9 @@ var actionOpts struct {
 var mrtOpts struct {
 	OutputDir  string
 	FileFormat string
+	Filename   string `long:"filename" description:"MRT file name"`
+	RecordCount int    `long:"count" description:"Number of records to inject"`
+	RecordSkip  int    `long:"skip" description:"Number of records to skip before injecting"`
 	Best       bool   `long:"only-best" description:"only keep best path routes"`
 	SkipV4     bool   `long:"no-ipv4" description:"Skip importing IPv4 routes"`
 	SkipV6     bool   `long:"no-ipv4" description:"Skip importing IPv6 routes"`

--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -108,7 +108,7 @@ var actionOpts struct {
 	NexthopAction       string `long:"next-hop" description:"specifying a next-hop action of policy"`
 }
 
-type mrtOpts struct {
+var mrtOpts struct {
 	OutputDir  string
 	FileFormat string
 	Best       bool   `long:"only-best" description:"only keep best path routes"`

--- a/gobgp/cmd/mrt.go
+++ b/gobgp/cmd/mrt.go
@@ -39,8 +39,11 @@ func injectMrt() error {
 	}
 
 	idx := 0
+	if mrtOpts.QueueSize < 1 {
+		return fmt.Errorf("Specified queue size is smaller than 1, refusing to run with unbounded memory usage")
+	}
 
-	ch := make(chan []*table.Path, 1<<20)
+	ch := make(chan []*table.Path, mrtOpts.QueueSize)
 	go func() {
 
 		var peers []*mrt.Peer
@@ -138,7 +141,7 @@ func injectMrt() error {
 				}
 
 				idx += 1
-				if idx == mrtOpts.RecordCount + mrtOpts.RecordSkip {
+				if idx == mrtOpts.RecordCount+mrtOpts.RecordSkip {
 					break
 				}
 			}
@@ -209,6 +212,7 @@ func NewMrtCmd() *cobra.Command {
 	mrtCmd.PersistentFlags().BoolVarP(&mrtOpts.Best, "only-best", "", false, "inject only best paths")
 	mrtCmd.PersistentFlags().BoolVarP(&mrtOpts.SkipV4, "no-ipv4", "", false, "Do not import IPv4 routes")
 	mrtCmd.PersistentFlags().BoolVarP(&mrtOpts.SkipV6, "no-ipv6", "", false, "Do not import IPv6 routes")
+	mrtCmd.PersistentFlags().IntVarP(&mrtOpts.QueueSize, "queue-size", "", 1<<10, "Maximum number of updates to keep queued")
 	mrtCmd.PersistentFlags().IPVarP(&mrtOpts.NextHop, "nexthop", "", nil, "Overwrite nexthop")
 	return mrtCmd
 }

--- a/gobgp/cmd/mrt.go
+++ b/gobgp/cmd/mrt.go
@@ -27,9 +27,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func injectMrt(filename string, count int, skip int) error {
+func injectMrt() error {
 
-	file, err := os.Open(filename)
+	file, err := os.Open(mrtOpts.Filename)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %s", err)
 	}
@@ -133,12 +133,12 @@ func injectMrt(filename string, count int, skip int) error {
 					paths = []*table.Path{best}
 				}
 
-				if idx >= skip {
+				if idx >= mrtOpts.RecordSkip {
 					ch <- paths
 				}
 
 				idx += 1
-				if idx == count+skip {
+				if idx == mrtOpts.RecordCount + mrtOpts.RecordSkip {
 					break
 				}
 			}
@@ -172,23 +172,24 @@ func NewMrtCmd() *cobra.Command {
 			if len(args) < 1 {
 				exitWithError(fmt.Errorf("usage: gobgp mrt inject global <filename> [<count> [<skip>]]"))
 			}
-			filename := args[0]
-			count := -1
-			skip := 0
+			mrtOpts.Filename = args[0]
 			if len(args) > 1 {
 				var err error
-				count, err = strconv.Atoi(args[1])
+				mrtOpts.RecordCount, err = strconv.Atoi(args[1])
 				if err != nil {
 					exitWithError(fmt.Errorf("invalid count value: %s", args[1]))
 				}
 				if len(args) > 2 {
-					skip, err = strconv.Atoi(args[2])
+					mrtOpts.RecordSkip, err = strconv.Atoi(args[2])
 					if err != nil {
 						exitWithError(fmt.Errorf("invalid skip value: %s", args[2]))
 					}
 				}
+			} else {
+				mrtOpts.RecordCount = -1
+				mrtOpts.RecordSkip = 0
 			}
-			err := injectMrt(filename, count, skip)
+			err := injectMrt()
 			if err != nil {
 				exitWithError(err)
 			}


### PR DESCRIPTION
As title says, it adds few handy options to import.

I'm not really sure what use `mrtOpts` was supposed to have, as only a `Best` bool was used out of it, so I repurposed it to type usedpass arguments to injectMrt