### PR TITLE
 table/policy: Support prefix representation in NeighborSet

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -1440,13 +1440,13 @@ func NewDefinedSetFromApiStruct(a *DefinedSet) (table.DefinedSet, error) {
 		}
 		return table.NewPrefixSetFromApiStruct(a.Name, prefixes)
 	case table.DEFINED_TYPE_NEIGHBOR:
-		list := make([]net.IP, 0, len(a.List))
+		list := make([]net.IPNet, 0, len(a.List))
 		for _, x := range a.List {
-			addr := net.ParseIP(x)
-			if addr == nil {
-				return nil, fmt.Errorf("invalid ip address format: %s", x)
+			_, addr, err := net.ParseCIDR(x)
+			if err != nil {
+				return nil, fmt.Errorf("invalid address or prefix: %s", x)
 			}
-			list = append(list, addr)
+			list = append(list, *addr)
 		}
 		return table.NewNeighborSetFromApiStruct(a.Name, list)
 	case table.DEFINED_TYPE_AS_PATH:

--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -5986,7 +5986,7 @@ type NeighborSet struct {
 	NeighborSetName string `mapstructure:"neighbor-set-name" json:"neighbor-set-name,omitempty"`
 	// original -> gobgp:neighbor-info
 	// original type is list of inet:ip-address
-	// neighbor ip address.
+	// neighbor ip address or prefix.
 	NeighborInfoList []string `mapstructure:"neighbor-info-list" json:"neighbor-info-list,omitempty"`
 }
 

--- a/docs/sources/cli-command-syntax.md
+++ b/docs/sources/cli-command-syntax.md
@@ -211,7 +211,7 @@ If you want to remove one element(prefix) of PrefixSet, to specify a prefix in a
 #### Syntax
 ```shell
 # add NeighborSet
-% gobgp policy neighbor add <neighbor set name> <neighbor address>
+% gobgp policy neighbor add <neighbor set name> <neighbor address/prefix>
 # delete a NeighborSet
 % gobgp policy neighbor del <neighbor set name>
 # delete a neighbor from a NeighborSet
@@ -227,7 +227,11 @@ If you want to add the NeighborSet：
 ```shell
 % gobgp policy neighbor add ns1 10.0.0.1
 ```
-A NeighborSet it is possible to have multiple address, if you want to remove the NeighborSet to specify only NeighborSet name.
+You can also specify a neighbor address range with the prefix representation:
+```shell
+% gobgp policy neighbor add ns 10.0.0.0/24
+``````
+A NeighborSet is possible to have multiple address, if you want to remove the NeighborSet to specify only NeighborSet name.
 ```shell
 % gobgp policy neighbor del ns1
 ```

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -168,7 +168,7 @@
         masklength-range = "24..32"
 [[defined-sets.neighbor-sets]]
    neighbor-set-name = "ns0"
-   neighbor-info-list = ["192.168.10.2"]
+   neighbor-info-list = ["192.168.10.2", "172.13.0.0/24"]
 [[defined-sets.bgp-defined-sets.community-sets]]
     community-set-name = "cs0"
     community-list = ["100:100"]

--- a/docs/sources/policy.md
+++ b/docs/sources/policy.md
@@ -272,6 +272,10 @@ prefix-sets and neighbor-sets section are prefix match part and neighbor match p
   [[defined-sets.neighbor-sets]]
     neighbor-set-name = "ns1"
     neighbor-info-list = ["10.0.255.1"]
+  # Prefix representations are also acceptable.
+  [[defined-sets.neighbor-sets]]
+    neighbor-set-name = "ns2"
+    neighbor-info-list = ["10.0.0.0/24"]
   ```
 
  - example 2

--- a/gobgp/cmd/policy.go
+++ b/gobgp/cmd/policy.go
@@ -176,7 +176,10 @@ func parseNeighborSet(args []string) (table.DefinedSet, error) {
 	for _, arg := range args {
 		address := net.ParseIP(arg)
 		if address.To4() == nil && address.To16() == nil {
-			return nil, fmt.Errorf("invalid address: %s\nplease enter ipv4 or ipv6 format", arg)
+			_, _, err := net.ParseCIDR(arg)
+			if err != nil {
+				return nil, fmt.Errorf("invalid address or prefix: %s\nplease enter ipv4 or ipv6 format", arg)
+			}
 		}
 	}
 	return table.NewNeighborSet(config.NeighborSet{

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -912,7 +912,7 @@ module gobgp {
 
     leaf-list neighbor-info {
       description
-            "neighbor ip address";
+            "neighbor ip address or prefix";
       type inet:ip-address;
     }
   }


### PR DESCRIPTION
Currently, "neighbor-set" supports only IP address representation
and IP prefix representation(such as "192.168.0.0/24") is not supported.

This commit enables to accept the prefix representation for "neighbor-set"
to allow neighbors to be specified as range.