### PR TITLE
config: Properly set config of PeerGroup member

### DIFF
--- a/config/util.go
+++ b/config/util.go
@@ -40,6 +40,32 @@ func detectConfigFileType(path, def string) string {
 	}
 }
 
+func (b *BgpConfigSet) getPeerGroup(n string) (*PeerGroup, error) {
+	if n == "" {
+		return nil, nil
+	}
+	for _, pg := range b.PeerGroups {
+		if n == pg.Config.PeerGroupName {
+			return &pg, nil
+		}
+	}
+	return nil, fmt.Errorf("no such peer-group: %s", n)
+}
+
+func (d *DynamicNeighbor) validate(b *BgpConfigSet) error {
+	if d.Config.PeerGroup == "" {
+		return fmt.Errorf("dynamic neighbor requires the peer group config")
+	}
+
+	if _, err := b.getPeerGroup(d.Config.PeerGroup); err != nil {
+		return err
+	}
+	if _, _, err := net.ParseCIDR(d.Config.Prefix); err != nil {
+		return fmt.Errorf("invalid dynamic neighbor prefix %s", d.Config.Prefix)
+	}
+	return nil
+}
+
 func (n *Neighbor) IsConfederationMember(g *Global) bool {
 	for _, member := range g.Confederation.Config.MemberAsList {
 		if member == n.Config.PeerAs {

--- a/server/peer.go
+++ b/server/peer.go
@@ -79,7 +79,7 @@ func newDynamicPeer(g *config.Global, neighborAddress string, pg *config.PeerGro
 		}).Debugf("Can't overwrite neighbor config: %s", err)
 		return nil
 	}
-	if err := config.SetDefaultNeighborConfigValues(&conf, g); err != nil {
+	if err := config.SetDefaultNeighborConfigValues(&conf, pg, g); err != nil {
 		log.WithFields(log.Fields{
 			"Topic": "Peer",
 			"Key":   neighborAddress,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -201,7 +201,7 @@ func TestNumGoroutineWithAddDeleteNeighbor(t *testing.T) {
 func newPeerandInfo(myAs, as uint32, address string, rib *table.TableManager) (*Peer, *table.PeerInfo) {
 	nConf := &config.Neighbor{Config: config.NeighborConfig{PeerAs: as, NeighborAddress: address}}
 	gConf := &config.Global{Config: config.GlobalConfig{As: myAs}}
-	config.SetDefaultNeighborConfigValues(nConf, gConf)
+	config.SetDefaultNeighborConfigValues(nConf, nil, gConf)
 	policy := table.NewRoutingPolicy()
 	policy.Reset(&config.RoutingPolicy{}, nil)
 	p := NewPeer(


### PR DESCRIPTION
Currently, the config of PeerGroup members are not set properly.

For example, if LocalAs of the neighbor is not set in the config file,
LocalAs will be set to Global.As as a default value.
After this, however, if the neighbor is a member of a peer group,
LocalAs will be unexpectedly overwritten by the peer group config.

This commit fixes this by setting default values after
applying the peer group config.

Adding to this, this commit avoids unnecessary applying
the peer group config.

Signed-off-by: Satoshi Fujimoto <satoshi.fujimoto7@gmail.com>