### PR TITLE
*: Fix problems pointed by 'go vet'

### DIFF
--- a/config/util_test.go
+++ b/config/util_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestdetectConfigFileType(t *testing.T) {
+func TestDetectConfigFileType(t *testing.T) {
 	assert := assert.New(t)
 
 	assert.Equal("toml", detectConfigFileType("bgpd.conf", "toml"))

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -3107,13 +3107,13 @@ func flowSpecFragmentParser(rf RouteFamily, args []string) (FlowSpecComponentInt
 		switch c {
 		case BitmaskFlagOpNameMap[BITMASK_FLAG_OP_MATCH]:
 			if op&BITMASK_FLAG_OP_MATCH != 0 {
-				err := fmt.Errorf("invalid flowspec fragment specifier: '=' flag appears multiple time", cmd)
+				err := fmt.Errorf("invalid flowspec fragment specifier: '=' flag appears multiple time: %s", cmd)
 				return nil, err
 			}
 			op |= BITMASK_FLAG_OP_MATCH
 		case BitmaskFlagOpNameMap[BITMASK_FLAG_OP_NOT]:
 			if op&BITMASK_FLAG_OP_NOT != 0 {
-				err := fmt.Errorf("invalid flowspec fragment specifier: '!' flag appears multiple time", cmd)
+				err := fmt.Errorf("invalid flowspec fragment specifier: '!' flag appears multiple time: %s", cmd)
 				return nil, err
 			}
 			op = op | BITMASK_FLAG_OP_NOT

--- a/zebra/zapi.go
+++ b/zebra/zapi.go
@@ -749,7 +749,6 @@ func (c *Client) SendRedistributeDelete(t ROUTE_TYPE) error {
 	} else {
 		return fmt.Errorf("unknown route type: %d", t)
 	}
-	return nil
 }
 
 func (c *Client) SendIPRoute(vrfId uint16, body *IPRouteBody, isWithdraw bool) error {
@@ -1032,7 +1031,7 @@ func (b *InterfaceAddressUpdateBody) Serialize(version uint8) ([]byte, error) {
 
 func (b *InterfaceAddressUpdateBody) String() string {
 	return fmt.Sprintf(
-		"idx: %d, flags: %d, addr: %s/%d",
+		"idx: %d, flags: %s, addr: %s/%d",
 		b.Index, b.Flags.String(), b.Prefix.String(), b.Length)
 }
 


### PR DESCRIPTION
In the near feature (likely in Go1.10),
'go test' will never work if 'go vet' fails.
(See: https://github.com/golang/go/issues/18084)

This commit is for dealing with such a situation
(and also for improving the quality of our code).

Signed-off-by: Satoshi Fujimoto <satoshi.fujimoto7@gmail.com>