### PR TITLE
packet/bgp: Avoid data race when serializing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ _unittest: &_unittest
   <<: *_dep_ensure
   script:
     - go test $(go list ./... | grep -v '/vendor/')
+    - if [ "$(go env GOARCH)" = "amd64" ]; then go test -race github.com/osrg/gobgp/packet/bgp -run ^Test_RaceCondition$; else echo 'skip'; fi
     - go build -o ./gobgp/gobgp   ./gobgp/
     - go build -o ./gobgpd/gobgpd ./gobgpd/
 

--- a/gobgp/cmd/global.go
+++ b/gobgp/cmd/global.go
@@ -460,7 +460,7 @@ func ParseEvpnEthernetAutoDiscoveryArgs(args []string) (bgp.AddrPrefixInterface,
 		ETag:  etag,
 		Label: label,
 	}
-	return bgp.NewEVPNNLRI(bgp.EVPN_ROUTE_TYPE_ETHERNET_AUTO_DISCOVERY, 0, r), extcomms, nil
+	return bgp.NewEVPNNLRI(bgp.EVPN_ROUTE_TYPE_ETHERNET_AUTO_DISCOVERY, r), extcomms, nil
 }
 
 func ParseEvpnMacAdvArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {
@@ -577,7 +577,7 @@ func ParseEvpnMacAdvArgs(args []string) (bgp.AddrPrefixInterface, []string, erro
 		Labels:           labels,
 		ETag:             uint32(eTag),
 	}
-	return bgp.NewEVPNNLRI(bgp.EVPN_ROUTE_TYPE_MAC_IP_ADVERTISEMENT, 0, r), extcomms, nil
+	return bgp.NewEVPNNLRI(bgp.EVPN_ROUTE_TYPE_MAC_IP_ADVERTISEMENT, r), extcomms, nil
 }
 
 func ParseEvpnMulticastArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {
@@ -651,7 +651,7 @@ func ParseEvpnMulticastArgs(args []string) (bgp.AddrPrefixInterface, []string, e
 		IPAddress:       ip,
 		ETag:            uint32(eTag),
 	}
-	return bgp.NewEVPNNLRI(bgp.EVPN_INCLUSIVE_MULTICAST_ETHERNET_TAG, 0, r), extcomms, nil
+	return bgp.NewEVPNNLRI(bgp.EVPN_INCLUSIVE_MULTICAST_ETHERNET_TAG, r), extcomms, nil
 }
 
 func ParseEvpnEthernetSegmentArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {
@@ -715,7 +715,7 @@ func ParseEvpnEthernetSegmentArgs(args []string) (bgp.AddrPrefixInterface, []str
 		IPAddressLength: uint8(ipLen),
 		IPAddress:       ip,
 	}
-	return bgp.NewEVPNNLRI(bgp.EVPN_ETHERNET_SEGMENT_ROUTE, 0, r), extcomms, nil
+	return bgp.NewEVPNNLRI(bgp.EVPN_ETHERNET_SEGMENT_ROUTE, r), extcomms, nil
 }
 
 func ParseEvpnIPPrefixArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {
@@ -803,7 +803,7 @@ func ParseEvpnIPPrefixArgs(args []string) (bgp.AddrPrefixInterface, []string, er
 		GWIPAddress:    gw,
 		Label:          label,
 	}
-	return bgp.NewEVPNNLRI(bgp.EVPN_IP_PREFIX, 0, r), extcomms, nil
+	return bgp.NewEVPNNLRI(bgp.EVPN_IP_PREFIX, r), extcomms, nil
 }
 
 func ParseEvpnArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -2307,6 +2307,15 @@ func (er *EVPNEthernetAutoDiscoveryRoute) rd() RouteDistinguisherInterface {
 	return er.RD
 }
 
