### PR TITLE
When AddPath withdraw, use path from OldKnownPathList to work with RTC.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -988,7 +988,7 @@ func (server *BgpServer) propagateUpdateToNeighbors(source *Peer, newPath *table
 			return family
 		}()
 		if targetPeer.isAddPathSendEnabled(f) {
-			if newPath.IsWithdraw {
+			if newPath.IsWithdraw && newPath.GetNlri().PathIdentifier() == 0 {
 				for _, dst := range dsts {
 					for _, path := range dst.OldKnownPathList {
 						if path.GetSource().Equal(newPath.GetSource()) {

--- a/server/server.go
+++ b/server/server.go
@@ -988,7 +988,18 @@ func (server *BgpServer) propagateUpdateToNeighbors(source *Peer, newPath *table
 			return family
 		}()
 		if targetPeer.isAddPathSendEnabled(f) {
-			bestList = []*table.Path{newPath}
+			if newPath.IsWithdraw {
+				for _, dst := range dsts {
+					for _, path := range dst.OldKnownPathList {
+						if path.GetSource().Equal(newPath.GetSource()) {
+							bestList = []*table.Path{path.Clone(true)}
+						}
+					}
+				}
+			}
+			if bestList == nil {
+				bestList = []*table.Path{newPath}
+			}
 			oldList = nil
 		} else if targetPeer.isRouteServerClient() {
 			bestList, oldList, _ = dstsToPaths(targetPeer.TableID(), targetPeer.AS(), dsts)

--- a/server/server.go
+++ b/server/server.go
@@ -996,7 +996,6 @@ func (server *BgpServer) propagateUpdateToNeighbors(source *Peer, newPath *table
 							pathIdentifier := newPath.GetNlri().PathIdentifier()
 							p.GetNlri().SetPathIdentifier(pathIdentifier)
 							bestList = []*table.Path{p}
-
 						}
 					}
 				}

--- a/server/server.go
+++ b/server/server.go
@@ -988,19 +988,20 @@ func (server *BgpServer) propagateUpdateToNeighbors(source *Peer, newPath *table
 			return family
 		}()
 		if targetPeer.isAddPathSendEnabled(f) {
+			clone := newPath.Clone(newPath.IsWithdraw)
 			if newPath.IsWithdraw {
 				for _, dst := range dsts {
 					for _, path := range dst.OldKnownPathList {
 						if path.GetSource().Equal(newPath.GetSource()) {
 							extCom := path.GetExtCommunities()
 							if extCom != nil {
-								newPath.SetExtCommunities(extCom, true)
+								clone.SetExtCommunities(extCom, false)
 							}
 						}
 					}
 				}
 			}
-			bestList = []*table.Path{newPath}
+			bestList = []*table.Path{clone}
 			oldList = nil
 		} else if targetPeer.isRouteServerClient() {
 			bestList, oldList, _ = dstsToPaths(targetPeer.TableID(), targetPeer.AS(), dsts)

--- a/server/server.go
+++ b/server/server.go
@@ -992,17 +992,15 @@ func (server *BgpServer) propagateUpdateToNeighbors(source *Peer, newPath *table
 				for _, dst := range dsts {
 					for _, path := range dst.OldKnownPathList {
 						if path.GetSource().Equal(newPath.GetSource()) {
-							p := path.Clone(true)
-							pathIdentifier := newPath.GetNlri().PathIdentifier()
-							p.GetNlri().SetPathIdentifier(pathIdentifier)
-							bestList = []*table.Path{p}
+							extCom := path.GetExtCommunities()
+							if extCom != nil {
+								newPath.SetExtCommunities(extCom, true)
+							}
 						}
 					}
 				}
 			}
-			if bestList == nil {
-				bestList = []*table.Path{newPath}
-			}
+			bestList = []*table.Path{newPath}
 			oldList = nil
 		} else if targetPeer.isRouteServerClient() {
 			bestList, oldList, _ = dstsToPaths(targetPeer.TableID(), targetPeer.AS(), dsts)

--- a/server/server.go
+++ b/server/server.go
@@ -988,11 +988,15 @@ func (server *BgpServer) propagateUpdateToNeighbors(source *Peer, newPath *table
 			return family
 		}()
 		if targetPeer.isAddPathSendEnabled(f) {
-			if newPath.IsWithdraw && newPath.GetNlri().PathIdentifier() == 0 {
+			if newPath.IsWithdraw {
 				for _, dst := range dsts {
 					for _, path := range dst.OldKnownPathList {
 						if path.GetSource().Equal(newPath.GetSource()) {
-							bestList = []*table.Path{path.Clone(true)}
+							p := path.Clone(true)
+							pathIdentifier := newPath.GetNlri().PathIdentifier()
+							p.GetNlri().SetPathIdentifier(pathIdentifier)
+							bestList = []*table.Path{p}
+
 						}
 					}
 				}


### PR DESCRIPTION
Should fix #1688.