### PR TITLE
server: fix dynamic neighbor crash

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -853,6 +853,8 @@ func (server *BgpServer) handleFSMMessage(peer *Peer, e *FsmMsg) {
 				peer.stopPeerRestarting()
 				go peer.stopFSM()
 				delete(server.neighborMap, peer.fsm.pConf.State.NeighborAddress)
+				server.broadcastPeerState(peer, oldState)
+				return
 			}
 		} else if peer.fsm.pConf.GracefulRestart.State.PeerRestarting && nextState == bgp.BGP_FSM_IDLE {
 			if peer.fsm.pConf.GracefulRestart.State.LongLivedEnabled {


### PR DESCRIPTION
close #1575

if L854 is executed before L924, we hit a crash because of closing a
channel twice. This fixes the isseu but We had better to refactor the
code to delete a peer.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>