### PR TITLE
table: fix Clone() to inherite the attribute hash value

### DIFF
--- a/table/path.go
+++ b/table/path.go
@@ -333,6 +333,7 @@ func (path *Path) Clone(isWithdraw bool) *Path {
 		parent:           path,
 		IsWithdraw:       isWithdraw,
 		IsNexthopInvalid: path.IsNexthopInvalid,
+		attrsHash:        path.attrsHash,
 	}
 }
 


### PR DESCRIPTION
CreateUpdateMsgFromPaths() assumes that a path has a proper hash
value. If a path doesn't, the function takes too long.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>