### PR TITLE
test/lib/{quagga,gobgp}: Add/Del routes without reloading daemons

### DIFF
--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -123,6 +123,18 @@ def try_several_times(f, t=3, s=1):
     raise e
 
 
+def assert_several_times(f, t=30, s=1):
+    e = AssertionError
+    for _ in range(t):
+        try:
+            f()
+        except AssertionError as e:
+            time.sleep(s)
+        else:
+            return
+    raise e
+
+
 def get_bridges():
     return try_several_times(lambda: local("docker network ls | awk 'NR > 1{print $2}'", capture=True)).split('\n')
 

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -140,11 +140,11 @@ class GoBGPContainer(BGPContainer):
                 daemons.append('ospfd')
         return daemons
 
-    def _wait_for_boot(self):
-        def _f_gobgp():
-            ret = self.local('gobgp global > /dev/null 2>&1; echo $?', capture=True)
-            return ret == '0'
+    def _is_running(self):
+        return self.local('gobgp global'
+                          ' > /dev/null 2>&1; echo $?', capture=True) == '0'
 
+    def _wait_for_boot(self):
         for daemon in self._get_enabled_quagga_daemons():
             def _f_quagga():
                 ret = self.local("vtysh -d {0} -c 'show run' > /dev/null 2>&1; echo $?".format(daemon), capture=True)
@@ -152,7 +152,7 @@ class GoBGPContainer(BGPContainer):
 
             wait_for_completion(_f_quagga)
 
-        wait_for_completion(_f_gobgp)
+        wait_for_completion(self._is_running)
 
     def run(self):
         super(GoBGPContainer, self).run()
@@ -557,34 +557,63 @@ class GoBGPContainer(BGPContainer):
             self.local('pkill {0} -SIGHUP'.format(daemon), capture=True)
         self.local('pkill gobgpd -SIGHUP', capture=True)
         self._wait_for_boot()
-        for v in chain.from_iterable(self.routes.itervalues()):
-            if v['rf'] == 'ipv4' or v['rf'] == 'ipv6':
-                r = CmdBuffer(' ')
-                r << 'gobgp global -a {0}'.format(v['rf'])
-                r << 'rib add {0}'.format(v['prefix'])
-                if v['identifier']:
-                    r << 'identifier {0}'.format(v['identifier'])
-                if v['next-hop']:
-                    r << 'nexthop {0}'.format(v['next-hop'])
-                if v['local-pref']:
-                    r << 'local-pref {0}'.format(v['local-pref'])
-                if v['med']:
-                    r << 'med {0}'.format(v['med'])
-                if v['community']:
-                    r << 'community {0}'.format(
-                        ','.join(v['community'])
-                        if isinstance(v['community'], (list, tuple)) else v['community'])
-                cmd = str(r)
-            elif v['rf'] == 'ipv4-flowspec' or v['rf'] == 'ipv6-flowspec':
-                cmd = 'gobgp global '\
-                      'rib add match {0} then {1} -a {2}'.format(' '.join(v['matchs']), ' '.join(v['thens']), v['rf'])
-            else:
-                raise Exception('unsupported route family: {0}'.format(v['rf']))
-            self.local(cmd)
+
+    def add_route(self, route, rf='ipv4', attribute=None, aspath=None,
+                  community=None, med=None, extendedcommunity=None,
+                  nexthop=None, matchs=None, thens=None,
+                  local_pref=None, identifier=None, reload_config=False):
+        if not self._is_running():
+            raise RuntimeError('GoBGP is not yet running')
+
+        self.routes.setdefault(route, [])
+        path = {
+            'prefix': route,
+            'rf': rf,
+            'attr': attribute,
+            'next-hop': nexthop,
+            'as-path': aspath,
+            'community': community,
+            'med': med,
+            'local-pref': local_pref,
+            'extended-community': extendedcommunity,
+            'identifier': identifier,
+            'matchs': matchs,
+            'thens': thens,
+        }
+
+        c = CmdBuffer(' ')
+        c << 'gobgp global rib -a {0} add'.format(rf)
+        if rf in ('ipv4', 'ipv6'):
+            c << route
+            if path['identifier']:
+                c << 'identifier {0}'.format(path['identifier'])
+            if path['next-hop']:
+                c << 'nexthop {0}'.format(path['next-hop'])
+            if path['local-pref']:
+                c << 'local-pref {0}'.format(path['local-pref'])
+            if path['med']:
+                c << 'med {0}'.format(path['med'])
+            if path['community']:
+                comm = str(path['community'])
+                if isinstance(path['community'], (list, tuple)):
+                    comm = ','.join(path['community'])
+                c << 'community {0}'.format(comm)
+        elif rf.endswith('-flowspec'):
+            c << 'match {0}'.format(' '.join(path['matchs']))
+            c << 'then {0}'.format(' '.join(path['thens']))
+        else:
+            raise Exception('unsupported address family: {0}'.format(rf))
+        self.local(str(c), capture=True)
+
+        self.routes[route].append(path)
 
     def del_route(self, route, identifier=None, reload_config=True):
