### PR TITLE
travis: also run unittests for 386

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
       before_script:
         - export GOOS="darwin"
         - go env
-    - <<: *_build
+    - <<: *_unittest
       env:
         - GOARCH="386"
       before_script:


### PR DESCRIPTION
This would catch some errors due to limited size of `int`.