### PR TITLE
cmd: fix getNeighbor() to take bogus neighbor name

### DIFF
--- a/gobgp/cmd/neighbor.go
+++ b/gobgp/cmd/neighbor.go
@@ -74,13 +74,6 @@ func getNeighbors(vrf string) (neighbors, error) {
 	return neighbors(n), err
 }
 
-func getNeighbor(name string, enableAdvertised bool) (*config.Neighbor, error) {
-	if net.ParseIP(name) == nil {
-		name = ""
-	}
-	return client.GetNeighbor(name, enableAdvertised)
-}
-
 func getASN(p *config.Neighbor) string {
 	asn := "*"
 	if p.State.PeerAs > 0 {
@@ -178,7 +171,7 @@ func showNeighbors(vrf string) error {
 }
 
 func showNeighbor(args []string) error {
-	p, e := getNeighbor(args[0], true)
+	p, e := client.GetNeighbor(args[0], true)
 	if e != nil {
 		return e
 	}
@@ -771,7 +764,7 @@ func showNeighborRib(r string, name string, args []string) error {
 	switch r {
 	case CMD_LOCAL, CMD_ADJ_IN, CMD_ACCEPTED, CMD_REJECTED, CMD_ADJ_OUT:
 		if rib.Info("").NumDestination == 0 {
-			peer, err := getNeighbor(name, false)
+			peer, err := client.GetNeighbor(name, false)
 			if err != nil {
 				return err
 			}
@@ -1105,7 +1098,7 @@ func NewNeighborCmd() *cobra.Command {
 						}
 					}
 					if addr == "" {
-						peer, err := getNeighbor(args[len(args)-1], false)
+						peer, err := client.GetNeighbor(args[len(args)-1], false)
 						if err != nil {
 							exitWithError(err)
 						}
@@ -1136,7 +1129,7 @@ func NewNeighborCmd() *cobra.Command {
 	policyCmd := &cobra.Command{
 		Use: CMD_POLICY,
 		Run: func(cmd *cobra.Command, args []string) {
-			peer, err := getNeighbor(args[0], false)
+			peer, err := client.GetNeighbor(args[0], false)
 			if err != nil {
 				exitWithError(err)
 			}
@@ -1153,7 +1146,7 @@ func NewNeighborCmd() *cobra.Command {
 		cmd := &cobra.Command{
 			Use: v,
 			Run: func(cmd *cobra.Command, args []string) {
-				peer, err := getNeighbor(args[0], false)
+				peer, err := client.GetNeighbor(args[0], false)
 				if err != nil {
 					exitWithError(err)
 				}
@@ -1169,7 +1162,7 @@ func NewNeighborCmd() *cobra.Command {
 			subcmd := &cobra.Command{
 				Use: w,
 				Run: func(subcmd *cobra.Command, args []string) {
-					peer, err := getNeighbor(args[len(args)-1], false)
+					peer, err := client.GetNeighbor(args[len(args)-1], false)
 					if err != nil {
 						exitWithError(err)
 					}

--- a/server/server.go
+++ b/server/server.go
@@ -1748,7 +1748,7 @@ func (s *BgpServer) GetNeighbor(address string, getAdvertised bool) (l []*config
 	s.mgmtOperation(func() error {
 		l = make([]*config.Neighbor, 0, len(s.neighborMap))
 		for k, peer := range s.neighborMap {
-			if address != "" && address != k {
+			if address != "" && address != k && address != peer.fsm.pConf.Config.NeighborInterface {
 				continue
 			}
 			l = append(l, peer.ToConfig(getAdvertised))


### PR DESCRIPTION
This fixes the ae7e572550df919c1b9990da8787fc1e860bc20d commit
regression. gobgp neighbor command takes a bogus neighbor name like
the following:

fujita@ubuntu:~/go/src/github.com/osrg/gobgp/gobgp$ ./gobgp n 1
BGP neighbor is 172.17.0.2, remote AS 65001
  BGP version 4, remote router ID unknown
  BGP state = active, up for 17496d 14:21:50
  BGP OutQ = 0, Flops = 0
  Hold time is 0, keepalive interval is 0 seconds
  Configured hold time is 60, keepalive interval is 20 seconds

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>