### PR TITLE
server/rpki.go - Fixes #1633 - fixed typo

### DIFF
--- a/server/rpki.go
+++ b/server/rpki.go
@@ -65,9 +65,9 @@ func (r roas) Less(i, j int) bool {
 	r1 := r[i]
 	r2 := r[j]
 
-	if r1.MaxLen < r1.MaxLen {
+	if r1.MaxLen < r2.MaxLen {
 		return true
-	} else if r1.MaxLen > r1.MaxLen {
+	} else if r1.MaxLen > r2.MaxLen {
 		return false
 	}
 


### PR DESCRIPTION
The typo in function Less() was causing logical error during comparison
and the comparison would always return whether AS number was less or not
regardless of Maxlen