### PR TITLE
rtc_test: Enhance test cases

### DIFF
--- a/test/scenario_test/rtc_test.py
+++ b/test/scenario_test/rtc_test.py
@@ -32,6 +32,10 @@ from lib.gobgp import GoBGPContainer
 
 class GoBGPTestBase(unittest.TestCase):
 
+    def assert_adv_count(self, src, dst, rf, count):
+        self.assertEqual(count, len(src.get_adj_rib_out(dst, rf=rf)))
+        self.assertEqual(count, len(dst.get_adj_rib_in(src, rf=rf)))
+
     @classmethod
     def setUpClass(cls):
         # +----+              +----+
@@ -47,11 +51,7 @@ class GoBGPTestBase(unittest.TestCase):
                             ctn_image_name=gobgp_ctn_image_name,
                             log_level=parser_option.gobgp_log_level)
 
-        ctns = {ctn.name: ctn for ctn in [g1, g2]}
-
-        initial_wait_time = max(ctn.run() for ctn in ctns.values())
-
-        time.sleep(initial_wait_time)
+        time.sleep(max(ctn.run() for ctn in [g1, g2]))
 
         g1.local("gobgp vrf add vrf1 rd 100:100 rt both 100:100")
         g1.local("gobgp vrf add vrf2 rd 200:200 rt both 200:200")
@@ -65,7 +65,6 @@ class GoBGPTestBase(unittest.TestCase):
 
         cls.g1 = g1
         cls.g2 = g2
-        cls.ctns = ctns
 
     # Test the problem which was reported on #1682
     # https://github.com/osrg/gobgp/issues/1682
@@ -79,24 +78,95 @@ class GoBGPTestBase(unittest.TestCase):
         self.g2.update_peer(self.g1, vpn=True, passwd='rtc', graceful_restart=True)
         self.g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g2)
 
-    def test_03_check_gobgp_adj_rib_out(self):
-        time.sleep(2)
-        self.assertEqual(1, len(self.g1.get_adj_rib_out(self.g2, rf='ipv4-l3vpn')))
-        self.assertEqual(1, len(self.g2.get_adj_rib_out(self.g1, rf='ipv4-l3vpn')))
+    def test_03_check_adj_rib(self):
+        # VRF<#>  g1   g2
+        #   1     (*)  (*)
+        #   2     (*)
+        #   3          (*)
+        #
+        # ( ): Empty VRF  (*): VRF with a route
+        self.assert_adv_count(self.g1, self.g2, 'rtc', 2)
+        self.assert_adv_count(self.g1, self.g2, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g2, self.g1, 'rtc', 2)
+        self.assert_adv_count(self.g2, self.g1, 'ipv4-l3vpn', 1)
 
     def test_04_add_vrf(self):
+        # VRF<#>  g1   g2
+        #   1     (*)  (*)
+        #   2     (*)
+        #   3     ( )  (*)
         self.g1.local("gobgp vrf add vrf3 rd 300:300 rt both 300:300")
-        time.sleep(2)
-        self.assertEqual(3, len(self.g1.get_adj_rib_out(self.g2, rf='rtc')))
-        self.assertEqual(2, len(self.g1.get_adj_rib_in(self.g2, rf='ipv4-l3vpn')))
+        time.sleep(1)
 
-    def test_05_del_vrf(self):
+        self.assert_adv_count(self.g1, self.g2, 'rtc', 3)
+        self.assert_adv_count(self.g1, self.g2, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g2, self.g1, 'rtc', 2)
+        self.assert_adv_count(self.g2, self.g1, 'ipv4-l3vpn', 2)
+
+    def test_05_add_route_on_vrf(self):
+        # VRF<#>  g1   g2
+        #   1     (*)  (*)
+        #   2     (*)
+        #   3     (*)  (*)
+        self.g1.local("gobgp vrf vrf3 rib add 10.0.0.0/24")
+        time.sleep(1)
+
+        self.assert_adv_count(self.g1, self.g2, 'rtc', 3)
+        self.assert_adv_count(self.g1, self.g2, 'ipv4-l3vpn', 2)
+
+        self.assert_adv_count(self.g2, self.g1, 'rtc', 2)
+        self.assert_adv_count(self.g2, self.g1, 'ipv4-l3vpn', 2)
+
+    def test_06_del_route_on_vrf(self):
+        # VRF<#>  g1   g2
+        #   1     (*)  (*)
+        #   2     (*)
+        #   3     ( )  (*)
+        self.g1.local("gobgp vrf vrf3 rib del 10.0.0.0/24")
+        time.sleep(1)
+
+        self.assert_adv_count(self.g1, self.g2, 'rtc', 3)
+        self.assert_adv_count(self.g1, self.g2, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g2, self.g1, 'rtc', 2)
+        self.assert_adv_count(self.g2, self.g1, 'ipv4-l3vpn', 2)
+
+    def test_07_del_vrf(self):
+        # VRF<#>  g1   g2
+        #   1     (*)  (*)
+        #   2     (*)
+        #   3          (*)
+        self.g1.local("gobgp vrf del vrf3")
+        time.sleep(1)
+
+        self.assert_adv_count(self.g1, self.g2, 'rtc', 2)
+        self.assert_adv_count(self.g1, self.g2, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g2, self.g1, 'rtc', 2)
+        self.assert_adv_count(self.g2, self.g1, 'ipv4-l3vpn', 1)
+
+    def test_08_del_vrf_with_route(self):
+        # VRF<#>  g1   g2
+        #   1          (*)
+        #   2     (*)
+        #   3          (*)
         self.g1.local("gobgp vrf del vrf1")
