### PR TITLE
packet/bgp: Improve FlowSpec CLI argument format and string representation

### DIFF
--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -25,10 +25,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
 	"github.com/osrg/gobgp/table"
-	"github.com/spf13/cobra"
 )
 
 type ExtCommType int
@@ -334,34 +335,28 @@ func ParseFlowSpecArgs(rf bgp.RouteFamily, args []string, rd bgp.RouteDistinguis
 		return nil, nil, fmt.Errorf("invalid format")
 	}
 	matchArgs := args[1:thenPos]
-	cmp, err := bgp.ParseFlowSpecComponents(rf, strings.Join(matchArgs, " "))
+
+	rules, err := bgp.ParseFlowSpecComponents(rf, strings.Join(matchArgs, " "))
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var nlri bgp.AddrPrefixInterface
-	var fnlri *bgp.FlowSpecNLRI
 	switch rf {
 	case bgp.RF_FS_IPv4_UC:
-		nlri = bgp.NewFlowSpecIPv4Unicast(cmp)
-		fnlri = &nlri.(*bgp.FlowSpecIPv4Unicast).FlowSpecNLRI
+		nlri = bgp.NewFlowSpecIPv4Unicast(rules)
 	case bgp.RF_FS_IPv6_UC:
-		nlri = bgp.NewFlowSpecIPv6Unicast(cmp)
-		fnlri = &nlri.(*bgp.FlowSpecIPv6Unicast).FlowSpecNLRI
+		nlri = bgp.NewFlowSpecIPv6Unicast(rules)
 	case bgp.RF_FS_IPv4_VPN:
-		nlri = bgp.NewFlowSpecIPv4VPN(rd, cmp)
-		fnlri = &nlri.(*bgp.FlowSpecIPv4VPN).FlowSpecNLRI
+		nlri = bgp.NewFlowSpecIPv4VPN(rd, rules)
 	case bgp.RF_FS_IPv6_VPN:
-		nlri = bgp.NewFlowSpecIPv6VPN(rd, cmp)
-		fnlri = &nlri.(*bgp.FlowSpecIPv6VPN).FlowSpecNLRI
+		nlri = bgp.NewFlowSpecIPv6VPN(rd, rules)
 	case bgp.RF_FS_L2_VPN:
-		nlri = bgp.NewFlowSpecL2VPN(rd, cmp)
-		fnlri = &nlri.(*bgp.FlowSpecL2VPN).FlowSpecNLRI
+		nlri = bgp.NewFlowSpecL2VPN(rd, rules)
 	default:
 		return nil, nil, fmt.Errorf("invalid route family")
 	}
-	var comms table.FlowSpecComponents
-	comms = fnlri.Value
-	sort.Sort(comms)
+
 	return nlri, args[thenPos+1:], nil
 }
 

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -4027,6 +4027,10 @@ func (n *FlowSpecNLRI) decodeFromBytes(rf RouteFamily, data []byte, options ...*
 		n.Value = append(n.Value, i)
 	}
 
+	// Sort Traffic Filtering Rules in types order to avoid the unordered rules
+	// are determined different.
+	sort.SliceStable(n.Value, func(i, j int) bool { return n.Value[i].Type() < n.Value[j].Type() })
+
 	return nil
 }
 
