### PR TITLE
Request to ignore common files created by IDEs and reports from py-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,13 @@ _cgo_export.*
 
 _testmain.go
 
+test/scenario_test/*.xml
+
 *.exe
 *.test
 *.prof
+
+# IDE workspace
+.idea
+.vscode
+


### PR DESCRIPTION
IDE creates its workspace configs in the project dir, which shall not be tracked

I also find that the `test/scenario_test/*.xml` reports should be ignored in git repo