### PR TITLE
config: Change "RedistributeRouteTypeList" to []string

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/osrg/gobgp/packet/bgp"
 	"github.com/osrg/gobgp/server"
 	"github.com/osrg/gobgp/table"
+	"github.com/osrg/gobgp/zebra"
 )
 
 type Server struct {
@@ -972,17 +973,14 @@ func (s *Server) GetRoa(ctx context.Context, arg *GetRoaRequest) (*GetRoaRespons
 }
 
 func (s *Server) EnableZebra(ctx context.Context, arg *EnableZebraRequest) (*EnableZebraResponse, error) {
-	l := make([]config.InstallProtocolType, 0, len(arg.RouteTypes))
 	for _, p := range arg.RouteTypes {
-		if err := config.InstallProtocolType(p).Validate(); err != nil {
+		if _, err := zebra.RouteTypeFromString(p); err != nil {
 			return &EnableZebraResponse{}, err
-		} else {
-			l = append(l, config.InstallProtocolType(p))
 		}
 	}
 	return &EnableZebraResponse{}, s.bgpServer.StartZebraClient(&config.ZebraConfig{
 		Url: arg.Url,
-		RedistributeRouteTypeList: l,
+		RedistributeRouteTypeList: arg.RouteTypes,
 		Version:                   uint8(arg.Version),
 		NexthopTriggerEnable:      arg.NexthopTriggerEnable,
 		NexthopTriggerDelay:       uint8(arg.NexthopTriggerDelay),

--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -1114,7 +1114,7 @@ type ZebraState struct {
 	// Configure url for zebra.
 	Url string `mapstructure:"url" json:"url,omitempty"`
 	// original -> gobgp:redistribute-route-type
-	RedistributeRouteTypeList []InstallProtocolType `mapstructure:"redistribute-route-type-list" json:"redistribute-route-type-list,omitempty"`
+	RedistributeRouteTypeList []string `mapstructure:"redistribute-route-type-list" json:"redistribute-route-type-list,omitempty"`
 	// original -> gobgp:version
 	// Configure version of zebra protocol.  Default is 2. Supported up to 3.
 	Version uint8 `mapstructure:"version" json:"version,omitempty"`
@@ -1135,7 +1135,7 @@ type ZebraConfig struct {
 	// Configure url for zebra.
 	Url string `mapstructure:"url" json:"url,omitempty"`
 	// original -> gobgp:redistribute-route-type
-	RedistributeRouteTypeList []InstallProtocolType `mapstructure:"redistribute-route-type-list" json:"redistribute-route-type-list,omitempty"`
+	RedistributeRouteTypeList []string `mapstructure:"redistribute-route-type-list" json:"redistribute-route-type-list,omitempty"`
 	// original -> gobgp:version
 	// Configure version of zebra protocol.  Default is 2. Supported up to 3.
 	Version uint8 `mapstructure:"version" json:"version,omitempty"`

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -1191,9 +1191,7 @@ module gobgp {
         "Configure url for zebra.";
     }
     leaf-list redistribute-route-type {
-      type identityref {
-        base ptypes:install-protocol-type;
-      }
+      type string;
     }
     leaf version {
       type uint8;


### PR DESCRIPTION
RedistributeRouteTypeList is []InstallProtocolType,
but InstallProtocolType only defines limited number of protocols,

And currently, EnableZebra() in gRPC API validates its request
with the protocols defined by InstallProtocolType,
so the protocols such as "babel" or "lldp" could not be configured
to Zebra, via gRPC API.

This patch fixes RedistributeRouteTypeList to be []string,
and fixes EnableZebra() to validate with the protocols defined
in zapi.go.

Signed-off-by: Satoshi Fujimoto <satoshi.fujimoto7@gmail.com>