### PR TITLE
packet/bgp: Remove raw binary field on PathAttribute struct

### DIFF
--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -4943,20 +4943,6 @@ func (p *PathAttribute) Serialize(value []byte, options ...*MarshallingOption) (
 	return buf, nil
 }
 
-func (p *PathAttribute) String() string {
-	return fmt.Sprintf("{Type: %s, Flags: %s}", p.Type, p.Flags)
-}
-
-func (p *PathAttribute) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		Type  BGPAttrType `json:"type"`
-		Flags BGPAttrFlag `json:"flags"`
-	}{
-		Type:  p.GetType(),
-		Flags: p.Flags,
-	})
-}
-
 type PathAttributeOrigin struct {
 	PathAttribute
 	Value uint8
@@ -7333,6 +7319,16 @@ func (p *PathAttributeAs4Path) String() string {
 	return strings.Join(params, " ")
 }
 
+func (p *PathAttributeAs4Path) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  BGPAttrType     `json:"type"`
+		Value []*As4PathParam `json:"as_paths"`
+	}{
+		Type:  p.GetType(),
+		Value: p.Value,
+	})
+}
+
 func NewPathAttributeAs4Path(value []*As4PathParam) *PathAttributeAs4Path {
 	t := BGP_ATTR_TYPE_AS4_PATH
 	return &PathAttributeAs4Path{
@@ -7369,6 +7365,22 @@ func (p *PathAttributeAs4Aggregator) Serialize(options ...*MarshallingOption) ([
 	binary.BigEndian.PutUint32(buf[0:], p.Value.AS)
 	copy(buf[4:], p.Value.Address.To4())
 	return p.PathAttribute.Serialize(buf, options...)
+}
+
+func (p *PathAttributeAs4Aggregator) String() string {
+	return fmt.Sprintf("{As4Aggregator: {AS: %d, Address: %s}}", p.Value.AS, p.Value.Address)
+}
+
+func (p *PathAttributeAs4Aggregator) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type    BGPAttrType `json:"type"`
+		AS      uint32      `json:"as"`
+		Address string      `json:"address"`
+	}{
+		Type:    p.GetType(),
+		AS:      p.Value.AS,
+		Address: p.Value.Address.String(),
+	})
 }
 
 func NewPathAttributeAs4Aggregator(as uint32, address string) *PathAttributeAs4Aggregator {
@@ -7570,6 +7582,24 @@ func (p *PathAttributeTunnelEncap) Serialize(options ...*MarshallingOption) ([]b
 		buf = append(buf, bbuf...)
 	}
 	return p.PathAttribute.Serialize(buf, options...)
+}
+
+func (p *PathAttributeTunnelEncap) String() string {
+	tlvList := make([]string, len(p.Value), len(p.Value))
+	for i, v := range p.Value {
+		tlvList[i] = v.String()
+	}
+	return fmt.Sprintf("{TunnelEncap: %s}", strings.Join(tlvList, ", "))
+}
+
+func (p *PathAttributeTunnelEncap) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  BGPAttrType       `json:"type"`
+		Value []*TunnelEncapTLV `json:"value"`
+	}{
+		Type:  p.Type,
+		Value: p.Value,
+	})
 }
 
 func NewPathAttributeTunnelEncap(value []*TunnelEncapTLV) *PathAttributeTunnelEncap {

--- a/packet/bgp/bgp_test.go
+++ b/packet/bgp/bgp_test.go
@@ -258,16 +258,7 @@ func Test_RFC5512(t *testing.T) {
 	assert.Equal(nil, err)
 	assert.Equal([]byte{0x3, 0xc, 0x0, 0x0, 0x0, 0x0, 0x0, 0x8}, buf)
 
-	subTlv := &TunnelEncapSubTLV{
-		Type:  ENCAP_SUBTLV_TYPE_COLOR,
-		Value: &TunnelEncapSubTLVColor{10},
-	}
-
-	tlv := &TunnelEncapTLV{
-		Type:  TUNNEL_TYPE_VXLAN,
-		Value: []*TunnelEncapSubTLV{subTlv},
-	}
-
+	tlv := NewTunnelEncapTLV(TUNNEL_TYPE_VXLAN, []TunnelEncapSubTLVInterface{NewTunnelEncapSubTLVColor(10)})
 	attr := NewPathAttributeTunnelEncap([]*TunnelEncapTLV{tlv})
 
 	buf1, err := attr.Serialize()

--- a/packet/bgp/helper.go
+++ b/packet/bgp/helper.go
@@ -141,8 +141,8 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 			PathAttribute: PathAttribute{
 				Flags: BGP_ATTR_FLAG_TRANSITIVE,
 				Type:  100,
-				Value: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 			},
+			Value: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 		},
 	}
 	n := []*IPAddrPrefix{NewIPAddrPrefix(24, "13.2.3.1")}

--- a/table/destination.go
+++ b/table/destination.go
@@ -831,11 +831,11 @@ func compareByOrigin(path1, path2 *Path) *Path {
 		return nil
 	}
 
-	origin1, n1 := binary.Uvarint(attribute1.(*bgp.PathAttributeOrigin).Value)
-	origin2, n2 := binary.Uvarint(attribute2.(*bgp.PathAttributeOrigin).Value)
+	origin1 := attribute1.(*bgp.PathAttributeOrigin).Value
+	origin2 := attribute2.(*bgp.PathAttributeOrigin).Value
 	log.WithFields(log.Fields{
 		"Topic": "Table",
-	}).Debugf("compareByOrigin -- origin1: %d(%d), origin2: %d(%d)", origin1, n1, origin2, n2)
+	}).Debugf("compareByOrigin -- origin1: %d, origin2: %d", origin1, origin2)
 
 	// If both paths have same origins
 	if origin1 == origin2 {

--- a/table/path.go
+++ b/table/path.go
@@ -1043,7 +1043,7 @@ func (path *Path) GetClusterList() []net.IP {
 
 func (path *Path) GetOrigin() (uint8, error) {
 	if attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGIN); attr != nil {
-		return attr.(*bgp.PathAttributeOrigin).Value[0], nil
+		return attr.(*bgp.PathAttributeOrigin).Value, nil
 	}
 	return 0, fmt.Errorf("no origin path attr")
 }


### PR DESCRIPTION
This PR removes "Value" field, which stores the raw decoded/serialized binary data, in order to reduce the memory usage.
Also implements some missing String()/MarshalJSON() functions.