### PR TITLE
cli: Show best path symbol on VRF RIB command

### DIFF
--- a/gobgp/cmd/neighbor.go
+++ b/gobgp/cmd/neighbor.go
@@ -701,6 +701,7 @@ func showNeighborRib(r string, name string, args []string) error {
 		showAge = false
 	case CMD_VRF:
 		def = bgp.RF_IPv4_UC
+		showBest = true
 	}
 	family, err := checkAddressFamily(def)
 	if err != nil {


### PR DESCRIPTION
This PR fixes to show the best path symbol (like `*>`) on `vrf <vame> rib` command.

Before:

```bash
$ gobgp vrf vrf1 rib -a ipv4
   Network              Next Hop             AS_PATH              Age        Attrs
   10.0.0.0/24          0.0.0.0                                   00:00:00   [{Origin: ?}]
```

After:

```bash
$ gobgp vrf vrf1 rib -a ipv4
   Network              Next Hop             AS_PATH              Age        Attrs
*> 10.0.0.0/24          0.0.0.0                                   00:00:00   [{Origin: ?}]
```