### PR TITLE
packet/bgp: Reduce struct size of "IPAddrPrefix" struct

### DIFF
--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -84,14 +84,15 @@ const (
 	BGP_ASPATH_ATTR_TYPE_CONFED_SET = 4
 )
 
+// ExtendedCommunityAttrType shows the BGP Extended Community Types.
 // RFC7153 5.1. Registries for the "Type" Field
-// RANGE	REGISTRATION PROCEDURES
-// 0x00-0x3F	Transitive First Come First Served
-// 0x40-0x7F	Non-Transitive First Come First Served
-// 0x80-0x8F	Transitive Experimental Use
-// 0x90-0xBF	Transitive Standards Action
-// 0xC0-0xCF	Non-Transitive Experimental Use
-// 0xD0-0xFF	Non-Transitive Standards Action
+// RANGE        REGISTRATION PROCEDURES
+// 0x00-0x3F    Transitive First Come First Served
+// 0x40-0x7F    Non-Transitive First Come First Served
+// 0x80-0x8F    Transitive Experimental Use
+// 0x90-0xBF    Transitive Standards Action
+// 0xC0-0xCF    Non-Transitive Experimental Use
+// 0xD0-0xFF    Non-Transitive Standards Action
 type ExtendedCommunityAttrType uint8
 
 const (
@@ -115,10 +116,11 @@ const (
 	EC_TYPE_GENERIC_TRANSITIVE_EXPERIMENTAL3      ExtendedCommunityAttrType = 0x82 // RFC7674
 )
 
+// ExtendedCommunityAttrSubType shows the BGP Extended Community Sub-Types.
 // RFC7153 5.2. Registries for the "Sub-Type" Field
-// RANGE	REGISTRATION PROCEDURES
-// 0x00-0xBF	First Come First Served
-// 0xC0-0xFF	IETF Review
+// RANGE        REGISTRATION PROCEDURES
+// 0x00-0xBF    First Come First Served
+// 0xC0-0xFF    IETF Review
 type ExtendedCommunityAttrSubType uint8
 
 const (
@@ -784,7 +786,7 @@ func (c *CapLongLivedGracefulRestart) DecodeFromBytes(data []byte) error {
 
 	valueLen := int(c.CapLen)
 	if valueLen%7 != 0 || len(data) < valueLen {
-		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "invalid length of long lived graceful restart capablity")
+		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "invalid length of long lived graceful restart capability")
 	}
 	for i := valueLen; i >= 7; i -= 7 {
 		t := &CapLongLivedGracefulRestartTuple{
@@ -1512,8 +1514,10 @@ func ParseRouteDistinguisher(rd string) (RouteDistinguisherInterface, error) {
 //
 // The label information carried (as part of NLRI) in the Withdrawn
 // Routes field should be set to 0x800000.
-const WITHDRAW_LABEL = uint32(0x800000)
-const ZERO_LABEL = uint32(0) // some platform uses this as withdraw label
+const (
+	WITHDRAW_LABEL uint32 = 0x800000
+	ZERO_LABEL     uint32 = 0 // some platform uses this as withdraw label
+)
 
 type MPLSLabelStack struct {
 	Labels []uint32
@@ -2136,7 +2140,8 @@ func (esi *EthernetSegmentIdentifier) String() string {
 	return s.String()
 }
 
-// Decode Ethernet Segment Identifier (ESI) from string slice.
+// ParseEthernetSegmentIdentifier decodes Ethernet Segment Identifier (ESI)
+// from string slice.
 //
 // The first element of args should be the Type field (e.g., "ARBITRARY",
 // "arbitrary", "ESI_ARBITRARY" or "esi_arbitrary") and "single-homed" is
@@ -3359,7 +3364,7 @@ func flowSpecPrefixParser(rf RouteFamily, typ BGPFlowSpecType, args []string) (F
 	return nil, fmt.Errorf("invalid address family: %s", rf.String())
 }
 
-func flowSpecIpProtoParser(_ RouteFamily, typ BGPFlowSpecType, args []string) (FlowSpecComponentInterface, error) {
+func flowSpecIPProtoParser(_ RouteFamily, typ BGPFlowSpecType, args []string) (FlowSpecComponentInterface, error) {
 	// args: List of pairs of Operator and IP protocol type
 	//
 	// Example:
@@ -3384,7 +3389,7 @@ func flowSpecIpProtoParser(_ RouteFamily, typ BGPFlowSpecType, args []string) (F
 	return parseFlowSpecNumericOpValues(typ, args, f)
 }
 
-func flowSpecTcpFlagParser(_ RouteFamily, typ BGPFlowSpecType, args []string) (FlowSpecComponentInterface, error) {
+func flowSpecTCPFlagParser(_ RouteFamily, typ BGPFlowSpecType, args []string) (FlowSpecComponentInterface, error) {
 	// args: List of pairs of Operand and TCP Flags
 	//
 	// Example:
@@ -3624,13 +3629,13 @@ func flowSpecVlanCosParser(rf RouteFamily, typ BGPFlowSpecType, args []string) (
 var flowSpecParserMap = map[BGPFlowSpecType]func(RouteFamily, BGPFlowSpecType, []string) (FlowSpecComponentInterface, error){
 	FLOW_SPEC_TYPE_DST_PREFIX:    flowSpecPrefixParser,
 	FLOW_SPEC_TYPE_SRC_PREFIX:    flowSpecPrefixParser,
-	FLOW_SPEC_TYPE_IP_PROTO:      flowSpecIpProtoParser,
+	FLOW_SPEC_TYPE_IP_PROTO:      flowSpecIPProtoParser,
 	FLOW_SPEC_TYPE_PORT:          flowSpecNumeric2BytesParser,
 	FLOW_SPEC_TYPE_DST_PORT:      flowSpecNumeric2BytesParser,
 	FLOW_SPEC_TYPE_SRC_PORT:      flowSpecNumeric2BytesParser,
 	FLOW_SPEC_TYPE_ICMP_TYPE:     flowSpecNumeric1ByteParser,
 	FLOW_SPEC_TYPE_ICMP_CODE:     flowSpecNumeric1ByteParser,
-	FLOW_SPEC_TYPE_TCP_FLAG:      flowSpecTcpFlagParser,
+	FLOW_SPEC_TYPE_TCP_FLAG:      flowSpecTCPFlagParser,
 	FLOW_SPEC_TYPE_PKT_LEN:       flowSpecNumeric2BytesParser,
 	FLOW_SPEC_TYPE_DSCP:          flowSpecDscpParser,
 	FLOW_SPEC_TYPE_FRAGMENT:      flowSpecFragmentParser,
@@ -4320,7 +4325,7 @@ func (n *FlowSpecNLRI) Serialize(options ...*MarshallingOption) ([]byte, error) 
 	if length > 0xfff {
 		return nil, fmt.Errorf("Too large: %d", length)
 	} else if length < 0xf0 {
-		length -= 1
+		length--
 		buf = append([]byte{byte(length)}, buf...)
 	} else {
 		length -= 2
@@ -4346,9 +4351,8 @@ func (n *FlowSpecNLRI) Len(options ...*MarshallingOption) int {
 	}
 	if l < 0xf0 {
 		return l + 1
-	} else {
-		return l + 2
 	}
+	return l + 2
 }
 
 func (n *FlowSpecNLRI) String() string {
@@ -5039,7 +5043,7 @@ func NewNotificationErrorCode(code, subcode uint8) NotificationErrorCode {
 	return NotificationErrorCode(uint16(code)<<8 | uint16(subcode))
 }
 
-var PathAttrFlags map[BGPAttrType]BGPAttrFlag = map[BGPAttrType]BGPAttrFlag{
+var PathAttrFlags = map[BGPAttrType]BGPAttrFlag{
 	BGP_ATTR_TYPE_ORIGIN:                   BGP_ATTR_FLAG_TRANSITIVE,
 	BGP_ATTR_TYPE_AS_PATH:                  BGP_ATTR_FLAG_TRANSITIVE,
 	BGP_ATTR_TYPE_NEXT_HOP:                 BGP_ATTR_FLAG_TRANSITIVE,
@@ -7962,35 +7966,35 @@ func (t *TunnelEncapTLV) DecodeFromBytes(data []byte) error {
 	return nil
 }
 
-func (p *TunnelEncapTLV) Serialize() ([]byte, error) {
+func (t *TunnelEncapTLV) Serialize() ([]byte, error) {
 	buf := make([]byte, 4)
-	for _, t := range p.Value {
-		tBuf, err := t.Serialize()
+	for _, tlv := range t.Value {
+		tBuf, err := tlv.Serialize()
 		if err != nil {
 			return nil, err
 		}
 		buf = append(buf, tBuf...)
 	}
-	binary.BigEndian.PutUint16(buf, uint16(p.Type))
+	binary.BigEndian.PutUint16(buf, uint16(t.Type))
 	binary.BigEndian.PutUint16(buf[2:], uint16(len(buf)-4))
 	return buf, nil
 }
 
-func (p *TunnelEncapTLV) String() string {
-	tlvList := make([]string, len(p.Value), len(p.Value))
-	for i, v := range p.Value {
+func (t *TunnelEncapTLV) String() string {
+	tlvList := make([]string, len(t.Value), len(t.Value))
+	for i, v := range t.Value {
 		tlvList[i] = v.String()
 	}
-	return fmt.Sprintf("{%s: %s}", p.Type, strings.Join(tlvList, ", "))
+	return fmt.Sprintf("{%s: %s}", t.Type, strings.Join(tlvList, ", "))
 }
 
-func (p *TunnelEncapTLV) MarshalJSON() ([]byte, error) {
+func (t *TunnelEncapTLV) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Type  TunnelType                   `json:"type"`
 		Value []TunnelEncapSubTLVInterface `json:"value"`
 	}{
-		Type:  p.Type,
-		Value: p.Value,
+		Type:  t.Type,
+		Value: t.Value,
 	})
 }
 
@@ -8915,19 +8919,18 @@ func NewBGPUpdateMessage(withdrawnRoutes []*IPAddrPrefix, pathattrs []PathAttrib
 func NewEndOfRib(family RouteFamily) *BGPMessage {
 	if family == RF_IPv4_UC {
 		return NewBGPUpdateMessage(nil, nil, nil)
-	} else {
-		afi, safi := RouteFamilyToAfiSafi(family)
-		t := BGP_ATTR_TYPE_MP_UNREACH_NLRI
-		unreach := &PathAttributeMpUnreachNLRI{
-			PathAttribute: PathAttribute{
-				Flags: PathAttrFlags[t],
-				Type:  t,
-			},
-			AFI:  afi,
-			SAFI: safi,
-		}
-		return NewBGPUpdateMessage(nil, []PathAttributeInterface{unreach}, nil)
 	}
+	afi, safi := RouteFamilyToAfiSafi(family)
+	t := BGP_ATTR_TYPE_MP_UNREACH_NLRI
+	unreach := &PathAttributeMpUnreachNLRI{
+		PathAttribute: PathAttribute{
+			Flags: PathAttrFlags[t],
+			Type:  t,
+		},
+		AFI:  afi,
+		SAFI: safi,
+	}
+	return NewBGPUpdateMessage(nil, []PathAttributeInterface{unreach}, nil)
 }
 
 type BGPNotification struct {
@@ -9370,10 +9373,9 @@ func (n *OpaqueNLRI) Flat() map[string]string {
 	return map[string]string{}
 }
 
-// Update a Flat representation by adding elements of the second
-// one. If two elements use same keys, values are separated with
-// ';'. In this case, it returns an error but the update has been
-// realized.
+// FlatUpdate updates a Flat representation by adding elements of the second
+// one. If two elements use same keys, values are separated with ';'. In this
+// case, it returns an error but the update has been realized.
 func FlatUpdate(f1, f2 map[string]string) error {
 	conflict := false
 	for k2, v2 := range f2 {
@@ -9386,7 +9388,6 @@ func FlatUpdate(f1, f2 map[string]string) error {
 	}
 	if conflict {
 		return fmt.Errorf("Keys conflict")
-	} else {
-		return nil
 	}
+	return nil
 }

--- a/packet/bgp/bgp_test.go
+++ b/packet/bgp/bgp_test.go
@@ -360,8 +360,8 @@ func Test_MPLSLabelStack(t *testing.T) {
 func Test_FlowSpecNlri(t *testing.T) {
 	assert := assert.New(t)
 	cmp := make([]FlowSpecComponentInterface, 0)
-	cmp = append(cmp, NewFlowSpecDestinationPrefix(NewIPAddrPrefix(24, "10.0.0.0")))
-	cmp = append(cmp, NewFlowSpecSourcePrefix(NewIPAddrPrefix(24, "10.0.0.0")))
+	cmp = append(cmp, NewFlowSpecDestinationPrefix(24, "10.0.0.0"))
+	cmp = append(cmp, NewFlowSpecSourcePrefix(24, "10.0.0.0"))
 	item1 := NewFlowSpecComponentItem(DEC_NUM_OP_EQ, TCP)
 	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_IP_PROTO, []*FlowSpecComponentItem{item1}))
 	item2 := NewFlowSpecComponentItem(DEC_NUM_OP_GT_EQ, 20)
@@ -448,8 +448,8 @@ func Test_IP6FlowSpecExtended(t *testing.T) {
 func Test_FlowSpecNlriv6(t *testing.T) {
 	assert := assert.New(t)
 	cmp := make([]FlowSpecComponentInterface, 0)
-	cmp = append(cmp, NewFlowSpecDestinationPrefix6(NewIPv6AddrPrefix(64, "2001::"), 12))
-	cmp = append(cmp, NewFlowSpecSourcePrefix6(NewIPv6AddrPrefix(64, "2001::"), 12))
+	cmp = append(cmp, NewFlowSpecDestinationPrefix6(64, 12, "2001::"))
+	cmp = append(cmp, NewFlowSpecSourcePrefix6(64, 12, "2001::"))
 	item1 := NewFlowSpecComponentItem(DEC_NUM_OP_EQ, TCP)
 	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_IP_PROTO, []*FlowSpecComponentItem{item1}))
 	item2 := NewFlowSpecComponentItem(DEC_NUM_OP_GT_EQ, 20)
@@ -546,8 +546,8 @@ func Test_NotificationErrorCode(t *testing.T) {
 func Test_FlowSpecNlriVPN(t *testing.T) {
 	assert := assert.New(t)
 	cmp := make([]FlowSpecComponentInterface, 0)
-	cmp = append(cmp, NewFlowSpecDestinationPrefix(NewIPAddrPrefix(24, "10.0.0.0")))
-	cmp = append(cmp, NewFlowSpecSourcePrefix(NewIPAddrPrefix(24, "10.0.0.0")))
+	cmp = append(cmp, NewFlowSpecDestinationPrefix(24, "10.0.0.0"))
+	cmp = append(cmp, NewFlowSpecSourcePrefix(24, "10.0.0.0"))
 	rd, _ := ParseRouteDistinguisher("100:100")
 	n1 := NewFlowSpecIPv4VPN(rd, cmp)
 	buf1, err := n1.Serialize()
@@ -743,7 +743,7 @@ func Test_AddPath(t *testing.T) {
 	}
 	opt = &MarshallingOption{AddPath: map[RouteFamily]BGPAddPathMode{RF_FS_IPv4_UC: BGP_ADD_PATH_BOTH}}
 	{
-		n1 := NewFlowSpecIPv4Unicast([]FlowSpecComponentInterface{NewFlowSpecDestinationPrefix(NewIPAddrPrefix(24, "10.0.0.0"))})
+		n1 := NewFlowSpecIPv4Unicast([]FlowSpecComponentInterface{NewFlowSpecDestinationPrefix(24, "10.0.0.0")})
 		n1.SetPathLocalIdentifier(60)
 		bits, err := n1.Serialize(opt)
 		assert.Nil(err)

--- a/packet/bgp/bgp_test.go
+++ b/packet/bgp/bgp_test.go
@@ -91,6 +91,7 @@ func Test_RouteTargetMembershipNLRIString(t *testing.T) {
 
 	// IPv4AddressSpecificExtended
 	buf = make([]byte, 13)
+	buf[0] = 12
 	binary.BigEndian.PutUint32(buf[1:5], 65546)
 	buf[5] = byte(EC_TYPE_TRANSITIVE_IP4_SPECIFIC) // typehigh
 	ip := net.ParseIP("10.0.0.1").To4()
@@ -108,6 +109,7 @@ func Test_RouteTargetMembershipNLRIString(t *testing.T) {
 
 	// FourOctetAsSpecificExtended
 	buf = make([]byte, 13)
+	buf[0] = 12
 	binary.BigEndian.PutUint32(buf[1:5], 65546)
 	buf[5] = byte(EC_TYPE_TRANSITIVE_FOUR_OCTET_AS_SPECIFIC) // typehigh
 	buf[6] = byte(EC_SUBTYPE_ROUTE_TARGET)                   // subtype
@@ -125,6 +127,7 @@ func Test_RouteTargetMembershipNLRIString(t *testing.T) {
 
 	// OpaqueExtended
 	buf = make([]byte, 13)
+	buf[0] = 12
 	binary.BigEndian.PutUint32(buf[1:5], 65546)
 	buf[5] = byte(EC_TYPE_TRANSITIVE_OPAQUE) // typehigh
 	binary.BigEndian.PutUint32(buf[9:], 1000000)
@@ -140,6 +143,7 @@ func Test_RouteTargetMembershipNLRIString(t *testing.T) {
 
 	// Unknown
 	buf = make([]byte, 13)
+	buf[0] = 12
 	binary.BigEndian.PutUint32(buf[1:5], 65546)
 	buf[5] = 0x04 // typehigh
 	binary.BigEndian.PutUint32(buf[9:], 1000000)

--- a/packet/bgp/constant.go
+++ b/packet/bgp/constant.go
@@ -35,7 +35,8 @@ const (
 	BGP_FSM_ESTABLISHED
 )
 
-// partially taken from http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+// Protocol shows assigned Internet Protocol Numbers.
+// Partially taken from http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
 type Protocol int
 
 const (
@@ -103,8 +104,8 @@ var TCPFlagNameMap = map[TCPFlag]string{
 	TCP_FLAG_ECE:    "E",
 }
 
-// Prepares a sorted list of flags because map iterations does not happen
-// in a consistent order in Golang.
+// TCPSortedFlags prepares a sorted list of flags because map iterations does
+// not happen in a consistent order in Golang.
 var TCPSortedFlags = []TCPFlag{
 	TCP_FLAG_FIN,
 	TCP_FLAG_SYN,
@@ -145,6 +146,8 @@ var BitmaskFlagOpNameMap = map[BitmaskFlagOp]string{
 	BITMASK_FLAG_OP_MATCH: "=",
 }
 
+// BitmaskFlagOpValueMap shows the combinations of the bit flags for the Flow
+// Spec Bitmask operator.
 // Note: Meaning of "" is different from that of the numeric operator because
 // RFC5575 says if the Match bit in the bitmask operand is set, it should be
 // "strictly" matching against the given value.
@@ -194,8 +197,8 @@ var FragmentFlagNameMap = map[FragmentFlag]string{
 	FRAG_FLAG_LAST:  "last-fragment",
 }
 
-// Prepares a sorted list of flags because map iterations does not happen
-// in a consistent order in Golang.
+// FragmentSortedFlags prepares a sorted list of flags because map iterations
+// does not happen in a consistent order in Golang.
 var FragmentSortedFlags = []FragmentFlag{
 	FRAG_FLAG_NOT,
 	FRAG_FLAG_DONT,
@@ -282,7 +285,8 @@ func (f DECNumOp) String() string {
 	return strings.Join(ops, "")
 }
 
-// Potentially taken from https://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml
+// EthernetType shows Ethernet Types.
+// Partially taken from https://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml
 type EthernetType int
 
 const (

--- a/packet/bgp/validate.go
+++ b/packet/bgp/validate.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-// Validator for BGPUpdate
+// ValidateUpdateMsg validates the given BGPUpdate message.
 func ValidateUpdateMsg(m *BGPUpdate, rfs map[RouteFamily]BGPAddPathMode, isEBGP bool, isConfed bool) (bool, error) {
 	var strongestError error
 
@@ -177,9 +177,8 @@ func ValidateAttribute(a PathAttributeInterface, rfs map[RouteFamily]BGPAddPathM
 			asParam, y := p.(*As4PathParam)
 			if y {
 				return asParam.Type
-			} else {
-				return p.(*AsPathParam).Type
 			}
+			return p.(*AsPathParam).Type
 		}
 		if isEBGP {
 			if isConfed {

--- a/packet/bgp/validate_test.go
+++ b/packet/bgp/validate_test.go
@@ -366,8 +366,8 @@ func Test_Validate_aspath(t *testing.T) {
 func Test_Validate_flowspec(t *testing.T) {
 	assert := assert.New(t)
 	cmp := make([]FlowSpecComponentInterface, 0)
-	cmp = append(cmp, NewFlowSpecDestinationPrefix(NewIPAddrPrefix(24, "10.0.0.0")))
-	cmp = append(cmp, NewFlowSpecSourcePrefix(NewIPAddrPrefix(24, "10.0.0.0")))
+	cmp = append(cmp, NewFlowSpecDestinationPrefix(24, "10.0.0.0"))
+	cmp = append(cmp, NewFlowSpecSourcePrefix(24, "10.0.0.0"))
 	item1 := NewFlowSpecComponentItem(DEC_NUM_OP_EQ, TCP)
 	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_IP_PROTO, []*FlowSpecComponentItem{item1}))
 	item2 := NewFlowSpecComponentItem(DEC_NUM_OP_GT_EQ, 20)
@@ -393,8 +393,8 @@ func Test_Validate_flowspec(t *testing.T) {
 	assert.Nil(err)
 
 	cmp = make([]FlowSpecComponentInterface, 0)
-	cmp = append(cmp, NewFlowSpecSourcePrefix(NewIPAddrPrefix(24, "10.0.0.0")))
-	cmp = append(cmp, NewFlowSpecDestinationPrefix(NewIPAddrPrefix(24, "10.0.0.0")))
+	cmp = append(cmp, NewFlowSpecSourcePrefix(24, "10.0.0.0"))
+	cmp = append(cmp, NewFlowSpecDestinationPrefix(24, "10.0.0.0"))
 	n1 = NewFlowSpecIPv4Unicast(cmp)
 	a = NewPathAttributeMpReachNLRI("", []AddrPrefixInterface{n1})
 	// Swaps components order to reproduce the rules order violation.

--- a/server/zclient.go
+++ b/server/zclient.go
@@ -231,18 +231,18 @@ func newIPRouteBody(dst pathList) (body *zebra.IPRouteBody, isWithdraw bool) {
 	switch path.GetRouteFamily() {
 	case bgp.RF_IPv4_UC, bgp.RF_IPv4_VPN:
 		if path.GetRouteFamily() == bgp.RF_IPv4_UC {
-			prefix = path.GetNlri().(*bgp.IPAddrPrefix).IPAddrPrefixDefault.Prefix.To4()
+			prefix = path.GetNlri().(*bgp.IPAddrPrefix).Prefix.To4()
 		} else {
-			prefix = path.GetNlri().(*bgp.LabeledVPNIPAddrPrefix).IPAddrPrefixDefault.Prefix.To4()
+			prefix = path.GetNlri().(*bgp.LabeledVPNIPAddrPrefix).Prefix.To4()
 		}
 		for _, p := range paths {
 			nexthops = append(nexthops, p.GetNexthop().To4())
 		}
 	case bgp.RF_IPv6_UC, bgp.RF_IPv6_VPN:
 		if path.GetRouteFamily() == bgp.RF_IPv6_UC {
-			prefix = path.GetNlri().(*bgp.IPv6AddrPrefix).IPAddrPrefixDefault.Prefix.To16()
+			prefix = path.GetNlri().(*bgp.IPv6AddrPrefix).Prefix.To16()
 		} else {
-			prefix = path.GetNlri().(*bgp.LabeledVPNIPv6AddrPrefix).IPAddrPrefixDefault.Prefix.To16()
+			prefix = path.GetNlri().(*bgp.LabeledVPNIPv6AddrPrefix).Prefix.To16()
 		}
 		for _, p := range paths {
 			nexthops = append(nexthops, p.GetNexthop().To16())


### PR DESCRIPTION
This patch refactors the inheritance (embedding) relationship of IPAddrPrefix and its derivatives and removes "addrlen" field. "addrlen" is used only to determine whether the given prefix is IPv4 or IPv6.