### PR TITLE
cli: Support address families when adding neighbor

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -100,7 +100,7 @@ func NewMpGracefulRestartFromConfigStruct(c *config.MpGracefulRestart) *MpGracef
 
 func NewAfiSafiConfigFromConfigStruct(c *config.AfiSafi) *AfiSafiConfig {
 	return &AfiSafiConfig{
-		Family:  uint32(c.State.Family),
+		Family:  extractFamilyFromConfigAfiSafi(c),
 		Enabled: c.Config.Enabled,
 	}
 }
@@ -223,7 +223,7 @@ func NewPeerFromConfigStruct(pconf *config.Neighbor) *Peer {
 	prefixLimits := make([]*PrefixLimit, 0, len(pconf.AfiSafis))
 	afiSafis := make([]*AfiSafi, 0, len(pconf.AfiSafis))
 	for _, f := range pconf.AfiSafis {
-		families = append(families, uint32(f.State.Family))
+		families = append(families, extractFamilyFromConfigAfiSafi(&f))
 		if prefixLimit := NewPrefixLimitFromConfigStruct(&f); prefixLimit != nil {
 			prefixLimits = append(prefixLimits, prefixLimit)
 		}

--- a/api/util.go
+++ b/api/util.go
@@ -160,3 +160,22 @@ func NewROAListFromApiStructList(l []*Roa) []*table.ROA {
 	}
 	return roas
 }
+
+func extractFamilyFromConfigAfiSafi(c *config.AfiSafi) uint32 {
+	if c == nil {
+		return 0
+	}
+	// If address family value is already stored in AfiSafiState structure,
+	// we prefer to use this value.
+	if c.State.Family != 0 {
+		return uint32(c.State.Family)
+	}
+	// In case that Neighbor structure came from CLI or gRPC, address family
+	// value in AfiSafiState structure can be omitted.
+	// Here extracts value from AfiSafiName field in AfiSafiConfig structure.
+	if rf, err := bgp.GetRouteFamily(string(c.Config.AfiSafiName)); err == nil {
+		return uint32(rf)
+	}
+	// Ignores invalid address family name
+	return 0
+}


### PR DESCRIPTION
fixes https://github.com/osrg/gobgp/issues/1486

Currently, "gobgp" command does not support to configure address families
capability when adding a new neighbor.

This patch introduces a new option field to "gobgp neighbor add" command
and enables to configure address families capability.

Example: Specify address family names in comma separated format
```bash
$ gobgp neighbor add 10.0.0.3 as 65003 family ipv4-unicast,l2vpn-evpn
$ gobgp neighbor 10.0.0.3
...(snip)...
  Neighbor capabilities:
    multiprotocol:
        ipv4-unicast:   advertised
        l2vpn-evpn:     advertised
    route-refresh:      advertised
    4-octet-as: advertised
...(snip)...
```

Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>