+        if not self._is_running():
+            raise RuntimeError('GoBGP is not yet running')
+
         if route not in self.routes:
             return
+
         new_paths = []
         for path in self.routes[route]:
             if path['identifier'] != identifier:
@@ -592,11 +621,14 @@ class GoBGPContainer(BGPContainer):
             else:
                 r = CmdBuffer(' ')
                 r << 'gobgp global -a {0}'.format(path['rf'])
-                r << 'rib del {0}'.format(path['prefix'])
+                prefix = path['prefix']
+                if path['rf'].endswith('-flowspec'):
+                    prefix = 'match {0}'.format(' '.join(path['matchs']))
+                r << 'rib del {0}'.format(prefix)
                 if identifier:
                     r << 'identifier {0}'.format(identifier)
                 cmd = str(r)
-                self.local(cmd)
+                self.local(cmd, capture=True)
         self.routes[route] = new_paths
         # no need to reload config
 

--- a/test/scenario_test/addpath_test.py
+++ b/test/scenario_test/addpath_test.py
@@ -21,7 +21,10 @@ import nose
 from fabric.api import local
 
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED
+from lib.base import (
+    BGP_FSM_ESTABLISHED,
+    assert_several_times,
+)
 from lib.gobgp import GoBGPContainer
 from lib.exabgp import ExaBGPContainer
 from lib.noseplugin import OptionParser, parser_option
@@ -74,148 +77,176 @@ class GoBGPTestBase(unittest.TestCase):
         self.e1.add_route(route='192.168.100.0/24', identifier=10, aspath=[100, 200, 300])
         self.e1.add_route(route='192.168.100.0/24', identifier=20, aspath=[100, 200])
         self.e1.add_route(route='192.168.100.0/24', identifier=30, aspath=[100])
-        # Because ExaBGPContainer will be restarted internally for adding or
-        # deleting routes, here waits for re-establishment.
-        self.g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.e1)
-        time.sleep(1)
 
     # test three routes are installed to the rib due to add-path feature
     def test_02_check_g1_global_rib(self):
-        rib = self.g1.get_global_rib()
-        self.assertEqual(len(rib), 1)
-        self.assertEqual(len(rib[0]['paths']), 3)
+        def f():
+            rib = self.g1.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 3)
+
+        assert_several_times(f)
 
     # test only the best path is advertised to g2
     def test_03_check_g2_global_rib(self):
-        rib = self.g2.get_global_rib()
-        self.assertEqual(len(rib), 1)
-        self.assertEqual(len(rib[0]['paths']), 1)
-        self.assertEqual(rib[0]['paths'][0]['aspath'], [100])
+        def f():
+            rib = self.g2.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 1)
+            self.assertEqual(rib[0]['paths'][0]['aspath'], [100])
+
+        assert_several_times(f)
 
     # test three routes are advertised to g3
     def test_04_check_g3_global_rib(self):
-        rib = self.g3.get_global_rib()
-        self.assertEqual(len(rib), 1)
-        self.assertEqual(len(rib[0]['paths']), 3)
+        def f():
+            rib = self.g3.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 3)
+
+        assert_several_times(f)
 
     # withdraw a route with path_id (no error check)
     def test_05_withdraw_route_with_path_id(self):
         self.e1.del_route(route='192.168.100.0/24', identifier=30)
-        # Because ExaBGPContainer will be restarted internally for adding or
-        # deleting routes, here waits for re-establishment.
-        self.g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.e1)
-        time.sleep(1)
 
     # test the withdrawn route is removed from the rib
     def test_06_check_g1_global_rib(self):
