### PR TITLE
server: Include data or reason to BMPPeerDownMessage

### DIFF
--- a/packet/bmp/bmp.go
+++ b/packet/bmp/bmp.go
@@ -391,8 +391,9 @@ func NewBMPPeerDownNotification(p BMPPeerHeader, reason uint8, notification *bgp
 	switch reason {
 	case BMP_PEER_DOWN_REASON_LOCAL_BGP_NOTIFICATION, BMP_PEER_DOWN_REASON_REMOTE_BGP_NOTIFICATION:
 		b.BGPNotification = notification
-	default:
+	case BMP_PEER_DOWN_REASON_LOCAL_NO_NOTIFICATION:
 		b.Data = data
+	default:
 	}
 	return &BMPMessage{
 		Header: BMPHeader{

--- a/packet/bmp/bmp_test.go
+++ b/packet/bmp/bmp_test.go
@@ -68,7 +68,7 @@ func Test_PeerUpNotification(t *testing.T) {
 
 func Test_PeerDownNotification(t *testing.T) {
 	p0 := NewBMPPeerHeader(0, 0, 1000, "10.0.0.1", 70000, "10.0.0.2", 1)
-	verify(t, NewBMPPeerDownNotification(*p0, BMP_PEER_DOWN_REASON_UNKNOWN, nil, []byte{0x3, 0xb}))
+	verify(t, NewBMPPeerDownNotification(*p0, BMP_PEER_DOWN_REASON_LOCAL_NO_NOTIFICATION, nil, []byte{0x3, 0xb}))
 	m := bgp.NewBGPNotificationMessage(1, 2, nil)
 	verify(t, NewBMPPeerDownNotification(*p0, BMP_PEER_DOWN_REASON_LOCAL_BGP_NOTIFICATION, m, nil))
 }

--- a/server/bmp.go
+++ b/server/bmp.go
@@ -205,17 +205,12 @@ func (b *bmpClient) loop() {
 							}
 						}
 					case *WatchEventPeerState:
-						info := &table.PeerInfo{
-							Address: msg.PeerAddress,
-							AS:      msg.PeerAS,
-							ID:      msg.PeerID,
-						}
 						if msg.State == bgp.BGP_FSM_ESTABLISHED {
-							if err := write(bmpPeerUp(msg.LocalAddress.String(), msg.LocalPort, msg.PeerPort, msg.SentOpen, msg.RecvOpen, bmp.BMP_PEER_TYPE_GLOBAL, false, 0, info, msg.Timestamp.Unix())); err != nil {
+							if err := write(bmpPeerUp(msg, bmp.BMP_PEER_TYPE_GLOBAL, false, 0)); err != nil {
 								return false
 							}
 						} else {
-							if err := write(bmpPeerDown(bmp.BMP_PEER_DOWN_REASON_UNKNOWN, bmp.BMP_PEER_TYPE_GLOBAL, false, 0, info, msg.Timestamp.Unix())); err != nil {
+							if err := write(bmpPeerDown(msg, bmp.BMP_PEER_TYPE_GLOBAL, false, 0)); err != nil {
 								return false
 							}
 						}
@@ -264,22 +259,22 @@ type bmpClient struct {
 	ribout ribout
 }
 
-func bmpPeerUp(laddr string, lport, rport uint16, sent, recv *bgp.BGPMessage, t uint8, policy bool, pd uint64, peeri *table.PeerInfo, timestamp int64) *bmp.BMPMessage {
+func bmpPeerUp(ev *WatchEventPeerState, t uint8, policy bool, pd uint64) *bmp.BMPMessage {
 	var flags uint8 = 0
 	if policy {
 		flags |= bmp.BMP_PEER_FLAG_POST_POLICY
 	}
-	ph := bmp.NewBMPPeerHeader(t, flags, pd, peeri.Address.String(), peeri.AS, peeri.ID.String(), float64(timestamp))
-	return bmp.NewBMPPeerUpNotification(*ph, laddr, lport, rport, sent, recv)
+	ph := bmp.NewBMPPeerHeader(t, flags, pd, ev.PeerAddress.String(), ev.PeerAS, ev.PeerID.String(), float64(ev.Timestamp.Unix()))
+	return bmp.NewBMPPeerUpNotification(*ph, ev.LocalAddress.String(), ev.LocalPort, ev.PeerPort, ev.SentOpen, ev.RecvOpen)
 }
 
-func bmpPeerDown(reason uint8, t uint8, policy bool, pd uint64, peeri *table.PeerInfo, timestamp int64) *bmp.BMPMessage {
+func bmpPeerDown(ev *WatchEventPeerState, t uint8, policy bool, pd uint64) *bmp.BMPMessage {
 	var flags uint8 = 0
 	if policy {
 		flags |= bmp.BMP_PEER_FLAG_POST_POLICY
 	}
-	ph := bmp.NewBMPPeerHeader(t, flags, pd, peeri.Address.String(), peeri.AS, peeri.ID.String(), float64(timestamp))
-	return bmp.NewBMPPeerDownNotification(*ph, reason, nil, []byte{})
+	ph := bmp.NewBMPPeerHeader(t, flags, pd, ev.PeerAddress.String(), ev.PeerAS, ev.PeerID.String(), float64(ev.Timestamp.Unix()))
+	return bmp.NewBMPPeerDownNotification(*ph, uint8(ev.StateReason.PeerDownReason), ev.StateReason.BGPNotification, ev.StateReason.Data)
 }
 
 func bmpPeerRoute(t uint8, policy bool, pd uint64, fourBytesAs bool, peeri *table.PeerInfo, timestamp int64, payload []byte) *bmp.BMPMessage {

--- a/server/fsm.go
+++ b/server/fsm.go
@@ -34,6 +34,17 @@ import (
 	"github.com/osrg/gobgp/table"
 )
 
+type PeerDownReason int
+
+const (
+	PEER_DOWN_REASON_UNKNOWN PeerDownReason = iota
+	PEER_DOWN_BY_LOCAL
+	PEER_DOWN_BY_LOCAL_WITHOUT_NOTIFICATION
+	PEER_DOWN_BY_REMOTE
+	PEER_DOWN_BY_REMOTE_WITHOUT_NOTIFICATION
+	PEER_DOWN_BY_BMP_CONFIGURATION
+)
+
 type FsmStateReason string
 
 const (

--- a/server/fsm.go
+++ b/server/fsm.go
@@ -21,7 +21,6 @@ import (
 	"math/rand"
 	"net"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/eapache/channels"
@@ -45,25 +44,91 @@ const (
 	PEER_DOWN_BY_BMP_CONFIGURATION
 )
 
-type FsmStateReason string
+type FsmStateReasonType uint8
 
 const (
-	FSM_DYING                   = "dying"
-	FSM_ADMIN_DOWN              = "admin-down"
-	FSM_READ_FAILED             = "read-failed"
-	FSM_WRITE_FAILED            = "write-failed"
-	FSM_NOTIFICATION_SENT       = "notification-sent"
-	FSM_NOTIFICATION_RECV       = "notification-received"
-	FSM_HOLD_TIMER_EXPIRED      = "hold-timer-expired"
-	FSM_IDLE_HOLD_TIMER_EXPIRED = "idle-hold-timer-expired"
-	FSM_RESTART_TIMER_EXPIRED   = "restart-timer-expired"
-	FSM_GRACEFUL_RESTART        = "graceful-restart"
-	FSM_INVALID_MSG             = "invalid-msg"
-	FSM_NEW_CONNECTION          = "new-connection"
-	FSM_OPEN_MSG_RECEIVED       = "open-msg-received"
-	FSM_OPEN_MSG_NEGOTIATED     = "open-msg-negotiated"
-	FSM_HARD_RESET              = "hard-reset"
+	FSM_DYING FsmStateReasonType = iota
+	FSM_ADMIN_DOWN
+	FSM_READ_FAILED
+	FSM_WRITE_FAILED
+	FSM_NOTIFICATION_SENT
+	FSM_NOTIFICATION_RECV
+	FSM_HOLD_TIMER_EXPIRED
+	FSM_IDLE_HOLD_TIMER_EXPIRED
+	FSM_RESTART_TIMER_EXPIRED
+	FSM_GRACEFUL_RESTART
+	FSM_INVALID_MSG
+	FSM_NEW_CONNECTION
+	FSM_OPEN_MSG_RECEIVED
+	FSM_OPEN_MSG_NEGOTIATED
+	FSM_HARD_RESET
 )
+
+type FsmStateReason struct {
+	Type            FsmStateReasonType
+	PeerDownReason  PeerDownReason
+	BGPNotification *bgp.BGPMessage
+	Data            []byte
+}
+
+func NewFsmStateReason(typ FsmStateReasonType, notif *bgp.BGPMessage, data []byte) *FsmStateReason {
+	var reasonCode PeerDownReason
+	switch typ {
+	case FSM_DYING, FSM_INVALID_MSG, FSM_NOTIFICATION_SENT, FSM_HOLD_TIMER_EXPIRED, FSM_IDLE_HOLD_TIMER_EXPIRED, FSM_RESTART_TIMER_EXPIRED:
+		reasonCode = PEER_DOWN_BY_LOCAL
+	case FSM_ADMIN_DOWN:
+		reasonCode = PEER_DOWN_BY_LOCAL_WITHOUT_NOTIFICATION
+	case FSM_NOTIFICATION_RECV, FSM_GRACEFUL_RESTART, FSM_HARD_RESET:
+		reasonCode = PEER_DOWN_BY_REMOTE
+	case FSM_READ_FAILED, FSM_WRITE_FAILED:
+		reasonCode = PEER_DOWN_BY_REMOTE_WITHOUT_NOTIFICATION
+	}
+	return &FsmStateReason{
+		Type:            typ,
+		PeerDownReason:  reasonCode,
+		BGPNotification: notif,
+		Data:            data,
+	}
+}
+
+func (r FsmStateReason) String() string {
+	switch r.Type {
+	case FSM_DYING:
+		return "dying"
+	case FSM_ADMIN_DOWN:
+		return "admin-down"
+	case FSM_READ_FAILED:
+		return "read-failed"
+	case FSM_WRITE_FAILED:
+		return "write-failed"
+	case FSM_NOTIFICATION_SENT:
+		body := r.BGPNotification.Body.(*bgp.BGPNotification)
+		return fmt.Sprintf("notification-sent %s", bgp.NewNotificationErrorCode(body.ErrorCode, body.ErrorSubcode).String())
+	case FSM_NOTIFICATION_RECV:
+		body := r.BGPNotification.Body.(*bgp.BGPNotification)
+		return fmt.Sprintf("notification-received %s", bgp.NewNotificationErrorCode(body.ErrorCode, body.ErrorSubcode).String())
+	case FSM_HOLD_TIMER_EXPIRED:
+		return "hold-timer-expired"
+	case FSM_IDLE_HOLD_TIMER_EXPIRED:
+		return "idle-hold-timer-expired"
+	case FSM_RESTART_TIMER_EXPIRED:
+		return "restart-timer-expired"
+	case FSM_GRACEFUL_RESTART:
+		return "graceful-restart"
+	case FSM_INVALID_MSG:
+		return "invalid-msg"
+	case FSM_NEW_CONNECTION:
+		return "new-connection"
+	case FSM_OPEN_MSG_RECEIVED:
+		return "open-msg-received"
+	case FSM_OPEN_MSG_NEGOTIATED:
+		return "open-msg-negotiated"
+	case FSM_HARD_RESET:
+		return "hard-reset"
+	default:
+		return "unknown"
+	}
+}
 
 type FsmMsgType int
 
@@ -75,13 +140,14 @@ const (
 )
 
 type FsmMsg struct {
-	MsgType   FsmMsgType
-	MsgSrc    string
-	MsgData   interface{}
-	PathList  []*table.Path
-	timestamp time.Time
-	payload   []byte
-	Version   uint
+	MsgType     FsmMsgType
+	MsgSrc      string
+	MsgData     interface{}
+	StateReason *FsmStateReason
+	PathList    []*table.Path
+	timestamp   time.Time
+	payload     []byte
+	Version     uint
 }
 
 type FsmOutgoingMsg struct {
@@ -128,7 +194,7 @@ type FSM struct {
 	gConf                *config.Global
 	pConf                *config.Neighbor
 	state                bgp.FSMState
-	reason               FsmStateReason
+	reason               *FsmStateReason
 	conn                 net.Conn
 	connCh               chan net.Conn
 	idleHoldTime         float64
@@ -300,14 +366,14 @@ func (fsm *FSM) LocalHostPort() (string, uint16) {
 	return hostport(fsm.conn.LocalAddr())
 }
 
-func (fsm *FSM) sendNotificationFromErrorMsg(e *bgp.MessageError) error {
+func (fsm *FSM) sendNotificationFromErrorMsg(e *bgp.MessageError) (*bgp.BGPMessage, error) {
 	if fsm.h != nil && fsm.h.conn != nil {
 		m := bgp.NewBGPNotificationMessage(e.TypeCode, e.SubTypeCode, e.Data)
 		b, _ := m.Serialize()
 		_, err := fsm.h.conn.Write(b)
 		if err == nil {
 			fsm.bgpMessageStateUpdate(m.Header.Type, false)
-			fsm.h.sentNotification = bgp.NewNotificationErrorCode(e.TypeCode, e.SubTypeCode).String()
+			fsm.h.sentNotification = m
 		}
 		fsm.h.conn.Close()
 		log.WithFields(log.Fields{
@@ -315,12 +381,12 @@ func (fsm *FSM) sendNotificationFromErrorMsg(e *bgp.MessageError) error {
 			"Key":   fsm.pConf.State.NeighborAddress,
 			"Data":  e,
 		}).Warn("sent notification")
-		return nil
+		return m, nil
 	}
-	return fmt.Errorf("can't send notification to %s since TCP connection is not established", fsm.pConf.State.NeighborAddress)
+	return nil, fmt.Errorf("can't send notification to %s since TCP connection is not established", fsm.pConf.State.NeighborAddress)
 }
 
-func (fsm *FSM) sendNotification(code, subType uint8, data []byte, msg string) error {
+func (fsm *FSM) sendNotification(code, subType uint8, data []byte, msg string) (*bgp.BGPMessage, error) {
 	e := bgp.NewMessageError(code, subType, data, msg)
 	return fsm.sendNotificationFromErrorMsg(e.(*bgp.MessageError))
 }
@@ -414,18 +480,18 @@ type FSMHandler struct {
 	fsm              *FSM
 	conn             net.Conn
 	msgCh            *channels.InfiniteChannel
-	errorCh          chan FsmStateReason
+	stateReasonCh    chan FsmStateReason
 	incoming         *channels.InfiniteChannel
 	stateCh          chan *FsmMsg
 	outgoing         *channels.InfiniteChannel
 	holdTimerResetCh chan bool
-	sentNotification string
+	sentNotification *bgp.BGPMessage
 }
 
 func NewFSMHandler(fsm *FSM, incoming *channels.InfiniteChannel, stateCh chan *FsmMsg, outgoing *channels.InfiniteChannel) *FSMHandler {
 	h := &FSMHandler{
 		fsm:              fsm,
-		errorCh:          make(chan FsmStateReason, 2),
+		stateReasonCh:    make(chan FsmStateReason, 2),
 		incoming:         incoming,
 		stateCh:          stateCh,
 		outgoing:         outgoing,
@@ -435,14 +501,14 @@ func NewFSMHandler(fsm *FSM, incoming *channels.InfiniteChannel, stateCh chan *F
 	return h
 }
 
-func (h *FSMHandler) idle() (bgp.FSMState, FsmStateReason) {
+func (h *FSMHandler) idle() (bgp.FSMState, *FsmStateReason) {
 	fsm := h.fsm
 
 	idleHoldTimer := time.NewTimer(time.Second * time.Duration(fsm.idleHoldTime))
 	for {
 		select {
 		case <-h.t.Dying():
-			return -1, FSM_DYING
+			return -1, NewFsmStateReason(FSM_DYING, nil, nil)
 		case <-fsm.gracefulRestartTimer.C:
 			if fsm.pConf.GracefulRestart.State.PeerRestarting {
 				log.WithFields(log.Fields{
@@ -450,7 +516,7 @@ func (h *FSMHandler) idle() (bgp.FSMState, FsmStateReason) {
 					"Key":   fsm.pConf.State.NeighborAddress,
 					"State": fsm.state.String(),
 				}).Warn("graceful restart timer expired")
-				return bgp.BGP_FSM_IDLE, FSM_RESTART_TIMER_EXPIRED
+				return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_RESTART_TIMER_EXPIRED, nil, nil)
 			}
 		case conn, ok := <-fsm.connCh:
 			if !ok {
@@ -471,7 +537,7 @@ func (h *FSMHandler) idle() (bgp.FSMState, FsmStateReason) {
 					"Duration": fsm.idleHoldTime,
 				}).Debug("IdleHoldTimer expired")
 				fsm.idleHoldTime = HOLDTIME_IDLE
-				return bgp.BGP_FSM_ACTIVE, FSM_IDLE_HOLD_TIMER_EXPIRED
+				return bgp.BGP_FSM_ACTIVE, NewFsmStateReason(FSM_IDLE_HOLD_TIMER_EXPIRED, nil, nil)
 
 			} else {
 				log.WithFields(log.Fields{"Topic": "Peer"}).Debug("IdleHoldTimer expired, but stay at idle because the admin state is DOWN")
@@ -494,12 +560,12 @@ func (h *FSMHandler) idle() (bgp.FSMState, FsmStateReason) {
 	}
 }
 
-func (h *FSMHandler) active() (bgp.FSMState, FsmStateReason) {
+func (h *FSMHandler) active() (bgp.FSMState, *FsmStateReason) {
 	fsm := h.fsm
 	for {
 		select {
 		case <-h.t.Dying():
-			return -1, FSM_DYING
+			return -1, NewFsmStateReason(FSM_DYING, nil, nil)
 		case conn, ok := <-fsm.connCh:
 			if !ok {
 				break
@@ -541,7 +607,7 @@ func (h *FSMHandler) active() (bgp.FSMState, FsmStateReason) {
 			}
 			// we don't implement delayed open timer so move to opensent right
 			// away.
-			return bgp.BGP_FSM_OPENSENT, FSM_NEW_CONNECTION
+			return bgp.BGP_FSM_OPENSENT, NewFsmStateReason(FSM_NEW_CONNECTION, nil, nil)
 		case <-fsm.gracefulRestartTimer.C:
 			if fsm.pConf.GracefulRestart.State.PeerRestarting {
 				log.WithFields(log.Fields{
@@ -549,16 +615,16 @@ func (h *FSMHandler) active() (bgp.FSMState, FsmStateReason) {
 					"Key":   fsm.pConf.State.NeighborAddress,
 					"State": fsm.state.String(),
 				}).Warn("graceful restart timer expired")
-				return bgp.BGP_FSM_IDLE, FSM_RESTART_TIMER_EXPIRED
+				return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_RESTART_TIMER_EXPIRED, nil, nil)
 			}
-		case err := <-h.errorCh:
-			return bgp.BGP_FSM_IDLE, err
+		case err := <-h.stateReasonCh:
+			return bgp.BGP_FSM_IDLE, &err
 		case stateOp := <-fsm.adminStateCh:
 			err := h.changeAdminState(stateOp.State)
 			if err == nil {
 				switch stateOp.State {
 				case ADMIN_STATE_DOWN:
-					return bgp.BGP_FSM_IDLE, FSM_ADMIN_DOWN
+					return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_ADMIN_DOWN, nil, nil)
 				case ADMIN_STATE_UP:
 					log.WithFields(log.Fields{
 						"Topic":      "Peer",
@@ -790,17 +856,17 @@ func (h *FSMHandler) handlingError(m *bgp.BGPMessage, e error, useRevisedError b
 }
 
 func (h *FSMHandler) recvMessageWithError() (*FsmMsg, error) {
-	sendToErrorCh := func(reason FsmStateReason) {
+	sendToStateReasonCh := func(typ FsmStateReasonType, notif *bgp.BGPMessage) {
 		// probably doesn't happen but be cautious
 		select {
-		case h.errorCh <- reason:
+		case h.stateReasonCh <- *NewFsmStateReason(typ, notif, nil):
 		default:
 		}
 	}
 
 	headerBuf, err := readAll(h.conn, bgp.BGP_HEADER_LENGTH)
 	if err != nil {
-		sendToErrorCh(FSM_READ_FAILED)
+		sendToStateReasonCh(FSM_READ_FAILED, nil)
 		return nil, err
 	}
 
@@ -825,7 +891,7 @@ func (h *FSMHandler) recvMessageWithError() (*FsmMsg, error) {
 
 	bodyBuf, err := readAll(h.conn, int(hd.Len)-bgp.BGP_HEADER_LENGTH)
 	if err != nil {
-		sendToErrorCh(FSM_READ_FAILED)
+		sendToStateReasonCh(FSM_READ_FAILED, nil)
 		return nil, err
 	}
 
@@ -944,9 +1010,9 @@ func (h *FSMHandler) recvMessageWithError() (*FsmMsg, error) {
 				}
 
 				if s := h.fsm.pConf.GracefulRestart.State; s.Enabled && s.NotificationEnabled && body.ErrorCode == bgp.BGP_ERROR_CEASE && body.ErrorSubcode == bgp.BGP_ERROR_SUB_HARD_RESET {
-					sendToErrorCh(FSM_HARD_RESET)
+					sendToStateReasonCh(FSM_HARD_RESET, m)
 				} else {
-					sendToErrorCh(FsmStateReason(fmt.Sprintf("%s %s", FSM_NOTIFICATION_RECV, bgp.NewNotificationErrorCode(body.ErrorCode, body.ErrorSubcode).String())))
+					sendToStateReasonCh(FSM_NOTIFICATION_RECV, m)
 				}
 				return nil, nil
 			}
@@ -1023,7 +1089,7 @@ func open2Cap(open *bgp.BGPOpen, n *config.Neighbor) (map[bgp.BGPCapabilityCode]
 	return capMap, negotiated
 }
 
-func (h *FSMHandler) opensent() (bgp.FSMState, FsmStateReason) {
+func (h *FSMHandler) opensent() (bgp.FSMState, *FsmStateReason) {
 	fsm := h.fsm
 	m := buildopen(fsm.gConf, fsm.pConf)
 	b, _ := m.Serialize()
@@ -1045,7 +1111,7 @@ func (h *FSMHandler) opensent() (bgp.FSMState, FsmStateReason) {
 		select {
 		case <-h.t.Dying():
 			h.conn.Close()
-			return -1, FSM_DYING
+			return -1, NewFsmStateReason(FSM_DYING, nil, nil)
 		case conn, ok := <-fsm.connCh:
 			if !ok {
 				break
@@ -1064,7 +1130,7 @@ func (h *FSMHandler) opensent() (bgp.FSMState, FsmStateReason) {
 					"State": fsm.state.String(),
 				}).Warn("graceful restart timer expired")
 				h.conn.Close()
-				return bgp.BGP_FSM_IDLE, FSM_RESTART_TIMER_EXPIRED
+				return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_RESTART_TIMER_EXPIRED, nil, nil)
 			}
 		case i, ok := <-h.msgCh.Out():
 			if !ok {
@@ -1079,8 +1145,8 @@ func (h *FSMHandler) opensent() (bgp.FSMState, FsmStateReason) {
 					body := m.Body.(*bgp.BGPOpen)
 					peerAs, err := bgp.ValidateOpenMsg(body, fsm.pConf.Config.PeerAs)
 					if err != nil {
-						fsm.sendNotificationFromErrorMsg(err.(*bgp.MessageError))
-						return bgp.BGP_FSM_IDLE, FSM_INVALID_MSG
+						m, _ := fsm.sendNotificationFromErrorMsg(err.(*bgp.MessageError))
+						return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_INVALID_MSG, m, nil)
 					}
 
 					// ASN negotiation was skipped
@@ -1160,7 +1226,7 @@ func (h *FSMHandler) opensent() (bgp.FSMState, FsmStateReason) {
 							}).Warn("restart flag is not set")
 							// send notification?
 							h.conn.Close()
-							return bgp.BGP_FSM_IDLE, FSM_INVALID_MSG
+							return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_INVALID_MSG, nil, nil)
 						}
 
 						// RFC 4724 3
@@ -1202,15 +1268,15 @@ func (h *FSMHandler) opensent() (bgp.FSMState, FsmStateReason) {
 					b, _ := msg.Serialize()
 					fsm.conn.Write(b)
 					fsm.bgpMessageStateUpdate(msg.Header.Type, false)
-					return bgp.BGP_FSM_OPENCONFIRM, FSM_OPEN_MSG_RECEIVED
+					return bgp.BGP_FSM_OPENCONFIRM, NewFsmStateReason(FSM_OPEN_MSG_RECEIVED, nil, nil)
 				} else {
 					// send notification?
 					h.conn.Close()
-					return bgp.BGP_FSM_IDLE, FSM_INVALID_MSG
+					return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_INVALID_MSG, nil, nil)
 				}
 			case *bgp.MessageError:
-				fsm.sendNotificationFromErrorMsg(e.MsgData.(*bgp.MessageError))
-				return bgp.BGP_FSM_IDLE, FSM_INVALID_MSG
+				m, _ := fsm.sendNotificationFromErrorMsg(e.MsgData.(*bgp.MessageError))
+				return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_INVALID_MSG, m, nil)
 			default:
 				log.WithFields(log.Fields{
 					"Topic": "Peer",
@@ -1219,20 +1285,20 @@ func (h *FSMHandler) opensent() (bgp.FSMState, FsmStateReason) {
 					"Data":  e.MsgData,
 				}).Panic("unknown msg type")
 			}
-		case err := <-h.errorCh:
+		case err := <-h.stateReasonCh:
 			h.conn.Close()
-			return bgp.BGP_FSM_IDLE, err
+			return bgp.BGP_FSM_IDLE, &err
 		case <-holdTimer.C:
-			fsm.sendNotification(bgp.BGP_ERROR_HOLD_TIMER_EXPIRED, 0, nil, "hold timer expired")
+			m, _ := fsm.sendNotification(bgp.BGP_ERROR_HOLD_TIMER_EXPIRED, 0, nil, "hold timer expired")
 			h.t.Kill(nil)
-			return bgp.BGP_FSM_IDLE, FSM_HOLD_TIMER_EXPIRED
+			return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_HOLD_TIMER_EXPIRED, m, nil)
 		case stateOp := <-fsm.adminStateCh:
 			err := h.changeAdminState(stateOp.State)
 			if err == nil {
 				switch stateOp.State {
 				case ADMIN_STATE_DOWN:
 					h.conn.Close()
-					return bgp.BGP_FSM_IDLE, FSM_ADMIN_DOWN
+					return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_ADMIN_DOWN, m, nil)
 				case ADMIN_STATE_UP:
 					log.WithFields(log.Fields{
 						"Topic":      "Peer",
@@ -1258,7 +1324,7 @@ func keepaliveTicker(fsm *FSM) *time.Ticker {
 	return time.NewTicker(sec)
 }
 
-func (h *FSMHandler) openconfirm() (bgp.FSMState, FsmStateReason) {
+func (h *FSMHandler) openconfirm() (bgp.FSMState, *FsmStateReason) {
 	fsm := h.fsm
 	ticker := keepaliveTicker(fsm)
 	h.msgCh = channels.NewInfiniteChannel()
@@ -1279,7 +1345,7 @@ func (h *FSMHandler) openconfirm() (bgp.FSMState, FsmStateReason) {
 		select {
 		case <-h.t.Dying():
 			h.conn.Close()
-			return -1, FSM_DYING
+			return -1, NewFsmStateReason(FSM_DYING, nil, nil)
 		case conn, ok := <-fsm.connCh:
 			if !ok {
 				break
@@ -1298,7 +1364,7 @@ func (h *FSMHandler) openconfirm() (bgp.FSMState, FsmStateReason) {
 					"State": fsm.state.String(),
 				}).Warn("graceful restart timer expired")
 				h.conn.Close()
-				return bgp.BGP_FSM_IDLE, FSM_RESTART_TIMER_EXPIRED
+				return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_RESTART_TIMER_EXPIRED, nil, nil)
 			}
 		case <-ticker.C:
 			m := bgp.NewBGPKeepAliveMessage()
@@ -1315,14 +1381,14 @@ func (h *FSMHandler) openconfirm() (bgp.FSMState, FsmStateReason) {
 			case *bgp.BGPMessage:
 				m := e.MsgData.(*bgp.BGPMessage)
 				if m.Header.Type == bgp.BGP_MSG_KEEPALIVE {
-					return bgp.BGP_FSM_ESTABLISHED, FSM_OPEN_MSG_NEGOTIATED
+					return bgp.BGP_FSM_ESTABLISHED, NewFsmStateReason(FSM_OPEN_MSG_NEGOTIATED, nil, nil)
 				}
 				// send notification ?
 				h.conn.Close()
-				return bgp.BGP_FSM_IDLE, FSM_INVALID_MSG
+				return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_INVALID_MSG, nil, nil)
 			case *bgp.MessageError:
-				fsm.sendNotificationFromErrorMsg(e.MsgData.(*bgp.MessageError))
-				return bgp.BGP_FSM_IDLE, FSM_INVALID_MSG
+				m, _ := fsm.sendNotificationFromErrorMsg(e.MsgData.(*bgp.MessageError))
+				return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_INVALID_MSG, m, nil)
 			default:
 				log.WithFields(log.Fields{
 					"Topic": "Peer",
@@ -1331,20 +1397,20 @@ func (h *FSMHandler) openconfirm() (bgp.FSMState, FsmStateReason) {
 					"Data":  e.MsgData,
 				}).Panic("unknown msg type")
 			}
-		case err := <-h.errorCh:
+		case err := <-h.stateReasonCh:
 			h.conn.Close()
-			return bgp.BGP_FSM_IDLE, err
+			return bgp.BGP_FSM_IDLE, &err
 		case <-holdTimer.C:
-			fsm.sendNotification(bgp.BGP_ERROR_HOLD_TIMER_EXPIRED, 0, nil, "hold timer expired")
+			m, _ := fsm.sendNotification(bgp.BGP_ERROR_HOLD_TIMER_EXPIRED, 0, nil, "hold timer expired")
 			h.t.Kill(nil)
-			return bgp.BGP_FSM_IDLE, FSM_HOLD_TIMER_EXPIRED
+			return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_HOLD_TIMER_EXPIRED, m, nil)
 		case stateOp := <-fsm.adminStateCh:
 			err := h.changeAdminState(stateOp.State)
 			if err == nil {
 				switch stateOp.State {
 				case ADMIN_STATE_DOWN:
 					h.conn.Close()
-					return bgp.BGP_FSM_IDLE, FSM_ADMIN_DOWN
+					return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_ADMIN_DOWN, nil, nil)
 				case ADMIN_STATE_UP:
 					log.WithFields(log.Fields{
 						"Topic":      "Peer",
@@ -1385,7 +1451,7 @@ func (h *FSMHandler) sendMessageloop() error {
 			return nil
 		}
 		if err := conn.SetWriteDeadline(time.Now().Add(time.Second * time.Duration(fsm.pConf.Timers.State.NegotiatedHoldTime))); err != nil {
-			h.errorCh <- FSM_WRITE_FAILED
+			h.stateReasonCh <- *NewFsmStateReason(FSM_WRITE_FAILED, nil, nil)
 			conn.Close()
 			return fmt.Errorf("failed to set write deadline")
 		}
@@ -1397,7 +1463,7 @@ func (h *FSMHandler) sendMessageloop() error {
 				"State": fsm.state.String(),
 				"Data":  err,
 			}).Warn("failed to send")
-			h.errorCh <- FSM_WRITE_FAILED
+			h.stateReasonCh <- *NewFsmStateReason(FSM_WRITE_FAILED, nil, nil)
 			conn.Close()
 			return fmt.Errorf("closed")
 		}
@@ -1427,7 +1493,7 @@ func (h *FSMHandler) sendMessageloop() error {
 					"Data":    body.Data,
 				}).Warn("sent notification")
 			}
-			h.errorCh <- FsmStateReason(fmt.Sprintf("%s %s", FSM_NOTIFICATION_SENT, bgp.NewNotificationErrorCode(body.ErrorCode, body.ErrorSubcode).String()))
+			h.stateReasonCh <- *NewFsmStateReason(FSM_NOTIFICATION_SENT, m, nil)
 			conn.Close()
 			return fmt.Errorf("closed")
 		case bgp.BGP_MSG_UPDATE:
@@ -1492,7 +1558,7 @@ func (h *FSMHandler) recvMessageloop() error {
 	}
 }
 
-func (h *FSMHandler) established() (bgp.FSMState, FsmStateReason) {
+func (h *FSMHandler) established() (bgp.FSMState, *FsmStateReason) {
 	fsm := h.fsm
 	h.conn = fsm.conn
 	h.t.Go(h.sendMessageloop)
@@ -1511,7 +1577,7 @@ func (h *FSMHandler) established() (bgp.FSMState, FsmStateReason) {
 	for {
 		select {
 		case <-h.t.Dying():
-			return -1, FSM_DYING
+			return -1, NewFsmStateReason(FSM_DYING, nil, nil)
 		case conn, ok := <-fsm.connCh:
 			if !ok {
 				break
@@ -1522,11 +1588,14 @@ func (h *FSMHandler) established() (bgp.FSMState, FsmStateReason) {
 				"Key":   fsm.pConf.State.NeighborAddress,
 				"State": fsm.state.String(),
 			}).Warn("Closed an accepted connection")
-		case err := <-h.errorCh:
+		case err := <-h.stateReasonCh:
 			h.conn.Close()
 			h.t.Kill(nil)
-			if s := fsm.pConf.GracefulRestart.State; s.Enabled && ((s.NotificationEnabled && strings.HasPrefix(string(err), FSM_NOTIFICATION_RECV)) || err == FSM_READ_FAILED || err == FSM_WRITE_FAILED) {
-				err = FSM_GRACEFUL_RESTART
+			if s := fsm.pConf.GracefulRestart.State; s.Enabled &&
+				(s.NotificationEnabled && err.Type == FSM_NOTIFICATION_RECV ||
+					err.Type == FSM_READ_FAILED ||
+					err.Type == FSM_WRITE_FAILED) {
+				err = *NewFsmStateReason(FSM_GRACEFUL_RESTART, nil, nil)
 				log.WithFields(log.Fields{
 					"Topic": "Peer",
 					"Key":   fsm.pConf.State.NeighborAddress,
@@ -1534,7 +1603,7 @@ func (h *FSMHandler) established() (bgp.FSMState, FsmStateReason) {
 				}).Info("peer graceful restart")
 				fsm.gracefulRestartTimer.Reset(time.Duration(fsm.pConf.GracefulRestart.State.PeerRestartTime) * time.Second)
 			}
-			return bgp.BGP_FSM_IDLE, err
+			return bgp.BGP_FSM_IDLE, &err
 		case <-holdTimer.C:
 			log.WithFields(log.Fields{
 				"Topic": "Peer",
@@ -1543,7 +1612,7 @@ func (h *FSMHandler) established() (bgp.FSMState, FsmStateReason) {
 			}).Warn("hold timer expired")
 			m := bgp.NewBGPNotificationMessage(bgp.BGP_ERROR_HOLD_TIMER_EXPIRED, 0, nil)
 			h.outgoing.In() <- &FsmOutgoingMsg{Notification: m}
-			return bgp.BGP_FSM_IDLE, FSM_HOLD_TIMER_EXPIRED
+			return bgp.BGP_FSM_IDLE, NewFsmStateReason(FSM_HOLD_TIMER_EXPIRED, m, nil)
 		case <-h.holdTimerResetCh:
 			if fsm.pConf.Timers.State.NegotiatedHoldTime != 0 {
 				holdTimer.Reset(time.Second * time.Duration(fsm.pConf.Timers.State.NegotiatedHoldTime))
@@ -1566,9 +1635,9 @@ func (h *FSMHandler) loop() error {
 	ch := make(chan bgp.FSMState)
 	oldState := fsm.state
 
+	var reason *FsmStateReason
 	f := func() error {
 		nextState := bgp.FSMState(-1)
-		var reason FsmStateReason
 		switch fsm.state {
 		case bgp.BGP_FSM_IDLE:
 			nextState, reason = h.idle()
@@ -1604,14 +1673,16 @@ func (h *FSMHandler) loop() error {
 		// The main goroutine sent the notificaiton due to
 		// deconfiguration or something.
 		reason := fsm.reason
-		if fsm.h.sentNotification != "" {
-			reason = FsmStateReason(fmt.Sprintf("%s %s", FSM_NOTIFICATION_SENT, fsm.h.sentNotification))
+		if fsm.h.sentNotification != nil {
+			reason.Type = FSM_NOTIFICATION_SENT
+			reason.PeerDownReason = PEER_DOWN_BY_LOCAL
+			reason.BGPNotification = fsm.h.sentNotification
 		}
 		log.WithFields(log.Fields{
 			"Topic":  "Peer",
 			"Key":    fsm.pConf.State.NeighborAddress,
 			"State":  fsm.state.String(),
-			"Reason": reason,
+			"Reason": reason.String(),
 		}).Info("Peer Down")
 	}
 
@@ -1623,13 +1694,13 @@ func (h *FSMHandler) loop() error {
 
 	// under zero means that tomb.Dying()
 	if nextState >= bgp.BGP_FSM_IDLE {
-		e := &FsmMsg{
-			MsgType: FSM_MSG_STATE_CHANGE,
-			MsgSrc:  fsm.pConf.State.NeighborAddress,
-			MsgData: nextState,
-			Version: h.fsm.version,
+		h.stateCh <- &FsmMsg{
+			MsgType:     FSM_MSG_STATE_CHANGE,
+			MsgSrc:      fsm.pConf.State.NeighborAddress,
+			MsgData:     nextState,
+			StateReason: reason,
+			Version:     h.fsm.version,
 		}
-		h.stateCh <- e
 	}
 	return nil
 }

--- a/server/fsm_test.go
+++ b/server/fsm_test.go
@@ -314,10 +314,10 @@ func makePeerAndHandler() (*Peer, *FSMHandler) {
 	}
 
 	h := &FSMHandler{
-		fsm:      p.fsm,
-		errorCh:  make(chan FsmStateReason, 2),
-		incoming: channels.NewInfiniteChannel(),
-		outgoing: p.outgoing,
+		fsm:           p.fsm,
+		stateReasonCh: make(chan FsmStateReason, 2),
+		incoming:      channels.NewInfiniteChannel(),
+		outgoing:      p.outgoing,
 	}
 
 	return p, h

--- a/server/server.go
+++ b/server/server.go
@@ -708,12 +708,12 @@ func (server *BgpServer) notifyPostPolicyUpdateWatcher(peer *Peer, pathList []*t
 	server.notifyWatcher(WATCH_EVENT_TYPE_POST_UPDATE, ev)
 }
 
-func createWatchEventPeerState(peer *Peer) *WatchEventPeerState {
+func newWatchEventPeerState(peer *Peer, m *FsmMsg) *WatchEventPeerState {
 	_, rport := peer.fsm.RemoteHostPort()
 	laddr, lport := peer.fsm.LocalHostPort()
 	sentOpen := buildopen(peer.fsm.gConf, peer.fsm.pConf)
 	recvOpen := peer.fsm.recvOpen
-	return &WatchEventPeerState{
+	e := &WatchEventPeerState{
 		PeerAS:        peer.fsm.peerInfo.AS,
 		LocalAS:       peer.fsm.peerInfo.LocalAS,
 		PeerAddress:   peer.fsm.peerInfo.Address,
@@ -728,12 +728,17 @@ func createWatchEventPeerState(peer *Peer) *WatchEventPeerState {
 		Timestamp:     time.Now(),
 		PeerInterface: peer.fsm.pConf.Config.NeighborInterface,
 	}
+
+	if m != nil {
+		e.StateReason = m.StateReason
+	}
+	return e
 }
 
 func (server *BgpServer) broadcastPeerState(peer *Peer, oldState bgp.FSMState) {
 	newState := peer.fsm.state
 	if oldState == bgp.BGP_FSM_ESTABLISHED || newState == bgp.BGP_FSM_ESTABLISHED {
-		server.notifyWatcher(WATCH_EVENT_TYPE_PEER_STATE, createWatchEventPeerState(peer))
+		server.notifyWatcher(WATCH_EVENT_TYPE_PEER_STATE, newWatchEventPeerState(peer))
 	}
 }
 
@@ -2612,6 +2617,7 @@ type WatchEventPeerState struct {
 	SentOpen      *bgp.BGPMessage
 	RecvOpen      *bgp.BGPMessage
 	State         bgp.FSMState
+	StateReason   *FsmStateReason
 	AdminState    AdminState
 	Timestamp     time.Time
 	PeerInterface string
@@ -2856,7 +2862,7 @@ func (s *BgpServer) Watch(opts ...WatchOption) (w *Watcher) {
 				if peer.fsm.state != bgp.BGP_FSM_ESTABLISHED {
 					continue
 				}
-				w.notify(createWatchEventPeerState(peer))
+				w.notify(newWatchEventPeerState(peer))
 			}
 		}
 		if w.opts.initBest && s.active() == nil {

--- a/server/server.go
+++ b/server/server.go
@@ -270,7 +270,7 @@ func (server *BgpServer) Serve() {
 				server.policy.Reset(nil, map[string]config.ApplyPolicy{peer.ID(): peer.fsm.pConf.ApplyPolicy})
 				server.neighborMap[remoteAddr] = peer
 				peer.startFSMHandler(server.fsmincomingCh, server.fsmStateCh)
-				server.broadcastPeerState(peer, bgp.BGP_FSM_ACTIVE)
+				server.broadcastPeerState(peer, bgp.BGP_FSM_ACTIVE, nil)
 				peer.PassConn(conn)
 			} else {
 				log.WithFields(log.Fields{
@@ -735,10 +735,10 @@ func newWatchEventPeerState(peer *Peer, m *FsmMsg) *WatchEventPeerState {
 	return e
 }
 
-func (server *BgpServer) broadcastPeerState(peer *Peer, oldState bgp.FSMState) {
+func (server *BgpServer) broadcastPeerState(peer *Peer, oldState bgp.FSMState, e *FsmMsg) {
 	newState := peer.fsm.state
 	if oldState == bgp.BGP_FSM_ESTABLISHED || newState == bgp.BGP_FSM_ESTABLISHED {
-		server.notifyWatcher(WATCH_EVENT_TYPE_PEER_STATE, newWatchEventPeerState(peer))
+		server.notifyWatcher(WATCH_EVENT_TYPE_PEER_STATE, newWatchEventPeerState(peer, e))
 	}
 }
 
@@ -1018,13 +1018,14 @@ func (server *BgpServer) handleFSMMessage(peer *Peer, e *FsmMsg) {
 		peer.fsm.pConf.State.SessionState = config.IntToSessionStateMap[int(nextState)]
 		peer.fsm.StateChange(nextState)
 
+		// PeerDown
 		if oldState == bgp.BGP_FSM_ESTABLISHED {
 			t := time.Now()
 			if t.Sub(time.Unix(peer.fsm.pConf.Timers.State.Uptime, 0)) < FLOP_THRESHOLD {
 				peer.fsm.pConf.State.Flops++
 			}
 			var drop []bgp.RouteFamily
-			if peer.fsm.reason == FSM_GRACEFUL_RESTART {
+			if peer.fsm.reason.Type == FSM_GRACEFUL_RESTART {
 				peer.fsm.pConf.GracefulRestart.State.PeerRestarting = true
 				var p []bgp.RouteFamily
 				p, drop = peer.forwardingPreservedFamilies()
@@ -1043,7 +1044,7 @@ func (server *BgpServer) handleFSMMessage(peer *Peer, e *FsmMsg) {
 				peer.stopPeerRestarting()
 				go peer.stopFSM()
 				delete(server.neighborMap, peer.fsm.pConf.State.NeighborAddress)
-				server.broadcastPeerState(peer, oldState)
+				server.broadcastPeerState(peer, oldState, e)
 				return
 			}
 		} else if peer.fsm.pConf.GracefulRestart.State.PeerRestarting && nextState == bgp.BGP_FSM_IDLE {
@@ -1195,7 +1196,7 @@ func (server *BgpServer) handleFSMMessage(peer *Peer, e *FsmMsg) {
 			peer.fsm.pConf.Timers.State = config.TimersState{}
 		}
 		peer.startFSMHandler(server.fsmincomingCh, server.fsmStateCh)
-		server.broadcastPeerState(peer, oldState)
+		server.broadcastPeerState(peer, oldState, e)
 	case FSM_MSG_ROUTE_REFRESH:
 		if peer.fsm.state != bgp.BGP_FSM_ESTABLISHED || e.timestamp.Unix() < peer.fsm.pConf.Timers.State.Uptime {
 			return
@@ -2045,7 +2046,7 @@ func (server *BgpServer) addNeighbor(c *config.Neighbor) error {
 		server.peerGroupMap[name].AddMember(*c)
 	}
 	peer.startFSMHandler(server.fsmincomingCh, server.fsmStateCh)
-	server.broadcastPeerState(peer, bgp.BGP_FSM_IDLE)
+	server.broadcastPeerState(peer, bgp.BGP_FSM_IDLE, nil)
 	return nil
 }
 
@@ -2862,7 +2863,7 @@ func (s *BgpServer) Watch(opts ...WatchOption) (w *Watcher) {
 				if peer.fsm.state != bgp.BGP_FSM_ESTABLISHED {
 					continue
 				}
-				w.notify(newWatchEventPeerState(peer))
+				w.notify(newWatchEventPeerState(peer, nil))
 			}
 		}
 		if w.opts.initBest && s.active() == nil {


### PR DESCRIPTION
RFC (https://tools.ietf.org/html/rfc7854#section-4.9) says that the BMPPeerDownMessage should contain a reason (1-5) and corresponding data.
This PR fixes to include a data or reason to BMPPeerDownMessage.

This fixes #1631.