### PR TITLE
config: Enable to configure VRF via config file

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -1250,6 +1250,112 @@ func (lhs *Mrt) Equal(rhs *Mrt) bool {
 }
 
 // struct for container gobgp:state.
+// Configured states of VRF.
+type VrfState struct {
+	// original -> gobgp:name
+	// Unique name among all VRF instances.
+	Name string `mapstructure:"name" json:"name,omitempty"`
+	// original -> gobgp:id
+	// Unique identifier among all VRF instances.
+	Id uint32 `mapstructure:"id" json:"id,omitempty"`
+	// original -> gobgp:rd
+	// Route Distinguisher for this VRF.
+	Rd string `mapstructure:"rd" json:"rd,omitempty"`
+	// original -> gobgp:import-rt
+	// List of import Route Targets for this VRF.
+	ImportRtList []string `mapstructure:"import-rt-list" json:"import-rt-list,omitempty"`
+	// original -> gobgp:export-rt
+	// List of export Route Targets for this VRF.
+	ExportRtList []string `mapstructure:"export-rt-list" json:"export-rt-list,omitempty"`
+}
+
+// struct for container gobgp:config.
+// Configuration parameters for VRF.
+type VrfConfig struct {
+	// original -> gobgp:name
+	// Unique name among all VRF instances.
+	Name string `mapstructure:"name" json:"name,omitempty"`
+	// original -> gobgp:id
+	// Unique identifier among all VRF instances.
+	Id uint32 `mapstructure:"id" json:"id,omitempty"`
+	// original -> gobgp:rd
+	// Route Distinguisher for this VRF.
+	Rd string `mapstructure:"rd" json:"rd,omitempty"`
+	// original -> gobgp:import-rt
+	// List of import Route Targets for this VRF.
+	ImportRtList []string `mapstructure:"import-rt-list" json:"import-rt-list,omitempty"`
+	// original -> gobgp:export-rt
+	// List of export Route Targets for this VRF.
+	ExportRtList []string `mapstructure:"export-rt-list" json:"export-rt-list,omitempty"`
+	// original -> gobgp:both-rt
+	// List of both import and export Route Targets for this VRF. Each
+	// configuration for import and export Route Targets will be preferred.
+	BothRtList []string `mapstructure:"both-rt-list" json:"both-rt-list,omitempty"`
+}
+
+func (lhs *VrfConfig) Equal(rhs *VrfConfig) bool {
+	if lhs == nil || rhs == nil {
+		return false
+	}
+	if lhs.Name != rhs.Name {
+		return false
+	}
+	if lhs.Id != rhs.Id {
+		return false
+	}
+	if lhs.Rd != rhs.Rd {
+		return false
+	}
+	if len(lhs.ImportRtList) != len(rhs.ImportRtList) {
+		return false
+	}
+	for idx, l := range lhs.ImportRtList {
+		if l != rhs.ImportRtList[idx] {
+			return false
+		}
+	}
+	if len(lhs.ExportRtList) != len(rhs.ExportRtList) {
+		return false
+	}
+	for idx, l := range lhs.ExportRtList {
+		if l != rhs.ExportRtList[idx] {
+			return false
+		}
+	}
+	if len(lhs.BothRtList) != len(rhs.BothRtList) {
+		return false
+	}
+	for idx, l := range lhs.BothRtList {
+		if l != rhs.BothRtList[idx] {
+			return false
+		}
+	}
+	return true
+}
+
+// struct for container gobgp:vrf.
+// VRF instance configurations on the local system.
+type Vrf struct {
+	// original -> gobgp:name
+	// original -> gobgp:vrf-config
+	// Configuration parameters for VRF.
+	Config VrfConfig `mapstructure:"config" json:"config,omitempty"`
+	// original -> gobgp:vrf-state
+	// Configured states of VRF.
+	State VrfState `mapstructure:"state" json:"state,omitempty"`
+}
+
+func (lhs *Vrf) Equal(rhs *Vrf) bool {
+	if lhs == nil || rhs == nil {
+		return false
+	}
+	if !lhs.Config.Equal(&(rhs.Config)) {
+		return false
+	}
+	return true
+}
+
+// struct for container gobgp:state.
 // Configuration parameters relating to BMP server.
 type BmpServerState struct {
 	// original -> gobgp:address
@@ -4785,6 +4891,8 @@ type Bgp struct {
 	RpkiServers []RpkiServer `mapstructure:"rpki-servers" json:"rpki-servers,omitempty"`
 	// original -> gobgp:bmp-servers
 	BmpServers []BmpServer `mapstructure:"bmp-servers" json:"bmp-servers,omitempty"`
+	// original -> gobgp:vrfs
+	Vrfs []Vrf `mapstructure:"vrfs" json:"vrfs,omitempty"`
 	// original -> gobgp:mrt-dump
 	MrtDump []Mrt `mapstructure:"mrt-dump" json:"mrt-dump,omitempty"`
 	// original -> gobgp:zebra
@@ -4860,6 +4968,22 @@ func (lhs *Bgp) Equal(rhs *Bgp) bool {
 		}
 		for i, r := range rhs.BmpServers {
 			if l, y := lmap[mapkey(i, string(r.Config.Address))]; !y {
+				return false
+			} else if !r.Equal(l) {
+				return false
+			}
+		}
+	}
+	if len(lhs.Vrfs) != len(rhs.Vrfs) {
+		return false
+	}
+	{
+		lmap := make(map[string]*Vrf)
+		for i, l := range lhs.Vrfs {
+			lmap[mapkey(i, string(l.Config.Name))] = &lhs.Vrfs[i]
+		}
+		for i, r := range rhs.Vrfs {
+			if l, y := lmap[mapkey(i, string(r.Config.Name))]; !y {
 				return false
 			} else if !r.Equal(l) {
 				return false

--- a/config/serve.go
+++ b/config/serve.go
@@ -1,11 +1,12 @@
 package config
 
 import (
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"os"
 	"os/signal"
 	"syscall"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 type BgpConfigSet struct {
@@ -14,6 +15,7 @@ type BgpConfigSet struct {
 	PeerGroups        []PeerGroup        `mapstructure:"peer-groups"`
 	RpkiServers       []RpkiServer       `mapstructure:"rpki-servers"`
 	BmpServers        []BmpServer        `mapstructure:"bmp-servers"`
+	Vrfs              []Vrf              `mapstructure:"vrfs"`
 	MrtDump           []Mrt              `mapstructure:"mrt-dump"`
 	Zebra             Zebra              `mapstructure:"zebra"`
 	Collector         Collector          `mapstructure:"collector"`

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -30,6 +30,18 @@
         route-monitoring-policy = "pre-policy"
         statistics-timeout = 3600
 
+[[vrfs]]
+    [vrfs.config]
+        name = "vrf1"
+        # If id is omitted, automatically assigned.
+        id = 1
+        rd = "65000:100"
+        # Each configuration for import and export RTs;
+        # import-rt-list
+        # export-rt-list
+        # are preferred than both-rt-list.
+        both-rt-list = ["65000:100"]
+
 [[mrt-dump]]
     [mrt-dump.config]
         dump-type = "updates"

--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -188,6 +188,31 @@ func main() {
 						log.Fatalf("failed to set bmp config: %s", err)
 					}
 				}
+				for _, vrf := range newConfig.Vrfs {
+					rd, err := bgp.ParseRouteDistinguisher(vrf.Config.Rd)
+					if err != nil {
+						log.Fatalf("failed to load vrf rd config: %s", err)
+					}
+					importRtList := make([]bgp.ExtendedCommunityInterface, 0, len(vrf.Config.ImportRtList))
+					for _, rtString := range vrf.Config.ImportRtList {
+						rt, err := bgp.ParseRouteTarget(rtString)
+						if err != nil {
+							log.Fatalf("failed to load vrf import rt config: %s", err)
+						}
+						importRtList = append(importRtList, rt)
+					}
+					exportRtList := make([]bgp.ExtendedCommunityInterface, 0, len(vrf.Config.ExportRtList))
+					for _, rtString := range vrf.Config.ExportRtList {
+						rt, err := bgp.ParseRouteTarget(rtString)
+						if err != nil {
+							log.Fatalf("failed to load vrf export rt config: %s", err)
+						}
+						exportRtList = append(exportRtList, rt)
+					}
+					if err := bgpServer.AddVrf(vrf.Config.Name, vrf.Config.Id, rd, importRtList, exportRtList); err != nil {
+						log.Fatalf("failed to set vrf config: %s", err)
+					}
+				}
 				for i, _ := range newConfig.MrtDump {
 					if len(newConfig.MrtDump[i].Config.FileName) == 0 {
 						continue

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -618,6 +618,90 @@ module gobgp {
       }
     }
   }
+  grouping gobgp-vrf-common {
+    description
+      "Common parameters for VRF configuration and state.";
+
+    leaf name {
+      description
+        "Unique name among all VRF instances.";
+      type string;
+    }
+
+    leaf id {
+      description
+        "Unique identifier among all VRF instances.";
+      type uint32;
+    }
+
+    leaf rd {
+      description
+        "Route Distinguisher for this VRF.";
+      type string;
+    }
+
+    leaf-list import-rt {
+      description
+        "List of import Route Targets for this VRF.";
+      type string;
+    }
+
+    leaf-list export-rt {
+      description
+        "List of export Route Targets for this VRF.";
+      type string;
+    }
+  }
+
+  grouping gobgp-vrf-config {
+    description
+      "Configuration parameters for VRF.";
+
+    leaf-list both-rt {
+      description
+        "List of both import and export Route Targets for this VRF. Each
+        configuration for import and export Route Targets will be preferred.";
+      type string;
+    }
+  }
+
+  grouping gobgp-vrf-set {
+    description "Set of VRF instance configuration and state";
+
+    container config {
+      description
+        "Configuration parameters for VRF.";
+      uses gobgp-vrf-common;
+      uses gobgp-vrf-config;
+    }
+
+    container state {
+      description
+        "Configured states of VRF.";
+      uses gobgp-vrf-common;
+    }
+  }
+
+  grouping gobgp-vrfs {
+    description
+      "Virtual Routing and Forwarding (VRF) instances.";
+
+    container vrfs {
+      list vrf {
+        description
+          "VRF instance configurations on the local system.";
+
+        key "name";
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+        }
+
+        uses gobgp-vrf-set;
+      }
+    }
+  }
 
   grouping long-lived-graceful-restart {
       container long-lived-graceful-restart {
@@ -1025,13 +1109,18 @@ module gobgp {
   }
 
   augment "/bgp:bgp" {
-    description "additional rpki configuration and state";
+    description "Additional RPKI configuration and state";
     uses gobgp-rpki-servers;
   }
 
   augment "/bgp:bgp" {
-    description "additional bmp configuration";
+    description "Additional BMP configuration and state";
     uses gobgp-bmp-servers;
+  }
+
+  augment "/bgp:bgp" {
+    description "Additional VRF configuration and state";
+    uses gobgp-vrfs;
   }
 
   typedef mrt-type {


### PR DESCRIPTION
This patch enables to configure VRF tables by using config file. This feature is asked frequently on Slack and mailing-list.

Example of Usage:

```toml
[[vrfs]]
  [vrfs.config]
    name = "vrf1"
    id = 1
    rd = "65000:100"
    both-rt-list = ["65000:100"]
```