### PR TITLE
cli: Support to advertise PMSI tunnel attribute

### DIFF
--- a/docs/sources/evpn.md
+++ b/docs/sources/evpn.md
@@ -149,7 +149,7 @@ $ gobgp global rib -a evpn del macadv aa:bb:cc:dd:ee:ff 10.0.0.1 esi AS 65000 10
 
 ```bash
 # Add a route
-$ gobgp global rib -a evpn add multicast <ip address> etag <etag> rd <rd> [rt <rt>...] [encap <encap type>]
+$ gobgp global rib -a evpn add multicast <ip address> etag <etag> rd <rd> [rt <rt>...] [encap <encap type>] [pmsi <type> [leaf-info-required] <label> <tunnel-id>]
 
 # Show routes
 $ gobgp global rib -a evpn [multicast]
@@ -169,11 +169,10 @@ $ gobgp global rib -a evpn
 $ gobgp global rib -a evpn del multicast 10.0.0.1 etag 100 rd 1.1.1.1:65000
 
 # With optionals
-$ gobgp global rib -a evpn add multicast 10.0.0.1 etag 100 rd 1.1.1.1:65000 rt 65000:200 encap vxlan
+$ gobgp global rib -a evpn add multicast 10.0.0.1 etag 100 rd 1.1.1.1:65000 rt 65000:200 encap vxlan pmsi ingress-repl 100 1.1.1.1
 $ gobgp global rib -a evpn multicast
    Network                                                   Labels     Next Hop             AS_PATH              Age        Attrs
-*> [type:multicast][rd:1.1.1.1:65000][etag:100][ip:10.0.0.1]            0.0.0.0                                   00:00:00   [{Origin: ?} {Extcomms: [65000:200], [VXLAN]}]
-$ gobgp global rib -a evpn del multicast 10.0.0.1 etag 100 rd 1.1.1.1:65000
+*> [type:multicast][rd:1.1.1.1:65000][etag:100][ip:10.0.0.1]            0.0.0.0                                   00:00:00   [{Origin: ?} {Pmsi: type: ingress-repl, label: 100, tunnel-id: 1.1.1.1} {Extcomms: [65000:200], [VXLAN]}]
 ```
 
 ### Ethernet Segment Route

