### PR TITLE
packet/bgp: return correct error, flowspec cmd badly args.

### DIFF
--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -3015,7 +3015,7 @@ func parseDecValuesCmd(myCmd string, validationFunc func(int) error) ([][2]int, 
 			}
 		case DECLogicOpNameMap[DEC_LOGIC_OP_AND], DECLogicOpNameMap[DEC_LOGIC_OP_OR]:
 			if index == 0 {
-				err := fmt.Errorf("Logic operator '%s' badly formatted", myCmd)
+				err := fmt.Errorf("Logic operator %s badly formatted", myCmd)
 				return nil, err
 			}
 			bit := DECLogicOpValueMap[myCmdChar]

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -3015,7 +3015,7 @@ func parseDecValuesCmd(myCmd string, validationFunc func(int) error) ([][2]int, 
 			}
 		case DECLogicOpNameMap[DEC_LOGIC_OP_AND], DECLogicOpNameMap[DEC_LOGIC_OP_OR]:
 			if index == 0 {
-				err := fmt.Errorf("Logic operator %s badly formatted", myCmd)
+				err := fmt.Errorf("Logic operator appears a first character")
 				return nil, err
 			}
 			bit := DECLogicOpValueMap[myCmdChar]

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -3014,6 +3014,10 @@ func parseDecValuesCmd(myCmd string, validationFunc func(int) error) ([][2]int, 
 				return nil, err
 			}
 		case DECLogicOpNameMap[DEC_LOGIC_OP_AND], DECLogicOpNameMap[DEC_LOGIC_OP_OR]:
+			if index == 0 {
+				err := fmt.Errorf("Logic operator '%s' badly formatted", myCmd)
+				return nil, err
+			}
 			bit := DECLogicOpValueMap[myCmdChar]
 			decOperatorsAndValues = append(decOperatorsAndValues, operatorValue)
 			if myCmdChar == DECLogicOpNameMap[DEC_LOGIC_OP_AND] {


### PR DESCRIPTION
Hi

This pull request solve under script having problem
https://gist.github.com/nnao45/e4617fec9d51d9ec498f4b4966bc9563

if adding flowspec such as 'match~' cmd, "source-port `<space><space>`==80", "source-port`<space>&`==80",
so, from cmd to NLRI, parsing Dissemination Values,

(source-port`<space><space>`==80)
```bash
args := strings.Split("match source 10.45.0.0/24 source-port  ==80 then accept", " ")
	path, err := cmd.ParsePath(bgp.RF_FS_IPv4_UC, args)
```
or

(source-port`<space>&`==80)
```bash
args := strings.Split("match source 10.45.0.0/24 source-port &==80 then accept", " ")
	path, err := cmd.ParsePath(bgp.RF_FS_IPv4_UC, args)
```

This command line is looked so bad.
but, non-error, and ↑Gist shows, 
```bash
Show a route's NLRI is,   [source:10.45.0.0/24][source-port:true ==80]
```
```bash
Show a route's NLRI is,   [source:10.45.0.0/24][source-port:true &==80]
```
(if use gobgp cmd, for example, "gobgp global rib -a ipv4-flowspec add match destination 10.45.0.0/24 source-port ' ==80' then accept")

I think, "???? what's true ==80?????"

so I was debugging,,,I guess it may be bug.
You know, when this command parse,
used by `func parseDecValuesCmd(myCmd string, validationFunc func(int) error) ([][2]int, error)`.
(and, space and & is defilned DECLogicOpNameMap[DEC_LOGIC_OP_AND], DECLogicOpNameMap[DEC_LOGIC_OP_OR])

when used myCmd in leading 1st  character " " or "&", occuring this problem.
this func,  myCmd in leading 1st character " " or "&", 
return value []int{0, 0}(this is uesd by makeing []FlowSpecComponentItem, I guess means "true")
so...Illegal string, leading 1st character " " or "&" is, parsing correct values and insert NLRI.

so, this send command, (source-port`<space><space>`==80) flowspec NLRI value(example, type 6) is this,
```bash
+----------------+
| port           |
+----------------+
| 06 00 00 81 50 |
+----------------+

+-------+----------+------------------------------+
| Value |          |                              |
+-------+----------+------------------------------+
|  0x06 | type     | source-port                  |
|  0x00 | operator | (will be parsed, as true?)   | 
|  0x00 | value    | 00(not used?)                |
|  0x81 | operator | end-of-list, value size=1, = |
|  0x50 | value    | 80                           |
+-------+----------+------------------------------+
```

It's illigal and Unintended value(I try to announce this NLRI , to ASR9001, can't received)

I think, "this problem is caused by, func parseDecValuesCmd 's args.", 
and "should be that args Beginning with the first character , NOT the space or &"

It's Answer is simple, and The least impact fix
```bash
func parseDecValuesCmd(myCmd string, validationFunc func(int) error) ([][2]int, error) {
<snip>
case DECLogicOpNameMap[DEC_LOGIC_OP_AND], DECLogicOpNameMap[DEC_LOGIC_OP_OR]:
			if index == 0 {
				err := fmt.Errorf("Logic operator appears a first character")
				return nil, err
			}
<snip>
```

if this fixed add, return will error, 
`Logic operator appears a first character`
and, another args command , Moving as usual.

I think, originally bad format, `<space>(=OR)`, `&(=AND)`, parseDecValuesCmd's mycmd is used leading 1st  character, wherefore, be expexted to return error.
What do you think？