### PR TITLE
Allow 0 value to roaManager.AS for library usage

### DIFF
--- a/server/rpki.go
+++ b/server/rpki.go
@@ -120,9 +120,6 @@ func (m *roaManager) SetAS(as uint32) error {
 }
 
 func (m *roaManager) AddServer(host string, lifetime int64) error {
-	if m.AS == 0 {
-		return fmt.Errorf("AS isn't configured yet")
-	}
 	address, port, err := net.SplitHostPort(host)
 	if err != nil {
 		return err


### PR DESCRIPTION
Currently, 0 is not allowed as `roaManager.AS`. In the case of using gobgp's RPKI library for a 
 monitoring, it probably can't have AS. So I'd like to use `0` for special purpose for such kind of systems. 