### PR TITLE
log: don't use global logger from logrus

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -48,7 +48,10 @@
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
-    "ptypes/any"
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp"
   ]
   revision = "748d386b5c1ea99658fd69fe9f03991ce86a90c1"
 
@@ -144,8 +147,8 @@
     ".",
     "hooks/syslog"
   ]
-  revision = "a3f95b5c423586578a4e099b11a46c2479628cac"
-  version = "1.0.2"
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
+  version = "v1.0.5"
 
 [[projects]]
   branch = "master"
@@ -209,6 +212,12 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  revision = "7f39a6fea4fe9364fb61e1def6a268a51b4f3a06"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -224,8 +233,11 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix"]
-  revision = "e312636bdaa2fac4f0acde9d17ab9fbad2b4ad10"
+  packages = [
+    "unix",
+    "windows"
+  ]
+  revision = "ad87a3a340fa7f3bed189293fbfa7a9b7e021ae1"
 
 [[projects]]
   branch = "master"
@@ -285,6 +297,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6100eb99bf349d89739e85e9549f95a8351710d0e70e63057b82c213fbab07fd"
+  inputs-digest = "b6d3a8726570620e3d59704a462d15f2748ec61f79bf7e7a8fd79a06d9385479"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -55,7 +55,7 @@
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"
-  version = "1.0.2"
+  version = "1.0.5"
 
 [[constraint]]
   branch = "master"

--- a/api/attribute.go
+++ b/api/attribute.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/osrg/gobgp/packet/bgp"
 )
@@ -175,7 +175,7 @@ func MarshalRD(rd bgp.RouteDistinguisherInterface) *any.Any {
 			Assigned: uint32(v.Assigned),
 		}
 	default:
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "protobuf",
 			"RD":    rd,
 		}).Warn("invalid rd type to marshal")
@@ -699,7 +699,7 @@ func MarshalRT(rt bgp.ExtendedCommunityInterface) *any.Any {
 			LocalAdmin:   uint32(v.LocalAdmin),
 		}
 	default:
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "protobuf",
 			"RT":    rt,
 		}).Warn("invalid rt type to marshal")
@@ -847,7 +847,7 @@ func NewExtendedCommunitiesAttributeFromNative(a *bgp.PathAttributeExtendedCommu
 				Value: v.Value,
 			}
 		default:
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic":     "protobuf",
 				"Community": value,
 			}).Warn("unsupported extended community")
@@ -1072,7 +1072,7 @@ func NewIP6ExtendedCommunitiesAttributeFromNative(a *bgp.PathAttributeIP6Extende
 				LocalAdmin: uint32(v.LocalAdmin),
 			}
 		default:
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic":     "protobuf",
 				"Attribute": value,
 			}).Warn("invalid ipv6 extended community")

--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -29,7 +29,7 @@ import (
 
 	farm "github.com/dgryski/go-farm"
 	"github.com/golang/protobuf/ptypes/any"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -71,7 +71,7 @@ func (s *Server) Serve() error {
 		defer wg.Done()
 		lis, err := net.Listen("tcp", host)
 		if err != nil {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "grpc",
 				"Key":   host,
 				"Error": err,
@@ -79,7 +79,7 @@ func (s *Server) Serve() error {
 			return
 		}
 		err = s.grpcServer.Serve(lis)
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "grpc",
 			"Key":   host,
 			"Error": err,

--- a/api/util.go
+++ b/api/util.go
@@ -25,6 +25,8 @@ import (
 	"github.com/osrg/gobgp/table"
 )
 
+var log = config.Logger
+
 type ToNativeOption struct {
 	LocalAS                 uint32
 	LocalID                 net.IP

--- a/config/serve.go
+++ b/config/serve.go
@@ -5,9 +5,13 @@ import (
 	"os/signal"
 	"syscall"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
+
+// Logger is the global log handler for GoBGP
+var Logger = logrus.New()
+var log = Logger
 
 type BgpConfigSet struct {
 	Global            Global             `mapstructure:"global"`
@@ -48,7 +52,7 @@ func ReadConfigfileServe(path, format string, configCh chan *BgpConfigSet) {
 			goto ERROR
 		}
 		if cnt == 0 {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Config",
 			}).Info("Finished reading the config file")
 		}
@@ -57,12 +61,12 @@ func ReadConfigfileServe(path, format string, configCh chan *BgpConfigSet) {
 		goto NEXT
 	ERROR:
 		if cnt == 0 {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Config",
 				"Error": err,
 			}).Fatalf("Can't read config file %s", path)
 		} else {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Config",
 				"Error": err,
 			}).Warningf("Can't read config file %s", path)
@@ -70,7 +74,7 @@ func ReadConfigfileServe(path, format string, configCh chan *BgpConfigSet) {
 	NEXT:
 		select {
 		case <-sigCh:
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Config",
 			}).Info("Reload the config file")
 		}
@@ -93,10 +97,10 @@ func UpdatePeerGroupConfig(curC, newC *BgpConfigSet) ([]PeerGroup, []PeerGroup, 
 		if idx := existPeerGroup(n.Config.PeerGroupName, curC.PeerGroups); idx < 0 {
 			addedPg = append(addedPg, n)
 		} else if !n.Equal(&curC.PeerGroups[idx]) {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Config",
 			}).Debugf("Current peer-group config:%s", curC.PeerGroups[idx])
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Config",
 			}).Debugf("New peer-group config:%s", n)
 			updatedPg = append(updatedPg, n)
