### PR TITLE
cmd: don't display uptime for a BGP session if no uptime information

### DIFF
--- a/gobgp/cmd/neighbor.go
+++ b/gobgp/cmd/neighbor.go
@@ -196,7 +196,12 @@ func showNeighbor(args []string) error {
 		id = p.State.RemoteRouterId
 	}
 	fmt.Printf("  BGP version 4, remote router ID %s\n", id)
-	fmt.Printf("  BGP state = %s, up for %s\n", p.State.SessionState, formatTimedelta(int64(p.Timers.State.Uptime)-time.Now().Unix()))
+	fmt.Printf("  BGP state = %s", p.State.SessionState)
+	if p.Timers.State.Uptime > 0 {
+		fmt.Printf(", up for %s\n", formatTimedelta(int64(p.Timers.State.Uptime)-time.Now().Unix()))
+	} else {
+		fmt.Print("\n")
+	}
 	fmt.Printf("  BGP OutQ = %d, Flops = %d\n", p.State.Queues.Output, p.State.Flops)
 	fmt.Printf("  Hold time is %d, keepalive interval is %d seconds\n", int(p.Timers.State.NegotiatedHoldTime), int(p.Timers.State.KeepaliveInterval))
 	fmt.Printf("  Configured hold time is %d, keepalive interval is %d seconds\n", int(p.Timers.Config.HoldTime), int(p.Timers.Config.KeepaliveInterval))


### PR DESCRIPTION
Otherwise, we get something like this:

    BGP neighbor is 2001:db8:4::2, remote AS 65000
      BGP version 4, remote router ID unknown
      BGP state = active, up for 17692d 16:53:12