### PR TITLE
don't process RTC Messages with Policies

### DIFF
--- a/table/policy.go
+++ b/table/policy.go
@@ -2868,7 +2868,7 @@ func (r *RoutingPolicy) ApplyPolicy(id string, dir PolicyDirection, before *Path
 		return nil
 	}
 
-	if before.IsWithdraw {
+	if before.IsWithdraw || before.GetRouteFamily() == bgp.RF_RTC_UC {
 		return before
 	}
 	result := ROUTE_TYPE_NONE


### PR DESCRIPTION
Currently Policy mechanism has no way to distinguish RTC messages from
proper Paths, e.g. AfiSafi Match.

When using RTC with default import/export reject all RTC messages
are rejected as well.

This commit is simple workaround for this issue.