### PR TITLE
mrt: Enable to dump locally generated routes

### DIFF
--- a/server/mrt.go
+++ b/server/mrt.go
@@ -392,12 +392,12 @@ func (m *mrtManager) enable(c *config.MrtConfig) error {
 }
 
 func (m *mrtManager) disable(c *config.MrtConfig) error {
-	if w, ok := m.writer[c.FileName]; !ok {
+	w, ok := m.writer[c.FileName]
+	if !ok {
 		return fmt.Errorf("%s doesn't exists", c.FileName)
-	} else {
-		w.Stop()
-		delete(m.writer, c.FileName)
 	}
+	w.Stop()
+	delete(m.writer, c.FileName)
 	return nil
 }
 


### PR DESCRIPTION
For reloading locally generated routes by using MRT dump file, this patch enables to include locally generated routes into TABLE_DUMPv2 records.

For the backward compatibility, this patch adds a new configure option "include-local" into "mrt-dump.config" section and please enable this option to include locally generated routes.

Configuration Example:

```toml
[[mrt-dump]]
  [mrt-dump.config]
    dump-type = "table"
    file-name = "/tmp/table.dump"
    dump-interval = 60
    include-local = true
```