### PR TITLE
table/message: Send EoR as the last of UPDATE messages

### DIFF
--- a/table/message.go
+++ b/table/message.go
@@ -350,13 +350,14 @@ type bucket struct {
 
 func CreateUpdateMsgFromPaths(pathList []*Path) []*bgp.BGPMessage {
 	var msgs []*bgp.BGPMessage
+	var eors []*bgp.BGPMessage
 
 	pathByAttrs := make(map[uint32][]*bucket)
 	for _, path := range pathList {
 		if path == nil {
 			continue
 		} else if path.IsEOR() {
-			msgs = append(msgs, bgp.NewEndOfRib(path.GetRouteFamily()))
+			eors = append(eors, bgp.NewEndOfRib(path.GetRouteFamily()))
 			continue
 		}
 		y := func(p *Path) bool {
@@ -439,6 +440,10 @@ func CreateUpdateMsgFromPaths(pathList []*Path) []*bgp.BGPMessage {
 				}
 			}
 		}
+	}
+
+	for _, eor := range eors {
+		msgs = append(msgs, eor)
 	}
 
 	return msgs


### PR DESCRIPTION
EoR should be sent at the end of the UPDATE messages,
but currently, EoR may be sent before RIB.
This commit fixes this problem.

This fixes #1463.

Signed-off-by: Satoshi Fujimoto <satoshi.fujimoto7@gmail.com>