### PR TITLE
config: allow unconfigured peer ASN

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -129,10 +129,6 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, g *Glo
 		}
 	}
 
-	if n.Config.PeerAs == 0 {
-		return fmt.Errorf("peer-as is not set for %s", n.Config.NeighborAddress)
-	}
-
 	if n.Config.LocalAs == 0 {
 		n.Config.LocalAs = g.Config.As
 		if !g.Confederation.Config.Enabled || n.IsConfederation(g) {


### PR DESCRIPTION
The commit ab953211 prohibits the unconfigured peer ASN but it breaks
the unnumbered BGP feature. The old behavior needs to be reverted.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>