### PR TITLE
packet/bgp: use strconv.ParseUint instead of strconv.Atoi()

### DIFF
--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -1392,17 +1392,17 @@ func ParseRouteDistinguisher(rd string) (RouteDistinguisherInterface, error) {
 	if err != nil {
 		return nil, err
 	}
-	assigned, _ := strconv.Atoi(elems[10])
+	assigned, _ := strconv.ParseUint(elems[10], 10, 32)
 	ip := net.ParseIP(elems[1])
 	switch {
 	case ip.To4() != nil:
 		return NewRouteDistinguisherIPAddressAS(elems[1], uint16(assigned)), nil
 	case elems[6] == "" && elems[7] == "":
-		asn, _ := strconv.Atoi(elems[8])
+		asn, _ := strconv.ParseUint(elems[8], 10, 16)
 		return NewRouteDistinguisherTwoOctetAS(uint16(asn), uint32(assigned)), nil
 	default:
-		fst, _ := strconv.Atoi(elems[7])
-		snd, _ := strconv.Atoi(elems[8])
+		fst, _ := strconv.ParseUint(elems[7], 10, 16)
+		snd, _ := strconv.ParseUint(elems[8], 10, 16)
 		asn := fst<<16 | snd
 		return NewRouteDistinguisherFourOctetAS(uint32(asn), uint16(assigned)), nil
 	}
@@ -1514,11 +1514,11 @@ func ParseMPLSLabelStack(buf string) (*MPLSLabelStack, error) {
 		goto ERR
 	}
 	for _, elem := range elems {
-		i, err := strconv.Atoi(elem)
+		i, err := strconv.ParseUint(elem, 10, 32)
 		if err != nil {
 			goto ERR
 		}
-		if i < 0 || i > ((1<<20)-1) {
+		if i > ((1 << 20) - 1) {
 			goto ERR
 		}
 		labels = append(labels, uint32(i))
@@ -2025,7 +2025,7 @@ func ParseEthernetSegmentIdentifier(args []string) (EthernetSegmentIdentifier, e
 	case "AS":
 		esi.Type = ESI_AS
 	default:
-		typ, err := strconv.Atoi(args[0])
+		typ, err := strconv.ParseUint(args[0], 10, 0)
 		if err != nil {
 			return esi, fmt.Errorf("invalid esi type: %s", args[0])
 		}
@@ -2048,7 +2048,7 @@ func ParseEthernetSegmentIdentifier(args []string) (EthernetSegmentIdentifier, e
 		}
 		copy(esi.Value[0:6], mac)
 		// Port Key or Bridge Priority
-		i, err := strconv.Atoi(args[2])
+		i, err := strconv.ParseUint(args[2], 10, 16)
 		if err != nil {
 			return esi, invalidEsiValuesError
 		}
@@ -2064,7 +2064,7 @@ func ParseEthernetSegmentIdentifier(args []string) (EthernetSegmentIdentifier, e
 		}
 		copy(esi.Value[0:6], mac)
 		// Local Discriminator
-		i, err := strconv.Atoi(args[2])
+		i, err := strconv.ParseUint(args[2], 10, 32)
 		if err != nil {
 			return esi, invalidEsiValuesError
 		}
@@ -2082,7 +2082,7 @@ func ParseEthernetSegmentIdentifier(args []string) (EthernetSegmentIdentifier, e
 		}
 		copy(esi.Value[0:4], ip.To4())
 		// Local Discriminator
-		i, err := strconv.Atoi(args[2])
+		i, err := strconv.ParseUint(args[2], 10, 32)
 		if err != nil {
 			return esi, invalidEsiValuesError
 		}
@@ -2092,13 +2092,13 @@ func ParseEthernetSegmentIdentifier(args []string) (EthernetSegmentIdentifier, e
 			return esi, invalidEsiValuesError
 		}
 		// AS
-		as, err := strconv.Atoi(args[1])
+		as, err := strconv.ParseUint(args[1], 10, 32)
 		if err != nil {
 			return esi, invalidEsiValuesError
 		}
 		binary.BigEndian.PutUint32(esi.Value[0:4], uint32(as))
 		// Local Discriminator
-		i, err := strconv.Atoi(args[2])
+		i, err := strconv.ParseUint(args[2], 10, 32)
 		if err != nil {
 			return esi, invalidEsiValuesError
 		}
@@ -6378,7 +6378,7 @@ func ParseExtendedCommunity(subtype ExtendedCommunityAttrSubType, com string) (E
 	if err != nil {
 		return nil, err
 	}
-	localAdmin, _ := strconv.Atoi(elems[10])
+	localAdmin, _ := strconv.ParseUint(elems[10], 10, 32)
 	ip := net.ParseIP(elems[1])
 	isTransitive := true
 	switch {
@@ -6387,11 +6387,11 @@ func ParseExtendedCommunity(subtype ExtendedCommunityAttrSubType, com string) (E
 	case ip.To16() != nil:
 		return NewIPv6AddressSpecificExtended(subtype, elems[1], uint16(localAdmin), isTransitive), nil
 	case elems[6] == "" && elems[7] == "":
-		asn, _ := strconv.Atoi(elems[8])
+		asn, _ := strconv.ParseUint(elems[8], 10, 16)
 		return NewTwoOctetAsSpecificExtended(subtype, uint16(asn), uint32(localAdmin), isTransitive), nil
 	default:
-		fst, _ := strconv.Atoi(elems[7])
-		snd, _ := strconv.Atoi(elems[8])
+		fst, _ := strconv.ParseUint(elems[7], 10, 16)
+		snd, _ := strconv.ParseUint(elems[8], 10, 16)
 		asn := fst<<16 | snd
 		return NewFourOctetAsSpecificExtended(subtype, uint32(asn), uint16(localAdmin), isTransitive), nil
 	}


### PR DESCRIPTION
Atoi() returns a signed int. On a 32-bit platform, this is not big
enough to fit an unsigned 32-bit int. Replace all occurrences of
Atoi() to ParseUint() with the appropriate size as a parameter.

This fix this failure:

```
--- FAIL: Test_ParseEthernetSegmentIdentifier (0.00s)
        Error Trace:    bgp_test.go:1181
        Error:          Expected nil, but got: &errors.errorString{s:"invalid esi values for type ESI_AS: [2864434397 287454020]"}

        Error Trace:    bgp_test.go:1182
        Error:          Not equal: bgp.EthernetSegmentIdentifier{Type:0x5, Value:[]uint8{0xaa, 0xbb, 0xcc, 0xdd, 0x11, 0x22, 0x33, 0x44, 0x0}} (expected)
                                != bgp.EthernetSegmentIdentifier{Type:0x5, Value:[]uint8{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}} (actual)

                        Diff:
                        --- Expected
                        +++ Actual
                        @@ -1,2 +1,2 @@
                        -(bgp.EthernetSegmentIdentifier) ESI_AS | as 2864434397, local discriminator 287454020
                        +(bgp.EthernetSegmentIdentifier) ESI_AS | as 0, local discriminator 0

FAIL
FAIL    github.com/osrg/gobgp/packet/bgp        0.003s
```

There are other occurrences of Atoi() that seems suspicious when parsing command-line. However, I didn't have time to look at them. Please pay attention to `fst` and `snd`. I believe they are 16 bits, right?