### PR TITLE
Close incoming channel in zapi on receive error

### DIFF
--- a/zebra/zapi.go
+++ b/zebra/zapi.go
@@ -623,6 +623,7 @@ func NewClient(network, address string, typ ROUTE_TYPE, version uint8) (*Client,
 
 	// Start receive loop only when the first message successfully received.
 	go func() {
+		defer close(incoming)
 		for {
 			if m, err := receiveSingleMsg(); err != nil {
 				return


### PR DESCRIPTION
Currently, it is not possible for a client of the zebra library to react to receive errors, e.g., when the far end closes the connection.

This simple fix allows a client to be notified about a receive error by closing the `incoming` channel.