### PR TITLE
cmd/global: Add and refine help messages for adding routes

### DIFF
--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -1246,15 +1246,21 @@ func modPath(resource string, name, modtype string, args []string) error {
 		ss = append(ss, "<DEC_NUM>")
 		etherTypes := strings.Join(ss, ", ")
 		helpErrMap := map[bgp.RouteFamily]error{}
-		ucHelpMsgFmt := fmt.Sprintf(`error: %s
-usage: %s rib -a %%s %s <PREFIX> [identifier <VALUE>] [origin { igp | egp | incomplete }] [aspath <VALUE>] [nexthop <ADDRESS>] [med <VALUE>] [local-pref <VALUE>] [community <VALUE>] [aigp metric <METRIC>] [large-community <VALUE>]`,
+		baseHelpMsgFmt := fmt.Sprintf(`error: %s
+usage: %s rib -a %%s %s <PREFIX> %%s [origin { igp | egp | incomplete }] [aspath <VALUE>] [nexthop <ADDRESS>] [med <VALUE>] [local-pref <VALUE>] [community <VALUE>] [aigp metric <METRIC>] [large-community <VALUE>] [aggregator <AS:ADDRESS>]`,
 			err,
 			cmdstr,
 			// <address family>
 			modtype,
+			// <label, rd>
 		)
-		helpErrMap[bgp.RF_IPv4_UC] = fmt.Errorf(ucHelpMsgFmt, "ipv4")
-		helpErrMap[bgp.RF_IPv6_UC] = fmt.Errorf(ucHelpMsgFmt, "ipv6")
+		helpErrMap[bgp.RF_IPv4_UC] = fmt.Errorf(baseHelpMsgFmt, "ipv4", "[identifier <VALUE>]")
+		helpErrMap[bgp.RF_IPv6_UC] = fmt.Errorf(baseHelpMsgFmt, "ipv6", "[identifier <VALUE>]")
+		helpErrMap[bgp.RF_IPv4_VPN] = fmt.Errorf(baseHelpMsgFmt, "vpnv4", "label <LABEL> rd <RD> [rt <RT>]")
+		helpErrMap[bgp.RF_IPv6_VPN] = fmt.Errorf(baseHelpMsgFmt, "vpnv6", "label <LABEL> rd <RD> [rt <RT>]")
+		helpErrMap[bgp.RF_IPv4_MPLS] = fmt.Errorf(baseHelpMsgFmt, "ipv4-mpls", "<LABEL>")
+		helpErrMap[bgp.RF_IPv6_MPLS] = fmt.Errorf(baseHelpMsgFmt, "ipv6-mpls", "<LABEL>")
+
 		fsHelpMsgFmt := fmt.Sprintf(`error: %s
 usage: %s rib -a %%s %s%%s match <MATCH> then <THEN>%%s%%s%%s
     <THEN> : { %s |

--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -1247,7 +1247,11 @@ func modPath(resource string, name, modtype string, args []string) error {
 		etherTypes := strings.Join(ss, ", ")
 		helpErrMap := map[bgp.RouteFamily]error{}
 		baseHelpMsgFmt := fmt.Sprintf(`error: %s
-usage: %s rib -a %%s %s <PREFIX> %%s [origin { igp | egp | incomplete }] [aspath <VALUE>] [nexthop <ADDRESS>] [med <VALUE>] [local-pref <VALUE>] [community <VALUE>] [aigp metric <METRIC>] [large-community <VALUE>] [aggregator <AS:ADDRESS>]`,
+usage: %s rib -a %%s %s <PREFIX> %%s [origin { igp | egp | incomplete }] [aspath <ASPATH>] [nexthop <ADDRESS>] [med <NUM>] [local-pref <NUM>] [community <COMMUNITY>] [aigp metric <NUM>] [large-community <LARGE_COMMUNITY>] [aggregator <AGGREGATOR>]
+	<ASPATH>: <AS>[,<AS>],
+	<COMMUNITY>: xxx:xxx|internet|planned-shut|accept-own|route-filter-translated-v4|route-filter-v4|route-filter-translated-v6|route-filter-v6|llgr-stale|no-llgr|blackhole|no-export|no-advertise|no-export-subconfed|no-peer,
+	<LARGE_COMMUNITY>: xxx:xxx:xxx[,<LARGE_COMMUNITY>],
+	<AGGREGATOR>: <AS>:<ADDRESS>`,
 			err,
 			cmdstr,
 			// <address family>


### PR DESCRIPTION
This PR contains the following fixes for help messages for adding routes via CLI:
* Show help messages when an user inputs an invalid L3VPN or MPLS routes
* Add a description to the parameter that was not sufficiently explained