### PR TITLE
server/server: Restart peers when capabilities are changed

### DIFF
--- a/config/util.go
+++ b/config/util.go
@@ -216,7 +216,7 @@ func existPeerGroup(n string, b []PeerGroup) int {
 	return -1
 }
 
-func CheckAfiSafisChange(x, y []AfiSafi) bool {
+func isAfiSafiChanged(x, y []AfiSafi) bool {
 	if len(x) != len(y) {
 		return true
 	}
@@ -230,6 +230,14 @@ func CheckAfiSafisChange(x, y []AfiSafi) bool {
 		}
 	}
 	return false
+}
+
+func (n *Neighbor) NeedsResendOpenMessage(new *Neighbor) bool {
+	return !n.Config.Equal(&new.Config) ||
+		!n.Transport.Config.Equal(&new.Transport.Config) ||
+		!n.AddPaths.Config.Equal(&new.AddPaths.Config) ||
+		!n.GracefulRestart.Config.Equal(&new.GracefulRestart.Config) ||
+		isAfiSafiChanged(n.AfiSafis, new.AfiSafis)
 }
 
 func ParseMaskLength(prefix, mask string) (int, int, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -2032,7 +2032,7 @@ func (s *BgpServer) updateNeighbor(c *config.Neighbor) (needsSoftResetIn bool, e
 		needsSoftResetIn = true
 	}
 
-	if !original.Config.Equal(&c.Config) || !original.Transport.Config.Equal(&c.Transport.Config) || config.CheckAfiSafisChange(original.AfiSafis, c.AfiSafis) {
+	if original.NeedsResendOpenMessage(c) {
 		sub := uint8(bgp.BGP_ERROR_SUB_OTHER_CONFIGURATION_CHANGE)
 		if original.Config.AdminDown != c.Config.AdminDown {
 			sub = bgp.BGP_ERROR_SUB_ADMINISTRATIVE_SHUTDOWN


### PR DESCRIPTION
If capabilities are added or removed by updating peer configs,
it is needed to resend Open Message contains the new capabilities.
But currently, GoBGP does not resend Open Message for
Add-Path and Graceful Restart capabilities.
This commit fixes it to resend Open Message for them.

Signed-off-by: Satoshi Fujimoto <satoshi.fujimoto7@gmail.com>