### PR TITLE
cli: Extend EVPN routes advertisement

### DIFF
--- a/docs/sources/evpn.md
+++ b/docs/sources/evpn.md
@@ -433,7 +433,7 @@ GoBGP will receive these four routes and re-advertise them to YABGP peer on "10.
 $ gobgp global rib -a evpn
    Network                                                  Labels     Next Hop             AS_PATH              Age        Attrs
 *> [type:A-D][rd:1.1.1.1:32867][esi:single-homed][etag:100] [161]      10.75.44.254                              hh:mm:ss   [{Extcomms: [esi-label: 8001]} {Origin: i} {LocalPref: 100}]
-*> [type:esi][rd:172.16.0.1:8888][esi:{0 [0 0 0 0 0 0 0 0 0]}][ip:192.168.0.1]            10.75.44.254                              hh:mm:ss   [{Extcomms: [es-import rt: 00:11:22:33:44:55]} {Origin: i} {LocalPref: 100}]
+*> [type:esi][rd:172.16.0.1:8888][esi:single-homed][ip:192.168.0.1]            10.75.44.254                              hh:mm:ss   [{Extcomms: [es-import rt: 00:11:22:33:44:55]} {Origin: i} {LocalPref: 100}]
 *> [type:macadv][rd:172.17.0.3:2][etag:108][mac:00:11:22:33:44:55][ip:11.11.11.1] [0]        10.75.44.254                              hh:mm:ss   [{Extcomms: [mac-mobility: 500, sticky]} {Origin: i} {LocalPref: 100} [ESI: single-homed]]
 *> [type:multicast][rd:172.16.0.1:5904][etag:100][ip:192.168.0.1]            10.75.44.254                              hh:mm:ss   [{Origin: i} {LocalPref: 100}]
 ```

--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -959,18 +959,18 @@ func modPath(resource string, name, modtype string, args []string) error {
 		fsHelpMsgFmt := fmt.Sprintf(`err: %s
 usage: %s rib %s%%smatch <MATCH_EXPR> then <THEN_EXPR> -a %%s
 %%s
-   <THEN_EXPR> : { %s | %s | %s <value> | %s <RT> | %s <value> | %s { sample | terminal | sample-terminal } | %s <RT>... }...
-   <RT> : xxx:yyy, xx.xx.xx.xx:yyy, xxx.xxx:yyy`, err, cmdstr, modtype,
+    <THEN_EXPR> : { %s | %s | %s <value> | %s <RT> | %s <value> | %s { sample | terminal | sample-terminal } | %s <RT>... }...
+    <RT> : xxx:yyy, xx.xx.xx.xx:yyy, xxx.xxx:yyy`, err, cmdstr, modtype,
 			ExtCommNameMap[ACCEPT], ExtCommNameMap[DISCARD],
 			ExtCommNameMap[RATE], ExtCommNameMap[REDIRECT],
 			ExtCommNameMap[MARK], ExtCommNameMap[ACTION], ExtCommNameMap[RT])
 		ipFsMatchExpr := fmt.Sprintf(`   <MATCH_EXPR> : { %s <PREFIX> [<OFFSET>] | %s <PREFIX> [<OFFSET>] |
                     %s <PROTO>... | %s [!] [=] <FRAGMENT_TYPE> | %s [!] [=] <TCPFLAG>... |
                     { %s | %s | %s | %s | %s | %s | %s | %s } <ITEM>... }...
-   <PROTO> : %s
-   <FRAGMENT_TYPE> : dont-fragment, is-fragment, first-fragment, last-fragment, not-a-fragment
-   <TCPFLAG> : %s
-   <ITEM> : & {<|<=|>|>=|==|!=}<value>`,
+    <PROTO> : %s
+    <FRAGMENT_TYPE> : dont-fragment, is-fragment, first-fragment, last-fragment, not-a-fragment
+    <TCPFLAG> : %s
+    <ITEM> : & {<|<=|>|>=|==|!=}<value>`,
 			bgp.FlowSpecNameMap[bgp.FLOW_SPEC_TYPE_DST_PREFIX],
 			bgp.FlowSpecNameMap[bgp.FLOW_SPEC_TYPE_SRC_PREFIX],
 			bgp.FlowSpecNameMap[bgp.FLOW_SPEC_TYPE_IP_PROTO],
@@ -992,8 +992,8 @@ usage: %s rib %s%%smatch <MATCH_EXPR> then <THEN_EXPR> -a %%s
 		helpErrMap[bgp.RF_FS_IPv4_VPN] = fmt.Errorf(fsHelpMsgFmt, " rd <RD> ", "ipv4-l3vpn-flowspec", ipFsMatchExpr)
 		helpErrMap[bgp.RF_FS_IPv6_VPN] = fmt.Errorf(fsHelpMsgFmt, " rd <RD> ", "ipv6-l3vpn-flowspec", ipFsMatchExpr)
 		macFsMatchExpr := fmt.Sprintf(`   <MATCH_EXPR> : { { %s | %s } <MAC> | %s <ETHER_TYPE> | { %s | %s | %s | %s | %s | %s | %s | %s } <ITEM>... }...
-   <ETHER_TYPE> : %s
-   <ITEM> : &?{<|>|=}<value>`,
+    <ETHER_TYPE> : %s
+    <ITEM> : &?{<|>|=}<value>`,
 			bgp.FlowSpecNameMap[bgp.FLOW_SPEC_TYPE_DST_MAC],
 			bgp.FlowSpecNameMap[bgp.FLOW_SPEC_TYPE_SRC_MAC],
 			bgp.FlowSpecNameMap[bgp.FLOW_SPEC_TYPE_ETHERNET_TYPE],

--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -505,11 +505,11 @@ func ParseEvpnIPPrefixArgs(args []string) (bgp.AddrPrefixInterface, []string, er
 		}
 	}
 
