### PR TITLE
path: Default value as Route Reflector

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -2,12 +2,13 @@ package config
 
 import (
 	"fmt"
+	"net"
+	"reflect"
+
 	"github.com/osrg/gobgp/packet/bgp"
 	"github.com/osrg/gobgp/packet/bmp"
 	"github.com/osrg/gobgp/packet/rtr"
 	"github.com/spf13/viper"
-	"net"
-	"reflect"
 )
 
 const (
@@ -232,6 +233,14 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, g *Glo
 	} else if n.TtlSecurity.Config.Enabled {
 		if n.TtlSecurity.Config.TtlMin == 0 {
 			n.TtlSecurity.Config.TtlMin = 255
+		}
+	}
+
+	if n.RouteReflector.Config.RouteReflectorClient {
+		if n.RouteReflector.Config.RouteReflectorClusterId == "" {
+			n.RouteReflector.Config.RouteReflectorClusterId = RrClusterIdType(g.Config.RouterId)
+		} else if id := net.ParseIP(string(n.RouteReflector.Config.RouteReflectorClusterId)).To4(); id == nil {
+			return fmt.Errorf("route-reflector-cluster-id should be specified in IPv4 address format")
 		}
 	}
 

--- a/table/path.go
+++ b/table/path.go
@@ -288,7 +288,11 @@ func UpdatePathAttrs(global *config.Global, peer *config.Neighbor, info *PeerInf
 				path.SetNexthop(localAddress)
 				path.setPathAttr(bgp.NewPathAttributeOriginatorId(info.LocalID.String()))
 			} else if path.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGINATOR_ID) == nil {
-				path.setPathAttr(bgp.NewPathAttributeOriginatorId(info.ID.String()))
+				if path.IsLocal() {
+					path.setPathAttr(bgp.NewPathAttributeOriginatorId(global.Config.RouterId))
+				} else {
+					path.setPathAttr(bgp.NewPathAttributeOriginatorId(info.ID.String()))
+				}
 			}
 			// When an RR reflects a route, it MUST prepend the local CLUSTER_ID to the CLUSTER_LIST.
 			// If the CLUSTER_LIST is empty, it MUST create a new one.


### PR DESCRIPTION
When acting as a Route Reflector, the current implementation will set the ORIGINATOR_ID attribute with "0.0.0.0" for locally generated paths, and also use "0.0.0.0" as the default of "route-reflector-cluster-id".

This PR fixes to set own Router ID as the ORIGINATOR_ID value and use "router-id" as the default value of "route-reflector-cluster-id".

For example, r1 is a Route Reflector and r2/r3 are its clients, with the current implementation,  r1's loccaly generated route "10.1.1.0/24" has the ORIGINATOR_ID with "0.0.0.0". Both "10.1.1.0/24" and r2's route "10.2.1.0/24" have [0.0.0.0] as the CLUSTER_LIST.

```toml
# Snip of r1's gobgpd.toml
[[peer-groups]]
  [peer-groups.route-reflector.config]
    route-reflector-client = true
    # route-reflector-cluster-id  # omitted
```

```bash
r3> gobgp global rib -a ipv4
   Network              Next Hop             AS_PATH              Age        Attrs
*> 10.1.1.0/24          10.0.0.1                                  00:00:00   [{Origin: ?} {LocalPref: 100} {Originator: 0.0.0.0} {ClusterList: [0.0.0.0]}]
*> 10.2.1.0/24          10.0.0.2                                  00:00:00   [{Origin: ?} {LocalPref: 100} {Originator: 2.2.2.2} {ClusterList: [0.0.0.0]}]
```

With this PR, r1's Router ID "1.1.1.1" is used for the both attribute value.

```bash
r3> gobgp global rib -a ipv4
   Network              Next Hop             AS_PATH              Age        Attrs
*> 10.1.1.0/24          10.0.0.1                                  00:00:00   [{Origin: ?} {LocalPref: 100} {Originator: 1.1.1.1} {ClusterList: [1.1.1.1]}]
*> 10.2.1.0/24          10.0.0.2                                  00:00:00   [{Origin: ?} {LocalPref: 100} {Originator: 2.2.2.2} {ClusterList: [1.1.1.1]}]
```
