### PR TITLE
simple staticcheck fixes

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -69,7 +69,7 @@ func (s *Server) Serve() error {
 
 	serve := func(host string) {
 		defer wg.Done()
-		lis, err := net.Listen("tcp", fmt.Sprintf(host))
+		lis, err := net.Listen("tcp", host)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"Topic": "grpc",

--- a/gobgp/cmd/policy.go
+++ b/gobgp/cmd/policy.go
@@ -65,7 +65,7 @@ func formatDefinedSet(head bool, typ string, indent int, list []table.DefinedSet
 			if i == 0 {
 				buff.WriteString(fmt.Sprintf(format, s.Name(), x))
 			} else {
-				buff.WriteString(fmt.Sprintf(sIndent))
+				buff.WriteString(fmt.Sprint(sIndent))
 				buff.WriteString(fmt.Sprintf(format, "", x))
 			}
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -169,7 +169,7 @@ func TestMonitor(test *testing.T) {
 		if len(rib.GetKnownPathList("", 0)) > 0 {
 			break
 		}
-		time.Sleep(1)
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	// Test WatchUpdate with "current" flag.

--- a/server/sockopt_darwin.go
+++ b/server/sockopt_darwin.go
@@ -39,19 +39,23 @@ func setsockoptIpTtl(fd int, family int, value int) error {
 
 func setListenTcpTTLSockopt(l *net.TCPListener, ttl int) error {
 	fi, family, err := extractFileAndFamilyFromTCPListener(l)
-	defer fi.Close()
 	if err != nil {
 		return err
 	}
+
+	defer fi.Close()
+
 	return setsockoptIpTtl(int(fi.Fd()), family, ttl)
 }
 
 func setTcpTTLSockopt(conn *net.TCPConn, ttl int) error {
 	fi, family, err := extractFileAndFamilyFromTCPConn(conn)
-	defer fi.Close()
 	if err != nil {
 		return err
 	}
+
+	defer fi.Close()
+
 	return setsockoptIpTtl(int(fi.Fd()), family, ttl)
 }
 


### PR DESCRIPTION
Some staticcheck issues that were identified: 

```
~/gocode/src/github.com/osrg/gobgp/api/grpc_server.go:72:45: printf-style function with dynamic first argument and no further arguments should use print-style function instead
~/gocode/src/github.com/osrg/gobgp/gobgp/cmd/policy.go:68:34: printf-style function with dynamic first argument and no further arguments should use print-style function instead                         
~/gocode/src/github.com/osrg/gobgp/server/server_test.go:172:14: sleeping for 1 nanoseconds is probably a bug. Be explicit if it isn't: time.Sleep(time.Nanosecond)                                     
~/gocode/src/github.com/osrg/gobgp/server/sockopt_darwin.go:42:2: should check returned error before deferring fi.Close()                                                                    
~/src/github.com/osrg/gobgp/server/sockopt_darwin.go:51:2: should check returned error before deferring fi.Close()
```