-        time.sleep(2)
-        self.assertEqual(2, len(self.g1.get_adj_rib_out(self.g2, rf='rtc')))
-        self.assertEqual(1, len(self.g1.get_adj_rib_in(self.g2, rf='ipv4-l3vpn')))
+        time.sleep(1)
 
-    def test_06_rr_setup(self):
+        self.assert_adv_count(self.g1, self.g2, 'rtc', 1)
+        self.assert_adv_count(self.g1, self.g2, 'ipv4-l3vpn', 0)
+
+        self.assert_adv_count(self.g2, self.g1, 'rtc', 2)
+        self.assert_adv_count(self.g2, self.g1, 'ipv4-l3vpn', 0)
+
+    def test_09_cleanup(self):
+        self.g1.local("gobgp vrf del vrf2")
+        self.g2.local("gobgp vrf del vrf1")
+        self.g2.local("gobgp vrf del vrf3")
+
+    def test_10_rr_setup(self):
         #               +------+
         #               |  g3  |
         #        +------| (RR) |------+
@@ -126,55 +196,119 @@ class GoBGPTestBase(unittest.TestCase):
         g3.add_peer(g5, vpn=True, is_rr_client=True)
         g5.add_peer(g3, vpn=True)
 
-        for v in [g3, g4, g5]:
-            self.ctns[v.name] = v
-
-    def test_07_neighbor_established(self):
-        g3 = self.ctns['g3']
-        g4 = self.ctns['g4']
-        g5 = self.ctns['g5']
         g3.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=g4)
         g3.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=g5)
 
-    def test_08_rr_test(self):
-        g3 = self.ctns['g3']
-        g4 = self.ctns['g4']
-        g5 = self.ctns['g5']
-        g4.local("gobgp vrf add vrf1 rd 100:100 rt both 100:100")
-        time.sleep(1)
-        g5.local("gobgp vrf add vrf1 rd 100:100 rt both 100:100")
+        self.__class__.g3 = g3
+        self.__class__.g4 = g4
+        self.__class__.g5 = g5
 
+    def test_11_rr_check_adj_rib_from_rr(self):
+        # VRF<#>  g3   g4   g5
+        #   1          ( )  ( )
+        #   2
+        #   3
+        self.g4.local("gobgp vrf add vrf1 rd 100:100 rt both 100:100")
+        self.g5.local("gobgp vrf add vrf1 rd 100:100 rt both 100:100")
         time.sleep(1)
 
         def check_rtc(client):
-            rib = g3.get_adj_rib_out(client, rf='rtc')
+            rib = self.g3.get_adj_rib_out(client, rf='rtc')
             self.assertEqual(1, len(rib))
             path = rib[0]
-            self.assertEqual(g3.peers[client]['local_addr'].split('/')[0], path['nexthop'])
+            self.assertEqual(self.g3.peers[client]['local_addr'].split('/')[0], path['nexthop'])
             ids = [attr['value'] for attr in path['attrs'] if attr['type'] == base.BGP_ATTR_TYPE_ORIGINATOR_ID]
             self.assertEqual(1, len(ids))
-            self.assertEqual(g3.router_id, ids[0])
+            self.assertEqual(self.g3.router_id, ids[0])
 
-        check_rtc(g4)
-        check_rtc(g5)
+        check_rtc(self.g4)
+        check_rtc(self.g5)
 
