### PR TITLE
config: Option to disable best path selection

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -462,7 +462,7 @@ func (s *Server) GetRib(ctx context.Context, arg *GetRibRequest) (*GetRibRespons
 					pp := ToPathApi(p)
 					switch arg.Table.Type {
 					case Resource_LOCAL, Resource_GLOBAL:
-						if i == 0 {
+						if i == 0 && !table.SelectionOptions.DisableBestPathSelection {
 							pp.Best = true
 						}
 					}
@@ -517,7 +517,7 @@ func (s *Server) GetPath(arg *GetPathRequest, stream GobgpApi_GetPathServer) err
 		for _, dst := range tbl.GetDestinations() {
 			for idx, path := range dst.GetAllKnownPathList() {
 				p := ToPathApi(path)
-				if idx == 0 {
+				if idx == 0 && !table.SelectionOptions.DisableBestPathSelection {
 					switch arg.Type {
 					case Resource_LOCAL, Resource_GLOBAL:
 						p.Best = true

--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -4517,6 +4517,10 @@ type RouteSelectionOptionsState struct {
 	// BGP best-path. The default is to select the route for
 	// which the metric to the next-hop is lowest.
 	IgnoreNextHopIgpMetric bool `mapstructure:"ignore-next-hop-igp-metric" json:"ignore-next-hop-igp-metric,omitempty"`
+	// original -> gobgp:disable-best-path-selection
+	// gobgp:disable-best-path-selection's original type is boolean.
+	// Disables best path selection process.
+	DisableBestPathSelection bool `mapstructure:"disable-best-path-selection" json:"disable-best-path-selection,omitempty"`
 }
 
 // struct for container bgp-mp:config.
@@ -4558,6 +4562,10 @@ type RouteSelectionOptionsConfig struct {
 	// BGP best-path. The default is to select the route for
 	// which the metric to the next-hop is lowest.
 	IgnoreNextHopIgpMetric bool `mapstructure:"ignore-next-hop-igp-metric" json:"ignore-next-hop-igp-metric,omitempty"`
+	// original -> gobgp:disable-best-path-selection
+	// gobgp:disable-best-path-selection's original type is boolean.
+	// Disables best path selection process.
+	DisableBestPathSelection bool `mapstructure:"disable-best-path-selection" json:"disable-best-path-selection,omitempty"`
 }
 
 func (lhs *RouteSelectionOptionsConfig) Equal(rhs *RouteSelectionOptionsConfig) bool {
@@ -4580,6 +4588,9 @@ func (lhs *RouteSelectionOptionsConfig) Equal(rhs *RouteSelectionOptionsConfig) 
 		return false
 	}
 	if lhs.IgnoreNextHopIgpMetric != rhs.IgnoreNextHopIgpMetric {
+		return false
+	}
+	if lhs.DisableBestPathSelection != rhs.DisableBestPathSelection {
 		return false
 	}
 	return true

--- a/server/server.go
+++ b/server/server.go
@@ -484,6 +484,10 @@ func clonePathList(pathList []*table.Path) []*table.Path {
 }
 
 func (server *BgpServer) notifyBestWatcher(best []*table.Path, multipath [][]*table.Path) {
+	if table.SelectionOptions.DisableBestPathSelection {
+		// Note: If best path selection disabled, no best path to notify.
+		return
+	}
 	clonedM := make([][]*table.Path, len(multipath))
 	for i, pathList := range multipath {
 		clonedM[i] = clonePathList(pathList)
@@ -555,6 +559,10 @@ func (server *BgpServer) notifyPostPolicyUpdateWatcher(peer *Peer, pathList []*t
 }
 
 func dstsToPaths(id string, dsts []*table.Destination, addpath bool) ([]*table.Path, []*table.Path, [][]*table.Path) {
+	if table.SelectionOptions.DisableBestPathSelection {
+		// Note: If best path selection disabled, there is no best path.
+		return nil, nil, nil
+	}
 	bestList := make([]*table.Path, 0, len(dsts))
 	oldList := make([]*table.Path, 0, len(dsts))
 	mpathList := make([][]*table.Path, 0, len(dsts))
@@ -790,6 +798,10 @@ func (server *BgpServer) propagateUpdate(peer *Peer, pathList []*table.Path) {
 }
 
 func (server *BgpServer) propagateUpdateToNeighbors(peer *Peer, dsts []*table.Destination, gBestList, gOldList []*table.Path) {
+	if table.SelectionOptions.DisableBestPathSelection {
+		// Note: If best path selection disabled, no best path to propagate.
+		return
+	}
 	families := make(map[bgp.RouteFamily][]*table.Destination)
 	for _, dst := range dsts {
 		family := dst.Family()

--- a/table/destination.go
+++ b/table/destination.go
@@ -36,6 +36,7 @@ type BestPathReason uint8
 
 const (
 	BPR_UNKNOWN BestPathReason = iota
+	BPR_DISABLED
 	BPR_ONLY_PATH
 	BPR_REACHABLE_NEXT_HOP
 	BPR_HIGHEST_WEIGHT
@@ -53,6 +54,7 @@ const (
 
 var BestPathReasonStringMap = map[BestPathReason]string{
 	BPR_UNKNOWN:            "Unknown",
+	BPR_DISABLED:           "Bestpath selection disabled",
 	BPR_ONLY_PATH:          "Only Path",
 	BPR_REACHABLE_NEXT_HOP: "Reachable Next Hop",
 	BPR_HIGHEST_WEIGHT:     "Highest Weight",
@@ -515,6 +517,12 @@ func (dest *Destination) implicitWithdraw() paths {
 }
 
 func (dest *Destination) computeKnownBestPath() (*Path, BestPathReason, error) {
+	if SelectionOptions.DisableBestPathSelection {
+		log.WithFields(log.Fields{
+			"Topic": "Table",
+		}).Debug("computeKnownBestPath skipped")
+		return nil, BPR_DISABLED, nil
+	}
 
 	// If we do not have any paths to this destination, then we do not have
 	// new best path.

--- a/table/table_manager.go
+++ b/table/table_manager.go
@@ -22,8 +22,9 @@ import (
 	"time"
 
 	farm "github.com/dgryski/go-farm"
-	"github.com/osrg/gobgp/packet/bgp"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/osrg/gobgp/packet/bgp"
 )
 
 const (
@@ -306,6 +307,10 @@ func (manager *TableManager) getDestinationCount(rfList []bgp.RouteFamily) int {
 }
 
 func (manager *TableManager) GetBestPathList(id string, rfList []bgp.RouteFamily) []*Path {
+	if SelectionOptions.DisableBestPathSelection {
+		// Note: If best path selection disabled, there is no best path.
+		return nil
+	}
 	paths := make([]*Path, 0, manager.getDestinationCount(rfList))
 	for _, t := range manager.tables(rfList...) {
 		paths = append(paths, t.Bests(id)...)
@@ -314,7 +319,9 @@ func (manager *TableManager) GetBestPathList(id string, rfList []bgp.RouteFamily
 }
 
 func (manager *TableManager) GetBestMultiPathList(id string, rfList []bgp.RouteFamily) [][]*Path {
-	if !UseMultiplePaths.Enabled {
+	if !UseMultiplePaths.Enabled || SelectionOptions.DisableBestPathSelection {
+		// Note: If multi path not enabled or best path selection disabled,
+		// there is no best multi path.
 		return nil
 	}
 	paths := make([][]*Path, 0, manager.getDestinationCount(rfList))

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -1217,6 +1217,22 @@ module gobgp {
     uses dynamic-neighbors;
   }
 
+  grouping disable-best-path-selection-config {
+    leaf disable-best-path-selection {
+      type boolean;
+      description
+        "Disables best path selection process.";
+    }
+  }
+
+  augment "/bgp:bgp/bgp:global/bgp:route-selection-options/bgp:config" {
+    uses disable-best-path-selection-config;
+  }
+
+  augment "/bgp:bgp/bgp:global/bgp:route-selection-options/bgp:state" {
+    uses disable-best-path-selection-config;
+  }
+
   augment "/bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi" {
       uses bgp-mp:all-afi-safi-common;
   }
@@ -1248,7 +1264,7 @@ module gobgp {
           uses route-target-membership-config;
       }
     }
-    
+
     uses long-lived-graceful-restart;
   }
 


### PR DESCRIPTION
In some use-cases, the option to disable best path selection is useful to reduce the compute resource usage.