-        rib = self.g1.get_global_rib()
-        self.assertEqual(len(rib), 1)
-        self.assertEqual(len(rib[0]['paths']), 2)
-        for path in rib[0]['paths']:
-            self.assertTrue(path['aspath'] == [100, 200, 300] or
-                            path['aspath'] == [100, 200])
+        def f():
+            rib = self.g1.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 2)
+            for path in rib[0]['paths']:
+                self.assertIn(path['aspath'], ([100, 200, 300],
+                                               [100, 200]))
+
+        assert_several_times(f)
 
     # test the best path is replaced due to the removal from g1 rib
     def test_07_check_g2_global_rib(self):
-        rib = self.g2.get_global_rib()
-        self.assertEqual(len(rib), 1)
-        self.assertEqual(len(rib[0]['paths']), 1)
-        self.assertEqual(rib[0]['paths'][0]['aspath'], [100, 200])
+        def f():
+            rib = self.g2.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 1)
+            self.assertEqual(rib[0]['paths'][0]['aspath'], [100, 200])
+
+        assert_several_times(f)
 
     # test the withdrawn route is removed from the rib of g3
     def test_08_check_g3_global_rib(self):
-        rib = self.g3.get_global_rib()
-        self.assertEqual(len(rib), 1)
-        self.assertEqual(len(rib[0]['paths']), 2)
-        for path in rib[0]['paths']:
-            self.assertTrue(path['aspath'] == [100, 200, 300] or
-                            path['aspath'] == [100, 200])
+        def f():
+            rib = self.g3.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 2)
+            for path in rib[0]['paths']:
+                self.assertIn(path['aspath'], ([100, 200, 300],
+                                               [100, 200]))
+
+        assert_several_times(f)
 
     # install a route with path_id via GoBGP CLI (no error check)
     def test_09_install_add_paths_route_via_cli(self):
         # identifier is duplicated with the identifier of the route from e1
         self.g1.add_route(route='192.168.100.0/24', identifier=10, local_pref=500)
-        time.sleep(1)  # XXX: wait for routes re-calculated and advertised
 
     # test the route from CLI is installed to the rib
     def test_10_check_g1_global_rib(self):
-        rib = self.g1.get_global_rib()
-        self.assertEqual(len(rib), 1)
-        self.assertEqual(len(rib[0]['paths']), 3)
-        for path in rib[0]['paths']:
-            self.assertTrue(path['aspath'] == [100, 200, 300] or
-                            path['aspath'] == [100, 200] or
-                            path['aspath'] == [])
-            if len(path['aspath']) == 0:
-                self.assertEqual(path['local-pref'], 500)
+        def f():
+            rib = self.g1.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 3)
+            for path in rib[0]['paths']:
+                self.assertIn(path['aspath'], ([100, 200, 300],
+                                               [100, 200],
+                                               []))
+                if not path['aspath']:  # path['aspath'] == []
+                    self.assertEqual(path['local-pref'], 500)
+
+        assert_several_times(f)
 
     # test the best path is replaced due to the CLI route from g1 rib
     def test_11_check_g2_global_rib(self):
-        rib = self.g2.get_global_rib()
-        self.assertEqual(len(rib), 1)
-        self.assertEqual(len(rib[0]['paths']), 1)
-        self.assertEqual(rib[0]['paths'][0]['aspath'], [])
+        def f():
+            rib = self.g2.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 1)
+            self.assertEqual(rib[0]['paths'][0]['aspath'], [])
+
+        assert_several_times(f)
 
     # test the route from CLI is advertised from g1
     def test_12_check_g3_global_rib(self):
-        rib = self.g3.get_global_rib()
-        self.assertEqual(len(rib), 1)
-        self.assertEqual(len(rib[0]['paths']), 3)
-        for path in rib[0]['paths']:
-            self.assertTrue(path['aspath'] == [100, 200, 300] or
-                            path['aspath'] == [100, 200] or
-                            path['aspath'] == [])
-            if len(path['aspath']) == 0:
-                self.assertEqual(path['local-pref'], 500)
+        def f():
+            rib = self.g3.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 3)
+            for path in rib[0]['paths']:
+                self.assertIn(path['aspath'], ([100, 200, 300],
+                                               [100, 200],
+                                               []))
+                if not path['aspath']:  # path['aspath'] == []
+                    self.assertEqual(path['local-pref'], 500)
+
+        assert_several_times(f)
 
     # remove non-existing route with path_id via GoBGP CLI (no error check)
     def test_13_remove_non_existing_add_paths_route_via_cli(self):
         # specify locally non-existing identifier which has the same value
         # with the identifier of the route from e1
         self.g1.del_route(route='192.168.100.0/24', identifier=20)
