### PR TITLE
travis: Run "dep ensure" before "go fmt" and "go vet"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,10 +89,10 @@ matrix:
 #
 # Misc
 #
-    - <<: *_go
-      script: test -z "$(go fmt ./...)"
-    - <<: *_go
-      script: test -z "$(go vet ./...)"
+    - <<: *_dep_ensure
+      script: test -z "$(go fmt $(go list ./... | grep -v '/vendor/'))"
+    - <<: *_dep_ensure
+      script: test -z "$(go vet $(go list ./... | grep -v '/vendor/'))"
     - <<: *_dep_ensure
       script: python test/scenario_test/ci-scripts/build_embeded_go.py docs/sources/lib.md
 #


### PR DESCRIPTION
Because "satori/go.uuid" changed some syntax of its API, "go fmt" and
"go vet" commands will fail with the latest codes.

This patch fixes to run dep ensure before running these tests and solves
this problem.

Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>