### PR TITLE
packet/bgp: use 71 for BGP LLGR capability code

### DIFF
--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -263,8 +263,8 @@ const (
 	BGP_CAP_FOUR_OCTET_AS_NUMBER        BGPCapabilityCode = 65
 	BGP_CAP_ADD_PATH                    BGPCapabilityCode = 69
 	BGP_CAP_ENHANCED_ROUTE_REFRESH      BGPCapabilityCode = 70
+	BGP_CAP_LONG_LIVED_GRACEFUL_RESTART BGPCapabilityCode = 71
 	BGP_CAP_ROUTE_REFRESH_CISCO         BGPCapabilityCode = 128
-	BGP_CAP_LONG_LIVED_GRACEFUL_RESTART BGPCapabilityCode = 129
 )
 
 var CapNameMap = map[BGPCapabilityCode]string{


### PR DESCRIPTION
Since the RFC is only a draft, IANA didn't attribute a code yet.
However, Juniper is supporting this feature since a long time and is
using 71. I don't know if Cisco is using the same value. BIRD will
ship soon with this capability too and will use 71 too. Wireshark also
understands capability code 71 as LLGR.

Tested with Juniper vRR 16.1 and this configuration:

```yaml
peer-groups:
  - config:
      peer-group-name: others
      peer-as: 65000
    ttl-security:
      config:
        enabled: true
        ttl-min: 255
    graceful-restart:
      config:
        enabled: true
        long-lived-enabled: true
        notification-enabled: true
        restart-time: 1
    afi-safis:
      - config:
          afi-safi-name: ipv6-unicast
        mp-graceful-restart:
          config:
            enabled: true
        long-lived-graceful-restart:
          config:
            enabled: true
            restart-time: 120
```

Enabling regular graceful restart for the appropriate AFI/SAFI is
needed to make LLGR work on the Juniper side. Unfortunately, GoBGP
doesn't allow to set restart-time to 0 (this is the same as using the
default value of 90s), therefore we have a small delay before LLGR
kicks in (during which routes are preserved). A way to set restart
time to 0 would be welcome.