### PR TITLE
 server: Empty path list in initial WatchEventUpdate

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2723,6 +2723,7 @@ func (s *BgpServer) Watch(opts ...WatchOption) (w *Watcher) {
 							Payload:      buf,
 							PostPolicy:   false,
 							Neighbor:     configNeighbor,
+							PathList:     []*table.Path{path},
 						})
 					}
 					eor := bgp.NewEndOfRib(rf)
@@ -2770,6 +2771,7 @@ func (s *BgpServer) Watch(opts ...WatchOption) (w *Watcher) {
 							Payload:     buf,
 							PostPolicy:  true,
 							Neighbor:    configNeighbor,
+							PathList:    []*table.Path{path},
 						})
 					}
 					eor := bgp.NewEndOfRib(rf)


### PR DESCRIPTION
Currently, MonitorRib API with ADJ_IN type and "current" flag returns the initial response with an empty path list when gRPC client connecting to GoBGP daemon.
This causes the client can not receive the current paths which GoBGP daemon already has.

This PR fixes to compose the initial MonitorRib response with the current paths.
Also, enhances the unit test cases for MonitorRib API.