### PR TITLE
config: Accept CLUSTER_ID as an integer value

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -323,7 +323,7 @@ func NewPeerFromConfigStruct(pconf *config.Neighbor) *Peer {
 		},
 		RouteReflector: &RouteReflector{
 			RouteReflectorClient:    pconf.RouteReflector.Config.RouteReflectorClient,
-			RouteReflectorClusterId: string(pconf.RouteReflector.Config.RouteReflectorClusterId),
+			RouteReflectorClusterId: string(pconf.RouteReflector.State.RouteReflectorClusterId),
 		},
 		RouteServer: &RouteServer{
 			RouteServerClient: pconf.RouteServer.Config.RouteServerClient,

--- a/config/bgp_configs_test.go
+++ b/config/bgp_configs_test.go
@@ -90,10 +90,7 @@ func extractTomlFromMarkdown(fileMd string, fileToml string) error {
 	}
 
 	fTomlWriter.Flush()
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-	return nil
+	return scanner.Err()
 }
 
 func TestConfigExample(t *testing.T) {

--- a/config/default.go
+++ b/config/default.go
@@ -187,11 +187,11 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, g *Glo
 			if len(afs) > i {
 				vv.Set("afi-safi", afs[i])
 			}
-			if rf, err := bgp.GetRouteFamily(string(n.AfiSafis[i].Config.AfiSafiName)); err != nil {
+			rf, err := bgp.GetRouteFamily(string(n.AfiSafis[i].Config.AfiSafiName))
+			if err != nil {
 				return err
-			} else {
-				n.AfiSafis[i].State.Family = rf
 			}
+			n.AfiSafis[i].State.Family = rf
 			n.AfiSafis[i].State.AfiSafiName = n.AfiSafis[i].Config.AfiSafiName
 			if !vv.IsSet("afi-safi.config.enabled") {
 				n.AfiSafis[i].Config.Enabled = true
@@ -263,7 +263,7 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, g *Glo
 func SetDefaultGlobalConfigValues(g *Global) error {
 	if len(g.AfiSafis) == 0 {
 		g.AfiSafis = []AfiSafi{}
-		for k, _ := range AfiSafiTypeToIntMap {
+		for k := range AfiSafiTypeToIntMap {
 			g.AfiSafis = append(g.AfiSafis, defaultAfiSafi(k, true))
 		}
 	}
@@ -324,7 +324,7 @@ func setDefaultPolicyConfigValuesWithViper(v *viper.Viper, p *PolicyDefinition) 
 	if err != nil {
 		return err
 	}
-	for i, _ := range p.Statements {
+	for i := range p.Statements {
 		vv := viper.New()
 		if len(stmts) > i {
 			vv.Set("statement", stmts[i])

--- a/config/default_linux.go
+++ b/config/default_linux.go
@@ -18,8 +18,9 @@ package config
 
 import (
 	"fmt"
-	"github.com/vishvananda/netlink"
 	"net"
+
+	"github.com/vishvananda/netlink"
 )
 
 func GetIPv6LinkLocalNeighborAddress(ifname string) (string, error) {
@@ -40,7 +41,7 @@ func GetIPv6LinkLocalNeighborAddress(ifname string) (string, error) {
 		}
 		if neigh.State&netlink.NUD_FAILED == 0 && neigh.IP.IsLinkLocalUnicast() && !local {
 			addr = neigh.IP
-			cnt += 1
+			cnt++
 		}
 	}
 

--- a/config/serve.go
+++ b/config/serve.go
@@ -147,9 +147,8 @@ func CheckPolicyDifference(currentPolicy *RoutingPolicy, newPolicy *RoutingPolic
 		"Topic": "Config",
 	}).Debugf("New policy:%s", newPolicy)
 
-	var result bool = false
+	var result bool
 	if currentPolicy == nil && newPolicy == nil {
-
 		result = false
 	} else {
 		if currentPolicy != nil && newPolicy != nil {

--- a/config/util_test.go
+++ b/config/util_test.go
@@ -16,8 +16,9 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDetectConfigFileType(t *testing.T) {

--- a/table/destination.go
+++ b/table/destination.go
@@ -150,7 +150,7 @@ func (i *PeerInfo) String() string {
 }
 
 func NewPeerInfo(g *config.Global, p *config.Neighbor) *PeerInfo {
-	id := net.ParseIP(string(p.RouteReflector.Config.RouteReflectorClusterId)).To4()
+	clusterID := net.ParseIP(string(p.RouteReflector.State.RouteReflectorClusterId)).To4()
 	// exclude zone info
 	naddr, _ := net.ResolveIPAddr("ip", p.State.NeighborAddress)
 	return &PeerInfo{
@@ -159,7 +159,7 @@ func NewPeerInfo(g *config.Global, p *config.Neighbor) *PeerInfo {
 		LocalID:                 net.ParseIP(g.Config.RouterId).To4(),
 		RouteReflectorClient:    p.RouteReflector.Config.RouteReflectorClient,
 		Address:                 naddr.IP,
-		RouteReflectorClusterID: id,
+		RouteReflectorClusterID: clusterID,
 		MultihopTtl:             p.EbgpMultihop.Config.MultihopTtl,
 		Confederation:           p.IsConfederationMember(g),
 	}

--- a/table/path.go
+++ b/table/path.go
@@ -289,16 +289,16 @@ func UpdatePathAttrs(global *config.Global, peer *config.Neighbor, info *PeerInf
 			}
 			// When an RR reflects a route, it MUST prepend the local CLUSTER_ID to the CLUSTER_LIST.
 			// If the CLUSTER_LIST is empty, it MUST create a new one.
-			id := string(peer.RouteReflector.Config.RouteReflectorClusterId)
+			clusterID := string(peer.RouteReflector.State.RouteReflectorClusterId)
 			if p := path.getPathAttr(bgp.BGP_ATTR_TYPE_CLUSTER_LIST); p == nil {
-				path.setPathAttr(bgp.NewPathAttributeClusterList([]string{id}))
+				path.setPathAttr(bgp.NewPathAttributeClusterList([]string{clusterID}))
 			} else {
 				clusterList := p.(*bgp.PathAttributeClusterList)
 				newClusterList := make([]string, 0, len(clusterList.Value))
 				for _, ip := range clusterList.Value {
 					newClusterList = append(newClusterList, ip.String())
 				}
-				path.setPathAttr(bgp.NewPathAttributeClusterList(append([]string{id}, newClusterList...)))
+				path.setPathAttr(bgp.NewPathAttributeClusterList(append([]string{clusterID}, newClusterList...)))
 			}
 		}
 


### PR DESCRIPTION
Currently, only IPv4 address is acceptable for the CLUSTER_ID setting, this patch enables to specify the CLUSTER_ID as a 32-bit unsigned integer.

With this expansion, "Config.RouteReflectorClusterId" stores the raw configured value for the CLUSTER_ID and "State.RouteReflectorClusterId" stores the value used for construct the CLUSTER_LIST attribute.

Fixes https://github.com/osrg/gobgp/issues/1719