@@ -120,10 +124,10 @@ func UpdateNeighborConfig(curC, newC *BgpConfigSet) ([]Neighbor, []Neighbor, []N
 		if idx := inSlice(n, curC.Neighbors); idx < 0 {
 			added = append(added, n)
 		} else if !n.Equal(&curC.Neighbors[idx]) {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Config",
 			}).Debugf("Current neighbor config:%s", curC.Neighbors[idx])
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Config",
 			}).Debugf("New neighbor config:%s", n)
 			updated = append(updated, n)
@@ -140,10 +144,10 @@ func UpdateNeighborConfig(curC, newC *BgpConfigSet) ([]Neighbor, []Neighbor, []N
 
 func CheckPolicyDifference(currentPolicy *RoutingPolicy, newPolicy *RoutingPolicy) bool {
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Config",
 	}).Debugf("Current policy:%s", currentPolicy)
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Config",
 	}).Debugf("New policy:%s", newPolicy)
 

--- a/docs/sources/lib.md
+++ b/docs/sources/lib.md
@@ -13,7 +13,7 @@ package main
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	api "github.com/osrg/gobgp/api"
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
@@ -23,7 +23,8 @@ import (
 )
 
 func main() {
-	log.SetLevel(log.DebugLevel)
+	log := config.Logger
+	log.SetLevel(logrus.DebugLevel)
 	s := gobgp.NewBgpServer()
 	go s.Serve()
 

--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -29,7 +29,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/jessevdk/go-flags"
 	"github.com/kr/pretty"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -42,6 +42,7 @@ import (
 )
 
 var version = "master"
+var log = config.Logger
 
 func marshalRouteTargets(l []string) ([]*any.Any, error) {
 	rtList := make([]*any.Any, 0, len(l))
@@ -106,17 +107,17 @@ func main() {
 
 	switch opts.LogLevel {
 	case "debug":
-		log.SetLevel(log.DebugLevel)
+		log.SetLevel(logrus.DebugLevel)
 	case "info":
-		log.SetLevel(log.InfoLevel)
+		log.SetLevel(logrus.InfoLevel)
 	default:
-		log.SetLevel(log.InfoLevel)
+		log.SetLevel(logrus.InfoLevel)
 	}
 
 	if opts.DisableStdlog == true {
-		log.SetOutput(ioutil.Discard)
+		log.Out = ioutil.Discard
 	} else {
-		log.SetOutput(os.Stdout)
+		log.Out = os.Stdout
 	}
 
 	if opts.UseSyslog != "" {
@@ -127,12 +128,12 @@ func main() {
 
 	if opts.LogPlain {
 		if opts.DisableStdlog {
-			log.SetFormatter(&log.TextFormatter{
+			log.Formatter = &logrus.TextFormatter{
 				DisableColors: true,
-			})
+			}
 		}
 	} else {
-		log.SetFormatter(&log.JSONFormatter{})
+		log.Formatter = &logrus.JSONFormatter{}
 	}
 
 	configCh := make(chan *config.BgpConfigSet)

--- a/gobgpd/util.go
+++ b/gobgpd/util.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"syscall"
 
-	log "github.com/sirupsen/logrus"
 	lSyslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 

--- a/gobmpd/main.go
+++ b/gobmpd/main.go
@@ -19,12 +19,15 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/osrg/gobgp/packet/bmp"
-	log "github.com/sirupsen/logrus"
 	"net"
 	"os"
 	"strconv"
+
+	"github.com/osrg/gobgp/config"
+	"github.com/osrg/gobgp/packet/bmp"
 )
+
+var log = config.Logger
 
 func connLoop(conn *net.TCPConn) {
 	addr := conn.RemoteAddr()

--- a/server/bmp.go
+++ b/server/bmp.go
@@ -21,11 +21,12 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
 	"github.com/osrg/gobgp/packet/bmp"
 	"github.com/osrg/gobgp/table"
-	log "github.com/sirupsen/logrus"
 )
 
 type ribout map[string][]*table.Path
@@ -82,7 +83,7 @@ func (r ribout) update(p *table.Path) bool {
 func (b *bmpClient) tryConnect() *net.TCPConn {
 	interval := 1
 	for {
-		log.WithFields(log.Fields{"Topic": "bmp"}).Debugf("Connecting BMP server:%s", b.host)
+		log.WithFields(logrus.Fields{"Topic": "bmp"}).Debugf("Connecting BMP server:%s", b.host)
 		conn, err := net.Dial("tcp", b.host)
 		if err != nil {
 			select {
@@ -95,7 +96,7 @@ func (b *bmpClient) tryConnect() *net.TCPConn {
 				interval *= 2
 			}
 		} else {
-			log.WithFields(log.Fields{"Topic": "bmp"}).Infof("BMP server is connected:%s", b.host)
+			log.WithFields(logrus.Fields{"Topic": "bmp"}).Infof("BMP server is connected:%s", b.host)
 			return conn.(*net.TCPConn)
 		}
 	}
@@ -116,7 +117,7 @@ func (b *bmpClient) loop() {
 			ops := []WatchOption{WatchPeerState(true)}
 			if b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH {
 				log.WithFields(
-					log.Fields{"Topic": "bmp"},
+					logrus.Fields{"Topic": "bmp"},
 				).Warn("both option for route-monitoring-policy is obsoleted")
 			}
 			if b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY || b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
@@ -136,7 +137,7 @@ func (b *bmpClient) loop() {
 
 			var tickerCh <-chan time.Time
 			if b.c.StatisticsTimeout == 0 {
-				log.WithFields(log.Fields{"Topic": "bmp"}).Debug("statistics reports disabled")
+				log.WithFields(logrus.Fields{"Topic": "bmp"}).Debug("statistics reports disabled")
 			} else {
 				t := time.NewTicker(time.Duration(b.c.StatisticsTimeout) * time.Second)
 				defer t.Stop()

--- a/server/fsm_test.go
+++ b/server/fsm_test.go
@@ -23,11 +23,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/eapache/channels"
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
 	"github.com/osrg/gobgp/table"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -255,7 +256,7 @@ func TestFSMHandlerEstablish_HoldTimerExpired(t *testing.T) {
 }
 
 func TestFSMHandlerOpenconfirm_HoldtimeZero(t *testing.T) {
-	log.SetLevel(log.DebugLevel)
+	log.SetLevel(logrus.DebugLevel)
 	assert := assert.New(t)
 	m := NewMockConnection(t)
 
@@ -278,7 +279,7 @@ func TestFSMHandlerOpenconfirm_HoldtimeZero(t *testing.T) {
 }
 
 func TestFSMHandlerEstablished_HoldtimeZero(t *testing.T) {
-	log.SetLevel(log.DebugLevel)
+	log.SetLevel(logrus.DebugLevel)
 	assert := assert.New(t)
 	m := NewMockConnection(t)
 

--- a/server/mrt.go
+++ b/server/mrt.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
@@ -105,7 +105,7 @@ func (m *mrtWriter) loop() error {
 					subtype = mrt.MESSAGE_AS4
 				}
 				if bm, err := mrt.NewMRTMessage(uint32(e.Timestamp.Unix()), mrt.BGP4MP, subtype, mp); err != nil {
-					log.WithFields(log.Fields{
+					log.WithFields(logrus.Fields{
 						"Topic": "mrt",
 						"Data":  e,
 						"Error": err,
@@ -126,7 +126,7 @@ func (m *mrtWriter) loop() error {
 				}
 
 				if bm, err := mrt.NewMRTMessage(t, mrt.TABLE_DUMPv2, mrt.PEER_INDEX_TABLE, mrt.NewPeerIndexTable(e.RouterId, "", peers)); err != nil {
-					log.WithFields(log.Fields{
+					log.WithFields(logrus.Fields{
 						"Topic": "mrt",
 						"Data":  e,
 						"Error": err,
@@ -168,7 +168,7 @@ func (m *mrtWriter) loop() error {
 				appendTableDumpMsg := func(path *table.Path, entries []*mrt.RibEntry, isAddPath bool) {
 					st := subtype(path, isAddPath)
 					if bm, err := mrt.NewMRTMessage(t, mrt.TABLE_DUMPv2, st, mrt.NewRib(seq, path.GetNlri(), entries)); err != nil {
-						log.WithFields(log.Fields{
+						log.WithFields(logrus.Fields{
 							"Topic": "mrt",
 							"Data":  e,
 							"Error": err,
@@ -219,7 +219,7 @@ func (m *mrtWriter) loop() error {
 				if _, err := m.file.Write(buf); err == nil {
 					m.file.Sync()
 				} else {
-					log.WithFields(log.Fields{
+					log.WithFields(logrus.Fields{
 						"Topic": "mrt",
 						"Error": err,
 					}).Warn("Can't write to destination MRT file")
@@ -230,7 +230,7 @@ func (m *mrtWriter) loop() error {
 			for _, e := range events {
 				for _, m := range serialize(e) {
 					if buf, err := m.Serialize(); err != nil {
-						log.WithFields(log.Fields{
+						log.WithFields(logrus.Fields{
 							"Topic": "mrt",
 							"Data":  e,
 							"Error": err,
@@ -254,7 +254,7 @@ func (m *mrtWriter) loop() error {
 			if err == nil {
 				m.file = file
 			} else {
-				log.WithFields(log.Fields{
+				log.WithFields(logrus.Fields{
 					"Topic": "mrt",
 					"Error": err,
 				}).Warn("can't rotate MRT file")
@@ -287,7 +287,7 @@ func mrtFileOpen(filename string, interval uint64) (*os.File, error) {
 	if interval != 0 {
 		realname = time.Now().Format(filename)
 	}
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic":         "mrt",
 		"Filename":      realname,
 		"Dump Interval": interval,
@@ -306,7 +306,7 @@ func mrtFileOpen(filename string, interval uint64) (*os.File, error) {
 
 	if j > 0 {
 		if err := os.MkdirAll(realname[0:j-1], 0755); err != nil {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "mrt",
 				"Error": err,
 			}).Warn("can't create MRT destination directory")
@@ -316,7 +316,7 @@ func mrtFileOpen(filename string, interval uint64) (*os.File, error) {
 
 	file, err := os.OpenFile(realname, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0644)
 	if err != nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "mrt",
 			"Error": err,
 		}).Warn("can't create MRT destination file")
@@ -355,7 +355,7 @@ func (m *mrtManager) enable(c *config.MrtConfig) error {
 
 	setRotationMin := func() {
 		if rInterval < MIN_ROTATION_INTERVAL {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "MRT",
 			}).Infof("minimum mrt rotation interval is %d seconds", MIN_ROTATION_INTERVAL)
 			rInterval = MIN_ROTATION_INTERVAL
@@ -365,7 +365,7 @@ func (m *mrtManager) enable(c *config.MrtConfig) error {
 	if c.DumpType == config.MRT_TYPE_TABLE {
 		if rInterval == 0 {
 			if dInterval < MIN_DUMP_INTERVAL {
-				log.WithFields(log.Fields{
+				log.WithFields(logrus.Fields{
 					"Topic": "MRT",
 				}).Infof("minimum mrt dump interval is %d seconds", MIN_DUMP_INTERVAL)
 				dInterval = MIN_DUMP_INTERVAL

--- a/server/rpki.go
+++ b/server/rpki.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/armon/go-radix"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 
 	"github.com/osrg/gobgp/config"
@@ -230,12 +230,12 @@ func (m *roaManager) HandleROAEvent(ev *ROAEvent) {
 		if ev.EventType == CONNECTED {
 			ev.conn.Close()
 		}
-		log.WithFields(log.Fields{"Topic": "rpki"}).Errorf("Can't find %s ROA server configuration", ev.Src)
+		log.WithFields(logrus.Fields{"Topic": "rpki"}).Errorf("Can't find %s ROA server configuration", ev.Src)
 		return
 	}
 	switch ev.EventType {
 	case DISCONNECTED:
-		log.WithFields(log.Fields{"Topic": "rpki"}).Infof("ROA server %s is disconnected", ev.Src)
+		log.WithFields(logrus.Fields{"Topic": "rpki"}).Infof("ROA server %s is disconnected", ev.Src)
 		client.state.Downtime = time.Now().Unix()
 		// clear state
 		client.endOfData = false
@@ -246,7 +246,7 @@ func (m *roaManager) HandleROAEvent(ev *ROAEvent) {
 		client.timer = time.AfterFunc(time.Duration(client.lifetime)*time.Second, client.lifetimeout)
 		client.oldSessionID = client.sessionID
 	case CONNECTED:
-		log.WithFields(log.Fields{"Topic": "rpki"}).Infof("ROA server %s is connected", ev.Src)
+		log.WithFields(logrus.Fields{"Topic": "rpki"}).Infof("ROA server %s is connected", ev.Src)
 		client.conn = ev.conn
 		client.state.Uptime = time.Now().Unix()
 		go client.established()
@@ -261,9 +261,9 @@ func (m *roaManager) HandleROAEvent(ev *ROAEvent) {
 		// all stale ROAs were deleted -> timer was cancelled
 		// so should not be here.
 		if client.oldSessionID != client.sessionID {
-			log.WithFields(log.Fields{"Topic": "rpki"}).Infof("Reconnected to %s. Ignore timeout", client.host)
+			log.WithFields(logrus.Fields{"Topic": "rpki"}).Infof("Reconnected to %s. Ignore timeout", client.host)
 		} else {
-			log.WithFields(log.Fields{"Topic": "rpki"}).Infof("Deleting all ROAs due to timeout with:%s", client.host)
+			log.WithFields(logrus.Fields{"Topic": "rpki"}).Infof("Deleting all ROAs due to timeout with:%s", client.host)
 			m.deleteAllROA(client.host)
 		}
 	}
@@ -296,7 +296,7 @@ func (m *roaManager) deleteROA(roa *table.ROA) {
 			return
 		}
 	}
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic":         "rpki",
 		"Prefix":        roa.Prefix.Prefix.String(),
 		"Prefix Length": roa.Prefix.Length,
@@ -399,7 +399,7 @@ func (c *roaManager) handleRTRMsg(client *roaClient, state *config.RpkiServerSta
 			received.Error++
 		}
 	} else {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "rpki",
 			"Host":  client.host,
 			"Error": err,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osrg/gobgp/config"
@@ -420,7 +420,7 @@ func TestFilterpathWithRejectPolicy(t *testing.T) {
 
 func TestPeerGroup(test *testing.T) {
 	assert := assert.New(test)
-	log.SetLevel(log.DebugLevel)
+	log.SetLevel(logrus.DebugLevel)
 	s := NewBgpServer()
 	go s.Serve()
 	err := s.Start(&config.Global{
@@ -504,7 +504,7 @@ func TestPeerGroup(test *testing.T) {
 
 func TestDynamicNeighbor(t *testing.T) {
 	assert := assert.New(t)
-	log.SetLevel(log.DebugLevel)
+	log.SetLevel(logrus.DebugLevel)
 	s1 := NewBgpServer()
 	go s1.Serve()
 	err := s1.Start(&config.Global{

--- a/server/sockopt.go
+++ b/server/sockopt.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
@@ -54,19 +54,19 @@ type TCPDialer struct {
 
 func (d *TCPDialer) DialTCP(addr string, port int) (*net.TCPConn, error) {
 	if d.AuthPassword != "" {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Peer",
 			"Key":   addr,
 		}).Warn("setting md5 for active connection is not supported")
 	}
 	if d.Ttl != 0 {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Peer",
 			"Key":   addr,
 		}).Warn("setting ttl for active connection is not supported")
 	}
 	if d.TtlMin != 0 {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Peer",
 			"Key":   addr,
 		}).Warn("setting min ttl for active connection is not supported")

--- a/server/sockopt_openbsd.go
+++ b/server/sockopt_openbsd.go
@@ -24,7 +24,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -320,12 +320,12 @@ func saAdd(address, key string) error {
 func saDelete(address string) error {
 	if spi, y := spiInMap[address]; y {
 		if err := rfkeyRequest(SADB_DELETE, address, "", spi, ""); err != nil {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Peer",
 				"Key":   address,
 			}).Info("failed to delete md5 for incoming")
 		} else {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Peer",
 				"Key":   address,
 			}).Info("can't find spi for md5 for incoming")
@@ -333,12 +333,12 @@ func saDelete(address string) error {
 	}
 	if spi, y := spiOutMap[address]; y {
 		if err := rfkeyRequest(SADB_DELETE, "", address, spi, ""); err != nil {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Peer",
 				"Key":   address,
 			}).Info("failed to delete md5 for outgoing")
 		} else {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Peer",
 				"Key":   address,
 			}).Info("can't find spi for md5 for outgoing")
@@ -433,19 +433,19 @@ type TCPDialer struct {
 
 func (d *TCPDialer) DialTCP(addr string, port int) (*net.TCPConn, error) {
 	if d.AuthPassword != "" {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Peer",
 			"Key":   addr,
 		}).Warn("setting md5 for active connection is not supported")
 	}
 	if d.Ttl != 0 {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Peer",
 			"Key":   addr,
 		}).Warn("setting ttl for active connection is not supported")
 	}
 	if d.TtlMin != 0 {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Peer",
 			"Key":   addr,
 		}).Warn("setting min ttl for active connection is not supported")

--- a/server/zclient.go
+++ b/server/zclient.go
@@ -24,7 +24,7 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/osrg/gobgp/packet/bgp"
 	"github.com/osrg/gobgp/table"
@@ -233,7 +233,7 @@ func newPathFromIPRouteMessage(m *zebra.Message) *table.Path {
 	origin := bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP)
 	pattr = append(pattr, origin)
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic":        "Zebra",
 		"RouteType":    body.Type.String(),
 		"Flag":         body.Flags.String(),
@@ -262,7 +262,7 @@ func newPathFromIPRouteMessage(m *zebra.Message) *table.Path {
 		}
 		pattr = append(pattr, bgp.NewPathAttributeMpReachNLRI(nexthop, []bgp.AddrPrefixInterface{nlri}))
 	default:
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Zebra",
 		}).Errorf("unsupport address family: %s", family)
 		return nil
@@ -303,7 +303,7 @@ func (z *zebraClient) getPathListWithNexthopUpdate(body *zebra.NexthopUpdateBody
 	for _, rf := range rfList {
 		tbl, _, err := z.server.GetRib("", rf, nil)
 		if err != nil {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic":  "Zebra",
 				"Family": rf.String(),
 				"Error":  err,
@@ -320,7 +320,7 @@ func (z *zebraClient) updatePathByNexthopCache(paths []*table.Path) {
 	paths = z.nexthopCache.applyToPathList(paths)
 	if len(paths) > 0 {
 		if err := z.server.UpdatePath("", paths); err != nil {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic":    "Zebra",
 				"PathList": paths,
 			}).Error("failed to update nexthop reachability")
@@ -345,7 +345,7 @@ func (z *zebraClient) loop() {
 			case *zebra.IPRouteBody:
 				if path := newPathFromIPRouteMessage(msg); path != nil {
 					if _, err := z.server.AddPath("", []*table.Path{path}); err != nil {
-						log.WithFields(log.Fields{
+						log.WithFields(logrus.Fields{
 							"Topic": "Zebra",
 							"Path":  path,
 							"Error": err,
@@ -425,7 +425,7 @@ func newZebraClient(s *BgpServer, url string, protos []string, version uint8, nh
 			break
 		}
 		// Retry with another Zebra message version
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Zebra",
 		}).Warnf("cannot connect to Zebra with message version %d. going to retry another version...", ver)
 	}

--- a/table/destination.go
+++ b/table/destination.go
@@ -23,7 +23,7 @@ import (
 	"net"
 	"sort"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
@@ -258,7 +258,7 @@ func (dd *Destination) GetMultiBestPath(id string) []*Path {
 func (dd *Destination) validatePath(path *Path) {
 	if path == nil || path.GetRouteFamily() != dd.routeFamily {
 
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic":      "Table",
 			"Key":        dd.GetNlri().String(),
 			"Path":       path,
@@ -317,7 +317,7 @@ func (dest *Destination) Calculate(newPath *Path) *Update {
 // stopped by the same policies.
 //
 func (dest *Destination) explicitWithdraw(withdraw *Path) *Path {
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 		"Key":   dest.GetNlri().String(),
 	}).Debug("Removing withdrawals")
@@ -325,7 +325,7 @@ func (dest *Destination) explicitWithdraw(withdraw *Path) *Path {
 	// If we have some withdrawals and no know-paths, it means it is safe to
 	// delete these withdraws.
 	if len(dest.knownPathList) == 0 {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Table",
 			"Key":   dest.GetNlri().String(),
 		}).Debug("Found withdrawals for path(s) that did not get installed")
@@ -344,7 +344,7 @@ func (dest *Destination) explicitWithdraw(withdraw *Path) *Path {
 
 	// We do no have any match for this withdraw.
 	if isFound == -1 {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Table",
 			"Key":   dest.GetNlri().String(),
 			"Path":  withdraw,
@@ -372,7 +372,7 @@ func (dest *Destination) implicitWithdraw(newPath *Path) {
 		// paths and when doing RouteRefresh (not EnhancedRouteRefresh)
 		// we get same paths again.
 		if newPath.GetSource().Equal(path.GetSource()) && newPath.GetNlri().PathIdentifier() == path.GetNlri().PathIdentifier() {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Table",
 				"Key":   dest.GetNlri().String(),
 				"Path":  path,
@@ -390,7 +390,7 @@ func (dest *Destination) implicitWithdraw(newPath *Path) {
 
 func (dest *Destination) computeKnownBestPath() (*Path, BestPathReason, error) {
 	if SelectionOptions.DisableBestPathSelection {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Table",
 		}).Debug("computeKnownBestPath skipped")
 		return nil, BPR_DISABLED, nil
@@ -402,7 +402,7 @@ func (dest *Destination) computeKnownBestPath() (*Path, BestPathReason, error) {
 		return nil, BPR_UNKNOWN, nil
 	}
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 	}).Debugf("computeKnownBestPath knownPathList: %d", len(dest.knownPathList))
 
@@ -516,7 +516,7 @@ func (dst *Destination) sort() {
 			var e error = nil
 			better, e = compareByRouterID(path1, path2)
 			if e != nil {
-				log.WithFields(log.Fields{
+				log.WithFields(logrus.Fields{
 					"Topic": "Table",
 					"Error": e,
 				}).Error("Could not get best path by comparing router ID")
@@ -664,7 +664,7 @@ func compareByReachableNexthop(path1, path2 *Path) *Path {
 	//
 	//	If no path matches this criteria, return nil.
 	//	For BGP Nexthop Tracking, evaluates next-hop is validated by IGP.
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 	}).Debugf("enter compareByReachableNexthop -- path1: %s, path2: %s", path1, path2)
 
@@ -684,7 +684,7 @@ func compareByHighestWeight(path1, path2 *Path) *Path {
 	//	is configured.
 	//	Return:
 	//	nil if best path among given paths cannot be decided, else best path.
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 	}).Debugf("enter compareByHighestWeight -- path1: %s, path2: %s", path1, path2)
 	return nil
@@ -699,7 +699,7 @@ func compareByLocalPref(path1, path2 *Path) *Path {
 	//	we return None.
 	//
 	//	# Default local-pref values is 100
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 	}).Debug("enter compareByLocalPref")
 	localPref1, _ := path1.GetLocalPref()
@@ -722,7 +722,7 @@ func compareByLocalOrigin(path1, path2 *Path) *Path {
 	// Returns None if given paths have same source.
 	//
 	// If both paths are from same sources we cannot compare them here.
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 	}).Debug("enter compareByLocalOrigin")
 	if path1.GetSource().Equal(path2.GetSource()) {
@@ -747,12 +747,12 @@ func compareByASPath(path1, path2 *Path) *Path {
 	// Shortest as-path length is preferred. If both path have same lengths,
 	// we return None.
 	if SelectionOptions.IgnoreAsPathLength {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Table",
 		}).Debug("compareByASPath -- skip")
 		return nil
 	}
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 	}).Debug("enter compareByASPath")
 	attribute1 := path1.getPathAttr(bgp.BGP_ATTR_TYPE_AS_PATH)
@@ -761,7 +761,7 @@ func compareByASPath(path1, path2 *Path) *Path {
 	// With addpath support, we could compare paths from API don't
 	// AS_PATH. No need to warn here.
 	if !path1.IsLocal() && !path2.IsLocal() && (attribute1 == nil || attribute2 == nil) {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic":   "Table",
 			"Key":     "compareByASPath",
 			"ASPath1": attribute1,
@@ -772,7 +772,7 @@ func compareByASPath(path1, path2 *Path) *Path {
 	l1 := path1.GetAsPathLen()
 	l2 := path2.GetAsPathLen()
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 	}).Debugf("compareByASPath -- l1: %d, l2: %d", l1, l2)
 	if l1 > l2 {
@@ -789,14 +789,14 @@ func compareByOrigin(path1, path2 *Path) *Path {
 	//
 	//	IGP is preferred over EGP; EGP is preferred over Incomplete.
 	//	If both paths have same origin, we return None.
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 	}).Debug("enter compareByOrigin")
 	attribute1 := path1.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGIN)
 	attribute2 := path2.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGIN)
 
 	if attribute1 == nil || attribute2 == nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic":   "Table",
 			"Key":     "compareByOrigin",
 			"Origin1": attribute1,
@@ -807,7 +807,7 @@ func compareByOrigin(path1, path2 *Path) *Path {
 
 	origin1 := attribute1.(*bgp.PathAttributeOrigin).Value
 	origin2 := attribute2.(*bgp.PathAttributeOrigin).Value
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 	}).Debugf("compareByOrigin -- origin1: %d, origin2: %d", origin1, origin2)
 
@@ -855,7 +855,7 @@ func compareByMED(path1, path2 *Path) *Path {
 	}()
 
 	if SelectionOptions.AlwaysCompareMed || isInternal || isSameAS {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Table",
 		}).Debug("enter compareByMED")
 		getMed := func(path *Path) uint32 {
@@ -869,7 +869,7 @@ func compareByMED(path1, path2 *Path) *Path {
 
 		med1 := getMed(path1)
 		med2 := getMed(path2)
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Table",
 		}).Debugf("compareByMED -- med1: %d, med2: %d", med1, med2)
 		if med1 == med2 {
@@ -879,7 +879,7 @@ func compareByMED(path1, path2 *Path) *Path {
 		}
 		return path2
 	} else {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Table",
 		}).Debugf("skip compareByMED %v %v %v", SelectionOptions.AlwaysCompareMed, isInternal, isSameAS)
 		return nil
@@ -892,11 +892,11 @@ func compareByASNumber(path1, path2 *Path) *Path {
 	//
 	//eBGP path is preferred over iBGP. If both paths are from same kind of
 	//peers, return None.
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 	}).Debug("enter compareByASNumber")
 
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 	}).Debugf("compareByASNumber -- p1Asn: %d, p2Asn: %d", path1.GetSource().AS, path2.GetSource().AS)
 	// Path from confederation member should be treated as internal (IBGP learned) path.
@@ -919,7 +919,7 @@ func compareByIGPCost(path1, path2 *Path) *Path {
 	//
 	//	Return None if igp cost is same.
 	// Currently BGPS has no concept of IGP and IGP cost.
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 	}).Debugf("enter compareByIGPCost -- path1: %v, path2: %v", path1, path2)
 	return nil
@@ -932,7 +932,7 @@ func compareByRouterID(path1, path2 *Path) (*Path, error) {
 	//	not pick best-path based on this criteria.
 	//	RFC: http://tools.ietf.org/html/rfc5004
 	//	We pick best path between two iBGP paths as usual.
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic": "Table",
 	}).Debug("enter compareByRouterID")
 

--- a/table/message.go
+++ b/table/message.go
@@ -19,8 +19,9 @@ import (
 	"bytes"
 	"reflect"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/osrg/gobgp/packet/bgp"
-	log "github.com/sirupsen/logrus"
 )
 
 func UpdatePathAttrs2ByteAs(msg *bgp.BGPUpdate) error {
@@ -148,7 +149,7 @@ func UpdatePathAttrs4ByteAs(msg *bgp.BGPUpdate) error {
 				if p.Type == bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET {
 					typ = "CONFED_SET"
 				}
-				log.WithFields(log.Fields{
+				log.WithFields(logrus.Fields{
 					"Topic": "Table",
 				}).Warnf("AS4_PATH contains %s segment %s. ignore", typ, p.String())
 				continue
@@ -159,7 +160,7 @@ func UpdatePathAttrs4ByteAs(msg *bgp.BGPUpdate) error {
 	}
 
 	if asLen+asConfedLen < as4Len {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Table",
 		}).Warn("AS4_PATH is longer than AS_PATH. ignore AS4_PATH")
 		return nil

--- a/table/path.go
+++ b/table/path.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
@@ -150,7 +150,7 @@ type Path struct {
 
 func NewPath(source *PeerInfo, nlri bgp.AddrPrefixInterface, isWithdraw bool, pattrs []bgp.PathAttributeInterface, timestamp time.Time, noImplicitWithdraw bool) *Path {
 	if !isWithdraw && pattrs == nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Table",
 			"Key":   nlri.String(),
 		}).Error("Need to provide path attributes for non-withdrawn path.")
@@ -304,7 +304,7 @@ func UpdatePathAttrs(global *config.Global, peer *config.Neighbor, info *PeerInf
 		}
 
 	} else {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Peer",
 			"Key":   peer.State.NeighborAddress,
 		}).Warnf("invalid peer type: %d", peer.State.PeerType)

--- a/table/policy.go
+++ b/table/policy.go
@@ -26,9 +26,8 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
-
 	radix "github.com/armon/go-radix"
+	"github.com/sirupsen/logrus"
 
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
@@ -334,7 +333,7 @@ func NewPrefix(c config.Prefix) (*Prefix, error) {
 		exp := regexp.MustCompile("(\\d+)\\.\\.(\\d+)")
 		elems := exp.FindStringSubmatch(maskRange)
 		if len(elems) != 3 {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic":           "Policy",
 				"Type":            "Prefix",
 				"MaskRangeFormat": maskRange,
@@ -1370,7 +1369,7 @@ func (c *NextHopCondition) String() string {
 // If NextHopSet's length is zero, return true.
 func (c *NextHopCondition) Evaluate(path *Path, options *PolicyOptions) bool {
 	if len(c.set.list) == 0 {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Policy",
 		}).Debug("NextHop doesn't have elements")
 		return true
@@ -1518,7 +1517,7 @@ func (c *NeighborCondition) Option() MatchOption {
 // If NeighborList's length is zero, return true.
 func (c *NeighborCondition) Evaluate(path *Path, options *PolicyOptions) bool {
 	if len(c.set.list) == 0 {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Policy",
 		}).Debug("NeighborList doesn't have elements")
 		return true
@@ -2408,7 +2407,7 @@ func (a *MedAction) Apply(path *Path, _ *PolicyOptions) *Path {
 	}
 
 	if err != nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Policy",
 			"Type":  "Med Action",
 			"Error": err,
@@ -2506,7 +2505,7 @@ func (a *AsPathPrependAction) Apply(path *Path, option *PolicyOptions) *Path {
 	if a.useLeftMost {
 		aspath := path.GetAsSeqList()
 		if len(aspath) == 0 {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Policy",
 				"Type":  "AsPathPrepend Action",
 			}).Warn("aspath length is zero.")
@@ -2514,7 +2513,7 @@ func (a *AsPathPrependAction) Apply(path *Path, option *PolicyOptions) *Path {
 		}
 		asn = aspath[0]
 		if asn == 0 {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Policy",
 				"Type":  "AsPathPrepend Action",
 			}).Warn("left-most ASN is not seq")
@@ -3692,7 +3691,7 @@ func (r *RoutingPolicy) DeletePolicy(x *Policy, all, preserve bool, activeId []s
 			err = fmt.Errorf("can't delete. policy %s is in use", name)
 			return
 		}
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Policy",
 			"Key":   name,
 		}).Debug("delete policy")
@@ -3703,7 +3702,7 @@ func (r *RoutingPolicy) DeletePolicy(x *Policy, all, preserve bool, activeId []s
 	if err == nil && !preserve {
 		for _, st := range y.Statements {
 			if !r.statementInUse(st) {
-				log.WithFields(log.Fields{
+				log.WithFields(logrus.Fields{
 					"Topic": "Policy",
 					"Key":   st.Name,
 				}).Debug("delete unused statement")
@@ -3753,7 +3752,7 @@ func (r *RoutingPolicy) ReplacePolicy(x *Policy, refer, preserve bool) (err erro
 	if err == nil && !preserve {
 		for _, st := range ys {
 			if !r.statementInUse(st) {
-				log.WithFields(log.Fields{
+				log.WithFields(logrus.Fields{
 					"Topic": "Policy",
 					"Key":   st.Name,
 				}).Debug("delete unused statement")
@@ -3902,7 +3901,7 @@ func (r *RoutingPolicy) Reset(rp *config.RoutingPolicy, ap map[string]config.App
 
 	if rp != nil {
 		if err := r.reload(*rp); err != nil {
-			log.WithFields(log.Fields{
+			log.WithFields(logrus.Fields{
 				"Topic": "Policy",
 			}).Errorf("failed to create routing policy: %s", err)
 			return err
@@ -3913,7 +3912,7 @@ func (r *RoutingPolicy) Reset(rp *config.RoutingPolicy, ap map[string]config.App
 		for _, dir := range []PolicyDirection{POLICY_DIRECTION_IN, POLICY_DIRECTION_IMPORT, POLICY_DIRECTION_EXPORT} {
 			ps, def, err := r.getAssignmentFromConfig(dir, c)
 			if err != nil {
-				log.WithFields(log.Fields{
+				log.WithFields(logrus.Fields{
 					"Topic": "Policy",
 					"Dir":   dir,
 				}).Errorf("failed to get policy info: %s", err)

--- a/table/policy_test.go
+++ b/table/policy_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/osrg/gobgp/config"
@@ -1011,7 +1011,7 @@ func TestAsPathCondition(t *testing.T) {
 		for _, a := range v {
 			result := c.Evaluate(a.path, nil)
 			if a.result != result {
-				log.WithFields(log.Fields{
+				log.WithFields(logrus.Fields{
 					"EXP":      k,
 					"ASSTR":    a.path.GetAsString(),
 					"Expected": a.result,

--- a/table/table.go
+++ b/table/table.go
@@ -23,9 +23,13 @@ import (
 	"unsafe"
 
 	"github.com/armon/go-radix"
+	"github.com/sirupsen/logrus"
+
+	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
-	log "github.com/sirupsen/logrus"
 )
+
+var log = config.Logger
 
 type LookupOption uint8
 
@@ -136,13 +140,13 @@ func (t *Table) deleteDest(dest *Destination) {
 
 func (t *Table) validatePath(path *Path) {
 	if path == nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Table",
 			"Key":   t.routeFamily,
 		}).Error("path is nil")
 	}
 	if path.GetRouteFamily() != t.routeFamily {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic":      "Table",
 			"Key":        t.routeFamily,
 			"Prefix":     path.GetNlri().String(),
@@ -154,7 +158,7 @@ func (t *Table) validatePath(path *Path) {
 		for _, as := range pathParam {
 			_, y := as.(*bgp.As4PathParam)
 			if !y {
-				log.WithFields(log.Fields{
+				log.WithFields(logrus.Fields{
 					"Topic": "Table",
 					"Key":   t.routeFamily,
 					"As":    as,
@@ -163,13 +167,13 @@ func (t *Table) validatePath(path *Path) {
 		}
 	}
 	if attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_AS4_PATH); attr != nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Table",
 			"Key":   t.routeFamily,
 		}).Fatal("AS4_PATH must be converted to AS_PATH")
 	}
 	if path.GetNlri() == nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Table",
 			"Key":   t.routeFamily,
 		}).Fatal("path's nlri is nil")
@@ -180,7 +184,7 @@ func (t *Table) getOrCreateDest(nlri bgp.AddrPrefixInterface) *Destination {
 	dest := t.GetDestination(nlri)
 	// If destination for given prefix does not exist we create it.
 	if dest == nil {
-		log.WithFields(log.Fields{
+		log.WithFields(logrus.Fields{
 			"Topic": "Table",
 			"Nlri":  nlri,
 		}).Debugf("create Destination")

--- a/table/table_manager.go
+++ b/table/table_manager.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	farm "github.com/dgryski/go-farm"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/osrg/gobgp/packet/bgp"
 )
@@ -132,7 +132,7 @@ func (manager *TableManager) AddVrf(name string, id uint32, rd bgp.RouteDistingu
 	if _, ok := manager.Vrfs[name]; ok {
 		return nil, fmt.Errorf("vrf %s already exists", name)
 	}
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic":    "Vrf",
 		"Key":      name,
 		"Rd":       rd,
@@ -167,7 +167,7 @@ func (manager *TableManager) DeleteVrf(name string) ([]*Path, error) {
 	for _, t := range manager.Tables {
 		msgs = append(msgs, t.deletePathsByVrf(vrf)...)
 	}
-	log.WithFields(log.Fields{
+	log.WithFields(logrus.Fields{
 		"Topic":    "Vrf",
 		"Key":      vrf.Name,
 		"Rd":       vrf.Rd,

--- a/table/table_manager_test.go
+++ b/table/table_manager_test.go
@@ -18,13 +18,12 @@ package table
 import (
 	_ "fmt"
 	"net"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/osrg/gobgp/packet/bgp"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/osrg/gobgp/packet/bgp"
 )
 
 // process BGPUpdate message
@@ -40,16 +39,6 @@ func (manager *TableManager) ProcessUpdate(fromPeer *PeerInfo, message *bgp.BGPM
 		pathList = append(pathList, b)
 	}
 	return pathList, nil
-}
-
-func getLogger(lv log.Level) *log.Logger {
-	var l *log.Logger = &log.Logger{
-		Out:       os.Stderr,
-		Formatter: new(log.JSONFormatter),
-		Hooks:     make(map[log.Level][]log.Hook),
-		Level:     lv,
-	}
-	return l
 }
 
 func peerR1() *PeerInfo {


### PR DESCRIPTION
Instead, use our own global logger. It is defined in config package
and users should be able to configure it this way. Example has been
updated to reflect this change.

Unfortunately, for the user, this is not totally a drop-in change:

 - Get the logger: `log := config.Logger`.
 - Remove import `github.com/sirupsen/logrus`, except when using
 - levels (like `logrus.DebugLevel`). In this case, don't name the
 - import as `log`, but keep `logrus`.
 - If using `log.SetOutput`, use `log.Output` instead.
 - If using `log.SetFormatter`, use `log.Formatter` instead.

With recent versions of logrus, no other changes are needed.

While this change is not as neat as to have a per-server logger, this
should fit most uses where we want to control how GoBGP do the logging
as a library.

See #1638.