### PR TITLE
RTC: Enable to advertise Default Route Target

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -3334,12 +3334,22 @@ func (lhs *LongLivedGracefulRestart) Equal(rhs *LongLivedGracefulRestart) bool {
 type RouteTargetMembershipState struct {
 	// original -> gobgp:deferral-time
 	DeferralTime uint16 `mapstructure:"deferral-time" json:"deferral-time,omitempty"`
+	// original -> gobgp:advertise-default
+	// gobgp:advertise-default's original type is boolean.
+	// Configure whether advertise the default route target or not. This can
+	// be used only when the given neighbor is a route reflector client.
+	AdvertiseDefault bool `mapstructure:"advertise-default" json:"advertise-default,omitempty"`
 }
 
 // struct for container gobgp:config.
 type RouteTargetMembershipConfig struct {
 	// original -> gobgp:deferral-time
 	DeferralTime uint16 `mapstructure:"deferral-time" json:"deferral-time,omitempty"`
+	// original -> gobgp:advertise-default
+	// gobgp:advertise-default's original type is boolean.
+	// Configure whether advertise the default route target or not. This can
+	// be used only when the given neighbor is a route reflector client.
+	AdvertiseDefault bool `mapstructure:"advertise-default" json:"advertise-default,omitempty"`
 }
 
 func (lhs *RouteTargetMembershipConfig) Equal(rhs *RouteTargetMembershipConfig) bool {
@@ -3347,6 +3357,9 @@ func (lhs *RouteTargetMembershipConfig) Equal(rhs *RouteTargetMembershipConfig) 
 		return false
 	}
 	if lhs.DeferralTime != rhs.DeferralTime {
+		return false
+	}
+	if lhs.AdvertiseDefault != rhs.AdvertiseDefault {
 		return false
 	}
 	return true

--- a/config/default.go
+++ b/config/default.go
@@ -203,6 +203,9 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, g *Glo
 				n.AfiSafis[i].AddPaths.Config.SendMax = n.AddPaths.Config.SendMax
 			}
 			n.AfiSafis[i].AddPaths.State.SendMax = n.AfiSafis[i].AddPaths.Config.SendMax
+			if !n.RouteReflector.Config.RouteReflectorClient && n.AfiSafis[i].RouteTargetMembership.Config.AdvertiseDefault {
+				return fmt.Errorf("advertise-default can be enabled for only route reflector client")
+			}
 		}
 	}
 

--- a/table/path.go
+++ b/table/path.go
@@ -179,6 +179,16 @@ func NewEOR(family bgp.RouteFamily) *Path {
 	}
 }
 
+func NewDefaultRouteTargetPath(source *PeerInfo) *Path {
+	nlri := bgp.NewRouteTargetMembershipNLRI(0, nil)
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_INCOMPLETE),
+		bgp.NewPathAttributeAsPath(nil),
+		bgp.NewPathAttributeMpReachNLRI("0.0.0.0", []bgp.AddrPrefixInterface{nlri}),
+	}
+	return NewPath(source, nlri, false, attrs, time.Now(), false)
+}
+
 func (path *Path) IsEOR() bool {
 	if path.info != nil && path.info.eor {
 		return true

--- a/table/table.go
+++ b/table/table.go
@@ -23,8 +23,9 @@ import (
 	"unsafe"
 
 	"github.com/armon/go-radix"
-	"github.com/osrg/gobgp/packet/bgp"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/osrg/gobgp/packet/bgp"
 )
 
 type LookupOption uint8
@@ -103,9 +104,12 @@ func (t *Table) deleteRTCPathsByVrf(vrf *Vrf, vrfs map[string]*Vrf) []*Path {
 	for _, target := range vrf.ImportRt {
 		lhs := target.String()
 		for _, dest := range t.destinations {
-			nlri := dest.GetNlri().(*bgp.RouteTargetMembershipNLRI)
-			rhs := nlri.RouteTarget.String()
-			if lhs == rhs && isLastTargetUser(vrfs, target) {
+			rhs := dest.GetNlri().(*bgp.RouteTargetMembershipNLRI).RouteTarget
+			if rhs == nil {
+				// Ignores the default route target.
+				continue
+			}
+			if lhs == rhs.String() && isLastTargetUser(vrfs, target) {
 				for _, p := range dest.knownPathList {
 					if p.IsLocal() {
 						pathList = append(pathList, p.Clone(true))

--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -384,7 +384,8 @@ class BGPContainer(Container):
                  graceful_restart=None, local_as=None, prefix_limit=None,
                  v6=False, llgr=None, vrf='', interface='', allow_as_in=0,
                  remove_private_as=None, replace_peer_as=False, addpath=False,
-                 treat_as_withdraw=False, remote_as=None):
+                 treat_as_withdraw=False, remote_as=None,
+                 advertise_default_rt=False):
         neigh_addr = ''
         local_addr = ''
         it = itertools.product(self.ip_addrs, peer.ip_addrs)
@@ -431,7 +432,8 @@ class BGPContainer(Container):
                             'replace_peer_as': replace_peer_as,
                             'addpath': addpath,
                             'treat_as_withdraw': treat_as_withdraw,
-                            'remote_as': remote_as or peer.asn}
+                            'remote_as': remote_as or peer.asn,
+                            'advertise_default_rt': advertise_default_rt}
         if self.is_running and reload_config:
             self.create_config()
             self.reload_config()

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -388,7 +388,15 @@ class GoBGPContainer(BGPContainer):
                 afi_safi_list.append({'config': {'afi-safi-name': 'l3vpn-ipv4-unicast'}})
                 afi_safi_list.append({'config': {'afi-safi-name': 'l3vpn-ipv6-unicast'}})
                 afi_safi_list.append({'config': {'afi-safi-name': 'l2vpn-evpn'}})
-                afi_safi_list.append({'config': {'afi-safi-name': 'rtc'}, 'route-target-membership': {'config': {'deferral-time': 10}}})
+                if info['is_rr_client'] and info['advertise_default_rt']:
+                    afi_safi_list.append(
+                        {'config': {'afi-safi-name': 'rtc'},
+                         'route-target-membership': {'config': {'deferral-time': 10,
+                                                                'advertise-default': True}}})
+                else:
+                    afi_safi_list.append(
+                        {'config': {'afi-safi-name': 'rtc'},
+                         'route-target-membership': {'config': {'deferral-time': 10}}})
 
             if info['flowspec']:
                 afi_safi_list.append({'config': {'afi-safi-name': 'ipv4-flowspec'}})

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -1327,9 +1327,15 @@ module gobgp {
   }
 
   grouping route-target-membership-config {
-      leaf deferral-time {
-        type uint16;
-      }
+    leaf deferral-time {
+      type uint16;
+    }
+    leaf advertise-default {
+      description
+        "Configure whether advertise the default route target or not. This can
+        be used only when the given neighbor is a route reflector client.";
+      type boolean;
+    }
   }
 
   grouping afi-safi-state {


### PR DESCRIPTION
This PR enables to advertise the default route target which suppress other specific route target advertisements. This can be used by a Route Reflector in order to reduce the amount of information exchanged between the Route Reflector and its clients.

Configuration Example:
```toml
  [[neighbors.afi-safis]]
    [neighbors.afi-safis.config]
      afi-safi-name = "rtc"
    [neighbors.afi-safis.route-target-membership.config]
      advertise-default = true
```

Also this PR includes some scenario test cases for the default route target advertisement.