### PR TITLE
Restore PathIdentifier for paths belonging to VRFs

### DIFF
--- a/table/path.go
+++ b/table/path.go
@@ -1153,10 +1153,14 @@ func (v *Vrf) ToGlobalPath(path *Path) error {
 	switch rf := path.GetRouteFamily(); rf {
 	case bgp.RF_IPv4_UC:
 		n := nlri.(*bgp.IPAddrPrefix)
+		pathIdentifier := path.GetNlri().PathIdentifier()
 		path.OriginInfo().nlri = bgp.NewLabeledVPNIPAddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(0), v.Rd)
+		path.GetNlri().SetPathIdentifier(pathIdentifier)
 	case bgp.RF_IPv6_UC:
 		n := nlri.(*bgp.IPv6AddrPrefix)
+		pathIdentifier := path.GetNlri().PathIdentifier()
 		path.OriginInfo().nlri = bgp.NewLabeledVPNIPv6AddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(0), v.Rd)
+		path.GetNlri().SetPathIdentifier(pathIdentifier)
 	case bgp.RF_EVPN:
 		n := nlri.(*bgp.EVPNNLRI)
 		switch n.RouteType {


### PR DESCRIPTION
When installing routes in a VRF the PathIdentifier is lost. This seems to be because we are replacing the `nlri` of the path with a new one that doesn't seem to maintain all the original attributes. This leads to the following situation:

```
# gobgp vrf red rib add -a ipv4 11.0.0.0/24 nexthop 1.1.1.2 identifier 2000000 aspath 1,2
# gobgp vrf red rib add -a ipv4 11.0.0.0/24 nexthop 1.1.1.1 identifier 1000000 aspath 3,4
# gobgp vrf red rib
  Network              Next Hop             AS_PATH              Age        Attrs
  11.0.0.0/24          1.1.1.1              3 4                  00:00:02   [{Origin: ?}]
```

As you can see even though the prefixes have different identifiers the first one is overwritten. This doesn't happen in the global rib:

```
# gobgp global rib add -a ipv4 11.0.0.0/24 nexthop 1.1.1.1 identifier 1000000 aspath 3,4
# gobgp global rib add -a ipv4 11.0.0.0/24 nexthop 1.1.1.2 identifier 2000000 aspath 3,4
# gobgp global rib
   Network              Next Hop             AS_PATH              Age        Attrs
*> 11.0.0.0/24          1.1.1.1              3 4                  00:00:08   [{Origin: ?}]
*  11.0.0.0/24          1.1.1.2              3 4                  00:00:02   [{Origin: ?}]
```

The patch in this PR solves this problem. This might not be your preferred way of fixing this and this might not be fixing all the problems of overwriting `path.OriginInfo().nlri` so feel free to scrap this PR and submit a patch of your own.

Thanks