### PR TITLE
config: Refactor some functions

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -43,64 +43,6 @@ func defaultAfiSafi(typ AfiSafiType, enable bool) AfiSafi {
 	}
 }
 
-// yaml is decoded as []interface{}
-// but toml is decoded as []map[string]interface{}.
-// currently, viper can't hide this difference.
-// handle the difference here.
-func extractArray(intf interface{}) ([]interface{}, error) {
-	if intf != nil {
-		list, ok := intf.([]interface{})
-		if ok {
-			return list, nil
-		}
-		l, ok := intf.([]map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("invalid configuration: neither []interface{} nor []map[string]interface{}")
-		}
-		list = make([]interface{}, 0, len(l))
-		for _, m := range l {
-			list = append(list, m)
-		}
-		return list, nil
-	}
-	return nil, nil
-}
-
-func getIPv6LinkLocalAddress(ifname string) (string, error) {
-	ifi, err := net.InterfaceByName(ifname)
-	if err != nil {
-		return "", err
-	}
-	addrs, err := ifi.Addrs()
-	if err != nil {
-		return "", err
-	}
-	for _, addr := range addrs {
-		ip := addr.(*net.IPNet).IP
-		if ip.To4() == nil && ip.IsLinkLocalUnicast() {
-			return fmt.Sprintf("%s%%%s", ip.String(), ifname), nil
-		}
-	}
-	return "", fmt.Errorf("no ipv6 link local address for %s", ifname)
-}
-
-func isLocalLinkLocalAddress(ifindex int, addr net.IP) (bool, error) {
-	ifi, err := net.InterfaceByIndex(ifindex)
-	if err != nil {
-		return false, err
-	}
-	addrs, err := ifi.Addrs()
-	if err != nil {
-		return false, err
-	}
-	for _, a := range addrs {
-		if ip, _, _ := net.ParseCIDR(a.String()); addr.Equal(ip) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 func SetDefaultNeighborConfigValues(n *Neighbor, pg *PeerGroup, g *Global) error {
 	// Determines this function is called against the same Neighbor struct,
 	// and if already called, returns immediately.

--- a/config/serve.go
+++ b/config/serve.go
@@ -75,24 +75,6 @@ func ReadConfigfileServe(path, format string, configCh chan *BgpConfigSet) {
 	}
 }
 
-func inSlice(n Neighbor, b []Neighbor) int {
-	for i, nb := range b {
-		if nb.State.NeighborAddress == n.State.NeighborAddress {
-			return i
-		}
-	}
-	return -1
-}
-
-func existPeerGroup(n string, b []PeerGroup) int {
-	for i, nb := range b {
-		if nb.Config.PeerGroupName == n {
-			return i
-		}
-	}
-	return -1
-}
-
 func ConfigSetToRoutingPolicy(c *BgpConfigSet) *RoutingPolicy {
 	return &RoutingPolicy{
 		DefinedSets:       c.DefinedSets,

--- a/server/fsm.go
+++ b/server/fsm.go
@@ -999,7 +999,7 @@ func open2Cap(open *bgp.BGPOpen, n *config.Neighbor) (map[bgp.BGPCapabilityCode]
 		capMap[bgp.BGP_CAP_MULTIPROTOCOL] = []bgp.ParameterCapabilityInterface{bgp.NewCapMultiProtocol(bgp.RF_IPv4_UC)}
 	}
 
-	local := config.CreateRfMap(n)
+	local := n.CreateRfMap()
 	remote := make(map[bgp.RouteFamily]bgp.BGPAddPathMode)
 	for _, c := range capMap[bgp.BGP_CAP_MULTIPROTOCOL] {
 		family := c.(*bgp.CapMultiProtocol).CapValue


### PR DESCRIPTION
For code readability, this commit make some arguments to receivers.

And default.go and serve.go has some functions which are not directly related to its main role.
This commit moves those functions to util.go, a more suitable place.