-        g4.local("gobgp vrf vrf1 rib add 40.0.0.0/24")
-        g5.local("gobgp vrf vrf1 rib add 50.0.0.0/24")
+        # VRF<#>  g3   g4   g5
+        #   1          (*)  (*)
+        #   2
+        #   3
+        self.g4.local("gobgp vrf vrf1 rib add 40.0.0.0/24")
+        self.g5.local("gobgp vrf vrf1 rib add 50.0.0.0/24")
         time.sleep(1)
 
         def check_ipv4_l3vpn(client):
-            rib = g3.get_adj_rib_out(client, rf='ipv4-l3vpn')
+            rib = self.g3.get_adj_rib_out(client, rf='ipv4-l3vpn')
             self.assertEqual(1, len(rib))
             path = rib[0]
-            self.assertNotEqual(g3.peers[client]['local_addr'].split('/')[0], path['nexthop'])
+            self.assertNotEqual(self.g3.peers[client]['local_addr'].split('/')[0], path['nexthop'])
             ids = [attr['value'] for attr in path['attrs'] if attr['type'] == base.BGP_ATTR_TYPE_ORIGINATOR_ID]
             self.assertEqual(1, len(ids))
             self.assertNotEqual(client.router_id, ids[0])
 
-        check_ipv4_l3vpn(g4)
-        check_ipv4_l3vpn(g5)
+        check_ipv4_l3vpn(self.g4)
+        check_ipv4_l3vpn(self.g5)
 
-    def test_09_rr_setup2(self):
+    def test_12_rr_add_vrf(self):
+        # VRF<#>  g3   g4   g5
+        #   1          (*)  (*)
+        #   2          ( )
+        #   3
+        self.g4.local("gobgp vrf add vrf2 rd 200:200 rt both 200:200")
+        time.sleep(1)
+
+        self.assert_adv_count(self.g4, self.g3, 'rtc', 2)
+        self.assert_adv_count(self.g4, self.g3, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g3, self.g4, 'rtc', 2)
+        self.assert_adv_count(self.g3, self.g4, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g5, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g5, self.g3, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g3, self.g5, 'rtc', 2)
+        self.assert_adv_count(self.g3, self.g5, 'ipv4-l3vpn', 1)
+
+    def test_13_rr_add_route_on_vrf(self):
+        # VRF<#>  g3   g4   g5
+        #   1          (*)  (*)
+        #   2          (*)
+        #   3
+        self.g4.local("gobgp vrf vrf2 rib add 40.0.0.0/24")
+        time.sleep(1)
+
+        self.assert_adv_count(self.g4, self.g3, 'rtc', 2)
+        self.assert_adv_count(self.g4, self.g3, 'ipv4-l3vpn', 2)
+
+        self.assert_adv_count(self.g3, self.g4, 'rtc', 2)
+        self.assert_adv_count(self.g3, self.g4, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g5, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g5, self.g3, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g3, self.g5, 'rtc', 2)
+        self.assert_adv_count(self.g3, self.g5, 'ipv4-l3vpn', 1)
+
+    def test_14_rr_del_vrf_with_route(self):
+        # VRF<#>  g3   g4   g5
+        #   1               (*)
+        #   2          (*)
+        #   3
+        self.g4.local("gobgp vrf del vrf1")
+        time.sleep(1)
+
+        self.assert_adv_count(self.g4, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g4, self.g3, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g3, self.g4, 'rtc', 2)
+        self.assert_adv_count(self.g3, self.g4, 'ipv4-l3vpn', 0)
+
+        self.assert_adv_count(self.g5, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g5, self.g3, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g3, self.g5, 'rtc', 2)
+        self.assert_adv_count(self.g3, self.g5, 'ipv4-l3vpn', 0)
+
+    def test_15_rr_cleanup(self):
+        self.g4.local("gobgp vrf del vrf2")
+        self.g5.local("gobgp vrf del vrf1")
+
+    def test_20_rr_and_non_rr_setup(self):
         # +----------+            +----------+
         # |    g1    |---(iBGP)---|    g2    |
         # | (Non RR  |            | (Non RR  |
@@ -193,67 +327,142 @@ class GoBGPTestBase(unittest.TestCase):
         # |     g4      |      |     g5      |
         # | (RR Client) |      | (RR Client) |
         # +-------------+      +-------------+
-        g1 = self.ctns['g1']
-        g2 = self.ctns['g2']
-        g3 = self.ctns['g3']
+        self.g3.add_peer(self.g1, vpn=True)
+        self.g1.add_peer(self.g3, vpn=True)
+        self.g3.add_peer(self.g2, vpn=True)
+        self.g2.add_peer(self.g3, vpn=True)
 
