### PR TITLE
scenario_test: Wait for GoBGP starting up

### DIFF
--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 
+import collections
 import json
 from itertools import chain
 from threading import Thread
@@ -27,7 +28,6 @@ from fabric.utils import indent
 import netaddr
 import toml
 import yaml
-import collections
 
 from lib.base import (
     wait_for_completion,
@@ -112,6 +112,12 @@ class GoBGPContainer(BGPContainer):
         cmd = "chmod 755 {0}/start.sh".format(self.config_dir)
         local(cmd, capture=True)
         self.local("{0}/start.sh".format(self.SHARED_VOLUME), detach=True)
+
+    def start_gobgp(self, graceful_restart=False):
+        if self._is_running():
+            raise RuntimeError('GoBGP is already running')
+        self._start_gobgp(graceful_restart=graceful_restart)
+        self._wait_for_boot()
 
     def stop_gobgp(self):
         self.local("pkill -INT gobgpd")

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -113,7 +113,7 @@ class GoBGPContainer(BGPContainer):
         local(cmd, capture=True)
         self.local("{0}/start.sh".format(self.SHARED_VOLUME), detach=True)
 
-    def graceful_restart(self):
+    def stop_gobgp(self):
         self.local("pkill -INT gobgpd")
 
     def _start_zebra(self):

--- a/test/scenario_test/graceful_restart_test.py
+++ b/test/scenario_test/graceful_restart_test.py
@@ -69,7 +69,7 @@ class GoBGPTestBase(unittest.TestCase):
     def test_02_graceful_restart(self):
         g1 = self.bgpds['g1']
         g2 = self.bgpds['g2']
-        g1.graceful_restart()
+        g1.stop_gobgp()
         g2.wait_for(expected_state=BGP_FSM_ACTIVE, peer=g1)
         self.assertTrue(len(g2.get_global_rib('10.10.20.0/24')) == 1)
         self.assertTrue(len(g2.get_global_rib('10.10.10.0/24')) == 1)
@@ -113,7 +113,7 @@ class GoBGPTestBase(unittest.TestCase):
         g1 = self.bgpds['g1']
         g2 = self.bgpds['g2']
         g3 = self.bgpds['g3']
-        g1.graceful_restart()
+        g1.stop_gobgp()
         g2.wait_for(expected_state=BGP_FSM_ACTIVE, peer=g1)
         self.assertTrue(len(g2.get_global_rib('10.10.20.0/24')) == 1)
         self.assertTrue(len(g2.get_global_rib('10.10.30.0/24')) == 1)
@@ -153,7 +153,7 @@ class GoBGPTestBase(unittest.TestCase):
         g2 = self.bgpds['g2']
         g3 = self.bgpds['g3']
 
-        g1.graceful_restart()
+        g1.stop_gobgp()
         g2.wait_for(expected_state=BGP_FSM_ACTIVE, peer=g1)
         g3.wait_for(expected_state=BGP_FSM_ACTIVE, peer=g1)
 

--- a/test/scenario_test/graceful_restart_test.py
+++ b/test/scenario_test/graceful_restart_test.py
@@ -160,8 +160,8 @@ class GoBGPTestBase(unittest.TestCase):
         g1._start_gobgp(graceful_restart=True)
 
         count = 0
-        while ((g1.get_neighbor_state(g2) != BGP_FSM_ESTABLISHED)
-                or (g1.get_neighbor_state(g3) != BGP_FSM_ESTABLISHED)):
+        while (g1.get_neighbor_state(g2) != BGP_FSM_ESTABLISHED
+               or g1.get_neighbor_state(g3) != BGP_FSM_ESTABLISHED):
             count += 1
             # assert connections are not refused
             self.assertTrue(g1.get_neighbor_state(g2) != BGP_FSM_IDLE)

--- a/test/scenario_test/graceful_restart_test.py
+++ b/test/scenario_test/graceful_restart_test.py
@@ -78,8 +78,7 @@ class GoBGPTestBase(unittest.TestCase):
                 self.assertTrue(p['stale'])
 
         g1.routes = {}
-        g1._start_gobgp(graceful_restart=True)
-        time.sleep(3)
+        g1.start_gobgp(graceful_restart=True)
         g1.add_route('10.10.20.0/24')
 
     def test_03_neighbor_established(self):
@@ -134,7 +133,7 @@ class GoBGPTestBase(unittest.TestCase):
         g2 = self.bgpds['g2']
         g3 = self.bgpds['g3']
 
-        g1._start_gobgp()
+        g1.start_gobgp()
 
         g1.del_peer(g2)
         g1.del_peer(g3)
@@ -157,7 +156,7 @@ class GoBGPTestBase(unittest.TestCase):
         g2.wait_for(expected_state=BGP_FSM_ACTIVE, peer=g1)
         g3.wait_for(expected_state=BGP_FSM_ACTIVE, peer=g1)
 
-        g1._start_gobgp(graceful_restart=True)
+        g1.start_gobgp(graceful_restart=True)
 
         count = 0
         while (g1.get_neighbor_state(g2) != BGP_FSM_ESTABLISHED

--- a/test/scenario_test/long_lived_graceful_restart_test.py
+++ b/test/scenario_test/long_lived_graceful_restart_test.py
@@ -88,7 +88,7 @@ class GoBGPTestBase(unittest.TestCase):
 
         time.sleep(1)
 
-        g2.graceful_restart()
+        g2.stop_gobgp()
         g1.wait_for(expected_state=BGP_FSM_ACTIVE, peer=g2)
 
         time.sleep(1)
@@ -140,7 +140,7 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertTrue(len(rib) == 1)
         self.assertTrue(g2.asn in rib[0]['paths'][0]['aspath'])
 
-        g2.graceful_restart()
+        g2.stop_gobgp()
         g1.wait_for(expected_state=BGP_FSM_ACTIVE, peer=g2)
 
         time.sleep(1)

--- a/test/scenario_test/long_lived_graceful_restart_test.py
+++ b/test/scenario_test/long_lived_graceful_restart_test.py
@@ -110,8 +110,7 @@ class GoBGPTestBase(unittest.TestCase):
         # withdrawn
         self.assertTrue(len(g4.get_global_rib('10.0.0.0/24')) == 0)
 
-        g2._start_gobgp(graceful_restart=True)
-        time.sleep(2)
+        g2.start_gobgp(graceful_restart=True)
         g2.local('gobgp global rib add 10.0.0.0/24')
         g2.local('gobgp global rib add 10.10.0.0/24')
 

--- a/test/scenario_test/vrf_neighbor_test2.py
+++ b/test/scenario_test/vrf_neighbor_test2.py
@@ -125,7 +125,7 @@ class GoBGPTestBase(unittest.TestCase):
         wait_for_completion(lambda: len(self.g5.get_global_rib()) == 1)
 
     def test_06_graceful_restart(self):
-        self.g1.graceful_restart()
+        self.g1.stop_gobgp()
         self.g3.wait_for(expected_state=BGP_FSM_ACTIVE, peer=self.g1)
 
         wait_for_completion(lambda: len(self.g3.get_global_rib(rf="vpnv4")) == 2)


### PR DESCRIPTION
For the stability of some scenario tests, this PR fixes to wait for GoBGP starting up after restarting GoBGP daemon.