### PR TITLE
server: reject route without origin attribute via AddPath()

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1520,6 +1520,12 @@ func (server *BgpServer) fixupApiPath(vrfId string, pathList []*table.Path) erro
 	}
 
 	for _, path := range pathList {
+		if !path.IsWithdraw {
+			if _, err := path.GetOrigin(); err != nil {
+				return err
+			}
+		}
+
 		if path.GetSource() == nil {
 			path.SetSource(pi)
 		}


### PR DESCRIPTION
We should do stricter validation. Probably, we should use
packet/bgp/validate.go.

close #1660

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>