### PR TITLE
server/server: Set rsRib to RS client in adding dynamic neighbor

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -251,7 +251,11 @@ func (server *BgpServer) Serve() {
 				log.WithFields(log.Fields{
 					"Topic": "Peer",
 				}).Debugf("Accepted a new dynamic neighbor from:%s", remoteAddr)
-				peer := newDynamicPeer(&server.bgpConfig.Global, remoteAddr, pg.Conf, server.globalRib, server.policy)
+				rib := server.globalRib
+				if pg.Conf.RouteServer.Config.RouteServerClient {
+					rib = server.rsRib
+				}
+				peer := newDynamicPeer(&server.bgpConfig.Global, remoteAddr, pg.Conf, rib, server.policy)
 				if peer == nil {
 					log.WithFields(log.Fields{
 						"Topic": "Peer",


### PR DESCRIPTION
Currently, globalRib is always set to dynamic neighbors even if they are route server clients.
This patch fixes to set rsRib when the neighbor is a route server client.

This fixes #1622.