@@ -4246,7 +4250,13 @@ func (n *FlowSpecIPv4Unicast) DecodeFromBytes(data []byte, options ...*Marshalli
 }
 
 func NewFlowSpecIPv4Unicast(value []FlowSpecComponentInterface) *FlowSpecIPv4Unicast {
-	return &FlowSpecIPv4Unicast{FlowSpecNLRI{Value: value, rf: RF_FS_IPv4_UC}}
+	sort.SliceStable(value, func(i, j int) bool { return value[i].Type() < value[j].Type() })
+	return &FlowSpecIPv4Unicast{
+		FlowSpecNLRI: FlowSpecNLRI{
+			Value: value,
+			rf:    RF_FS_IPv4_UC,
+		},
+	}
 }
 
 type FlowSpecIPv4VPN struct {
@@ -4258,7 +4268,14 @@ func (n *FlowSpecIPv4VPN) DecodeFromBytes(data []byte, options ...*MarshallingOp
 }
 
 func NewFlowSpecIPv4VPN(rd RouteDistinguisherInterface, value []FlowSpecComponentInterface) *FlowSpecIPv4VPN {
-	return &FlowSpecIPv4VPN{FlowSpecNLRI{Value: value, rf: RF_FS_IPv4_VPN, rd: rd}}
+	sort.SliceStable(value, func(i, j int) bool { return value[i].Type() < value[j].Type() })
+	return &FlowSpecIPv4VPN{
+		FlowSpecNLRI: FlowSpecNLRI{
+			Value: value,
+			rf:    RF_FS_IPv4_VPN,
+			rd:    rd,
+		},
+	}
 }
 
 type FlowSpecIPv6Unicast struct {
@@ -4270,10 +4287,13 @@ func (n *FlowSpecIPv6Unicast) DecodeFromBytes(data []byte, options ...*Marshalli
 }
 
 func NewFlowSpecIPv6Unicast(value []FlowSpecComponentInterface) *FlowSpecIPv6Unicast {
-	return &FlowSpecIPv6Unicast{FlowSpecNLRI{
-		Value: value,
-		rf:    RF_FS_IPv6_UC,
-	}}
+	sort.SliceStable(value, func(i, j int) bool { return value[i].Type() < value[j].Type() })
+	return &FlowSpecIPv6Unicast{
+		FlowSpecNLRI: FlowSpecNLRI{
+			Value: value,
+			rf:    RF_FS_IPv6_UC,
+		},
+	}
 }
 
 type FlowSpecIPv6VPN struct {
@@ -4285,11 +4305,14 @@ func (n *FlowSpecIPv6VPN) DecodeFromBytes(data []byte, options ...*MarshallingOp
 }
 
 func NewFlowSpecIPv6VPN(rd RouteDistinguisherInterface, value []FlowSpecComponentInterface) *FlowSpecIPv6VPN {
-	return &FlowSpecIPv6VPN{FlowSpecNLRI{
-		Value: value,
-		rf:    RF_FS_IPv6_VPN,
-		rd:    rd,
-	}}
+	sort.SliceStable(value, func(i, j int) bool { return value[i].Type() < value[j].Type() })
+	return &FlowSpecIPv6VPN{
+		FlowSpecNLRI: FlowSpecNLRI{
+			Value: value,
+			rf:    RF_FS_IPv6_VPN,
+			rd:    rd,
+		},
+	}
 }
 
 type FlowSpecL2VPN struct {
@@ -4301,11 +4324,14 @@ func (n *FlowSpecL2VPN) DecodeFromBytes(data []byte, options ...*MarshallingOpti
 }
 
 func NewFlowSpecL2VPN(rd RouteDistinguisherInterface, value []FlowSpecComponentInterface) *FlowSpecL2VPN {
-	return &FlowSpecL2VPN{FlowSpecNLRI{
-		Value: value,
-		rf:    RF_FS_L2_VPN,
-		rd:    rd,
-	}}
+	sort.SliceStable(value, func(i, j int) bool { return value[i].Type() < value[j].Type() })
+	return &FlowSpecL2VPN{
+		FlowSpecNLRI: FlowSpecNLRI{
+			Value: value,
+			rf:    RF_FS_L2_VPN,
+			rd:    rd,
+		},
+	}
 }
 
 type OpaqueNLRI struct {

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -3772,11 +3772,11 @@ func formatProto(op int, value int) string {
 
 func formatTCPFlag(op int, value int) string {
 	var retString string
-	if op&BITMASK_FLAG_OP_MATCH > 0 {
-		retString = fmt.Sprintf("%s%s", retString, BitmaskFlagOpNameMap[BITMASK_FLAG_OP_MATCH])
-	}
 	if op&BITMASK_FLAG_OP_NOT > 0 {
 		retString = fmt.Sprintf("%s%s", retString, BitmaskFlagOpNameMap[BITMASK_FLAG_OP_NOT])
+	}
+	if op&BITMASK_FLAG_OP_MATCH > 0 {
+		retString = fmt.Sprintf("%s%s", retString, BitmaskFlagOpNameMap[BITMASK_FLAG_OP_MATCH])
 	}
 
 	// Prepare a sorted list of flags because map iterations does not happen
@@ -3802,11 +3802,11 @@ func formatTCPFlag(op int, value int) string {
 
 func formatFragment(op int, value int) string {
 	var retString string
-	if op&BITMASK_FLAG_OP_MATCH > 0 {
-		retString = fmt.Sprintf("%s%s", retString, BitmaskFlagOpNameMap[BITMASK_FLAG_OP_MATCH])
-	}
 	if op&BITMASK_FLAG_OP_NOT > 0 {
 		retString = fmt.Sprintf("%s%s", retString, BitmaskFlagOpNameMap[BITMASK_FLAG_OP_NOT])
+	}
+	if op&BITMASK_FLAG_OP_MATCH > 0 {
+		retString = fmt.Sprintf("%s%s", retString, BitmaskFlagOpNameMap[BITMASK_FLAG_OP_MATCH])
 	}
 
 	// Prepare a sorted list of flags because map iterations does not happen

--- a/packet/bgp/bgp_test.go
+++ b/packet/bgp/bgp_test.go
@@ -787,20 +787,21 @@ func Test_CompareFlowSpecNLRI(t *testing.T) {
 	assert := assert.New(t)
 	cmp, err := ParseFlowSpecComponents(RF_FS_IPv4_UC, "destination 10.0.0.2/32 source 10.0.0.1/32 destination-port ==3128 protocol tcp")
 	assert.Nil(err)
-	n1 := &FlowSpecNLRI{Value: cmp, rf: RF_FS_IPv4_UC}
+	// Note: Use NewFlowSpecIPv4Unicast() for the consistent ordered rules.
+	n1 := NewFlowSpecIPv4Unicast(cmp).FlowSpecNLRI
 	cmp, err = ParseFlowSpecComponents(RF_FS_IPv4_UC, "source 10.0.0.0/24 destination-port ==3128 protocol tcp")
 	assert.Nil(err)
-	n2 := &FlowSpecNLRI{Value: cmp, rf: RF_FS_IPv4_UC}
-	cmp, err = ParseFlowSpecComponents(RF_FS_IPv4_UC, "source 10.0.0.9/32 port ==80 ==8080 destination-port >8080&<8080 ==3128 source-port >1024 protocol ==udp ==tcp")
-	n3 := &FlowSpecNLRI{Value: cmp, rf: RF_FS_IPv4_UC}
-	assert.Nil(err)
-	cmp, err = ParseFlowSpecComponents(RF_FS_IPv4_UC, "destination 192.168.0.2/32")
-	n4 := &FlowSpecNLRI{Value: cmp, rf: RF_FS_IPv4_UC}
-	assert.Nil(err)
-	r, err := CompareFlowSpecNLRI(n1, n2)
+	n2 := NewFlowSpecIPv4Unicast(cmp).FlowSpecNLRI
+	r, err := CompareFlowSpecNLRI(&n1, &n2)
 	assert.Nil(err)
 	assert.True(r > 0)
-	r, err = CompareFlowSpecNLRI(n3, n4)
+	cmp, err = ParseFlowSpecComponents(RF_FS_IPv4_UC, "source 10.0.0.9/32 port ==80 ==8080 destination-port >8080&<8080 ==3128 source-port >1024 protocol ==udp ==tcp")
+	n3 := NewFlowSpecIPv4Unicast(cmp).FlowSpecNLRI
+	assert.Nil(err)
+	cmp, err = ParseFlowSpecComponents(RF_FS_IPv4_UC, "destination 192.168.0.2/32")
+	n4 := NewFlowSpecIPv4Unicast(cmp).FlowSpecNLRI
+	assert.Nil(err)
+	r, err = CompareFlowSpecNLRI(&n3, &n4)
 	assert.Nil(err)
 	assert.True(r < 0)
 }

--- a/packet/bgp/constant.go
+++ b/packet/bgp/constant.go
@@ -70,21 +70,6 @@ var ProtocolNameMap = map[Protocol]string{
 	SCTP:    "sctp",
 }
 
-var ProtocolValueMap = map[string]Protocol{
-	ProtocolNameMap[ICMP]: ICMP,
-	ProtocolNameMap[IGMP]: IGMP,
-	ProtocolNameMap[TCP]:  TCP,
-	ProtocolNameMap[EGP]:  EGP,
-	ProtocolNameMap[IGP]:  IGP,
-	ProtocolNameMap[UDP]:  UDP,
-	ProtocolNameMap[RSVP]: RSVP,
-	ProtocolNameMap[GRE]:  GRE,
-	ProtocolNameMap[OSPF]: OSPF,
-	ProtocolNameMap[IPIP]: IPIP,
-	ProtocolNameMap[PIM]:  PIM,
-	ProtocolNameMap[SCTP]: SCTP,
-}
-
 func (p Protocol) String() string {
 	name, ok := ProtocolNameMap[p]
 	if !ok {
@@ -96,14 +81,15 @@ func (p Protocol) String() string {
 type TCPFlag int
 
 const (
-	TCP_FLAG_FIN    = 0x01
-	TCP_FLAG_SYN    = 0x02
-	TCP_FLAG_RST    = 0x04
-	TCP_FLAG_PUSH   = 0x08
-	TCP_FLAG_ACK    = 0x10
-	TCP_FLAG_URGENT = 0x20
-	TCP_FLAG_ECE    = 0x40
-	TCP_FLAG_CWR    = 0x80
+	_               TCPFlag = iota
+	TCP_FLAG_FIN            = 0x01
+	TCP_FLAG_SYN            = 0x02
+	TCP_FLAG_RST            = 0x04
+	TCP_FLAG_PUSH           = 0x08
+	TCP_FLAG_ACK            = 0x10
+	TCP_FLAG_URGENT         = 0x20
+	TCP_FLAG_ECE            = 0x40
+	TCP_FLAG_CWR            = 0x80
 )
 
 var TCPFlagNameMap = map[TCPFlag]string{
@@ -117,25 +103,38 @@ var TCPFlagNameMap = map[TCPFlag]string{
 	TCP_FLAG_ECE:    "E",
 }
 
-var TCPFlagValueMap = map[string]TCPFlag{
-	TCPFlagNameMap[TCP_FLAG_FIN]:    TCP_FLAG_FIN,
-	TCPFlagNameMap[TCP_FLAG_SYN]:    TCP_FLAG_SYN,
-	TCPFlagNameMap[TCP_FLAG_RST]:    TCP_FLAG_RST,
-	TCPFlagNameMap[TCP_FLAG_PUSH]:   TCP_FLAG_PUSH,
-	TCPFlagNameMap[TCP_FLAG_ACK]:    TCP_FLAG_ACK,
-	TCPFlagNameMap[TCP_FLAG_URGENT]: TCP_FLAG_URGENT,
-	TCPFlagNameMap[TCP_FLAG_CWR]:    TCP_FLAG_CWR,
-	TCPFlagNameMap[TCP_FLAG_ECE]:    TCP_FLAG_ECE,
+// Prepares a sorted list of flags because map iterations does not happen
+// in a consistent order in Golang.
+var TCPSortedFlags = []TCPFlag{
+	TCP_FLAG_FIN,
+	TCP_FLAG_SYN,
+	TCP_FLAG_RST,
+	TCP_FLAG_PUSH,
+	TCP_FLAG_ACK,
+	TCP_FLAG_URGENT,
+	TCP_FLAG_ECE,
+	TCP_FLAG_CWR,
+}
+
+func (f TCPFlag) String() string {
+	flags := make([]string, 0, len(TCPSortedFlags))
+	for _, v := range TCPSortedFlags {
+		if f&v > 0 {
+			flags = append(flags, TCPFlagNameMap[v])
+		}
+	}
+	return strings.Join(flags, "")
 }
 
 type BitmaskFlagOp int
 
 const (
-	BITMASK_FLAG_OP_OR    = 0x00
-	BITMASK_FLAG_OP_AND   = 0x40
-	BITMASK_FLAG_OP_END   = 0x80
-	BITMASK_FLAG_OP_NOT   = 0x02
-	BITMASK_FLAG_OP_MATCH = 0x01
+	BITMASK_FLAG_OP_OR        BitmaskFlagOp = iota
+	BITMASK_FLAG_OP_MATCH                   = 0x01
+	BITMASK_FLAG_OP_NOT                     = 0x02
+	BITMASK_FLAG_OP_NOT_MATCH               = 0x03
+	BITMASK_FLAG_OP_AND                     = 0x40
+	BITMASK_FLAG_OP_END                     = 0x80
 )
 
 var BitmaskFlagOpNameMap = map[BitmaskFlagOp]string{
@@ -146,22 +145,30 @@ var BitmaskFlagOpNameMap = map[BitmaskFlagOp]string{
 	BITMASK_FLAG_OP_MATCH: "=",
 }
 
-var BitmaskFlagOpValueMap = map[string]BitmaskFlagOp{
-	BitmaskFlagOpNameMap[BITMASK_FLAG_OP_OR]:    BITMASK_FLAG_OP_OR,
-	BitmaskFlagOpNameMap[BITMASK_FLAG_OP_AND]:   BITMASK_FLAG_OP_AND,
-	BitmaskFlagOpNameMap[BITMASK_FLAG_OP_END]:   BITMASK_FLAG_OP_END,
-	BitmaskFlagOpNameMap[BITMASK_FLAG_OP_NOT]:   BITMASK_FLAG_OP_NOT,
-	BitmaskFlagOpNameMap[BITMASK_FLAG_OP_MATCH]: BITMASK_FLAG_OP_MATCH,
+func (f BitmaskFlagOp) String() string {
+	ops := make([]string, 0)
+	if f&BITMASK_FLAG_OP_AND > 0 {
+		ops = append(ops, BitmaskFlagOpNameMap[BITMASK_FLAG_OP_AND])
+	} else {
+		ops = append(ops, BitmaskFlagOpNameMap[BITMASK_FLAG_OP_OR])
+	}
+	if f&BITMASK_FLAG_OP_NOT > 0 {
+		ops = append(ops, BitmaskFlagOpNameMap[BITMASK_FLAG_OP_NOT])
+	}
+	if f&BITMASK_FLAG_OP_MATCH > 0 {
+		ops = append(ops, BitmaskFlagOpNameMap[BITMASK_FLAG_OP_MATCH])
+	}
+	return strings.Join(ops, "")
 }
 
 type FragmentFlag int
 
 const (
-	FRAG_FLAG_NOT   = 0x00
-	FRAG_FLAG_DONT  = 0x01
-	FRAG_FLAG_IS    = 0x02
-	FRAG_FLAG_FIRST = 0x04
-	FRAG_FLAG_LAST  = 0x08
+	FRAG_FLAG_NOT   FragmentFlag = iota
+	FRAG_FLAG_DONT               = 0x01
+	FRAG_FLAG_IS                 = 0x02
+	FRAG_FLAG_FIRST              = 0x04
+	FRAG_FLAG_LAST               = 0x08
 )
 
 var FragmentFlagNameMap = map[FragmentFlag]string{
@@ -172,25 +179,41 @@ var FragmentFlagNameMap = map[FragmentFlag]string{
 	FRAG_FLAG_LAST:  "last-fragment",
 }
 
-var FragmentFlagValueMap = map[string]FragmentFlag{
-	FragmentFlagNameMap[FRAG_FLAG_NOT]:   FRAG_FLAG_NOT,
-	FragmentFlagNameMap[FRAG_FLAG_DONT]:  FRAG_FLAG_DONT,
-	FragmentFlagNameMap[FRAG_FLAG_IS]:    FRAG_FLAG_IS,
-	FragmentFlagNameMap[FRAG_FLAG_FIRST]: FRAG_FLAG_FIRST,
-	FragmentFlagNameMap[FRAG_FLAG_LAST]:  FRAG_FLAG_LAST,
+// Prepares a sorted list of flags because map iterations does not happen
+// in a consistent order in Golang.
+var FragmentSortedFlags = []FragmentFlag{
+	FRAG_FLAG_NOT,
+	FRAG_FLAG_DONT,
+	FRAG_FLAG_IS,
+	FRAG_FLAG_FIRST,
+	FRAG_FLAG_LAST,
+}
+
+func (f FragmentFlag) String() string {
+	flags := make([]string, 0, len(FragmentSortedFlags))
+	for _, v := range FragmentSortedFlags {
+		if f&v > 0 {
+			flags = append(flags, FragmentFlagNameMap[v])
+		}
+	}
+	// Note: If multiple bits are set, joins them with "+".
+	return strings.Join(flags, "+")
 }
 
 type DECNumOp int
 
 const (
-	DEC_NUM_OP_TRUE   = 0x00 // true always with END bit set
-	DEC_NUM_OP_EQ     = 0x01
-	DEC_NUM_OP_GT     = 0x02
-	DEC_NUM_OP_GT_EQ  = 0x03
-	DEC_NUM_OP_LT     = 0x04
-	DEC_NUM_OP_LT_EQ  = 0x05
-	DEC_NUM_OP_NOT_EQ = 0x06
-	DEC_NUM_OP_FALSE  = 0x07 // true always with END bit set
+	DEC_NUM_OP_TRUE   DECNumOp = iota // true always with END bit set
+	DEC_NUM_OP_EQ              = 0x01
+	DEC_NUM_OP_GT              = 0x02
+	DEC_NUM_OP_GT_EQ           = 0x03
+	DEC_NUM_OP_LT              = 0x04
+	DEC_NUM_OP_LT_EQ           = 0x05
+	DEC_NUM_OP_NOT_EQ          = 0x06
+	DEC_NUM_OP_FALSE           = 0x07 // false always with END bit set
+	DEC_NUM_OP_OR              = 0x00
+	DEC_NUM_OP_AND             = 0x40
+	DEC_NUM_OP_END             = 0x80
 )
 
 var DECNumOpNameMap = map[DECNumOp]string{
@@ -202,49 +225,31 @@ var DECNumOpNameMap = map[DECNumOp]string{
 	DEC_NUM_OP_LT_EQ:  "<=",
 	DEC_NUM_OP_NOT_EQ: "!=",
 	DEC_NUM_OP_FALSE:  "false",
+	//DEC_NUM_OP_OR:   " ", // duplicate with DEC_NUM_OP_TRUE
+	DEC_NUM_OP_AND: "&",
+	DEC_NUM_OP_END: "E",
 }
 
-var DECNumOpValueMap = map[string]DECNumOp{
-	DECNumOpNameMap[DEC_NUM_OP_TRUE]:   DEC_NUM_OP_TRUE,
-	DECNumOpNameMap[DEC_NUM_OP_EQ]:     DEC_NUM_OP_EQ,
-	DECNumOpNameMap[DEC_NUM_OP_GT]:     DEC_NUM_OP_GT,
-	DECNumOpNameMap[DEC_NUM_OP_GT_EQ]:  DEC_NUM_OP_GT_EQ,
-	DECNumOpNameMap[DEC_NUM_OP_LT]:     DEC_NUM_OP_LT,
-	DECNumOpNameMap[DEC_NUM_OP_LT_EQ]:  DEC_NUM_OP_LT_EQ,
-	DECNumOpNameMap[DEC_NUM_OP_NOT_EQ]: DEC_NUM_OP_NOT_EQ,
-	DECNumOpNameMap[DEC_NUM_OP_FALSE]:  DEC_NUM_OP_FALSE,
-}
-
-type DECLogicOp int
-
-const (
-	DEC_LOGIC_OP_END = 0x80
-	DEC_LOGIC_OP_OR  = 0x00
-	DEC_LOGIC_OP_AND = 0x40
-)
-
-var DECLogicOpNameMap = map[DECLogicOp]string{
-	DEC_LOGIC_OP_OR:  " ",
-	DEC_LOGIC_OP_AND: "&",
-	DEC_LOGIC_OP_END: "E",
-}
-
-var DECLogicOpValueMap = map[string]DECLogicOp{
-	DECLogicOpNameMap[DEC_LOGIC_OP_OR]:  DEC_LOGIC_OP_OR,
-	DECLogicOpNameMap[DEC_LOGIC_OP_AND]: DEC_LOGIC_OP_AND,
-	DECLogicOpNameMap[DEC_LOGIC_OP_END]: DEC_LOGIC_OP_END,
-}
-
-func (f TCPFlag) String() string {
-	ss := make([]string, 0, 6)
-	for _, v := range []TCPFlag{TCP_FLAG_FIN, TCP_FLAG_SYN, TCP_FLAG_RST, TCP_FLAG_PUSH, TCP_FLAG_ACK, TCP_FLAG_URGENT, TCP_FLAG_CWR, TCP_FLAG_ECE} {
-		if f&v > 0 {
-			ss = append(ss, TCPFlagNameMap[v])
+func (f DECNumOp) String() string {
+	ops := make([]string, 0)
+	logicFlag := DECNumOp(f & 0xc0) // higher 2 bits
+	if logicFlag&DEC_NUM_OP_AND > 0 {
+		ops = append(ops, DECNumOpNameMap[DEC_NUM_OP_AND])
+	} else {
+		ops = append(ops, " ") // DEC_NUM_OP_OR
+	}
+	// Omits DEC_NUM_OP_END
+	cmpFlag := DECNumOp(f & 0x7) // lower 3 bits
+	for v, s := range DECNumOpNameMap {
+		if cmpFlag == v {
+			ops = append(ops, s)
+			break
 		}
 	}
-	return strings.Join(ss, "|")
+	return strings.Join(ops, "")
 }
 
+// Potentially taken from https://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml
 type EthernetType int
 
 const (
@@ -281,27 +286,9 @@ var EthernetTypeNameMap = map[EthernetType]string{
 	LOOPBACK:        "loopback",
 }
 
-var EthernetTypeValueMap = map[string]EthernetType{
-	EthernetTypeNameMap[IPv4]:            IPv4,
-	EthernetTypeNameMap[ARP]:             ARP,
-	EthernetTypeNameMap[RARP]:            RARP,
-	EthernetTypeNameMap[VMTP]:            VMTP,
-	EthernetTypeNameMap[APPLE_TALK]:      APPLE_TALK,
-	EthernetTypeNameMap[AARP]:            AARP,
-	EthernetTypeNameMap[IPX]:             IPX,
-	EthernetTypeNameMap[SNMP]:            SNMP,
-	EthernetTypeNameMap[NET_BIOS]:        NET_BIOS,
-	EthernetTypeNameMap[XTP]:             XTP,
-	EthernetTypeNameMap[IPv6]:            IPv6,
-	EthernetTypeNameMap[PPPoE_DISCOVERY]: PPPoE_DISCOVERY,
-	EthernetTypeNameMap[PPPoE_SESSION]:   PPPoE_SESSION,
-	EthernetTypeNameMap[LOOPBACK]:        LOOPBACK,
-}
-
 func (t EthernetType) String() string {
-	n, ok := EthernetTypeNameMap[t]
-	if !ok {
-		return fmt.Sprintf("%d", t)
+	if name, ok := EthernetTypeNameMap[t]; ok {
+		return name
 	}
-	return n
+	return fmt.Sprintf("%d", t)
 }

--- a/packet/bgp/constant.go
+++ b/packet/bgp/constant.go
@@ -145,6 +145,21 @@ var BitmaskFlagOpNameMap = map[BitmaskFlagOp]string{
 	BITMASK_FLAG_OP_MATCH: "=",
 }
 
+// Note: Meaning of "" is different from that of the numeric operator because
+// RFC5575 says if the Match bit in the bitmask operand is set, it should be
+// "strictly" matching against the given value.
+var BitmaskFlagOpValueMap = map[string]BitmaskFlagOp{
+	" ":  BITMASK_FLAG_OP_OR,
+	"":   BITMASK_FLAG_OP_OR,
+	"==": BITMASK_FLAG_OP_MATCH,
+	"=":  BITMASK_FLAG_OP_MATCH,
+	"!":  BITMASK_FLAG_OP_NOT,
+	"!=": BITMASK_FLAG_OP_NOT_MATCH,
+	"=!": BITMASK_FLAG_OP_NOT_MATCH, // For the backward compatibility
+	"&":  BITMASK_FLAG_OP_AND,
+	"E":  BITMASK_FLAG_OP_END,
+}
+
 func (f BitmaskFlagOp) String() string {
 	ops := make([]string, 0)
 	if f&BITMASK_FLAG_OP_AND > 0 {
@@ -228,6 +243,24 @@ var DECNumOpNameMap = map[DECNumOp]string{
 	//DEC_NUM_OP_OR:   " ", // duplicate with DEC_NUM_OP_TRUE
 	DEC_NUM_OP_AND: "&",
 	DEC_NUM_OP_END: "E",
+}
+
+var DECNumOpValueMap = map[string]DECNumOp{
+	"true":  DEC_NUM_OP_TRUE,
+	"":      DEC_NUM_OP_EQ,
+	"==":    DEC_NUM_OP_EQ,
+	"=":     DEC_NUM_OP_EQ,
+	">":     DEC_NUM_OP_GT,
+	">=":    DEC_NUM_OP_GT_EQ,
+	"<":     DEC_NUM_OP_LT,
+	"<=":    DEC_NUM_OP_LT_EQ,
+	"!=":    DEC_NUM_OP_NOT_EQ,
+	"=!":    DEC_NUM_OP_NOT_EQ,
+	"!":     DEC_NUM_OP_NOT_EQ,
+	"false": DEC_NUM_OP_FALSE,
+	" ":     DEC_NUM_OP_OR,
+	"&":     DEC_NUM_OP_AND,
+	"E":     DEC_NUM_OP_END,
 }
 
 func (f DECNumOp) String() string {

--- a/packet/bgp/validate_test.go
+++ b/packet/bgp/validate_test.go
@@ -388,8 +388,8 @@ func Test_Validate_flowspec(t *testing.T) {
 	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_TCP_FLAG, []*FlowSpecComponentItem{item5, item6}))
 	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_PKT_LEN, []*FlowSpecComponentItem{item2, item3, item4}))
 	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_DSCP, []*FlowSpecComponentItem{item2, item3, item4}))
-	isFlagment := 0x02
-	item7 := NewFlowSpecComponentItem(isFlagment, 0)
+	isFragment := 0x02
+	item7 := NewFlowSpecComponentItem(isFragment, 0)
 	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_FRAGMENT, []*FlowSpecComponentItem{item7}))
 	n1 := NewFlowSpecIPv4Unicast(cmp)
 	a := NewPathAttributeMpReachNLRI("", []AddrPrefixInterface{n1})
@@ -402,6 +402,8 @@ func Test_Validate_flowspec(t *testing.T) {
 	cmp = append(cmp, NewFlowSpecDestinationPrefix(NewIPAddrPrefix(24, "10.0.0.0")))
 	n1 = NewFlowSpecIPv4Unicast(cmp)
 	a = NewPathAttributeMpReachNLRI("", []AddrPrefixInterface{n1})
+	// Swaps components order to reproduce the rules order violation.
+	n1.Value[0], n1.Value[1] = n1.Value[1], n1.Value[0]
 	_, err = ValidateAttribute(a, m, false, false)
 	assert.NotNil(err)
 }

--- a/table/path.go
+++ b/table/path.go
@@ -136,20 +136,6 @@ type Validation struct {
 	UnmatchedLength []*ROA
 }
 
-type FlowSpecComponents []bgp.FlowSpecComponentInterface
-
-func (c FlowSpecComponents) Len() int {
-	return len(c)
-}
-
-func (c FlowSpecComponents) Swap(i, j int) {
-	c[i], c[j] = c[j], c[i]
-}
-
-func (c FlowSpecComponents) Less(i, j int) bool {
-	return c[i].Type() < c[j].Type()
-}
-
 type Path struct {
 	info       *originInfo
 	IsWithdraw bool
@@ -171,25 +157,6 @@ func NewPath(source *PeerInfo, nlri bgp.AddrPrefixInterface, isWithdraw bool, pa
 			"Key":   nlri.String(),
 		}).Error("Need to provide path attributes for non-withdrawn path.")
 		return nil
-	}
-
-	if nlri != nil && (nlri.SAFI() == bgp.SAFI_FLOW_SPEC_UNICAST || nlri.SAFI() == bgp.SAFI_FLOW_SPEC_VPN) {
-		var coms FlowSpecComponents
-		var f *bgp.FlowSpecNLRI
-		switch nlri.(type) {
-		case *bgp.FlowSpecIPv4Unicast:
-			f = &nlri.(*bgp.FlowSpecIPv4Unicast).FlowSpecNLRI
-		case *bgp.FlowSpecIPv4VPN:
-			f = &nlri.(*bgp.FlowSpecIPv4VPN).FlowSpecNLRI
-		case *bgp.FlowSpecIPv6Unicast:
-			f = &nlri.(*bgp.FlowSpecIPv6Unicast).FlowSpecNLRI
-		case *bgp.FlowSpecIPv6VPN:
-			f = &nlri.(*bgp.FlowSpecIPv6VPN).FlowSpecNLRI
-		}
-		if f != nil {
-			coms = f.Value
-			sort.Sort(coms)
-		}
 	}
 
 	return &Path{


### PR DESCRIPTION
Currently, the parser for the string representation of FlowSpec rules splits the given string into characters and validates them character by character. So we need to handle the unexpected white spaces carefully.
This problem is related to https://github.com/osrg/gobgp/pull/1489.

This PR introduces the regular expressions to parse the FlowSpec rules and simplify the parser.
With these patches, the robustness for the unexpectedly inserted white spaces like "   &   ==   tcp   " will be improved.

Also, includes some improvements for the string representation of the FlowSpec rules.
Example:
- The NOT MATCH operand of "tcp-flags" is replace from "=!" to "!="
- The combined "fragment" value will be joined with "+" (e.g. "is-fragment+first-fragment")

FYI, I will update documents for the FlowSpec on another PR.