### PR TITLE
For better cleanup after tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ _cgo_export.*
 
 _testmain.go
 
-test/scenario_test/*.xml
+test/scenario_test/nosetest*.xml
 
 *.exe
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,13 @@ _cgo_export.*
 
 _testmain.go
 
+test/scenario_test/*.xml
+
 *.exe
 *.test
 *.prof
+
+# IDE workspace
+.idea
+.vscode
+

--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -49,7 +49,7 @@ BGP_ATTR_TYPE_MP_REACH_NLRI = 14
 BGP_ATTR_TYPE_EXTENDED_COMMUNITIES = 16
 
 # with this prefix, we can do filtering in `docker ps`
-CONTAINER_NAME_PREFIX = 'osrg-gobgp-test'
+CONTAINER_NAME_PREFIX = 'gobgp-test'
 TEST_NETWORK_LABEL = CONTAINER_NAME_PREFIX
 
 env.abort_exception = RuntimeError

--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -48,6 +48,10 @@ BGP_ATTR_TYPE_CLUSTER_LIST = 10
 BGP_ATTR_TYPE_MP_REACH_NLRI = 14
 BGP_ATTR_TYPE_EXTENDED_COMMUNITIES = 16
 
+# with this prefix, we can do filtering in `docker ps`
+CONTAINER_NAME_PREFIX = 'osrg-gobgp-test'
+TEST_NETWORK_LABEL = CONTAINER_NAME_PREFIX
+
 env.abort_exception = RuntimeError
 output.stderr = False
 
@@ -156,7 +160,7 @@ class Bridge(object):
             v6 = ''
             if self.subnet.version == 6:
                 v6 = '--ipv6'
-            self.id = local('docker network create --driver bridge {0} --subnet {1} {2}'.format(v6, subnet, self.name), capture=True)
+            self.id = local('docker network create --driver bridge {0} --subnet {1} --label {2} {3}'.format(v6, subnet, TEST_NETWORK_LABEL, self.name), capture=True)
         try_several_times(f)
 
         self.self_ip = self_ip
@@ -200,8 +204,9 @@ class Container(object):
 
     def docker_name(self):
         if TEST_PREFIX == DEFAULT_TEST_PREFIX:
-            return self.name
-        return '{0}_{1}'.format(TEST_PREFIX, self.name)
+            return '{0}_{1}'.format(CONTAINER_NAME_PREFIX, self.name)
+        return '{0}_{1}_{2}'.format(CONTAINER_NAME_PREFIX,
+                                    TEST_PREFIX, self.name)
 
     def next_if_name(self):
         name = 'eth{0}'.format(len(self.eths) + 1)

--- a/test/scenario_test/README.md
+++ b/test/scenario_test/README.md
@@ -110,9 +110,8 @@ A lot of containers, networks temporary files are created during the test.
 Let's clean up.
 
 ```shell
-$ sudo docker rm -f $(sudo docker ps -a -q -f "name=osrg-gobgp-test_*")
-$ sudo docker network prune -f --filter "label=osrg-gobgp-test"
+$ sudo docker rm -f $(sudo docker ps -a -q -f "name=gobgp-test_*")
+$ sudo docker network prune -f --filter "label=gobgp-test"
 $ sudo rm -rf /tmp/gobgp
 ```
 
-You could run `bash test/scenario_test/cleanup.sh` directly.

--- a/test/scenario_test/README.md
+++ b/test/scenario_test/README.md
@@ -110,7 +110,9 @@ A lot of containers, networks temporary files are created during the test.
 Let's clean up.
 
 ```shell
-$ sudo docker rm -f $(sudo docker ps -a -q)
-$ sudo docker network prune -f
+$ sudo docker rm -f $(sudo docker ps -a -q -f "name=osrg-gobgp-test_*")
+$ sudo docker network prune -f --filter "label=osrg-gobgp-test"
 $ sudo rm -rf /tmp/gobgp
 ```
+
+You could run `bash test/scenario_test/cleanup.sh` directly.

--- a/test/scenario_test/cleanup.sh
+++ b/test/scenario_test/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo docker rm -f $(sudo docker ps -a -q -f "name=osrg-gobgp-test_*")
+sudo docker network prune -f --filter "label=osrg-gobgp-test"
+sudo rm -rf /tmp/gobgp

--- a/test/scenario_test/cleanup.sh
+++ b/test/scenario_test/cleanup.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-sudo docker rm -f $(sudo docker ps -a -q -f "name=osrg-gobgp-test_*")
-sudo docker network prune -f --filter "label=osrg-gobgp-test"
-sudo rm -rf /tmp/gobgp


### PR DESCRIPTION
added container name prefix
added network label

so later on when we do cleanup, we can filter the containers and networks created by the test. So other setups would not be affected 