### PR TITLE
gobgp/cmd: add message gRPC connection error

### DIFF
--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -281,7 +281,7 @@ func newClient() *cli.Client {
 	target := net.JoinHostPort(globalOpts.Host, strconv.Itoa(globalOpts.Port))
 	client, err := cli.New(target, grpcOpts...)
 	if err != nil {
-		exitWithError(err)
+		exitWithError(fmt.Errorf("failed to connect to %s over gRPC: %s", target, err))
 	}
 	return client
 }


### PR DESCRIPTION
Adds a user-friendly error message on gRPC connection error.

Resolves: #1701