### PR TITLE
travis: Cross-compile test on i386 arch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,12 @@ matrix:
       before_script:
         - export GOOS="darwin"
         - go env
+    - <<: *_build
+      env:
+        - GOARCH="386"
+      before_script:
+        - export GOARCH="386"
+        - go env
 #
 # Misc
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,15 +57,27 @@ matrix:
 #
 # Cross-compile
 #
+# Note: We use "before_script" to enable "go env" settings. The following keeps
+# "env" sections as just markers of Travis-CI Web UI.
+# See https://github.com/travis-ci/travis-ci/issues/6126
     - <<: *_build
       env:
-        - GOOS=windows
+        - GOOS="windows"
+      before_script:
+        - export GOOS="windows"
+        - go env
     - <<: *_build
       env:
-        - GOOS=freebsd
+        - GOOS="freebsd"
+      before_script:
+        - export GOOS="freebsd"
+        - go env
     - <<: *_build
       env:
-        - GOOS=darwin
+        - GOOS="darwin"
+      before_script:
+        - export GOOS="darwin"
+        - go env
 #
 # Misc
 #


### PR DESCRIPTION
This patch introduces a new test for cross-compile on i386 arch in order to check out errors like; https://github.com/osrg/gobgp/issues/1509

Also, Travis-CI unexpectedly overrides the "go env" variables after running `gimme`, this patch fixes to use "before_script" to avoid this issue.