-        g1.local("gobgp vrf del vrf2")
-        g1.local("gobgp vrf del vrf3")
-        g2.local("gobgp vrf del vrf1")
-        g2.local("gobgp vrf del vrf3")
+        self.g3.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g1)
+        self.g3.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g2)
 
-        g3.add_peer(g1, vpn=True)
-        g1.add_peer(g3, vpn=True)
-        g3.add_peer(g2, vpn=True)
-        g2.add_peer(g3, vpn=True)
-
-        g3.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=g1)
-        g3.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=g2)
-
-    def test_10_rr_test2(self):
-        g1 = self.ctns['g1']
-        g2 = self.ctns['g2']
-        g3 = self.ctns['g3']
-        g4 = self.ctns['g4']
-        g5 = self.ctns['g5']
-
-        self.assertEqual(0, len(g1.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
-        self.assertEqual(0, len(g2.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
-
-        g1.local("gobgp vrf add vrf1 rd 100:100 rt both 100:100")
-        g1.local("gobgp vrf vrf1 rib add 10.0.0.0/24")
-
+    def test_21_rr_and_non_rr_add_vrf_on_rr_clients(self):
+        # VRF<#>  g1   g2   g3   g4   g5
+        #   1                    (*)  (*)
+        #   2
+        #   3
+        self.g4.local("gobgp vrf add vrf1 rd 100:100 rt both 100:100")
+        self.g5.local("gobgp vrf add vrf1 rd 100:100 rt both 100:100")
+        self.g4.local("gobgp vrf vrf1 rib add 40.0.0.0/24")
+        self.g5.local("gobgp vrf vrf1 rib add 50.0.0.0/24")
         time.sleep(1)
 
-        self.assertEqual(2, len(g1.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
-        self.assertEqual(0, len(g2.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
-        self.assertEqual(1, len(g3.get_adj_rib_in(g1, rf='ipv4-l3vpn')))
-        self.assertEqual(0, len(g3.get_adj_rib_in(g2, rf='ipv4-l3vpn')))
-        self.assertEqual(2, len(g4.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
-        self.assertEqual(2, len(g5.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
+        self.assert_adv_count(self.g4, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g4, self.g3, 'ipv4-l3vpn', 1)
 
-        g2.local("gobgp vrf add vrf2 rd 200:200 rt both 200:200")
-        g2.local("gobgp vrf vrf2 rib add 20.0.0.0/24")
+        self.assert_adv_count(self.g3, self.g1, 'rtc', 1)
+        self.assert_adv_count(self.g3, self.g1, 'ipv4-l3vpn', 0)
 
+        self.assert_adv_count(self.g1, self.g3, 'rtc', 0)
+        self.assert_adv_count(self.g1, self.g3, 'ipv4-l3vpn', 0)
+
+        self.assert_adv_count(self.g3, self.g4, 'rtc', 1)
+        self.assert_adv_count(self.g3, self.g4, 'ipv4-l3vpn', 1)
+
+    def test_22_rr_and_non_rr_add_vrf_on_non_rr_client(self):
+        # VRF<#>  g1   g2   g3   g4   g5
+        #   1     (*)            (*)  (*)
+        #   2
+        #   3
+        self.g1.local("gobgp vrf add vrf1 rd 100:100 rt both 100:100")
+        self.g1.local("gobgp vrf vrf1 rib add 10.0.0.0/24")
         time.sleep(1)
 
-        self.assertEqual(2, len(g1.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
-        self.assertEqual(0, len(g2.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
-        self.assertEqual(1, len(g3.get_adj_rib_in(g1, rf='ipv4-l3vpn')))
-        self.assertEqual(0, len(g3.get_adj_rib_in(g2, rf='ipv4-l3vpn')))
-        self.assertEqual(2, len(g4.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
-        self.assertEqual(2, len(g5.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
+        self.assert_adv_count(self.g4, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g4, self.g3, 'ipv4-l3vpn', 1)
 
-        g4.local("gobgp vrf add vrf2 rd 200:200 rt both 200:200")
+        self.assert_adv_count(self.g5, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g5, self.g3, 'ipv4-l3vpn', 1)
 
+        self.assert_adv_count(self.g3, self.g1, 'rtc', 1)
+        self.assert_adv_count(self.g3, self.g1, 'ipv4-l3vpn', 2)
+
+        self.assert_adv_count(self.g3, self.g2, 'rtc', 1)
+        self.assert_adv_count(self.g3, self.g2, 'ipv4-l3vpn', 0)
+
+        self.assert_adv_count(self.g1, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g1, self.g3, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g2, self.g3, 'rtc', 0)
+        self.assert_adv_count(self.g2, self.g3, 'ipv4-l3vpn', 0)
+
+        self.assert_adv_count(self.g3, self.g4, 'rtc', 1)
+        self.assert_adv_count(self.g3, self.g4, 'ipv4-l3vpn', 2)
+
+        self.assert_adv_count(self.g3, self.g5, 'rtc', 1)
+        self.assert_adv_count(self.g3, self.g5, 'ipv4-l3vpn', 2)
+
+    def test_23_rr_and_non_rr_add_another_vrf_on_non_rr_client(self):
+        # VRF<#>  g1   g2   g3   g4   g5
+        #   1     (*)            (*)  (*)
+        #   2          (*)
+        #   3
+        self.g2.local("gobgp vrf add vrf2 rd 200:200 rt both 200:200")
+        self.g2.local("gobgp vrf vrf2 rib add 20.0.0.0/24")
         time.sleep(1)
 
-        self.assertEqual(2, len(g1.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
-        self.assertEqual(0, len(g2.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
-        self.assertEqual(1, len(g3.get_adj_rib_in(g1, rf='ipv4-l3vpn')))
-        self.assertEqual(1, len(g3.get_adj_rib_in(g2, rf='ipv4-l3vpn')))
-        self.assertEqual(3, len(g4.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
-        self.assertEqual(2, len(g5.get_adj_rib_in(g3, rf='ipv4-l3vpn')))
+        self.assert_adv_count(self.g4, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g4, self.g3, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g5, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g5, self.g3, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g3, self.g1, 'rtc', 1)
+        self.assert_adv_count(self.g3, self.g1, 'ipv4-l3vpn', 2)
+
+        self.assert_adv_count(self.g3, self.g2, 'rtc', 1)
+        self.assert_adv_count(self.g3, self.g2, 'ipv4-l3vpn', 0)
+
+        self.assert_adv_count(self.g1, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g1, self.g3, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g2, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g2, self.g3, 'ipv4-l3vpn', 0)
+
+        self.assert_adv_count(self.g3, self.g4, 'rtc', 2)
+        self.assert_adv_count(self.g3, self.g4, 'ipv4-l3vpn', 2)
+
+        self.assert_adv_count(self.g3, self.g5, 'rtc', 2)
+        self.assert_adv_count(self.g3, self.g5, 'ipv4-l3vpn', 2)
+
+    def test_24_rr_and_non_rr_add_another_vrf_on_rr_client(self):
+        # VRF<#>  g1   g2   g3   g4   g5
+        #   1     (*)            (*)  (*)
+        #   2          (*)       (*)
+        #   3
+        self.g4.local("gobgp vrf add vrf2 rd 200:200 rt both 200:200")
+        self.g4.local("gobgp vrf vrf2 rib add 40.0.0.0/24")
+        time.sleep(1)
+
+        self.assert_adv_count(self.g4, self.g3, 'rtc', 2)
+        self.assert_adv_count(self.g4, self.g3, 'ipv4-l3vpn', 2)
+
+        self.assert_adv_count(self.g5, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g5, self.g3, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g3, self.g1, 'rtc', 2)
+        self.assert_adv_count(self.g3, self.g1, 'ipv4-l3vpn', 2)
+
+        self.assert_adv_count(self.g3, self.g2, 'rtc', 2)
+        self.assert_adv_count(self.g3, self.g2, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g1, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g1, self.g3, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g2, self.g3, 'rtc', 1)
+        self.assert_adv_count(self.g2, self.g3, 'ipv4-l3vpn', 1)
+
+        self.assert_adv_count(self.g3, self.g4, 'rtc', 2)
+        self.assert_adv_count(self.g3, self.g4, 'ipv4-l3vpn', 3)
+
+        self.assert_adv_count(self.g3, self.g5, 'rtc', 2)
+        self.assert_adv_count(self.g3, self.g5, 'ipv4-l3vpn', 2)
+
+    def test_25_rr_and_non_rr_clenup(self):
+        self.g1.local("gobgp vrf del vrf1")
+        self.g2.local("gobgp vrf del vrf2")
+        self.g4.local("gobgp vrf del vrf1")
+        self.g4.local("gobgp vrf del vrf2")
+        self.g5.local("gobgp vrf del vrf1")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR includes test cases for the issues;
- Route Target Constraints cause infinite UPDATE loop #1630
- When AddPath and RTC are both enabled, route withdraw won't be sent. #1688
- Applying rtfilter on eBGP sessions #1651

Also, fixes some an issues which found by extending test cases;
- RTC advertisement between RR and non RR clients