### PR TITLE
Enable GoBGP to resolve next-hop with FRR/Zebra for VRF routes 

### DIFF
--- a/server/zclient.go
+++ b/server/zclient.go
@@ -505,9 +505,11 @@ func (z *zebraClient) loop() {
 			case *WatchEventUpdate:
 				if body, isWithdraw := newNexthopRegisterBody(msg.PathList, z.nhtManager); body != nil {
 					vrfId := uint16(0)
-                    			if vrf, _ := z.server.globalRib.GetVrf(msg.Neighbor.Config.Vrf); vrf != nil {
-                        			vrfId = uint16(vrf.Id)
-                    			}
+					for _, vrf := range z.server.GetVrf() {
+						if vrf.Name == msg.Neighbor.Config.Vrf {
+							vrfId = uint16(vrf.Id)
+						}
+					}
 					z.client.SendNexthopRegister(vrfId, body, isWithdraw)
 				}
 			}

--- a/server/zclient.go
+++ b/server/zclient.go
@@ -504,7 +504,11 @@ func (z *zebraClient) loop() {
 				}
 			case *WatchEventUpdate:
 				if body, isWithdraw := newNexthopRegisterBody(msg.PathList, z.nhtManager); body != nil {
-					z.client.SendNexthopRegister(0, body, isWithdraw)
+					vrfId := uint16(0)
+                    			if vrf, _ := z.server.globalRib.GetVrf(msg.Neighbor.Config.Vrf); vrf != nil {
+                        			vrfId = uint16(vrf.Id)
+                    			}
+					z.client.SendNexthopRegister(vrfId, body, isWithdraw)
 				}
 			}
 		}

--- a/table/table_manager.go
+++ b/table/table_manager.go
@@ -179,6 +179,13 @@ func (manager *TableManager) DeleteVrf(name string) ([]*Path, error) {
 	return msgs, nil
 }
 
+func (manager *TableManager) GetVrf(name string) (*Vrf, error) {
+    if vrf, ok := manager.Vrfs[name]; ok {
+        return vrf, nil
+    }
+    return nil, fmt.Errorf("vrf %s not found", name)
+}
+
 func (manager *TableManager) calculate(dsts []*Destination) []*Destination {
 	emptyDsts := make([]*Destination, 0, len(dsts))
 	clonedDsts := make([]*Destination, 0, len(dsts))

--- a/table/table_manager.go
+++ b/table/table_manager.go
@@ -179,13 +179,6 @@ func (manager *TableManager) DeleteVrf(name string) ([]*Path, error) {
 	return msgs, nil
 }
 
-func (manager *TableManager) GetVrf(name string) (*Vrf, error) {
-    if vrf, ok := manager.Vrfs[name]; ok {
-        return vrf, nil
-    }
-    return nil, fmt.Errorf("vrf %s not found", name)
-}
-
 func (manager *TableManager) calculate(dsts []*Destination) []*Destination {
 	emptyDsts := make([]*Destination, 0, len(dsts))
 	clonedDsts := make([]*Destination, 0, len(dsts))


### PR DESCRIPTION
Hi

I have updated how VRF ID is determined before  z.client.SendNexthopRegister() method is invoked. This is based on the suggestion made by @iwaseyusuke .  I have tested it in my test-bed and the fix works as expected (i.e., GoBGP is able to resolve next-hop of VRF routes using information provided by FRR/Zebra, and then is able to communicate these routes to FRR/Zebra for ultimate installation in Linux Kernel forwarding table of respective VRFs).

aman