--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -1240,9 +1240,16 @@ func modPath(resource string, name, modtype string, args []string) error {
 		ss = append(ss, "<DEC_NUM>")
 		etherTypes := strings.Join(ss, ", ")
 		helpErrMap := map[bgp.RouteFamily]error{}
-		helpErrMap[bgp.RF_IPv4_UC] = fmt.Errorf("usage: %s rib %s <PREFIX> [identifier <VALUE>] [origin { igp | egp | incomplete }] [aspath <VALUE>] [nexthop <ADDRESS>] [med <VALUE>] [local-pref <VALUE>] [community <VALUE>] [aigp metric <METRIC>] [large-community <VALUE> ] -a ipv4", cmdstr, modtype)
-		helpErrMap[bgp.RF_IPv6_UC] = fmt.Errorf("usage: %s rib %s <PREFIX> [identifier <VALUE>] [origin { igp | egp | incomplete }] [aspath <VALUE>] [nexthop <ADDRESS>] [med <VALUE>] [local-pref <VALUE>] [community <VALUE>] [aigp metric <METRIC>] [large-community <VALUE> ] -a ipv6", cmdstr, modtype)
-		fsHelpMsgFmt := fmt.Sprintf(`err: %s
+		ucHelpMsgFmt := fmt.Sprintf(`error: %s
+usage: %s rib -a %%s %s <PREFIX> [identifier <VALUE>] [origin { igp | egp | incomplete }] [aspath <VALUE>] [nexthop <ADDRESS>] [med <VALUE>] [local-pref <VALUE>] [community <VALUE>] [aigp metric <METRIC>] [large-community <VALUE>]`,
+			err,
+			cmdstr,
+			// <address family>
+			modtype,
+		)
+		helpErrMap[bgp.RF_IPv4_UC] = fmt.Errorf(ucHelpMsgFmt, "ipv4")
+		helpErrMap[bgp.RF_IPv6_UC] = fmt.Errorf(ucHelpMsgFmt, "ipv6")
+		fsHelpMsgFmt := fmt.Sprintf(`error: %s
 usage: %s rib -a %%s %s%%s match <MATCH> then <THEN>%%s%%s%%s
     <THEN> : { %s |
                %s |
@@ -1340,13 +1347,23 @@ usage: %s rib -a %%s %s%%s match <MATCH> then <THEN>%%s%%s%%s
 		helpErrMap[bgp.RF_FS_IPv4_VPN] = fmt.Errorf(fsHelpMsgFmt, "ipv4-l3vpn-flowspec", " rd <RD>", " [rt <RT>]", rdHelpMsgFmt, ipv4FsMatchExpr)
 		helpErrMap[bgp.RF_FS_IPv6_VPN] = fmt.Errorf(fsHelpMsgFmt, "ipv6-l3vpn-flowspec", " rd <RD>", " [rt <RT>]", rdHelpMsgFmt, ipv6FsMatchExpr)
 		helpErrMap[bgp.RF_FS_L2_VPN] = fmt.Errorf(fsHelpMsgFmt, "l2vpn-flowspec", " rd <RD>", " [rt <RT>]", rdHelpMsgFmt, l2vpnFsMatchExpr)
-		helpErrMap[bgp.RF_EVPN] = fmt.Errorf(`usage: %s rib %s { a-d <A-D> | macadv <MACADV> | multicast <MULTICAST> | esi <ESI> | prefix <PREFIX> } -a evpn
+		helpErrMap[bgp.RF_EVPN] = fmt.Errorf(`error: %s
+usage: %s rib %s { a-d <A-D> | macadv <MACADV> | multicast <MULTICAST> | esi <ESI> | prefix <PREFIX> } -a evpn
     <A-D>       : esi <esi> etag <etag> label <label> rd <rd> [rt <rt>...] [encap <encap type>] [esi-label <esi-label> [single-active | all-active]]
     <MACADV>    : <mac address> <ip address> [esi <esi>] etag <etag> label <label> rd <rd> [rt <rt>...] [encap <encap type>] [default-gateway]
     <MULTICAST> : <ip address> etag <etag> rd <rd> [rt <rt>...] [encap <encap type>]
     <ESI>       : <ip address> esi <esi> rd <rd> [rt <rt>...] [encap <encap type>]
-    <PREFIX>    : <ip prefix> [gw <gateway>] [esi <esi>] etag <etag> [label <label>] rd <rd> [rt <rt>...] [encap <encap type>] [router-mac <mac address>]`, cmdstr, modtype)
-		helpErrMap[bgp.RF_OPAQUE] = fmt.Errorf(`usage: %s rib %s key <KEY> [value <VALUE>]`, cmdstr, modtype)
+    <PREFIX>    : <ip prefix> [gw <gateway>] [esi <esi>] etag <etag> [label <label>] rd <rd> [rt <rt>...] [encap <encap type>] [router-mac <mac address>]`,
+			err,
+			cmdstr,
+			modtype,
+		)
+		helpErrMap[bgp.RF_OPAQUE] = fmt.Errorf(`error: %s
+usage: %s rib %s key <KEY> [value <VALUE>]`,
+			err,
+			cmdstr,
+			modtype,
+		)
 		if err, ok := helpErrMap[rf]; ok {
 			return err
 		}

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -7758,6 +7758,53 @@ func NewPathAttributePmsiTunnel(typ PmsiTunnelType, isLeafInfoRequired bool, lab
 	}
 }
 
+func ParsePmsiTunnel(args []string) (*PathAttributePmsiTunnel, error) {
+	// Format:
+	// "<type>" ["leaf-info-required"] "<label>" "<tunnel-id>"
+	if len(args) < 3 {
+		return nil, fmt.Errorf("invalid pmsi tunnel arguments: %s", args)
+	}
+
+	pmsi := NewPathAttributePmsiTunnel(0, false, 0, nil)
+
+	switch args[0] {
+	case "ingress-repl":
+		pmsi.TunnelType = PMSI_TUNNEL_TYPE_INGRESS_REPL
+	default:
+		typ, err := strconv.ParseUint(args[0], 10, 8)
+		if err != nil {
+			return nil, fmt.Errorf("invalid pmsi tunnel type: %s", args[0])
+		}
+		pmsi.TunnelType = PmsiTunnelType(typ)
+	}
+
+	indx := 1
+	if args[indx] == "leaf-info-required" {
+		pmsi.IsLeafInfoRequired = true
+		indx++
+	}
+
+	label, err := strconv.ParseUint(args[indx], 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pmsi tunnel label: %s", args[indx])
+	}
+	pmsi.Label = uint32(label)
+	indx++
+
+	switch pmsi.TunnelType {
+	case PMSI_TUNNEL_TYPE_INGRESS_REPL:
+		ip := net.ParseIP(args[indx])
+		if ip == nil {
+			return nil, fmt.Errorf("invalid pmsi tunnel identifier: %s", args[indx])
+		}
+		pmsi.TunnelID = &IngressReplTunnelID{Value: ip}
+	default:
+		pmsi.TunnelID = &DefaultPmsiTunnelID{Value: []byte(args[indx])}
+	}
+
+	return pmsi, nil
+}
+
 type AigpTLVType uint8
 
 const (

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -2025,7 +2025,7 @@ func ParseEthernetSegmentIdentifier(args []string) (EthernetSegmentIdentifier, e
 	case "AS":
 		esi.Type = ESI_AS
 	default:
-		typ, err := strconv.ParseUint(args[0], 10, 0)
+		typ, err := strconv.ParseUint(args[0], 10, 8)
 		if err != nil {
 			return esi, fmt.Errorf("invalid esi type: %s", args[0])
 		}


### PR DESCRIPTION
This patch enables "gobgp" command to advertise the PMSI Tunnel Attribute which is appended to the EVPN Inclusive Multicast Ethernet Tag routes for example.

Usage Example:

```bash
$ gobgp global rib -a evpn add multicast 10.0.0.1 etag 10 rd 65000:100 pmsi ingress-repl 100 1.1.1.1
$ gobgp global rib -a evpn
   Network                                              Labels     Next Hop             AS_PATH              Age        Attrs
*> [type:multicast][rd:65000:100][etag:10][ip:10.0.0.1]            0.0.0.0                                   00:00:00   [{Origin: ?} {Pmsi: type: ingress-repl, label: 100, tunnel-id: 1.1.1.1}]
```