### PR TITLE
doc: remove "gobgp global as" from documentation

### DIFF
--- a/docs/sources/cli-command-syntax.md
+++ b/docs/sources/cli-command-syntax.md
@@ -20,8 +20,6 @@ gobgp has six subcommands.
 ### 1.1 Global Configuration
 #### syntax
 ```shell
-# configure global setting and start acting as bgp daemon
-% gobgp global as <VALUE> router-id <VALUE> [listen-port <VALUE>] [listen-addresses <VALUE>...] [mpls-label-min <VALUE>] [mpls-label-max <VALUE>]
 # delete global setting and stop acting as bgp daemon (all peer sessions will be closed)
 % gobgp global del all
 # show global setting

--- a/docs/sources/unnumbered-bgp.md
+++ b/docs/sources/unnumbered-bgp.md
@@ -60,7 +60,6 @@ advertisement.
 ## Configuration via CLI
 
 ```bash
-$ gobgp global as 64512 router-id 192.168.255.1
 $ gobgp neighbor add interface eth0
 $ gobgp neighbor eth0
 BGP neighbor is fe80::42:acff:fe11:3%eth0, remote AS 65001


### PR DESCRIPTION
This subcommand doesn't exist. Dunno if it was present at some point.