-        time.sleep(1)  # XXX: wait for routes re-calculated and advertised
 
     # test none of route is removed by non-existing path_id via CLI
     def test_14_check_g1_global_rib(self):
-        rib = self.g1.get_global_rib()
-        self.assertEqual(len(rib), 1)
-        self.assertEqual(len(rib[0]['paths']), 3)
-        for path in rib[0]['paths']:
-            self.assertTrue(path['aspath'] == [100, 200, 300] or
-                            path['aspath'] == [100, 200] or
-                            path['aspath'] == [])
-            if len(path['aspath']) == 0:
-                self.assertEqual(path['local-pref'], 500)
+        def f():
+            rib = self.g1.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 3)
+            for path in rib[0]['paths']:
+                self.assertIn(path['aspath'], ([100, 200, 300],
+                                               [100, 200],
+                                               []))
+                if not path['aspath']:  # path['aspath'] == []
+                    self.assertEqual(path['local-pref'], 500)
+
+        assert_several_times(f)
 
     # remove route with path_id via GoBGP CLI (no error check)
     def test_15_remove_add_paths_route_via_cli(self):
         self.g1.del_route(route='192.168.100.0/24', identifier=10)
-        time.sleep(1)  # XXX: wait for routes re-calculated and advertised
 
     # test the route is removed from the rib via CLI
     def test_16_check_g1_global_rib(self):
-        rib = self.g1.get_global_rib()
-        self.assertEqual(len(rib), 1)
-        self.assertEqual(len(rib[0]['paths']), 2)
-        for path in rib[0]['paths']:
-            self.assertTrue(path['aspath'] == [100, 200, 300] or
-                            path['aspath'] == [100, 200])
+        def f():
+            rib = self.g1.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 2)
+            for path in rib[0]['paths']:
+                self.assertIn(path['aspath'], ([100, 200, 300],
+                                               [100, 200]))
+
+        assert_several_times(f)
 
     # test the best path is replaced the removal from g1 rib
     def test_17_check_g2_global_rib(self):
-        rib = self.g2.get_global_rib()
-        self.assertEqual(len(rib), 1)
-        self.assertEqual(len(rib[0]['paths']), 1)
-        self.assertEqual(rib[0]['paths'][0]['aspath'], [100, 200])
+        def f():
+            rib = self.g2.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 1)
+            self.assertEqual(rib[0]['paths'][0]['aspath'], [100, 200])
+
+        assert_several_times(f)
 
     # test the removed route from CLI is withdrawn by g1
     def test_18_check_g3_global_rib(self):
-        rib = self.g3.get_global_rib()
-        self.assertEqual(len(rib), 1)
-        self.assertEqual(len(rib[0]['paths']), 2)
-        for path in rib[0]['paths']:
-            self.assertTrue(path['aspath'] == [100, 200, 300] or
-                            path['aspath'] == [100, 200])
+        def f():
+            rib = self.g3.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 2)
+            for path in rib[0]['paths']:
+                self.assertIn(path['aspath'], ([100, 200, 300],
+                                               [100, 200]))
+
+        assert_several_times(f)
 
 
 if __name__ == '__main__':

--- a/test/scenario_test/aspath_test.py
+++ b/test/scenario_test/aspath_test.py
@@ -25,7 +25,10 @@ import nose
 from lib.noseplugin import OptionParser, parser_option
 
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED
+from lib.base import (
+    BGP_FSM_ESTABLISHED,
+    assert_several_times,
+)
 from lib.gobgp import GoBGPContainer
 from lib.quagga import QuaggaBGPContainer
 
@@ -69,8 +72,10 @@ class GoBGPTestBase(unittest.TestCase):
         self.q1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g2)
 
     def test_02_check_reject_as_loop(self):
-        time.sleep(1)
-        self.assertTrue(len(self.g2.get_global_rib()) == 0)
+        def f():
+            self.assertEqual(len(self.g2.get_global_rib()), 0)
+
+        assert_several_times(f)
 
     def test_03_update_peer(self):
         self.g2.update_peer(self.q1, allow_as_in=10)
@@ -78,8 +83,10 @@ class GoBGPTestBase(unittest.TestCase):
         self.q1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g2)
 
     def test_04_check_accept_as_loop(self):
