### PR TITLE
config/util: Fix to add Unnumbered BGP neighbor via CLI

### DIFF
--- a/config/util.go
+++ b/config/util.go
@@ -179,7 +179,7 @@ func ExtractNeighborAddress(c *Neighbor) (string, error) {
 	if addr == "" {
 		addr = c.Config.NeighborAddress
 		if addr == "" {
-			return "", fmt.Errorf("NeighborAddress is not configured")
+			return GetIPv6LinkLocalNeighborAddress(c.Config.NeighborInterface)
 		}
 	}
 	return addr, nil


### PR DESCRIPTION
Currently, Unnumbered BGP neighbors cannot be added via CLI
because link local address is not extracted before it is used.
This PR fixes it by returning the link local neighbor address
when extracting neighbor address.

Signed-off-by: Satoshi Fujimoto <satoshi.fujimoto7@gmail.com>