### PR TITLE
table: follow changes of go.uuid library

### DIFF
--- a/table/path.go
+++ b/table/path.go
@@ -389,7 +389,7 @@ func (path *Path) SetUUID(id []byte) {
 }
 
 func (path *Path) AssignNewUUID() {
-	path.OriginInfo().uuid = uuid.NewV4()
+	path.OriginInfo().uuid = uuid.Must(uuid.NewV4())
 }
 
 func (path *Path) Filter(id string, reason PolicyDirection) {


### PR DESCRIPTION
The return value of go.uuid library has been changed from single to multiple since https://github.com/satori/go.uuid/commit/0ef6afb2f6cdd6cdaeee3885a95099c63f18fc8c.
It seems to have to use uuid.Must() helper instead.