### PR TITLE
Addpath()return-non-empty-uuid

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1283,9 +1283,11 @@ func (s *BgpServer) AddPath(vrfId string, pathList []*table.Path) (uuidBytes []b
 		if err := s.fixupApiPath(vrfId, pathList); err != nil {
 			return err
 		}
-		for _, p := range pathList{
-			p.AssignNewUUID()
-			uuidBytes = append(uuidBytes, p.UUID().Bytes()...)
+		if len(pathList) > 0 {
+				for _, p := range pathList{
+				p.AssignNewUUID()
+				uuidBytes = append(uuidBytes, p.UUID().Bytes()...)
+			}
 		}
 		s.propagateUpdate(nil, pathList)
 		return nil

--- a/server/server.go
+++ b/server/server.go
@@ -1285,7 +1285,7 @@ func (s *BgpServer) AddPath(vrfId string, pathList []*table.Path) (uuidBytes []b
 		}
 		for _, p := range pathList{
 			p.AssignNewUUID()
-			uuidBytes = append(uuidBytes, p.UUID().Byte()...)
+			uuidBytes = append(uuidBytes, p.UUID().Bytes()...)
 		}
 		s.propagateUpdate(nil, pathList)
 		return nil


### PR DESCRIPTION
Hi.

This pull request is under snippet having problem solutions.
https://gist.github.com/nao4arale/942c4e9465387f5fda9227da00495e86

go run this snippet,

```bash
go run main.go
Added a route's UUID is,  00000000-0000-0000-0000-000000000000
Show a route's UUID is,   81c8ba72-2362-4eb0-849b-e73cec34be8d
```

Why Addpath() return empty []bytes?
If this IsProblem & NOT Intending things, please pull.
After change code, go run this snippet,

```bash
go run main.go
Added a route's UUID is,  714a87ee-b990-4e6e-9db6-8114171c753a
Show a route's UUID is,   714a87ee-b990-4e6e-9db6-8114171c753a
```

That's Grate? :wink: