### PR TITLE
cmd: Prevent accepting unexpected argument names

### DIFF
--- a/gobgp/cmd/common_test.go
+++ b/gobgp/cmd/common_test.go
@@ -25,8 +25,13 @@ import (
 func Test_ExtractReserved(t *testing.T) {
 	assert := assert.New(t)
 	args := strings.Split("10 rt 100:100 med 10 nexthop 10.0.0.1 aigp metric 10 local-pref 100", " ")
-	keys := []string{"rt", "med", "nexthop", "aigp", "local-pref"}
-	m := extractReserved(args, keys)
+	keys := map[string]int{
+		"rt":         PARAM_LIST,
+		"med":        PARAM_SINGLE,
+		"nexthop":    PARAM_SINGLE,
+		"aigp":       PARAM_LIST,
+		"local-pref": PARAM_SINGLE}
+	m, _ := extractReserved(args, keys)
 	fmt.Println(m)
 	assert.True(len(m["rt"]) == 1)
 	assert.True(len(m["med"]) == 1)

--- a/gobgp/cmd/neighbor.go
+++ b/gobgp/cmd/neighbor.go
@@ -973,13 +973,22 @@ func modNeighborPolicy(remoteIP, policyType, cmdType string, args []string) erro
 }
 
 func modNeighbor(cmdType string, args []string) error {
-	m := extractReserved(args, []string{"interface", "as", "family", "vrf", "route-reflector-client", "route-server-client", "allow-own-as", "remove-private-as", "replace-peer-as"})
+	params := map[string]int{"interface": PARAM_SINGLE}
 	usage := fmt.Sprintf("usage: gobgp neighbor %s [ <neighbor-address> | interface <neighbor-interface> ]", cmdType)
 	if cmdType == CMD_ADD {
+		params["as"] = PARAM_SINGLE
+		params["family"] = PARAM_SINGLE
+		params["vrf"] = PARAM_SINGLE
+		params["route-reflector-client"] = PARAM_SINGLE
+		params["route-server-client"] = PARAM_FLAG
+		params["allow-own-as"] = PARAM_SINGLE
+		params["remove-private-as"] = PARAM_SINGLE
+		params["replace-peer-as"] = PARAM_FLAG
 		usage += " as <VALUE> [ family <address-families-list> | vrf <vrf-name> | route-reflector-client [<cluster-id>] | route-server-client | allow-own-as <num> | remove-private-as (all|replace) | replace-peer-as ]"
 	}
 
-	if (len(m[""]) != 1 && len(m["interface"]) != 1) || len(m["as"]) > 1 || len(m["family"]) > 1 || len(m["vrf"]) > 1 || len(m["route-reflector-client"]) > 1 || len(m["allow-own-as"]) > 1 || len(m["remove-private-as"]) > 1 {
+	m, err := extractReserved(args, params)
+	if err != nil || (len(m[""]) != 1 && len(m["interface"]) != 1) {
 		return fmt.Errorf("%s", usage)
 	}
 	unnumbered := len(m["interface"]) > 0

--- a/gobgp/cmd/vrf.go
+++ b/gobgp/cmd/vrf.go
@@ -93,8 +93,11 @@ func modVrf(typ string, args []string) error {
 	var err error
 	switch typ {
 	case CMD_ADD:
-		a := extractReserved(args, []string{"rd", "rt", "id"})
-		if len(a[""]) != 1 || len(a["rd"]) != 1 || len(a["rt"]) < 2 || len(a["id"]) > 1 {
+		a, err := extractReserved(args, map[string]int{
+			"rd": PARAM_SINGLE,
+			"rt": PARAM_LIST,
+			"id": PARAM_SINGLE})
+		if err != nil || len(a[""]) != 1 || len(a["rd"]) != 1 || len(a["rt"]) < 2 {
 			return fmt.Errorf("Usage: gobgp vrf add <vrf name> [ id <id> ] rd <rd> rt { import | export | both } <rt>...")
 		}
 		name := a[""][0]


### PR DESCRIPTION
In CLI operation, currently, unexpected argument names
(such as 'aspath' for 'gobgp neighbor add')
may pass the validations and return no errors.
This commit prevents accepting those argument names
by specifying the number of expected arguments for each argument names.