### PR TITLE
table/path: require mandatory BGP attributes for a proposed path

### DIFF
--- a/table/path.go
+++ b/table/path.go
@@ -161,6 +161,19 @@ func NewPath(source *PeerInfo, nlri bgp.AddrPrefixInterface, isWithdraw bool, pa
 		return nil
 	}
 
+	if !isWithdraw {
+		originFound := false
+		for _, a := range pattrs {
+			if a.GetType() == bgp.BGP_ATTR_TYPE_ORIGIN {
+				originFound = true
+				break
+			}
+		}
+		if !originFound {
+			pattrs = append(pattrs, bgp.NewPathAttributeOrigin(0))
+		}
+	}
+
 	return &Path{
 		info: &originInfo{
 			nlri:               nlri,


### PR DESCRIPTION
[RFC4271 Section 5.1](https://tools.ietf.org/html/rfc4271#section-5.1) lists
well-known mandatory attributes. They are `ORIGIN`, `AS_PATH`, `NEXT_HOP`.
With this commit, the `NewPath()` function has a check to ensure that the
attributes are present when the function is being called.

Resolves: #1660

Signed-off-by: Paul Greenberg <greenpau@outlook.com>