### PR TITLE
test/lib: Allow unconfigured peer-as for Unnumbered BGP

### DIFF
--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -366,15 +366,17 @@ class GoBGPContainer(BGPContainer):
 
             neigh_addr = None
             interface = None
+            peer_as = None
             if info['interface'] == '':
                 neigh_addr = info['neigh_addr'].split('/')[0]
+                peer_as = info['remote_as']
             else:
                 interface = info['interface']
             n = {
                 'config': {
                     'neighbor-address': neigh_addr,
                     'neighbor-interface': interface,
-                    'peer-as': info['remote_as'],
+                    'peer-as': peer_as,
                     'auth-password': info['passwd'],
                     'vrf': info['vrf'],
                     'remove-private-as': info['remove_private_as'],


### PR DESCRIPTION
For Unnumbered BGP, neighbor AS number isn't needed
to be specified, so 'peer-as' should not be specified
in the scenario test for Unnumbered BGP.
However, currently 'peer-as' is always specified
in test/lib/gobgp.py

This PR solves this by not specifying `peer-as`
if 'neighbor-interface' is configured.

Signed-off-by: Satoshi Fujimoto <satoshi.fujimoto7@gmail.com>