-        time.sleep(1)
-        self.assertTrue(len(self.g2.get_global_rib()) == 1)
+        def f():
+            self.assertEqual(len(self.g2.get_global_rib()), 1)
+
+        assert_several_times(f)
 
     def test_05_check_remove_private_as_peer_all(self):
         g3 = GoBGPContainer(name='g3', asn=100, router_id='192.168.0.4',
@@ -102,8 +109,13 @@ class GoBGPTestBase(unittest.TestCase):
         self.g2.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=g3)
         g3.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=g4)
 
-        time.sleep(1)
-        self.assertTrue(g4.get_global_rib()[0]['paths'][0]['aspath'] == [100])
+        def f():
+            rib = g4.get_global_rib()
+            self.assertEqual(len(rib), 1)
+            self.assertEqual(len(rib[0]['paths']), 1)
+            self.assertEqual(rib[0]['paths'][0]['aspath'], [100])
+
+        assert_several_times(f)
 
     def test_06_check_remove_private_as_peer_replace(self):
         g3 = self.ctns['g3']
@@ -112,8 +124,11 @@ class GoBGPTestBase(unittest.TestCase):
 
         g3.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=g4)
 
-        time.sleep(1)
-        self.assertTrue(g4.get_global_rib()[0]['paths'][0]['aspath'] == [100, 100, 100, 100])
+        def f():
+            rib = g4.get_global_rib()
+            self.assertEqual(rib[0]['paths'][0]['aspath'], [100, 100, 100, 100])
+
+        assert_several_times(f)
 
     def test_07_check_replace_peer_as(self):
         g5 = GoBGPContainer(name='g5', asn=100, router_id='192.168.0.6',
@@ -127,8 +142,11 @@ class GoBGPTestBase(unittest.TestCase):
 
         g4.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=g5)
 
-        time.sleep(1)
-        self.assertTrue(g5.get_global_rib()[0]['paths'][0]['aspath'] == [200, 200, 200, 200, 200])
+        def f():
+            rib = g5.get_global_rib()
+            self.assertEqual(rib[0]['paths'][0]['aspath'], [200, 200, 200, 200, 200])
+
+        assert_several_times(f)
 
 
 if __name__ == '__main__':

--- a/test/scenario_test/ibgp_router_test.py
+++ b/test/scenario_test/ibgp_router_test.py
@@ -51,19 +51,18 @@ class GoBGPTestBase(unittest.TestCase):
         qs = [q1, q2]
         ctns = [g1, q1, q2]
 
-        # advertise a route from q1, q2
-        for idx, c in enumerate(qs):
-            route = '10.0.{0}.0/24'.format(idx + 1)
-            c.add_route(route)
-
         initial_wait_time = max(ctn.run() for ctn in ctns)
-
         time.sleep(initial_wait_time)
 
         # ibgp peer. loop topology
         for a, b in combinations(ctns, 2):
             a.add_peer(b)
             b.add_peer(a)
+
+        # advertise a route from q1, q2
+        for idx, c in enumerate(qs):
+            route = '10.0.{0}.0/24'.format(idx + 1)
+            c.add_route(route)
 
         cls.gobgp = g1
         cls.quaggas = {'q1': q1, 'q2': q2}
@@ -163,13 +162,13 @@ class GoBGPTestBase(unittest.TestCase):
     def test_07_add_ebgp_peer(self):
         q3 = QuaggaBGPContainer(name='q3', asn=65001, router_id='192.168.0.4')
         self.quaggas['q3'] = q3
-
-        q3.add_route('10.0.3.0/24')
-
         initial_wait_time = q3.run()
         time.sleep(initial_wait_time)
+
         self.gobgp.add_peer(q3)
         q3.add_peer(self.gobgp)
+
+        q3.add_route('10.0.3.0/24')
 
         self.gobgp.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=q3)
 
@@ -246,14 +245,14 @@ class GoBGPTestBase(unittest.TestCase):
     def test_15_add_ebgp_peer(self):
         q4 = QuaggaBGPContainer(name='q4', asn=65001, router_id='192.168.0.5')
         self.quaggas['q4'] = q4
+        initial_wait_time = q4.run()
+        time.sleep(initial_wait_time)
+
+        self.gobgp.add_peer(q4)
+        q4.add_peer(self.gobgp)
 
         prefix = '10.0.4.0/24'
         q4.add_route(prefix)
-
-        initial_wait_time = q4.run()
-        time.sleep(initial_wait_time)
-        self.gobgp.add_peer(q4)
-        q4.add_peer(self.gobgp)
 
         self.gobgp.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=q4)
 

