### PR TITLE
zclinet: Enable to request MPLS label range to FRRouting

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -1116,13 +1116,18 @@ type ZebraState struct {
 	// original -> gobgp:redistribute-route-type
 	RedistributeRouteTypeList []InstallProtocolType `mapstructure:"redistribute-route-type-list" json:"redistribute-route-type-list,omitempty"`
 	// original -> gobgp:version
-	// Configure version of zebra protocol.  Default is 2. Supported up to 3.
+	// Configure version of zebra protocol. Default is 2.
+	// Supported version are 2 or 3 for Quagga and 4 for FRRouting.
 	Version uint8 `mapstructure:"version" json:"version,omitempty"`
 	// original -> gobgp:nexthop-trigger-enable
 	// gobgp:nexthop-trigger-enable's original type is boolean.
 	NexthopTriggerEnable bool `mapstructure:"nexthop-trigger-enable" json:"nexthop-trigger-enable,omitempty"`
 	// original -> gobgp:nexthop-trigger-delay
 	NexthopTriggerDelay uint8 `mapstructure:"nexthop-trigger-delay" json:"nexthop-trigger-delay,omitempty"`
+	// original -> gobgp:mpls-label-range-size
+	// Configure MPLS label range size which will be requested to
+	// FRR/Zebra.
+	MplsLabelRangeSize uint32 `mapstructure:"mpls-label-range-size" json:"mpls-label-range-size,omitempty"`
 }
 
 // struct for container gobgp:config.
@@ -1137,13 +1142,18 @@ type ZebraConfig struct {
 	// original -> gobgp:redistribute-route-type
 	RedistributeRouteTypeList []InstallProtocolType `mapstructure:"redistribute-route-type-list" json:"redistribute-route-type-list,omitempty"`
 	// original -> gobgp:version
-	// Configure version of zebra protocol.  Default is 2. Supported up to 3.
+	// Configure version of zebra protocol. Default is 2.
+	// Supported version are 2 or 3 for Quagga and 4 for FRRouting.
 	Version uint8 `mapstructure:"version" json:"version,omitempty"`
 	// original -> gobgp:nexthop-trigger-enable
 	// gobgp:nexthop-trigger-enable's original type is boolean.
 	NexthopTriggerEnable bool `mapstructure:"nexthop-trigger-enable" json:"nexthop-trigger-enable,omitempty"`
 	// original -> gobgp:nexthop-trigger-delay
 	NexthopTriggerDelay uint8 `mapstructure:"nexthop-trigger-delay" json:"nexthop-trigger-delay,omitempty"`
+	// original -> gobgp:mpls-label-range-size
+	// Configure MPLS label range size which will be requested to
+	// FRR/Zebra.
+	MplsLabelRangeSize uint32 `mapstructure:"mpls-label-range-size" json:"mpls-label-range-size,omitempty"`
 }
 
 func (lhs *ZebraConfig) Equal(rhs *ZebraConfig) bool {
@@ -1171,6 +1181,9 @@ func (lhs *ZebraConfig) Equal(rhs *ZebraConfig) bool {
 		return false
 	}
 	if lhs.NexthopTriggerDelay != rhs.NexthopTriggerDelay {
+		return false
+	}
+	if lhs.MplsLabelRangeSize != rhs.MplsLabelRangeSize {
 		return false
 	}
 	return true

--- a/server/server.go
+++ b/server/server.go
@@ -1394,8 +1394,17 @@ func (s *BgpServer) StartZebraClient(c *config.ZebraConfig) error {
 			protos = append(protos, string(p))
 		}
 		var err error
-		s.zclient, err = newZebraClient(s, c.Url, protos, c.Version, c.NexthopTriggerEnable, c.NexthopTriggerDelay)
-		return err
+		s.zclient, err = newZebraClient(s, c.Url, protos, c.Version, c.NexthopTriggerEnable, c.NexthopTriggerDelay, c.MplsLabelRangeSize)
+		if err != nil {
+			return err
+		}
+		if s.globalRib != nil && s.zclient.client.Version >= 4 && c.MplsLabelRangeSize > 0 {
+			if err := s.globalRib.EnableMplsLabelAllocation(); err != nil {
+				s.zclient.stop()
+				return err
+			}
+		}
+		return nil
 	}, false)
 }
 
@@ -1708,9 +1717,24 @@ func (s *BgpServer) AddVrf(name string, id uint32, rd bgp.RouteDistinguisherInte
 			AS:      s.bgpConfig.Global.Config.As,
 			LocalID: net.ParseIP(s.bgpConfig.Global.Config.RouterId).To4(),
 		}
