### PR TITLE
packet/bgp: Flatten structure of OpaqueExtended

### DIFF
--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -206,10 +206,7 @@ func encapParser(args []string) ([]bgp.ExtendedCommunityInterface, error) {
 	default:
 		return nil, fmt.Errorf("invalid encap type")
 	}
-	o := bgp.NewOpaqueExtended(true)
-	o.SubType = bgp.EC_SUBTYPE_ENCAPSULATION
-	o.Value = &bgp.EncapExtended{TunnelType: typ}
-	return []bgp.ExtendedCommunityInterface{o}, nil
+	return []bgp.ExtendedCommunityInterface{bgp.NewEncapExtended(typ)}, nil
 }
 
 func esiLabelParser(args []string) ([]bgp.ExtendedCommunityInterface, error) {
@@ -254,12 +251,7 @@ func defaultGatewayParser(args []string) ([]bgp.ExtendedCommunityInterface, erro
 	if len(args) < 1 || args[0] != ExtCommNameMap[DEFAULT_GATEWAY] {
 		return nil, fmt.Errorf("invalid default-gateway")
 	}
-	o := &bgp.OpaqueExtended{
-		IsTransitive: true,
-		Value:        &bgp.DefaultGatewayExtended{},
-		SubType:      bgp.EC_SUBTYPE_DEFAULT_GATEWAY,
-	}
-	return []bgp.ExtendedCommunityInterface{o}, nil
+	return []bgp.ExtendedCommunityInterface{bgp.NewDefaultGatewayExtended()}, nil
 }
 
 func validationParser(args []string) ([]bgp.ExtendedCommunityInterface, error) {
@@ -277,10 +269,7 @@ func validationParser(args []string) ([]bgp.ExtendedCommunityInterface, error) {
 	default:
 		return nil, fmt.Errorf("invalid validation state")
 	}
-	o := bgp.NewOpaqueExtended(true)
-	o.SubType = bgp.EC_SUBTYPE_ORIGIN_VALIDATION
-	o.Value = &bgp.ValidationExtended{Value: typ}
-	return []bgp.ExtendedCommunityInterface{o}, nil
+	return []bgp.ExtendedCommunityInterface{bgp.NewValidationExtended(typ)}, nil
 }
 
 var ExtCommParserMap = map[ExtCommType]func([]string) ([]bgp.ExtendedCommunityInterface, error){

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -185,7 +185,7 @@ func (p TunnelType) String() string {
 	case TUNNEL_TYPE_MPLS:
 		return "mpls"
 	case TUNNEL_TYPE_MPLS_IN_GRE:
-		return "mpls-ingre"
+		return "mpls-in-gre"
 	case TUNNEL_TYPE_VXLAN_GRE:
 		return "vxlan-gre"
 	case TUNNEL_TYPE_MPLS_IN_UDP:

--- a/packet/bgp/helper.go
+++ b/packet/bgp/helper.go
@@ -67,7 +67,7 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 		NewIPv4AddressSpecificExtended(EC_SUBTYPE_ROUTE_TARGET, "192.2.1.2", 3000, isTransitive),
 		NewOpaqueExtended(false, []byte{1, 2, 3, 4, 5, 6, 7}),
 		NewValidationExtended(VALIDATION_STATE_INVALID),
-		&UnknownExtended{Type: 99, Value: []byte{0, 1, 2, 3, 4, 5, 6, 7}},
+		NewUnknownExtended(99, []byte{0, 1, 2, 3, 4, 5, 6, 7}),
 		NewESILabelExtended(1000, true),
 		NewESImportRouteTarget("11:22:33:44:55:66"),
 		NewMacMobilityExtended(123, false),

--- a/packet/bgp/helper.go
+++ b/packet/bgp/helper.go
@@ -65,12 +65,8 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 		NewTwoOctetAsSpecificExtended(EC_SUBTYPE_ROUTE_TARGET, 10003, 3<<20, isTransitive),
 		NewFourOctetAsSpecificExtended(EC_SUBTYPE_ROUTE_TARGET, 1<<20, 300, isTransitive),
 		NewIPv4AddressSpecificExtended(EC_SUBTYPE_ROUTE_TARGET, "192.2.1.2", 3000, isTransitive),
-		&OpaqueExtended{
-			Value: &DefaultOpaqueExtendedValue{[]byte{255, 1, 2, 3, 4, 5, 6, 7}},
-		},
-		&OpaqueExtended{
-			Value: &ValidationExtended{Value: VALIDATION_STATE_INVALID},
-		},
+		NewOpaqueExtended(false, []byte{1, 2, 3, 4, 5, 6, 7}),
+		NewValidationExtended(VALIDATION_STATE_INVALID),
 		&UnknownExtended{Type: 99, Value: []byte{0, 1, 2, 3, 4, 5, 6, 7}},
 		NewESILabelExtended(1000, true),
 		NewESImportRouteTarget("11:22:33:44:55:66"),


### PR DESCRIPTION
This PR flattens `OpaqueExtended` structure to improve the usability.

With the current implementation:
```go
var e bgp.ExtendedCommunityInterface
...
e = &bgp.OpaqueExtended{
	IsTransitive: true,
	SubType:      bgp.EC_SUBTYPE_ENCAPSULATION,
	Value: &bgp.EncapExtended{
		TunnelType: bgp.TUNNEL_TYPE_VXLAN,
	},
}
```

With this PR:
```go
var e bgp.ExtendedCommunityInterface
...
e = &bgp.EncapExtended{
	TunnelType: bgp.TUNNEL_TYPE_VXLAN,
}
```
or
```go
var e bgp.ExtendedCommunityInterface
...
e = bgp.NewEncapExtended(bgp.TUNNEL_TYPE_VXLAN)
```

Also, this PR include a fix of a typo and some improvements for `UnknownExtended`.