-	ip, n, err := net.ParseCIDR(m[""][0])
+	_, nw, err := net.ParseCIDR(m[""][0])
 	if err != nil {
 		return nil, nil, err
 	}
-	ones, _ := n.Mask.Size()
+	ones, _ := nw.Mask.Size()
 
 	var gw net.IP
 	if len(m["gw"]) > 0 {
@@ -549,7 +549,7 @@ func ParseEvpnIPPrefixArgs(args []string) (bgp.AddrPrefixInterface, []string, er
 		RD:             rd,
 		ETag:           etag,
 		IPPrefixLength: uint8(ones),
-		IPPrefix:       ip,
+		IPPrefix:       nw.IP,
 		GWIPAddress:    gw,
 		Label:          label,
 	}

--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -1035,7 +1035,7 @@ usage: %s rib %s%%smatch <MATCH_EXPR> then <THEN_EXPR> -a %%s
 	return err
 }
 
-func showGlobalConfig(args []string) error {
+func showGlobalConfig() error {
 	g, err := client.GetServer()
 	if err != nil {
 		return err
@@ -1105,7 +1105,7 @@ func NewGlobalCmd() *cobra.Command {
 			if len(args) != 0 {
 				err = modGlobalConfig(args)
 			} else {
-				err = showGlobalConfig(args)
+				err = showGlobalConfig()
 			}
 			if err != nil {
 				exitWithError(err)

--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -771,11 +771,11 @@ func ParsePath(rf bgp.RouteFamily, args []string) (*table.Path, error) {
 		if len(args) < 1 {
 			return nil, fmt.Errorf("invalid format")
 		}
-		ip, net, err := net.ParseCIDR(args[0])
+		ip, nw, err := net.ParseCIDR(args[0])
 		if err != nil {
 			return nil, err
 		}
-		ones, _ := net.Mask.Size()
+		ones, _ := nw.Mask.Size()
 		if rf == bgp.RF_IPv4_UC {
 			if ip.To4() == nil {
 				return nil, fmt.Errorf("invalid ipv4 prefix")
@@ -803,8 +803,8 @@ func ParsePath(rf bgp.RouteFamily, args []string) (*table.Path, error) {
 		if len(args) < 5 || args[1] != "label" || args[3] != "rd" {
 			return nil, fmt.Errorf("invalid format")
 		}
-		ip, net, _ := net.ParseCIDR(args[0])
-		ones, _ := net.Mask.Size()
+		ip, nw, _ := net.ParseCIDR(args[0])
+		ones, _ := nw.Mask.Size()
 
 		label := 0
 		if label, err = strconv.Atoi(args[2]); err != nil {
@@ -835,8 +835,8 @@ func ParsePath(rf bgp.RouteFamily, args []string) (*table.Path, error) {
 			return nil, fmt.Errorf("invalid format")
 		}
 
-		ip, net, _ := net.ParseCIDR(args[0])
-		ones, _ := net.Mask.Size()
+		ip, nw, _ := net.ParseCIDR(args[0])
+		ones, _ := nw.Mask.Size()
 
 		mpls, err := bgp.ParseMPLSLabelStack(args[1])
 		if err != nil {

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -2479,7 +2479,7 @@ func (er *EVPNEthernetSegmentRoute) String() string {
 	// For the purpose of BGP route key processing, only the Ethernet
 	// Segment ID, IP Address Length, and Originating Router's IP Address
 	// fields are considered to be part of the prefix in the NLRI.
-	return fmt.Sprintf("[type:esi][rd:%s][esi:%d][ip:%s]", er.RD, er.ESI, er.IPAddress)
+	return fmt.Sprintf("[type:esi][rd:%s][esi:%s][ip:%s]", er.RD, er.ESI.String(), er.IPAddress)
 }
 
 func (er *EVPNEthernetSegmentRoute) MarshalJSON() ([]byte, error) {

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -1973,7 +1973,7 @@ func (esi *EthernetSegmentIdentifier) String() string {
 		s.WriteString(fmt.Sprintf("router id %s, ", net.IP(esi.Value[:4])))
 		s.WriteString(fmt.Sprintf("local discriminator %d", binary.BigEndian.Uint32(esi.Value[4:8])))
 	case ESI_AS:
-		s.WriteString(fmt.Sprintf("as %d:%d, ", binary.BigEndian.Uint16(esi.Value[:2]), binary.BigEndian.Uint16(esi.Value[2:4])))
+		s.WriteString(fmt.Sprintf("as %d, ", binary.BigEndian.Uint32(esi.Value[:4])))
 		s.WriteString(fmt.Sprintf("local discriminator %d", binary.BigEndian.Uint32(esi.Value[4:8])))
 	default:
 		s.WriteString(fmt.Sprintf("value %s", esi.Value))


### PR DESCRIPTION
This PR enables "gobgp" command to advertise the EVPN routes which related to "Multihoming Functions".

- Ethernet Auto-discovery route advertisement
- Ethernet Segment route advertisement
- Other already supported routes with ESI advertisement

Also, includes some improvements for advertising EVPN routes using "gobgp" command.

**Note:** This PR does not yet implement the routes handling logic for EVPN Multihoming (described RFC7432 and draft-ietf-bess-evpn-overlay), just only implements the route injection via CLI.