-		if pathList, e := s.globalRib.AddVrf(name, id, rd, im, ex, pi); e != nil {
-			return e
-		} else if len(pathList) > 0 {
+		pathList, err := s.globalRib.AddVrf(name, id, rd, im, ex, pi)
+		if err != nil {
+			if _, ok := err.(*table.MplsLabelRangeFullError); ok {
+				var start, end uint32
+				if start, end, err = s.zclient.requestMplsLabelAllocation(); err != nil {
+					return err
+				}
+				if err = s.globalRib.AllocateMplsLabelRange(start, end); err != nil {
+					return err
+				}
+				if pathList, err = s.globalRib.AddVrf(name, id, rd, im, ex, pi); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+		if len(pathList) > 0 {
 			s.propagateUpdate(nil, pathList)
 		}
 		return nil

--- a/table/path.go
+++ b/table/path.go
@@ -1128,12 +1128,12 @@ func (v *Vrf) ToGlobalPath(path *Path) error {
 	case bgp.RF_IPv4_UC:
 		n := nlri.(*bgp.IPAddrPrefix)
 		pathIdentifier := path.GetNlri().PathIdentifier()
-		path.OriginInfo().nlri = bgp.NewLabeledVPNIPAddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(0), v.Rd)
+		path.OriginInfo().nlri = bgp.NewLabeledVPNIPAddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(v.MplsLabel()), v.Rd)
 		path.GetNlri().SetPathIdentifier(pathIdentifier)
 	case bgp.RF_IPv6_UC:
 		n := nlri.(*bgp.IPv6AddrPrefix)
 		pathIdentifier := path.GetNlri().PathIdentifier()
-		path.OriginInfo().nlri = bgp.NewLabeledVPNIPv6AddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(0), v.Rd)
+		path.OriginInfo().nlri = bgp.NewLabeledVPNIPv6AddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(v.MplsLabel()), v.Rd)
 		path.GetNlri().SetPathIdentifier(pathIdentifier)
 	case bgp.RF_EVPN:
 		n := nlri.(*bgp.EVPNNLRI)
@@ -1157,11 +1157,11 @@ func (p *Path) ToGlobal(vrf *Vrf) *Path {
 	switch rf := p.GetRouteFamily(); rf {
 	case bgp.RF_IPv4_UC:
 		n := nlri.(*bgp.IPAddrPrefix)
-		nlri = bgp.NewLabeledVPNIPAddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(0), vrf.Rd)
+		nlri = bgp.NewLabeledVPNIPAddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(vrf.MplsLabel()), vrf.Rd)
 		nlri.SetPathIdentifier(pathId)
 	case bgp.RF_IPv6_UC:
 		n := nlri.(*bgp.IPv6AddrPrefix)
-		nlri = bgp.NewLabeledVPNIPv6AddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(0), vrf.Rd)
+		nlri = bgp.NewLabeledVPNIPv6AddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(vrf.MplsLabel()), vrf.Rd)
 		nlri.SetPathIdentifier(pathId)
 	case bgp.RF_EVPN:
 		n := nlri.(*bgp.EVPNNLRI)

--- a/table/vrf.go
+++ b/table/vrf.go
@@ -19,12 +19,24 @@ import (
 	"github.com/osrg/gobgp/packet/bgp"
 )
 
+type vrfOption struct {
+	mplsLabel uint32
+}
+
 type Vrf struct {
 	Name     string
 	Id       uint32
 	Rd       bgp.RouteDistinguisherInterface
 	ImportRt []bgp.ExtendedCommunityInterface
 	ExportRt []bgp.ExtendedCommunityInterface
+	option   *vrfOption
+}
+
+func (v *Vrf) MplsLabel() uint32 {
+	if v.option == nil {
+		return 0
+	}
+	return v.option.mplsLabel
 }
 
 func (v *Vrf) Clone() *Vrf {
@@ -35,12 +47,14 @@ func (v *Vrf) Clone() *Vrf {
 		}
 		return l
 	}
+	option := *v.option
 	return &Vrf{
 		Name:     v.Name,
 		Id:       v.Id,
 		Rd:       v.Rd,
 		ImportRt: f(v.ImportRt),
 		ExportRt: f(v.ExportRt),
+		option:   &option,
 	}
 }
 

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -1198,13 +1198,20 @@ module gobgp {
     leaf version {
       type uint8;
       description
-        "Configure version of zebra protocol.  Default is 2. Supported up to 3.";
+        "Configure version of zebra protocol. Default is 2.
+        Supported version are 2 or 3 for Quagga and 4 for FRRouting.";
     }
     leaf nexthop-trigger-enable {
       type boolean;
     }
     leaf nexthop-trigger-delay {
       type uint8;
+    }
+    leaf mpls-label-range-size {
+      type uint32;
+      description
+        "Configure MPLS label range size which will be requested to
+        FRR/Zebra.";
     }
   }
 


### PR DESCRIPTION
With FRRouting, MPLS label allocation is maintained on Zebra daemon, so GoBGP need to request the label range allocation to Zebra daemon in order to allocate a label to VRFs with MPLS VPN.

Example of Configuration:

```toml
[zebra.config]
  enabled = true
  url = "unix:/var/run/frr/zserv.api"
  redistribute-route-type-list = ["connect"]
  version = 4
  mpls-label-range-size = 100
```

Note: "version >= 4" is required to use this feature.