### PR TITLE
api: remove table/ usage in util.go

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -244,24 +244,17 @@ func (cli *Client) SoftReset(addr string, family bgp.RouteFamily) error {
 	return cli.softreset(addr, family, api.SoftResetNeighborRequest_BOTH)
 }
 
-func (cli *Client) getRIB(resource api.Resource, name string, family bgp.RouteFamily, prefixes []*table.LookupPrefix) (*table.Table, error) {
-	prefixList := make([]*api.TableLookupPrefix, 0, len(prefixes))
-	for _, p := range prefixes {
-		prefixList = append(prefixList, &api.TableLookupPrefix{
-			Prefix:       p.Prefix,
-			LookupOption: api.TableLookupOption(p.LookupOption),
-		})
-	}
+func (cli *Client) getRIB(resource api.Resource, name string, family bgp.RouteFamily, prefixes []*api.TableLookupPrefix) (*api.Table, error) {
 	stream, err := cli.cli.GetPath(context.Background(), &api.GetPathRequest{
 		Type:     resource,
 		Family:   uint32(family),
 		Name:     name,
-		Prefixes: prefixList,
+		Prefixes: prefixes,
 	})
 	if err != nil {
 		return nil, err
 	}
-	pathMap := make(map[string][]*table.Path)
+	pathMap := make(map[string][]*api.Path)
 	for {
 		p, err := stream.Recv()
 		if err != nil {
@@ -274,44 +267,40 @@ func (cli *Client) getRIB(resource api.Resource, name string, family bgp.RouteFa
 		if err != nil {
 			return nil, err
 		}
-		var path *table.Path
-		if p.Identifier > 0 {
-			path, err = p.ToNativePath()
-		} else {
-			path, err = p.ToNativePath(api.ToNativeOption{
-				NLRI: nlri,
-			})
-		}
-		if err != nil {
-			return nil, err
-		}
 		nlriStr := nlri.String()
-		pathMap[nlriStr] = append(pathMap[nlriStr], path)
+		pathMap[nlriStr] = append(pathMap[nlriStr], p)
 	}
-	dstList := make([]*table.Destination, 0, len(pathMap))
+	dstList := make([]*api.Destination, 0, len(pathMap))
 	for _, pathList := range pathMap {
-		dstList = append(dstList, table.NewDestination(pathList[0].GetNlri(), 0, pathList...))
+		nlri, _ := pathList[0].GetNativeNlri()
+		dstList = append(dstList, &api.Destination{
+			Prefix: nlri.String(),
+			Paths:  pathList,
+		})
 	}
-	return table.NewTable(family, dstList...), nil
+	return &api.Table{
+		Family:       uint32(family),
+		Destinations: dstList,
+	}, nil
 }
 
-func (cli *Client) GetRIB(family bgp.RouteFamily, prefixes []*table.LookupPrefix) (*table.Table, error) {
+func (cli *Client) GetRIB(family bgp.RouteFamily, prefixes []*api.TableLookupPrefix) (*api.Table, error) {
 	return cli.getRIB(api.Resource_GLOBAL, "", family, prefixes)
 }
 
-func (cli *Client) GetLocalRIB(name string, family bgp.RouteFamily, prefixes []*table.LookupPrefix) (*table.Table, error) {
+func (cli *Client) GetLocalRIB(name string, family bgp.RouteFamily, prefixes []*api.TableLookupPrefix) (*api.Table, error) {
 	return cli.getRIB(api.Resource_LOCAL, name, family, prefixes)
 }
 
-func (cli *Client) GetAdjRIBIn(name string, family bgp.RouteFamily, prefixes []*table.LookupPrefix) (*table.Table, error) {
+func (cli *Client) GetAdjRIBIn(name string, family bgp.RouteFamily, prefixes []*api.TableLookupPrefix) (*api.Table, error) {
 	return cli.getRIB(api.Resource_ADJ_IN, name, family, prefixes)
 }
 
-func (cli *Client) GetAdjRIBOut(name string, family bgp.RouteFamily, prefixes []*table.LookupPrefix) (*table.Table, error) {
+func (cli *Client) GetAdjRIBOut(name string, family bgp.RouteFamily, prefixes []*api.TableLookupPrefix) (*api.Table, error) {
 	return cli.getRIB(api.Resource_ADJ_OUT, name, family, prefixes)
 }
 
-func (cli *Client) GetVRFRIB(name string, family bgp.RouteFamily, prefixes []*table.LookupPrefix) (*table.Table, error) {
+func (cli *Client) GetVRFRIB(name string, family bgp.RouteFamily, prefixes []*api.TableLookupPrefix) (*api.Table, error) {
 	return cli.getRIB(api.Resource_VRF, name, family, prefixes)
 }
 
@@ -834,14 +823,14 @@ func (cli *Client) GetRPKI() ([]*config.RpkiServer, error) {
 	return servers, nil
 }
 
-func (cli *Client) GetROA(family bgp.RouteFamily) ([]*table.ROA, error) {
+func (cli *Client) GetROA(family bgp.RouteFamily) ([]*api.Roa, error) {
 	rsp, err := cli.cli.GetRoa(context.Background(), &api.GetRoaRequest{
 		Family: uint32(family),
 	})
 	if err != nil {
 		return nil, err
 	}
-	return api.NewROAListFromApiStructList(rsp.Roas)
+	return rsp.Roas, nil
 }
 
 func (cli *Client) AddRPKIServer(address string, port, lifetime int) error {
@@ -920,12 +909,8 @@ type MonitorRIBClient struct {
 	stream api.GobgpApi_MonitorRibClient
 }
 
-func (c *MonitorRIBClient) Recv() (*table.Destination, error) {
-	d, err := c.stream.Recv()
-	if err != nil {
-		return nil, err
-	}
-	return d.ToNativeDestination()
+func (c *MonitorRIBClient) Recv() (*api.Destination, error) {
+	return c.stream.Recv()
 }
 
 func (cli *Client) MonitorRIB(family bgp.RouteFamily, current bool) (*MonitorRIBClient, error) {

--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -354,3 +354,15 @@ func exitWithError(err error) {
 	printError(err)
 	os.Exit(1)
 }
+
+func getNextHopFromPathAttributes(attrs []bgp.PathAttributeInterface) net.IP {
+	for _, attr := range attrs {
+		switch a := attr.(type) {
+		case *bgp.PathAttributeNextHop:
+			return a.Value
+		case *bgp.PathAttributeMpReachNLRI:
+			return a.Nexthop
+		}
+	}
+	return nil
+}

--- a/gobgp/cmd/neighbor.go
+++ b/gobgp/cmd/neighbor.go
@@ -16,6 +16,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -29,6 +30,8 @@ import (
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
 	"github.com/osrg/gobgp/table"
+
+	api "github.com/osrg/gobgp/api"
 )
 
 // used in showRoute() to determine the width of each column
@@ -428,18 +431,21 @@ type AsPathFormat struct {
 	separator string
 }
 
-func getPathSymbolString(p *table.Path, idx int, showBest bool) string {
+func getPathSymbolString(p *api.Path, idx int, showBest bool) string {
 	symbols := ""
-	if p.IsStale() {
+	if p.Stale {
 		symbols += "S"
 	}
-	switch p.ValidationStatus() {
-	case config.RPKI_VALIDATION_RESULT_TYPE_NOT_FOUND:
-		symbols += "N"
-	case config.RPKI_VALIDATION_RESULT_TYPE_VALID:
-		symbols += "V"
-	case config.RPKI_VALIDATION_RESULT_TYPE_INVALID:
-		symbols += "I"
+	if v := p.GetValidationDetail(); v != nil {
+		switch v.State {
+		case api.RPKIValidation_STATE_NOT_FOUND:
+			symbols += "N"
+		case api.RPKIValidation_STATE_VALID:
+			symbols += "V"
+		case api.RPKIValidation_STATE_INVALID:
+			symbols += "I"
+		}
+
 	}
 	if showBest {
 		if idx == 0 && !p.IsNexthopInvalid {
@@ -451,9 +457,9 @@ func getPathSymbolString(p *table.Path, idx int, showBest bool) string {
 	return symbols
 }
 
-func getPathAttributeString(p *table.Path) string {
+func getPathAttributeString(nlri bgp.AddrPrefixInterface, attrs []bgp.PathAttributeInterface) string {
 	s := make([]string, 0)
-	for _, a := range p.GetPathAttrs() {
+	for _, a := range attrs {
 		switch a.GetType() {
 		case bgp.BGP_ATTR_TYPE_NEXT_HOP, bgp.BGP_ATTR_TYPE_MP_REACH_NLRI, bgp.BGP_ATTR_TYPE_AS_PATH, bgp.BGP_ATTR_TYPE_AS4_PATH:
 			continue
@@ -461,7 +467,7 @@ func getPathAttributeString(p *table.Path) string {
 			s = append(s, a.String())
 		}
 	}
-	switch n := p.GetNlri().(type) {
+	switch n := nlri.(type) {
 	case *bgp.EVPNNLRI:
 		// We print non route key fields like path attributes.
 		switch route := n.RouteTypeData.(type) {
@@ -477,8 +483,8 @@ func getPathAttributeString(p *table.Path) string {
 	return fmt.Sprint(s)
 }
 
-func makeShowRouteArgs(p *table.Path, idx int, now time.Time, showAge, showBest, showLabel bool, showIdentifier bgp.BGPAddPathMode) []interface{} {
-	nlri := p.GetNlri()
+func makeShowRouteArgs(p *api.Path, idx int, now time.Time, showAge, showBest, showLabel bool, showIdentifier bgp.BGPAddPathMode) []interface{} {
+	nlri, _ := p.GetNativeNlri()
 
 	// Path Symbols (e.g. "*>")
 	args := []interface{}{getPathSymbolString(p, idx, showBest)}
@@ -486,9 +492,9 @@ func makeShowRouteArgs(p *table.Path, idx int, now time.Time, showAge, showBest,
 	// Path Identifier
 	switch showIdentifier {
 	case bgp.BGP_ADD_PATH_RECEIVE:
-		args = append(args, fmt.Sprint(nlri.PathIdentifier()))
+		args = append(args, fmt.Sprint(p.GetIdentifier()))
 	case bgp.BGP_ADD_PATH_SEND:
-		args = append(args, fmt.Sprint(nlri.PathLocalIdentifier()))
+		args = append(args, fmt.Sprint(p.GetLocalIdentifier()))
 	}
 
 	// NLRI
@@ -497,28 +503,38 @@ func makeShowRouteArgs(p *table.Path, idx int, now time.Time, showAge, showBest,
 	// Label
 	label := ""
 	if showLabel {
-		label = p.GetLabelString()
+		label = bgp.LabelString(nlri)
 		args = append(args, label)
 	}
 
+	attrs, _ := p.GetNativePathAttributes()
 	// Next Hop
 	nexthop := "fictitious"
-	if n := p.GetNexthop(); n != nil {
-		nexthop = p.GetNexthop().String()
+	if n := getNextHopFromPathAttributes(attrs); n != nil {
+		nexthop = n.String()
 	}
 	args = append(args, nexthop)
 
 	// AS_PATH
-	aspathstr := p.GetAsString()
+	aspathstr := func() string {
+		for _, attr := range attrs {
+			switch a := attr.(type) {
+			case *bgp.PathAttributeAsPath:
+				return bgp.AsPathString(a)
+			}
+		}
+		return ""
+	}()
 	args = append(args, aspathstr)
 
 	// Age
 	if showAge {
-		args = append(args, formatTimedelta(int64(now.Sub(p.GetTimestamp()).Seconds())))
+		t := time.Unix(p.Age, 0)
+		args = append(args, formatTimedelta(int64(now.Sub(t).Seconds())))
 	}
 
 	// Path Attributes
-	pattrstr := getPathAttributeString(p)
+	pattrstr := getPathAttributeString(nlri, attrs)
 	args = append(args, pattrstr)
 
 	updateColumnWidth(nlri.String(), nexthop, aspathstr, label)
@@ -526,11 +542,11 @@ func makeShowRouteArgs(p *table.Path, idx int, now time.Time, showAge, showBest,
 	return args
 }
 
-func showRoute(destinationList [][]*table.Path, showAge, showBest, showLabel bool, showIdentifier bgp.BGPAddPathMode) {
-	var pathStrs [][]interface{}
+func showRoute(dsts []*api.Destination, showAge, showBest, showLabel bool, showIdentifier bgp.BGPAddPathMode) {
+	pathStrs := make([][]interface{}, 0, len(dsts))
 	now := time.Now()
-	for _, pathList := range destinationList {
-		for idx, p := range pathList {
+	for _, dst := range dsts {
+		for idx, p := range dst.Paths {
 			pathStrs = append(pathStrs, makeShowRouteArgs(p, idx, now, showAge, showBest, showLabel, showIdentifier))
 		}
 	}
@@ -564,8 +580,7 @@ func showRoute(destinationList [][]*table.Path, showAge, showBest, showLabel boo
 	}
 }
 
-func checkOriginAsWasNotShown(p *table.Path, shownAs map[uint32]struct{}) bool {
-	asPath := p.GetAsPath().Value
+func checkOriginAsWasNotShown(p *api.Path, asPath []bgp.AsPathParamInterface, shownAs map[uint32]struct{}) bool {
 	// the path was generated in internal
 	if len(asPath) == 0 {
 		return false
@@ -580,59 +595,67 @@ func checkOriginAsWasNotShown(p *table.Path, shownAs map[uint32]struct{}) bool {
 	return true
 }
 
-func showValidationInfo(p *table.Path, shownAs map[uint32]struct{}) error {
-	asPath := p.GetAsPath().Value
+func showValidationInfo(p *api.Path, shownAs map[uint32]struct{}) error {
+	var asPath []bgp.AsPathParamInterface
+	attrs, _ := p.GetNativePathAttributes()
+	for _, attr := range attrs {
+		if attr.GetType() == bgp.BGP_ATTR_TYPE_AS_PATH {
+			asPath = attr.(*bgp.PathAttributeAsPath).Value
+		}
+	}
+
+	nlri, _ := p.GetNativeNlri()
 	if len(asPath) == 0 {
-		return fmt.Errorf("The path to %s was locally generated.\n", p.GetNlri().String())
-	} else if !checkOriginAsWasNotShown(p, shownAs) {
+		return fmt.Errorf("The path to %s was locally generated.\n", nlri.String())
+	} else if !checkOriginAsWasNotShown(p, asPath, shownAs) {
 		return nil
 	}
 
-	status := p.Validation().Status
-	reason := p.Validation().Reason
+	status := p.GetValidationDetail().State
+	reason := p.GetValidationDetail().Reason
 	asList := asPath[len(asPath)-1].GetAS()
 	origin := asList[len(asList)-1]
 
-	fmt.Printf("Target Prefix: %s, AS: %d\n", p.GetNlri().String(), origin)
+	fmt.Printf("Target Prefix: %s, AS: %d\n", nlri.String(), origin)
 	fmt.Printf("  This route is %s", status)
 	switch status {
-	case config.RPKI_VALIDATION_RESULT_TYPE_INVALID:
+	case api.RPKIValidation_STATE_INVALID:
 		fmt.Printf("  reason: %s\n", reason)
 		switch reason {
-		case table.RPKI_VALIDATION_REASON_TYPE_AS:
+		case api.RPKIValidation_REASON_AS:
 			fmt.Println("  No VRP ASN matches the route origin ASN.")
-		case table.RPKI_VALIDATION_REASON_TYPE_LENGTH:
+		case api.RPKIValidation_REASON_LENGTH:
 			fmt.Println("  Route Prefix length is greater than the maximum length allowed by VRP(s) matching this route origin ASN.")
 		}
-	case config.RPKI_VALIDATION_RESULT_TYPE_NOT_FOUND:
+	case api.RPKIValidation_STATE_NOT_FOUND:
 		fmt.Println("\n  No VRP Covers the Route Prefix")
 	default:
 		fmt.Print("\n\n")
 	}
 
-	printVRPs := func(l []*table.ROA) {
+	printVRPs := func(l []*api.Roa) {
 		if len(l) == 0 {
 			fmt.Println("    No Entry")
 		} else {
 			var format string
-			if ip, _, _ := net.ParseCIDR(p.GetNlri().String()); ip.To4() != nil {
+			if ip, _, _ := net.ParseCIDR(nlri.String()); ip.To4() != nil {
 				format = "    %-18s %-6s %-10s\n"
 			} else {
 				format = "    %-42s %-6s %-10s\n"
 			}
 			fmt.Printf(format, "Network", "AS", "MaxLen")
 			for _, m := range l {
-				fmt.Printf(format, m.Prefix, fmt.Sprint(m.AS), fmt.Sprint(m.MaxLen))
+				fmt.Printf(format, m.Prefix, fmt.Sprint(m.As), fmt.Sprint(m.Maxlen))
 			}
 		}
 	}
 
 	fmt.Println("  Matched VRPs: ")
-	printVRPs(p.Validation().Matched)
+	printVRPs(p.GetValidationDetail().Matched)
 	fmt.Println("  Unmatched AS VRPs: ")
-	printVRPs(p.Validation().UnmatchedAs)
+	printVRPs(p.GetValidationDetail().UnmatchedAs)
 	fmt.Println("  Unmatched Length VRPs: ")
-	printVRPs(p.Validation().UnmatchedLength)
+	printVRPs(p.GetValidationDetail().UnmatchedLength)
 
 	return nil
 }
@@ -673,7 +696,6 @@ func showRibInfo(r, name string) error {
 	fmt.Printf("Table %s\n", family)
 	fmt.Printf("Destination: %d, Path: %d\n", info.NumDestination, info.NumPath)
 	return nil
-
 }
 
 func parseCIDRorIP(str string) (net.IP, *net.IPNet, error) {
@@ -717,7 +739,7 @@ func showNeighborRib(r string, name string, args []string) error {
 		showLabel = true
 	}
 
-	var filter []*table.LookupPrefix
+	var filter []*api.TableLookupPrefix
 	if len(args) > 0 {
 		target := args[0]
 		switch family {
@@ -728,13 +750,13 @@ func showNeighborRib(r string, name string, args []string) error {
 				return err
 			}
 		}
-		var option table.LookupOption
+		var option api.TableLookupOption
 		args = args[1:]
 		for len(args) != 0 {
 			if args[0] == "longer-prefixes" {
-				option = table.LOOKUP_LONGER
+				option = api.TableLookupOption_LOOKUP_LONGER
 			} else if args[0] == "shorter-prefixes" {
-				option = table.LOOKUP_SHORTER
+				option = api.TableLookupOption_LOOKUP_SHORTER
 			} else if args[0] == "validation" {
 				if r != CMD_ADJ_IN {
 					return fmt.Errorf("RPKI information is supported for only adj-in.")
@@ -745,14 +767,14 @@ func showNeighborRib(r string, name string, args []string) error {
 			}
 			args = args[1:]
 		}
-		filter = []*table.LookupPrefix{&table.LookupPrefix{
+		filter = []*api.TableLookupPrefix{&api.TableLookupPrefix{
 			Prefix:       target,
 			LookupOption: option,
 		},
 		}
 	}
 
-	var rib *table.Table
+	var rib *api.Table
 	switch r {
 	case CMD_GLOBAL:
 		rib, err = client.GetRIB(family, filter)
@@ -774,7 +796,7 @@ func showNeighborRib(r string, name string, args []string) error {
 
 	switch r {
 	case CMD_LOCAL, CMD_ADJ_IN, CMD_ACCEPTED, CMD_REJECTED, CMD_ADJ_OUT:
-		if rib.Info("", 0).NumDestination == 0 {
+		if len(rib.Destinations) == 0 {
 			peer, err := client.GetNeighbor(name, false)
 			if err != nil {
 				return err
@@ -786,9 +808,9 @@ func showNeighborRib(r string, name string, args []string) error {
 	}
 
 	if globalOpts.Json {
-		d := make(map[string]*table.Destination)
+		d := make(map[string]*api.Destination)
 		for _, dst := range rib.GetDestinations() {
-			d[dst.GetNlri().String()] = dst
+			d[dst.Prefix] = dst
 		}
 		j, _ := json.Marshal(d)
 		fmt.Println(string(j))
@@ -797,46 +819,67 @@ func showNeighborRib(r string, name string, args []string) error {
 
 	if validationTarget != "" {
 		// show RPKI validation info
-		addr, _, err := net.ParseCIDR(validationTarget)
-		if err != nil {
-			return err
-		}
-		var nlri bgp.AddrPrefixInterface
-		if addr.To16() == nil {
-			nlri, _ = bgp.NewPrefixFromRouteFamily(bgp.AFI_IP, bgp.SAFI_UNICAST, validationTarget)
-		} else {
-			nlri, _ = bgp.NewPrefixFromRouteFamily(bgp.AFI_IP6, bgp.SAFI_UNICAST, validationTarget)
-		}
-		d := rib.GetDestination(nlri)
+		d := func() *api.Destination {
+			for _, dst := range rib.GetDestinations() {
+				if dst.Prefix == validationTarget {
+					return dst
+				}
+			}
+			return nil
+		}()
 		if d == nil {
 			fmt.Println("Network not in table")
 			return nil
 		}
 		shownAs := make(map[uint32]struct{})
-		for _, p := range d.GetAllKnownPathList() {
+		for _, p := range d.GetPaths() {
 			if err := showValidationInfo(p, shownAs); err != nil {
 				return err
 			}
 		}
 	} else {
 		// show RIB
-		var ds [][]*table.Path
-		for _, d := range rib.GetSortedDestinations() {
-			var ps []*table.Path
+		dsts := rib.GetDestinations()
+		switch family {
+		case bgp.RF_IPv4_UC, bgp.RF_IPv6_UC:
+			type d struct {
+				prefix net.IP
+				dst    *api.Destination
+			}
+			l := make([]*d, 0, len(dsts))
+			for _, dst := range dsts {
+				_, p, _ := net.ParseCIDR(dst.Prefix)
+				l = append(l, &d{prefix: p.IP, dst: dst})
+			}
+
+			sort.Slice(l, func(i, j int) bool {
+				return bytes.Compare(l[i].prefix, l[j].prefix) < 0
+			})
+
+			dsts = make([]*api.Destination, 0, len(dsts))
+			for _, s := range l {
+				dsts = append(dsts, s.dst)
+			}
+		}
+
+		for _, d := range dsts {
 			switch r {
 			case CMD_ACCEPTED:
-				for _, p := range d.GetAllKnownPathList() {
-					ps = append(ps, p)
+				l := make([]*api.Path, 0, len(d.Paths))
+				for _, p := range d.GetPaths() {
+					if !p.Filtered {
+						l = append(l, p)
+					}
 				}
+				d.Paths = l
 			case CMD_REJECTED:
 				// always nothing
+				d.Paths = []*api.Path{}
 			default:
-				ps = d.GetAllKnownPathList()
 			}
-			ds = append(ds, ps)
 		}
-		if len(ds) > 0 {
-			showRoute(ds, showAge, showBest, showLabel, showIdentifier)
+		if len(dsts) > 0 {
+			showRoute(dsts, showAge, showBest, showLabel, showIdentifier)
 		} else {
 			fmt.Println("Network not in table")
 		}

--- a/gobgp/cmd/rpki.go
+++ b/gobgp/cmd/rpki.go
@@ -90,11 +90,10 @@ func showRPKITable(args []string) error {
 	}
 	fmt.Printf(format, "Network", "Maxlen", "AS", "Server")
 	for _, r := range roas {
-		host, _, _ := net.SplitHostPort(r.Src)
-		if len(args) > 0 && args[0] != host {
+		if len(args) > 0 && args[0] != r.Conf.Address {
 			continue
 		}
-		fmt.Printf(format, r.Prefix.String(), fmt.Sprint(r.MaxLen), fmt.Sprint(r.AS), r.Src)
+		fmt.Printf(format, r.Prefix, fmt.Sprint(r.Maxlen), fmt.Sprint(r.As), net.JoinHostPort(r.Conf.Address, r.Conf.RemotePort))
 	}
 	return nil
 }

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -1073,6 +1073,34 @@ type AddrPrefixInterface interface {
 	SetPathLocalIdentifier(uint32)
 }
 
+func LabelString(nlri AddrPrefixInterface) string {
+	label := ""
+	switch n := nlri.(type) {
+	case *LabeledIPAddrPrefix:
+		label = n.Labels.String()
+	case *LabeledIPv6AddrPrefix:
+		label = n.Labels.String()
+	case *LabeledVPNIPAddrPrefix:
+		label = n.Labels.String()
+	case *LabeledVPNIPv6AddrPrefix:
+		label = n.Labels.String()
+	case *EVPNNLRI:
+		switch route := n.RouteTypeData.(type) {
+		case *EVPNEthernetAutoDiscoveryRoute:
+			label = fmt.Sprintf("[%d]", route.Label)
+		case *EVPNMacIPAdvertisementRoute:
+			var l []string
+			for _, i := range route.Labels {
+				l = append(l, strconv.Itoa(int(i)))
+			}
+			label = fmt.Sprintf("[%s]", strings.Join(l, ","))
+		case *EVPNIPPrefixRoute:
+			label = fmt.Sprintf("[%d]", route.Label)
+		}
+	}
+	return label
+}
+
 type PrefixDefault struct {
 	id      uint32
 	localId uint32
@@ -5254,6 +5282,44 @@ type AsPathParamInterface interface {
 	ASLen() int
 	MarshalJSON() ([]byte, error)
 	String() string
+}
+
+func AsPathString(aspath *PathAttributeAsPath) string {
+	s := bytes.NewBuffer(make([]byte, 0, 64))
+	for i, param := range aspath.Value {
+		segType := param.GetType()
+		asList := param.GetAS()
+		if i != 0 {
+			s.WriteString(" ")
+		}
+
+		sep := " "
+		switch segType {
+		case BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
+			s.WriteString("(")
+		case BGP_ASPATH_ATTR_TYPE_CONFED_SET:
+			s.WriteString("[")
+			sep = ","
+		case BGP_ASPATH_ATTR_TYPE_SET:
+			s.WriteString("{")
+			sep = ","
+		}
+		for j, as := range asList {
+			s.WriteString(fmt.Sprintf("%d", as))
+			if j != len(asList)-1 {
+				s.WriteString(sep)
+			}
+		}
+		switch segType {
+		case BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
+			s.WriteString(")")
+		case BGP_ASPATH_ATTR_TYPE_CONFED_SET:
+			s.WriteString("]")
+		case BGP_ASPATH_ATTR_TYPE_SET:
+			s.WriteString("}")
+		}
+	}
+	return s.String()
 }
 
 type AsPathParam struct {

--- a/server/server.go
+++ b/server/server.go
@@ -2833,7 +2833,7 @@ func (w *Watcher) Generate(t WatchEventType) error {
 			pathList := func() map[string][]*table.Path {
 				pathList := make(map[string][]*table.Path)
 				for _, t := range rib.Tables {
-					for _, dst := range t.GetSortedDestinations() {
+					for _, dst := range t.GetDestinations() {
 						if paths := dst.GetKnownPathList(id, as); len(paths) > 0 {
 							pathList[dst.GetNlri().String()] = clonePathList(paths)
 						}

--- a/table/path.go
+++ b/table/path.go
@@ -22,8 +22,6 @@ import (
 	"math"
 	"net"
 	"sort"
-	"strconv"
-	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -610,39 +608,7 @@ func (path *Path) GetAsPathLen() int {
 func (path *Path) GetAsString() string {
 	s := bytes.NewBuffer(make([]byte, 0, 64))
 	if aspath := path.GetAsPath(); aspath != nil {
-		for i, param := range aspath.Value {
-			segType := param.GetType()
-			asList := param.GetAS()
-			if i != 0 {
-				s.WriteString(" ")
-			}
-
-			sep := " "
-			switch segType {
-			case bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
-				s.WriteString("(")
-			case bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET:
-				s.WriteString("[")
-				sep = ","
-			case bgp.BGP_ASPATH_ATTR_TYPE_SET:
-				s.WriteString("{")
-				sep = ","
-			}
-			for j, as := range asList {
-				s.WriteString(fmt.Sprintf("%d", as))
-				if j != len(asList)-1 {
-					s.WriteString(sep)
-				}
-			}
-			switch segType {
-			case bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
-				s.WriteString(")")
-			case bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET:
-				s.WriteString("]")
-			case bgp.BGP_ASPATH_ATTR_TYPE_SET:
-				s.WriteString("}")
-			}
-		}
+		return bgp.AsPathString(aspath)
 	}
 	return s.String()
 }
@@ -677,31 +643,7 @@ func (path *Path) getAsListOfSpecificType(getAsSeq, getAsSet bool) []uint32 {
 }
 
 func (path *Path) GetLabelString() string {
-	label := ""
-	switch n := path.GetNlri().(type) {
-	case *bgp.LabeledIPAddrPrefix:
-		label = n.Labels.String()
-	case *bgp.LabeledIPv6AddrPrefix:
-		label = n.Labels.String()
-	case *bgp.LabeledVPNIPAddrPrefix:
-		label = n.Labels.String()
-	case *bgp.LabeledVPNIPv6AddrPrefix:
-		label = n.Labels.String()
-	case *bgp.EVPNNLRI:
-		switch route := n.RouteTypeData.(type) {
-		case *bgp.EVPNEthernetAutoDiscoveryRoute:
-			label = fmt.Sprintf("[%d]", route.Label)
-		case *bgp.EVPNMacIPAdvertisementRoute:
-			var l []string
-			for _, i := range route.Labels {
-				l = append(l, strconv.Itoa(int(i)))
-			}
-			label = fmt.Sprintf("[%s]", strings.Join(l, ","))
-		case *bgp.EVPNIPPrefixRoute:
-			label = fmt.Sprintf("[%d]", route.Label)
-		}
-	}
-	return label
+	return bgp.LabelString(path.GetNlri())
 }
 
 // PrependAsn prepends AS number.

--- a/table/table.go
+++ b/table/table.go
@@ -18,7 +18,6 @@ package table
 import (
 	"fmt"
 	"net"
-	"sort"
 	"strings"
 	"unsafe"
 
@@ -188,27 +187,6 @@ func (t *Table) getOrCreateDest(nlri bgp.AddrPrefixInterface) *Destination {
 		t.setDestination(dest)
 	}
 	return dest
-}
-
-func (t *Table) GetSortedDestinations() []*Destination {
-	results := make([]*Destination, 0, len(t.GetDestinations()))
-	switch t.routeFamily {
-	case bgp.RF_IPv4_UC, bgp.RF_IPv6_UC:
-		r := radix.New()
-		for _, dst := range t.GetDestinations() {
-			r.Insert(AddrToRadixkey(dst.nlri), dst)
-		}
-		r.Walk(func(s string, v interface{}) bool {
-			results = append(results, v.(*Destination))
-			return false
-		})
-	default:
-		for _, dst := range t.GetDestinations() {
-			results = append(results, dst)
-		}
-		sort.Sort(destinations(results))
-	}
-	return results
 }
 
 func (t *Table) GetDestinations() map[string]*Destination {


### PR DESCRIPTION
This is a part of work removing table/ usage in api/. api/ will depend
on only protobuf stuff and packet/.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>