### PR TITLE
test: avoid fabric version 2.0

### DIFF
--- a/test/pip-requires.txt
+++ b/test/pip-requires.txt
@@ -1,7 +1,7 @@
 nose
 toml
 pyyaml
-fabric
+fabric<2.0.0
 netaddr
 nsenter
 docker-py


### PR DESCRIPTION
Seems that fabric v2 doesn't work with the current files. Let's keep
using v1.X for now.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>