### PR TITLE
cli-command-syntax.md: Missing arg to show VRF RIB

### DIFF
--- a/docs/sources/cli-command-syntax.md
+++ b/docs/sources/cli-command-syntax.md
@@ -428,11 +428,11 @@ If you want to remove one element(extended community) of ExtCommunitySet, to spe
 #### Syntax
 ```shell
 # add routes to vrf
-% gobgp vrf <vrf name> rib add <prefix> -a <address family>
+% gobgp vrf <vrf name> rib add <prefix> [-a <address family>]
 # del routes from vrf
-% gobgp vrf <vrf name> rib del <prefix> -a <address family>
+% gobgp vrf <vrf name> rib del <prefix> [-a <address family>]
 # show routes in vrf
-% gobgp vrf <vrf name>
+% gobgp vrf <vrf name> rib [-a <address family>]
 ```
 
 #### Example


### PR DESCRIPTION
This patch fixes the example on the doc for showing the VRF RIB where
the "rib" keyword is missing to execute the command.

Also, the "-a <adddress family>" is an option and this patch puts it
into brackets.

Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>