### PR TITLE
server: Withdraw routes when received RTM withdrawal

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -899,7 +899,9 @@ func (server *BgpServer) propagateUpdate(peer *Peer, pathList []*table.Path) {
 				}
 				var candidates []*table.Path
 				if path.IsWithdraw {
-					candidates, _ = server.getBestFromLocal(peer, fs)
+					// Note: The paths to be withdrawn are filtered because the
+					// given RT on RTM NLRI is already removed from adj-RIB-in.
+					_, candidates = server.getBestFromLocal(peer, fs)
 				} else {
 					candidates = server.globalRib.GetBestPathList(peer.TableID(), 0, fs)
 				}
@@ -916,7 +918,8 @@ func (server *BgpServer) propagateUpdate(peer *Peer, pathList []*table.Path) {
 					}
 				}
 				if path.IsWithdraw {
-					paths = server.processOutgoingPaths(peer, nil, paths)
+					// Skips filtering because the paths are already filtered
+					// and the withdrawal does not need the path attributes.
 				} else {
 					paths = server.processOutgoingPaths(peer, paths, nil)
 				}

--- a/test/scenario_test/rtc_test.py
+++ b/test/scenario_test/rtc_test.py
@@ -94,9 +94,7 @@ class GoBGPTestBase(unittest.TestCase):
         self.g1.local("gobgp vrf del vrf1")
         time.sleep(2)
         self.assertEqual(2, len(self.g1.get_adj_rib_out(self.g2, rf='rtc')))
-        # TODO:
-        # g2 should withdraw VPN routes when received a RTM withdrawal.
-        # self.assertEqual(1, len(self.g1.get_adj_rib_in(self.g2, rf='ipv4-l3vpn')))
+        self.assertEqual(1, len(self.g1.get_adj_rib_in(self.g2, rf='ipv4-l3vpn')))
 
     def test_06_rr_setup(self):
         #               +------+


### PR DESCRIPTION
Because the RTM is removed from adj-RIB-in before collecting the
candidate routes to be withdrawn, the candidates are unexpectedly
filtered before sending withdraw messages. Then on the peers, the VPN
routes are left on.

This patch fixes to selects candidates from the filtered paths and send
withdraw messages as expected. Also resolves the TODO in
"test/scenario_test/rtc_test.py".

Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>