### PR TITLE
fix withdraw with addpath and rtc enabled

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -988,7 +988,17 @@ func (server *BgpServer) propagateUpdateToNeighbors(source *Peer, newPath *table
 			return family
 		}()
 		if targetPeer.isAddPathSendEnabled(f) {
-			bestList = []*table.Path{newPath}
+			if newPath.IsWithdraw {
+				bestList = func() []*table.Path {
+					l := make([]*table.Path, 0, len(dsts))
+					for _, d := range dsts {
+						l = append(l, d.GetWithdrawnPath()...)
+					}
+					return l
+				}()
+			} else {
+				bestList = []*table.Path{newPath}
+			}
 			oldList = nil
 		} else if targetPeer.isRouteServerClient() {
 			bestList, oldList, _ = dstsToPaths(targetPeer.TableID(), targetPeer.AS(), dsts)

--- a/table/destination.go
+++ b/table/destination.go
@@ -557,6 +557,29 @@ func getMultiBestPath(id string, pathList []*Path) []*Path {
 	return list
 }
 
+func (u *Update) GetWithdrawnPath() []*Path {
+	if len(u.KnownPathList) == len(u.OldKnownPathList) {
+		return nil
+	}
+
+	l := make([]*Path, 0, len(u.OldKnownPathList))
+
+	for _, p := range u.OldKnownPathList {
+		y := func() bool {
+			for _, old := range u.KnownPathList {
+				if p == old {
+					return true
+				}
+			}
+			return false
+		}()
+		if !y {
+			l = append(l, p.Clone(true))
+		}
+	}
+	return l
+}
+
 func (u *Update) GetChanges(id string, as uint32, peerDown bool) (*Path, *Path, []*Path) {
 	best, old := func(id string) (*Path, *Path) {
 		old := getBestPath(id, as, u.OldKnownPathList)

--- a/table/destination_test.go
+++ b/table/destination_test.go
@@ -421,3 +421,21 @@ func TestIdMap(t *testing.T) {
 	_, err := d.localIdMap.FindandSetZeroBit()
 	assert.NotNil(t, err)
 }
+
+func TestGetWithdrawnPath(t *testing.T) {
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+	}
+	p1 := NewPath(nil, bgp.NewIPAddrPrefix(24, "13.2.3.0"), false, attrs, time.Now(), false)
+	p2 := NewPath(nil, bgp.NewIPAddrPrefix(24, "13.2.4.0"), false, attrs, time.Now(), false)
+	p3 := NewPath(nil, bgp.NewIPAddrPrefix(24, "13.2.5.0"), false, attrs, time.Now(), false)
+
+	u := &Update{
+		KnownPathList:    []*Path{p2},
+		OldKnownPathList: []*Path{p1, p2, p3},
+	}
+
+	l := u.GetWithdrawnPath()
+	assert.Equal(t, len(l), 2)
+	assert.Equal(t, l[0].GetNlri(), p1.GetNlri())
+}


### PR DESCRIPTION
Needs withdrawn paths that includes attributes. The attributes are
necessary because they are used with rtc table to check if the paths
were sent.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>