### PR TITLE
packet/bgp: JSON encode of MP_UNREACH_NLRI attribute

### DIFF
--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -6042,6 +6042,20 @@ func (p *PathAttributeMpUnreachNLRI) Serialize(options ...*MarshallingOption) ([
 	return p.PathAttribute.Serialize(options...)
 }
 
+func (p *PathAttributeMpUnreachNLRI) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  BGPAttrType           `json:"type"`
+		AFI   uint16                `json:"afi"`
+		SAFI  uint8                 `json:"safi"`
+		Value []AddrPrefixInterface `json:"value"`
+	}{
+		Type:  p.GetType(),
+		AFI:   p.AFI,
+		SAFI:  p.SAFI,
+		Value: p.Value,
+	})
+}
+
 func (p *PathAttributeMpUnreachNLRI) String() string {
 	if len(p.Value) > 0 {
 		return fmt.Sprintf("{MpUnreach(%s): {NLRIs: %s}}", AfiSafiToRouteFamily(p.AFI, p.SAFI), p.Value)

--- a/packet/bgp/bgp_test.go
+++ b/packet/bgp/bgp_test.go
@@ -873,6 +873,62 @@ func Test_MpReachNLRIWithIPv6PrefixWithIPv4Peering(t *testing.T) {
 	assert.Equal(bufin, bufout)
 }
 
+func Test_MpReachNLRIWithIPv6(t *testing.T) {
+	assert := assert.New(t)
+	bufin := []byte{
+		0x90, 0x0e, 0x00, 0x1e, // flags(1), type(1), length(2),
+		0x00, 0x02, 0x01, 0x10, // afi(2), safi(1), nexthoplen(1)
+		0x20, 0x01, 0x0d, 0xb8, // nexthop(16)
+		0x00, 0x01, 0x00, 0x00, // = "2001:db8:1::1"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+		0x00,                   // reserved(1)
+		0x40, 0x20, 0x01, 0x0d, // nlri(9)
+		0xb8, 0x00, 0x53, 0x00, // = "2001:db8:53::/64"
+		0x00,
+	}
+	// Test DecodeFromBytes()
+	p := &PathAttributeMpReachNLRI{}
+	err := p.DecodeFromBytes(bufin)
+	assert.Nil(err)
+	// Test decoded values
+	assert.Equal(BGPAttrFlag(0x90), p.Flags)
+	assert.Equal(BGPAttrType(0xe), p.Type)
+	assert.Equal(uint16(0x1e), p.Length)
+	assert.Equal(uint16(AFI_IP6), p.AFI)
+	assert.Equal(uint8(SAFI_UNICAST), p.SAFI)
+	assert.Equal(net.ParseIP("2001:db8:1::1"), p.Nexthop)
+	value := []AddrPrefixInterface{
+		NewIPv6AddrPrefix(64, "2001:db8:53::"),
+	}
+	assert.Equal(value, p.Value)
+}
+
+func Test_MpUnreachNLRIWithIPv6(t *testing.T) {
+	assert := assert.New(t)
+	bufin := []byte{
+		0x90, 0x0f, 0x00, 0x0c, // flags(1), type(1), length(2),
+		0x00, 0x02, 0x01, // afi(2), safi(1),
+		0x40, 0x20, 0x01, 0x0d, // nlri(9)
+		0xb8, 0x00, 0x53, 0x00, // = "2001:db8:53::/64"
+		0x00,
+	}
+	// Test DecodeFromBytes()
+	p := &PathAttributeMpUnreachNLRI{}
+	err := p.DecodeFromBytes(bufin)
+	assert.Nil(err)
+	// Test decoded values
+	assert.Equal(BGPAttrFlag(0x90), p.Flags)
+	assert.Equal(BGPAttrType(0xf), p.Type)
+	assert.Equal(uint16(0x0c), p.Length)
+	assert.Equal(uint16(AFI_IP6), p.AFI)
+	assert.Equal(uint8(SAFI_UNICAST), p.SAFI)
+	value := []AddrPrefixInterface{
+		NewIPv6AddrPrefix(64, "2001:db8:53::"),
+	}
+	assert.Equal(value, p.Value)
+}
+
 func Test_MpReachNLRIWithIPv6PrefixWithLinkLocalNexthop(t *testing.T) {
 	assert := assert.New(t)
 	bufin := []byte{


### PR DESCRIPTION
MP_REACH_NLRI was already correctly encoded in JSON, while this was
not the case for MP_UNREACH_NLRI.

Before:

```json
"PathAttributes": [
  {
    "type": 15,
    "value": "AAIBQCABDbgAEwAA"
  }
]
```

After:

```json
"PathAttributes": [
  {
    "type": 15,
    "afi": 2,
    "value": [
      {
        "prefix": "2001:db8:8::/64"
      }
    ],
    "safi": 1
  }
]
```

This commit also adds two tests not directly related to JSON encoding
as I was first thinking the problem may be related to incorrect
parsing of the path attribute.