### PR TITLE
cmd/neighbor: Avoid shifted RIB display 

### DIFF
--- a/gobgp/cmd/monitor.go
+++ b/gobgp/cmd/monitor.go
@@ -44,7 +44,8 @@ func NewMonitorCmd() *cobra.Command {
 				j, _ := json.Marshal(dst.GetAllKnownPathList())
 				fmt.Println(string(j))
 			} else {
-				ShowRoute(dst.GetAllKnownPathList(), false, false, false, true, false, showIdentifier)
+				ds := [][]*table.Path{dst.GetAllKnownPathList()}
+				ShowRoute(ds, false, false, false, true, false, showIdentifier)
 			}
 		}
 	}

--- a/gobgp/cmd/monitor.go
+++ b/gobgp/cmd/monitor.go
@@ -26,6 +26,56 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func makeMonitorRouteArgs(p *table.Path, showIdentifier bgp.BGPAddPathMode) []interface{} {
+	pathStr := make([]interface{}, 0)
+
+	// Title
+	title := "ROUTE"
+	if p.IsWithdraw {
+		title = "DELROUTE"
+	}
+	pathStr = append(pathStr, title)
+
+	// NLRI
+	// If Add-Path required, append Path Identifier.
+	nlri := p.GetNlri()
+	if showIdentifier != bgp.BGP_ADD_PATH_NONE {
+		pathStr = append(pathStr, nlri.PathIdentifier())
+	}
+	pathStr = append(pathStr, nlri)
+
+	// Next Hop
+	nexthop := "fictitious"
+	if n := p.GetNexthop(); n != nil {
+		nexthop = p.GetNexthop().String()
+	}
+	pathStr = append(pathStr, nexthop)
+
+	// AS_PATH
+	pathStr = append(pathStr, p.GetAsString())
+
+	// Path Attributes
+	pathStr = append(pathStr, getPathAttributeString(p))
+
+	return pathStr
+}
+
+func monitorRoute(pathList []*table.Path, showIdentifier bgp.BGPAddPathMode) {
+	var pathStrs [][]interface{}
+
+	for _, p := range pathList {
+		pathStrs = append(pathStrs, makeMonitorRouteArgs(p, showIdentifier))
+	}
+
+	format := "[%s] %s via %s aspath [%s] attrs %s\n"
+	if showIdentifier != bgp.BGP_ADD_PATH_NONE {
+		format = "[%s] %d:%s via %s aspath [%s] attrs %s\n"
+	}
+	for _, pathStr := range pathStrs {
+		fmt.Printf(format, pathStr...)
+	}
+}
+
 func NewMonitorCmd() *cobra.Command {
 
 	var current bool
@@ -44,8 +94,7 @@ func NewMonitorCmd() *cobra.Command {
 				j, _ := json.Marshal(dst.GetAllKnownPathList())
 				fmt.Println(string(j))
 			} else {
-				ds := [][]*table.Path{dst.GetAllKnownPathList()}
-				ShowRoute(ds, false, false, false, true, false, showIdentifier)
+				monitorRoute(dst.GetAllKnownPathList(), showIdentifier)
 			}
 		}
 	}

--- a/table/path.go
+++ b/table/path.go
@@ -22,6 +22,8 @@ import (
 	"math"
 	"net"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -720,6 +722,34 @@ func (path *Path) getAsListofSpecificType(getAsSeq, getAsSet bool) []uint32 {
 		}
 	}
 	return asList
+}
+
+func (path *Path) GetLabelString() string {
+	label := ""
+	switch n := path.GetNlri().(type) {
+	case *bgp.LabeledIPAddrPrefix:
+		label = n.Labels.String()
+	case *bgp.LabeledIPv6AddrPrefix:
+		label = n.Labels.String()
+	case *bgp.LabeledVPNIPAddrPrefix:
+		label = n.Labels.String()
+	case *bgp.LabeledVPNIPv6AddrPrefix:
+		label = n.Labels.String()
+	case *bgp.EVPNNLRI:
+		switch route := n.RouteTypeData.(type) {
+		case *bgp.EVPNEthernetAutoDiscoveryRoute:
+			label = fmt.Sprintf("[%d]", route.Label)
+		case *bgp.EVPNMacIPAdvertisementRoute:
+			var l []string
+			for _, i := range route.Labels {
+				l = append(l, strconv.Itoa(int(i)))
+			}
+			label = fmt.Sprintf("[%s]", strings.Join(l, ","))
+		case *bgp.EVPNIPPrefixRoute:
+			label = fmt.Sprintf("[%d]", route.Label)
+		}
+	}
+	return label
 }
 
 // PrependAsn prepends AS number.


### PR DESCRIPTION
Currently, display of RIB may be shifted from route to route
because placement is calculated for each destination.

This PR avoides the shifted display by calculating the placement
with whole of the destinations.

Also this PR does some refactoring.