### PR TITLE
api: Allow multiple NLRIs in single MpReachNLRIAttribute

### DIFF
--- a/api/attribute.go
+++ b/api/attribute.go
@@ -1291,12 +1291,7 @@ func UnmarshalPathAttributes(values []*any.Any) ([]bgp.PathAttributeInterface, e
 		case *ClusterListAttribute:
 			attr, err = v.ToNative()
 		case *MpReachNLRIAttribute:
-			var nlri *bgp.PathAttributeMpReachNLRI
-			nlri, err = v.ToNative()
-			if len(nlri.Value) > 1 {
-				return nil, fmt.Errorf("multiple nlri in a single mp_reach_nlri are not supported")
-			}
-			attr = nlri
+			attr, err = v.ToNative()
 		case *MpUnreachNLRIAttribute:
 			attr, err = v.ToNative()
 		case *ExtendedCommunitiesAttribute:


### PR DESCRIPTION
Currently, api.UnmarshalPathAttributes() does not allow the multiple NLRIs in a single MpReachNLRIAttribute because when AddPath API supposes only single NLRI is composed. This assumption is equivalent to that "message Path" structure should have single NLRI for calling AddPath
API.

But to represent the received UPDATE messages from peers, a single MpReachNLRIAttribute can contain the multiple NLRIs.

This patch fixes to allow the multiple NLRIs in a single MpReachNLRIAttribute and removes this constraint.

---
Also this PR and https://github.com/osrg/gobgp/pull/1754 will solve the CI errors on https://github.com/osrg/gobgp/pull/1731