### PR TITLE
table: fix converting 2bytes to 4bytes AS PATH

### DIFF
--- a/table/message.go
+++ b/table/message.go
@@ -169,8 +169,7 @@ func UpdatePathAttrs4ByteAs(msg *bgp.BGPUpdate) error {
 			keepNum -= param.ASLen()
 		} else {
 			// only SEQ param reaches here
-			param.AS = param.AS[:keepNum]
-			newParams = append(newParams, param)
+			newParams = append(newParams, bgp.NewAs4PathParam(param.Type, param.AS[:keepNum]))
 			keepNum = 0
 		}
 
@@ -183,11 +182,10 @@ func UpdatePathAttrs4ByteAs(msg *bgp.BGPUpdate) error {
 		lastParam := newParams[len(newParams)-1]
 		if param.Type == lastParam.Type && param.Type == bgp.BGP_ASPATH_ATTR_TYPE_SEQ {
 			if len(lastParam.AS)+len(param.AS) > 255 {
-				lastParam.AS = append(lastParam.AS, param.AS[:255-len(lastParam.AS)]...)
-				param.AS = param.AS[255-len(lastParam.AS):]
-				newParams = append(newParams, param)
+				newParams[len(newParams)-1] = bgp.NewAs4PathParam(param.Type, append(lastParam.AS, param.AS[:255-len(lastParam.AS)]...))
+				newParams = append(newParams, bgp.NewAs4PathParam(param.Type, param.AS[255-len(lastParam.AS):]))
 			} else {
-				lastParam.AS = append(lastParam.AS, param.AS...)
+				newParams[len(newParams)-1] = bgp.NewAs4PathParam(param.Type, append(lastParam.AS, param.AS...))
 			}
 		} else {
 			newParams = append(newParams, param)

--- a/table/message_test.go
+++ b/table/message_test.go
@@ -327,6 +327,50 @@ func TestAsPathAs4TransInvalid4(t *testing.T) {
 	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[4], uint32(40001))
 }
 
+func TestASPathAs4TransMultipleParams(t *testing.T) {
+	as1 := []uint16{17676, 2914, 174, 50607}
+	as2 := []uint16{bgp.AS_TRANS, bgp.AS_TRANS}
+	params := []bgp.AsPathParamInterface{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as1), bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as2)}
+	aspath := bgp.NewPathAttributeAsPath(params)
+
+	as41 := []uint32{2914, 174, 50607}
+	as42 := []uint32{198035, 198035}
+	as4param1 := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as41)
+	as4param2 := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as42)
+	param4s := []*bgp.As4PathParam{as4param1, as4param2}
+	as4path := bgp.NewPathAttributeAs4Path(param4s)
+	msg := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{aspath, as4path}, nil).Body.(*bgp.BGPUpdate)
+	UpdatePathAttrs4ByteAs(msg)
+	for _, param := range msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value {
+		p := param.(*bgp.As4PathParam)
+		assert.Equal(t, p.Num, uint8(len(p.AS)))
+	}
+}
+
+func TestASPathAs4TransMultipleLargeParams(t *testing.T) {
+	as1 := make([]uint16, 0, 255)
+	for i := 0; i < 255-5; i++ {
+		as1 = append(as1, uint16(i+1))
+	}
+	as1 = append(as1, []uint16{17676, 2914, 174, 50607}...)
+	as2 := []uint16{bgp.AS_TRANS, bgp.AS_TRANS}
+	params := []bgp.AsPathParamInterface{bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as1), bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as2)}
+	aspath := bgp.NewPathAttributeAsPath(params)
+
+	as41 := []uint32{2914, 174, 50607}
+	as42 := []uint32{198035, 198035}
+	as4param1 := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as41)
+	as4param2 := bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, as42)
+	param4s := []*bgp.As4PathParam{as4param1, as4param2}
+	as4path := bgp.NewPathAttributeAs4Path(param4s)
+	msg := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{aspath, as4path}, nil).Body.(*bgp.BGPUpdate)
+	UpdatePathAttrs4ByteAs(msg)
+	for _, param := range msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value {
+		p := param.(*bgp.As4PathParam)
+		assert.Equal(t, p.Num, uint8(len(p.AS)))
+	}
+}
+
 func TestAggregator4BytesASes(t *testing.T) {
 	getAggr := func(msg *bgp.BGPUpdate) *bgp.PathAttributeAggregator {
 		for _, attr := range msg.PathAttributes {


### PR DESCRIPTION
On some conditions, we add some ASes to As4PathParam.AS but don't
update As4PathParam.Num (the number of ASes). It breaks serialization
of AS4PathParam.

Instead of modifying the internal of As4PathParam, let's create a new
As4PathParam object.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>