--- a/test/scenario_test/route_reflector_test.py
+++ b/test/scenario_test/route_reflector_test.py
@@ -61,13 +61,7 @@ class GoBGPTestBase(unittest.TestCase):
         qs = [q1, q2, q3, q4]
         ctns = [g1, q1, q2, q3, q4]
 
-        # advertise a route from q1, q2
-        for idx, c in enumerate(qs):
-            route = '10.0.{0}.0/24'.format(idx + 1)
-            c.add_route(route)
-
         initial_wait_time = max(ctn.run() for ctn in ctns)
-
         time.sleep(initial_wait_time)
 
         # g1 as a route reflector
@@ -79,6 +73,11 @@ class GoBGPTestBase(unittest.TestCase):
         q3.add_peer(g1)
         g1.add_peer(q4)
         q4.add_peer(g1)
+
+        # advertise a route from q1, q2
+        for idx, c in enumerate(qs):
+            route = '10.0.{0}.0/24'.format(idx + 1)
+            c.add_route(route)
 
         cls.gobgp = g1
         cls.quaggas = {'q1': q1, 'q2': q2, 'q3': q3, 'q4': q4}

--- a/test/scenario_test/route_server_ipv4_v6_test.py
+++ b/test/scenario_test/route_server_ipv4_v6_test.py
@@ -52,16 +52,7 @@ class GoBGPIPv6Test(unittest.TestCase):
         v4 = [q1, q2]
         v6 = [q3, q4]
 
-        for idx, q in enumerate(v4):
-            route = '10.0.{0}.0/24'.format(idx + 1)
-            q.add_route(route)
-
-        for idx, q in enumerate(v6):
-            route = '2001:{0}::/96'.format(idx + 1)
-            q.add_route(route, rf='ipv6')
-
         initial_wait_time = max(ctn.run() for ctn in ctns)
-
         time.sleep(initial_wait_time)
 
         for ctn in v4:
@@ -71,6 +62,14 @@ class GoBGPIPv6Test(unittest.TestCase):
         for ctn in v6:
             g1.add_peer(ctn, is_rs_client=True, v6=True)
             ctn.add_peer(g1, v6=True)
+
+        for idx, q in enumerate(v4):
+            route = '10.0.{0}.0/24'.format(idx + 1)
+            q.add_route(route)
+
+        for idx, q in enumerate(v6):
+            route = '2001:{0}::/96'.format(idx + 1)
+            q.add_route(route, rf='ipv6')
 
         cls.gobgp = g1
         cls.quaggas = {'q1': q1, 'q2': q2, 'q3': q3, 'q4': q4}

--- a/test/scenario_test/route_server_test2.py
+++ b/test/scenario_test/route_server_test2.py
@@ -47,22 +47,20 @@ class GoBGPTestBase(unittest.TestCase):
         g2 = GoBGPContainer(name='g2', asn=65001, router_id='192.168.0.2',
                             ctn_image_name=gobgp_ctn_image_name)
         e1 = ExaBGPContainer(name='e1', asn=65002, router_id='192.168.0.3')
-        ctns = [g1, g2, e1]
 
-        # advertise a route from route-server-clients
-        cls.clients = {}
-        for idx, cli in enumerate((g2, e1)):
-            route = '10.0.{0}.0/24'.format(idx)
-            cli.add_route(route)
-            cls.clients[cli.name] = cli
+        ctns = [g1, g2, e1]
+        cls.clients = {cli.name: cli for cli in (g2, e1)}
 
         initial_wait_time = max(ctn.run() for ctn in ctns)
-
         time.sleep(initial_wait_time)
 
-        for cli in cls.clients.itervalues():
+        for cli in cls.clients.values():
             g1.add_peer(cli, is_rs_client=True, passwd='passwd', passive=True, prefix_limit=10)
             cli.add_peer(g1, passwd='passwd')
+
+        # advertise a route from route-server-clients
+        g2.add_route('10.0.0.0/24')
+        e1.add_route('10.0.1.0/24')
 
         cls.gobgp = g1
 


### PR DESCRIPTION
With the current implementation, when adding or deleting routes on QuaggaBGPContainer or GoBGPContainer, it is required to reloading or rebooting daemons because new routes are added via their configure file.
This causes the frequent reloading of daemons and makes the scenario tests unstable.

This patch fixes to use their CLI commands ("gobgp" command for GoBGP, "vtysh" for Quagga) and reduces the number of restating daemons, then improves the stability of the scenario tests.