+func NewEVPNEthernetAutoDiscoveryRoute(rd RouteDistinguisherInterface, esi EthernetSegmentIdentifier, etag uint32, label uint32) *EVPNNLRI {
+	return NewEVPNNLRI(EVPN_ROUTE_TYPE_ETHERNET_AUTO_DISCOVERY, &EVPNEthernetAutoDiscoveryRoute{
+		RD:    rd,
+		ESI:   esi,
+		ETag:  etag,
+		Label: label,
+	})
+}
+
 type EVPNMacIPAdvertisementRoute struct {
 	RD               RouteDistinguisherInterface
 	ESI              EthernetSegmentIdentifier
@@ -2441,6 +2450,30 @@ func (er *EVPNMacIPAdvertisementRoute) rd() RouteDistinguisherInterface {
 	return er.RD
 }
 
+func NewEVPNMacIPAdvertisementRoute(rd RouteDistinguisherInterface, esi EthernetSegmentIdentifier, etag uint32, macAddress string, ipAddress string, labels []uint32) *EVPNNLRI {
+	mac, _ := net.ParseMAC(macAddress)
+	var ipLen uint8
+	ip := net.ParseIP(ipAddress)
+	if ip != nil {
+		if ipv4 := ip.To4(); ipv4 != nil {
+			ipLen = 32
+			ip = ipv4
+		} else {
+			ipLen = 128
+		}
+	}
+	return NewEVPNNLRI(EVPN_ROUTE_TYPE_MAC_IP_ADVERTISEMENT, &EVPNMacIPAdvertisementRoute{
+		RD:               rd,
+		ESI:              esi,
+		ETag:             etag,
+		MacAddressLength: 6,
+		MacAddress:       mac,
+		IPAddressLength:  ipLen,
+		IPAddress:        ip,
+		Labels:           labels,
+	})
+}
+
 type EVPNMulticastEthernetTagRoute struct {
 	RD              RouteDistinguisherInterface
 	ETag            uint32
@@ -2522,6 +2555,22 @@ func (er *EVPNMulticastEthernetTagRoute) rd() RouteDistinguisherInterface {
 	return er.RD
 }
 
+func NewEVPNMulticastEthernetTagRoute(rd RouteDistinguisherInterface, etag uint32, ipAddress string) *EVPNNLRI {
+	ipLen := uint8(32)
+	ip := net.ParseIP(ipAddress)
+	if ipv4 := ip.To4(); ipv4 != nil {
+		ip = ipv4
+	} else {
+		ipLen = 128
+	}
+	return NewEVPNNLRI(EVPN_INCLUSIVE_MULTICAST_ETHERNET_TAG, &EVPNMulticastEthernetTagRoute{
+		RD:              rd,
+		ETag:            etag,
+		IPAddressLength: ipLen,
+		IPAddress:       ip,
+	})
+}
+
 type EVPNEthernetSegmentRoute struct {
 	RD              RouteDistinguisherInterface
 	ESI             EthernetSegmentIdentifier
@@ -2600,6 +2649,22 @@ func (er *EVPNEthernetSegmentRoute) MarshalJSON() ([]byte, error) {
 
 func (er *EVPNEthernetSegmentRoute) rd() RouteDistinguisherInterface {
 	return er.RD
+}
+
+func NewEVPNEthernetSegmentRoute(rd RouteDistinguisherInterface, esi EthernetSegmentIdentifier, ipAddress string) *EVPNNLRI {
+	ipLen := uint8(32)
+	ip := net.ParseIP(ipAddress)
+	if ipv4 := ip.To4(); ipv4 != nil {
+		ip = ipv4
+	} else {
+		ipLen = 128
+	}
+	return NewEVPNNLRI(EVPN_ETHERNET_SEGMENT_ROUTE, &EVPNEthernetSegmentRoute{
+		RD:              rd,
+		ESI:             esi,
+		IPAddressLength: ipLen,
+		IPAddress:       ip,
+	})
 }
 
 type EVPNIPPrefixRoute struct {
@@ -2734,6 +2799,24 @@ func (er *EVPNIPPrefixRoute) MarshalJSON() ([]byte, error) {
 
 func (er *EVPNIPPrefixRoute) rd() RouteDistinguisherInterface {
 	return er.RD
+}
+
+func NewEVPNIPPrefixRoute(rd RouteDistinguisherInterface, esi EthernetSegmentIdentifier, etag uint32, ipPrefixLength uint8, ipPrefix string, gateway string, label uint32) *EVPNNLRI {
+	ip := net.ParseIP(ipPrefix)
+	gw := net.ParseIP(gateway)
+	if ipv4 := ip.To4(); ipv4 != nil {
+		ip = ipv4
+		gw = gw.To4()
+	}
+	return NewEVPNNLRI(EVPN_IP_PREFIX, &EVPNIPPrefixRoute{
+		RD:             rd,
+		ESI:            esi,
+		ETag:           etag,
+		IPPrefixLength: ipPrefixLength,
+		IPPrefix:       ip,
+		GWIPAddress:    gw,
+		Label:          label,
+	})
 }
 
 type EVPNRouteTypeInterface interface {

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -2855,11 +2855,15 @@ func (n *EVPNNLRI) RD() RouteDistinguisherInterface {
 	return n.RouteTypeData.rd()
 }
 
-func NewEVPNNLRI(routetype uint8, length uint8, routetypedata EVPNRouteTypeInterface) *EVPNNLRI {
+func NewEVPNNLRI(routeType uint8, routeTypeData EVPNRouteTypeInterface) *EVPNNLRI {
+	var l uint8
+	if routeTypeData != nil {
+		l = uint8(routeTypeData.Len())
+	}
 	return &EVPNNLRI{
-		RouteType:     routetype,
-		Length:        length,
-		RouteTypeData: routetypedata,
+		RouteType:     routeType,
+		Length:        l,
+		RouteTypeData: routeTypeData,
 	}
 }
 
@@ -4681,7 +4685,7 @@ func NewPrefixFromRouteFamily(afi uint16, safi uint8) (prefix AddrPrefixInterfac
 	case RF_IPv6_MPLS:
 		prefix = NewLabeledIPv6AddrPrefix(0, "", *NewMPLSLabelStack())
 	case RF_EVPN:
-		prefix = NewEVPNNLRI(0, 0, nil)
+		prefix = NewEVPNNLRI(0, nil)
 	case RF_RTC_UC:
 		prefix = &RouteTargetMembershipNLRI{}
 	case RF_IPv4_ENCAP:

--- a/packet/bgp/bgp_race_test.go
+++ b/packet/bgp/bgp_race_test.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2018 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build race
+
+package bgp
+
+import (
+	"testing"
+	"time"
+)
+
+// Test_RaceCondition detects data races when serialization.
+// Currently tests only attributes contained in UPDATE message.
+func Test_RaceCondition(t *testing.T) {
+	m := NewTestBGPUpdateMessage()
+	updateBody := m.Body.(*BGPUpdate)
+
+	go func(body *BGPUpdate) {
+		for _, v := range body.WithdrawnRoutes {
+			v.Serialize()
+		}
+		for _, v := range body.PathAttributes {
+			v.Serialize()
+		}
+		for _, v := range body.NLRI {
+			v.Serialize()
+		}
+	}(updateBody)
+
+	time.Sleep(time.Second)
+
+	updateBody.Serialize()
+}

--- a/packet/bgp/bgp_test.go
+++ b/packet/bgp/bgp_test.go
@@ -585,7 +585,7 @@ func Test_EVPNIPPrefixRoute(t *testing.T) {
 		GWIPAddress:    net.IP{10, 10, 10, 10},
 		Label:          1000,
 	}
-	n1 := NewEVPNNLRI(EVPN_IP_PREFIX, 0, r)
+	n1 := NewEVPNNLRI(EVPN_IP_PREFIX, r)
 	buf1, err := n1.Serialize()
 	assert.Nil(err)
 	n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_EVPN))
@@ -722,13 +722,13 @@ func Test_AddPath(t *testing.T) {
 	}
 	opt = &MarshallingOption{AddPath: map[RouteFamily]BGPAddPathMode{RF_EVPN: BGP_ADD_PATH_BOTH}}
 	{
-		n1 := NewEVPNNLRI(EVPN_ROUTE_TYPE_ETHERNET_AUTO_DISCOVERY, 0,
+		n1 := NewEVPNNLRI(EVPN_ROUTE_TYPE_ETHERNET_AUTO_DISCOVERY,
 			&EVPNEthernetAutoDiscoveryRoute{NewRouteDistinguisherFourOctetAS(5, 6),
 				EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, 2, 2})
 		n1.SetPathLocalIdentifier(40)
 		bits, err := n1.Serialize(opt)
 		assert.Nil(err)
-		n2 := NewEVPNNLRI(0, 0, nil)
+		n2 := NewEVPNNLRI(0, nil)
 		err = n2.DecodeFromBytes(bits, opt)
 		assert.Nil(err)
 		assert.Equal(n2.PathIdentifier(), uint32(40))

--- a/packet/bgp/helper.go
+++ b/packet/bgp/helper.go
@@ -15,10 +15,6 @@
 
 package bgp
 
-import (
-	"net"
-)
-
 func NewTestBGPOpenMessage() *BGPMessage {
 	p1 := NewOptionParameterCapability(
 		[]ParameterCapabilityInterface{NewCapRouteRefresh()})
@@ -90,22 +86,12 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 	prefixes4 := []AddrPrefixInterface{NewLabeledIPAddrPrefix(25, "192.168.0.0",
 		*NewMPLSLabelStack(5, 6, 7))}
 
-	mac, _ := net.ParseMAC("01:23:45:67:89:ab")
 	prefixes5 := []AddrPrefixInterface{
-		NewEVPNNLRI(EVPN_ROUTE_TYPE_ETHERNET_AUTO_DISCOVERY,
-			&EVPNEthernetAutoDiscoveryRoute{NewRouteDistinguisherFourOctetAS(5, 6),
-				EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, 2, 2}),
-		NewEVPNNLRI(EVPN_ROUTE_TYPE_MAC_IP_ADVERTISEMENT,
-			&EVPNMacIPAdvertisementRoute{NewRouteDistinguisherFourOctetAS(5, 6),
-				EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, 3, 48,
-				mac, 32, net.ParseIP("192.2.1.2"),
-				[]uint32{3, 4}}),
-		NewEVPNNLRI(EVPN_INCLUSIVE_MULTICAST_ETHERNET_TAG,
-			&EVPNMulticastEthernetTagRoute{NewRouteDistinguisherFourOctetAS(5, 6), 3, 32, net.ParseIP("192.2.1.2")}),
-		NewEVPNNLRI(EVPN_ETHERNET_SEGMENT_ROUTE,
-			&EVPNEthernetSegmentRoute{NewRouteDistinguisherFourOctetAS(5, 6),
-				EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)},
-				32, net.ParseIP("192.2.1.1")}),
+		NewEVPNEthernetAutoDiscoveryRoute(NewRouteDistinguisherFourOctetAS(5, 6), EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, 2, 2),
+		NewEVPNMacIPAdvertisementRoute(NewRouteDistinguisherFourOctetAS(5, 6), EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, 3, "01:23:45:67:89:ab", "192.2.1.2", []uint32{3, 4}),
+		NewEVPNMulticastEthernetTagRoute(NewRouteDistinguisherFourOctetAS(5, 6), 3, "192.2.1.2"),
+		NewEVPNEthernetSegmentRoute(NewRouteDistinguisherFourOctetAS(5, 6), EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, "192.2.1.1"),
+		NewEVPNIPPrefixRoute(NewRouteDistinguisherFourOctetAS(5, 6), EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, 5, 24, "192.2.1.0", "192.3.1.1", 5),
 	}
 
 	p := []PathAttributeInterface{

--- a/packet/bgp/helper.go
+++ b/packet/bgp/helper.go
@@ -92,17 +92,17 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 
 	mac, _ := net.ParseMAC("01:23:45:67:89:ab")
 	prefixes5 := []AddrPrefixInterface{
-		NewEVPNNLRI(EVPN_ROUTE_TYPE_ETHERNET_AUTO_DISCOVERY, 0,
+		NewEVPNNLRI(EVPN_ROUTE_TYPE_ETHERNET_AUTO_DISCOVERY,
 			&EVPNEthernetAutoDiscoveryRoute{NewRouteDistinguisherFourOctetAS(5, 6),
 				EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, 2, 2}),
-		NewEVPNNLRI(EVPN_ROUTE_TYPE_MAC_IP_ADVERTISEMENT, 0,
+		NewEVPNNLRI(EVPN_ROUTE_TYPE_MAC_IP_ADVERTISEMENT,
 			&EVPNMacIPAdvertisementRoute{NewRouteDistinguisherFourOctetAS(5, 6),
 				EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, 3, 48,
 				mac, 32, net.ParseIP("192.2.1.2"),
 				[]uint32{3, 4}}),
-		NewEVPNNLRI(EVPN_INCLUSIVE_MULTICAST_ETHERNET_TAG, 0,
+		NewEVPNNLRI(EVPN_INCLUSIVE_MULTICAST_ETHERNET_TAG,
 			&EVPNMulticastEthernetTagRoute{NewRouteDistinguisherFourOctetAS(5, 6), 3, 32, net.ParseIP("192.2.1.2")}),
-		NewEVPNNLRI(EVPN_ETHERNET_SEGMENT_ROUTE, 0,
+		NewEVPNNLRI(EVPN_ETHERNET_SEGMENT_ROUTE,
 			&EVPNEthernetSegmentRoute{NewRouteDistinguisherFourOctetAS(5, 6),
 				EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)},
 				32, net.ParseIP("192.2.1.1")}),

--- a/packet/bgp/helper.go
+++ b/packet/bgp/helper.go
@@ -119,13 +119,7 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 		NewPathAttributeMpUnreachNLRI(prefixes1),
 		//NewPathAttributeMpReachNLRI("112.22.2.0", []AddrPrefixInterface{}),
 		//NewPathAttributeMpUnreachNLRI([]AddrPrefixInterface{}),
-		&PathAttributeUnknown{
-			PathAttribute: PathAttribute{
-				Flags: BGP_ATTR_FLAG_TRANSITIVE,
-				Type:  100,
-			},
-			Value: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
-		},
+		NewPathAttributeUnknown(BGP_ATTR_FLAG_TRANSITIVE, 100, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
 	}
 	n := []*IPAddrPrefix{NewIPAddrPrefix(24, "13.2.3.1")}
 	return NewBGPUpdateMessage(w, p, n)

--- a/table/path.go
+++ b/table/path.go
@@ -1194,7 +1194,7 @@ func (p *Path) ToGlobal(vrf *Vrf) *Path {
 				IPAddress:        old.IPAddress,
 				Labels:           old.Labels,
 			}
-			nlri = bgp.NewEVPNNLRI(n.RouteType, n.Length, new)
+			nlri = bgp.NewEVPNNLRI(n.RouteType, new)
 		case bgp.EVPN_INCLUSIVE_MULTICAST_ETHERNET_TAG:
 			old := n.RouteTypeData.(*bgp.EVPNMulticastEthernetTagRoute)
 			new := &bgp.EVPNMulticastEthernetTagRoute{
@@ -1203,7 +1203,7 @@ func (p *Path) ToGlobal(vrf *Vrf) *Path {
 				IPAddressLength: old.IPAddressLength,
 				IPAddress:       old.IPAddress,
 			}
-			nlri = bgp.NewEVPNNLRI(n.RouteType, n.Length, new)
+			nlri = bgp.NewEVPNNLRI(n.RouteType, new)
 		}
 	default:
 		return p


### PR DESCRIPTION
This PR fixes `Serialize()` functions of parsers in `packet/bgp/bgp.go` in order to avoid data races when serializing BGP UPDATE messages.

similar to https://github.com/osrg/gobgp/issues/1614