### PR TITLE
Fix: ruby client failed with "Enum value '_' does not start with an uppercase letter as is required for Ruby constants"

### DIFF
--- a/api/gobgp.proto
+++ b/api/gobgp.proto
@@ -83,7 +83,7 @@ service GobgpApi {
 
 // Constants for address families
 enum Family {
-  _ = 0;
+  RESERVED = 0;
   IPv4 = 65537;
   IPv6 = 131073;
   IPv4_MC = 65538;


### PR DESCRIPTION
fix #1718