### PR TITLE
Introduce a common label for containers and networks created in gobgp tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ _cgo_export.*
 
 _testmain.go
 
-test/scenario_test/*.xml
+test/scenario_test/nosetest*.xml
 
 *.exe
 *.test

--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -48,9 +48,9 @@ BGP_ATTR_TYPE_CLUSTER_LIST = 10
 BGP_ATTR_TYPE_MP_REACH_NLRI = 14
 BGP_ATTR_TYPE_EXTENDED_COMMUNITIES = 16
 
-# with this prefix, we can do filtering in `docker ps`
-CONTAINER_NAME_PREFIX = 'gobgp-test'
-TEST_NETWORK_LABEL = CONTAINER_NAME_PREFIX
+# with this label, we can do filtering in `docker ps` and `docker network prune`
+TEST_CONTAINER_LABEL = 'gobgp-test'
+TEST_NETWORK_LABEL = TEST_CONTAINER_LABEL
 
 env.abort_exception = RuntimeError
 output.stderr = False
@@ -204,9 +204,8 @@ class Container(object):
 
     def docker_name(self):
         if TEST_PREFIX == DEFAULT_TEST_PREFIX:
-            return '{0}_{1}'.format(CONTAINER_NAME_PREFIX, self.name)
-        return '{0}_{1}_{2}'.format(CONTAINER_NAME_PREFIX,
-                                    TEST_PREFIX, self.name)
+            return '{0}'.format(self.name)
+        return '{0}_{1}'.format(TEST_PREFIX, self.name)
 
     def next_if_name(self):
         name = 'eth{0}'.format(len(self.eths) + 1)
@@ -218,7 +217,7 @@ class Container(object):
         c << "docker run --privileged=true"
         for sv in self.shared_volumes:
             c << "-v {0}:{1}".format(sv[0], sv[1])
-        c << "--name {0} -id {1}".format(self.docker_name(), self.image)
+        c << "--name {0} -l {1} -id {2}".format(self.docker_name(), TEST_CONTAINER_LABEL, self.image)
         self.id = try_several_times(lambda: local(str(c), capture=True))
         self.is_running = True
         self.local("ip li set up dev lo")

--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -48,6 +48,10 @@ BGP_ATTR_TYPE_CLUSTER_LIST = 10
 BGP_ATTR_TYPE_MP_REACH_NLRI = 14
 BGP_ATTR_TYPE_EXTENDED_COMMUNITIES = 16
 
+# with this prefix, we can do filtering in `docker ps`
+CONTAINER_NAME_PREFIX = 'gobgp-test'
+TEST_NETWORK_LABEL = CONTAINER_NAME_PREFIX
+
 env.abort_exception = RuntimeError
 output.stderr = False
 
@@ -156,7 +160,7 @@ class Bridge(object):
             v6 = ''
             if self.subnet.version == 6:
                 v6 = '--ipv6'
-            self.id = local('docker network create --driver bridge {0} --subnet {1} {2}'.format(v6, subnet, self.name), capture=True)
+            self.id = local('docker network create --driver bridge {0} --subnet {1} --label {2} {3}'.format(v6, subnet, TEST_NETWORK_LABEL, self.name), capture=True)
         try_several_times(f)
 
         self.self_ip = self_ip
@@ -200,8 +204,9 @@ class Container(object):
 
     def docker_name(self):
         if TEST_PREFIX == DEFAULT_TEST_PREFIX:
-            return self.name
-        return '{0}_{1}'.format(TEST_PREFIX, self.name)
+            return '{0}_{1}'.format(CONTAINER_NAME_PREFIX, self.name)
+        return '{0}_{1}_{2}'.format(CONTAINER_NAME_PREFIX,
+                                    TEST_PREFIX, self.name)
 
     def next_if_name(self):
         name = 'eth{0}'.format(len(self.eths) + 1)

--- a/test/scenario_test/README.md
+++ b/test/scenario_test/README.md
@@ -110,7 +110,7 @@ A lot of containers, networks temporary files are created during the test.
 Let's clean up.
 
 ```shell
-$ sudo docker rm -f $(sudo docker ps -a -q)
-$ sudo docker network prune -f
+$ sudo docker rm -f $(sudo docker ps -a -q -f "name=gobgp-test_*")
+$ sudo docker network prune -f --filter "label=gobgp-test"
 $ sudo rm -rf /tmp/gobgp
 ```

--- a/test/scenario_test/README.md
+++ b/test/scenario_test/README.md
@@ -110,7 +110,7 @@ A lot of containers, networks temporary files are created during the test.
 Let's clean up.
 
 ```shell
-$ sudo docker rm -f $(sudo docker ps -a -q -f "name=gobgp-test_*")
+$ sudo docker rm -f $(sudo docker ps -a -q -f "label=gobgp-test")
 $ sudo docker network prune -f --filter "label=gobgp-test"
 $ sudo rm -rf /tmp/gobgp
 ```


### PR DESCRIPTION
use a common prefix for containers for easy cleaning up;
use label for networks in order to avoid colliding with others