### PR TITLE
gobgp/cmd/neighbor: Avoid showing "*" for remote AS when it is configured

### DIFF
--- a/gobgp/cmd/neighbor.go
+++ b/gobgp/cmd/neighbor.go
@@ -59,6 +59,9 @@ func getNeighbor(name string, enableAdvertised bool) (*config.Neighbor, error) {
 }
 
 func getASN(p *config.Neighbor) string {
+	if p.Config.PeerAs > 0 {
+		return fmt.Sprint(p.Config.PeerAs)
+	}
 	asn := "*"
 	if p.State.PeerAs > 0 {
 		asn = fmt.Sprint(p.State.PeerAs)


### PR DESCRIPTION
When remote AS is configured and its peer isn't established, `gobgp neighbor` shows `*` as AS.

```bash
% gobgp neighbor
Peer                           AS  Up/Down State       |#Received  Accepted
192.168.0.1                 *    never Idle(Admin) |        0         0
2001:db8::1                 *    never Idle(Admin) |        0         0
```
I believe it should show configured AS if it exists.
This PR will fix this issue like below. 

```bash
% gobgp neighbor
Peer                           AS  Up/Down State       |#Received  Accepted
192.168.0.1                65000   never Idle(Admin) |        0         0
2001:db8::1                65000    never Idle(Admin) |        0         0
```
