### PR TITLE
travis: use old Trusty images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ _python: &_python
 _docker: &_docker
   <<: *_python
   sudo: required
+  dist: trusty
+  group: deprecated-2017Q4
   before_install:
     - test $TRAVIS_OS_NAME == "linux" && sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
     - test $TRAVIS_OS_NAME == "linux" && sudo sysctl -w net.ipv6.conf.default.disable_ipv6=0


### PR DESCRIPTION
Use the old images for now because seems that some tests always fail on the new image.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>