### PR TITLE
Fixing all megacheck errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ _dep_ensure: &_dep_ensure
 _unittest: &_unittest
   <<: *_dep_ensure
   script:
-    - go test $(go list ./... | grep -v '/vendor/')
+    - go test $(go list ./... | grep -v '/vendor/') -timeout 120s
     - if [ "$(go env GOARCH)" = "amd64" ]; then go test -race github.com/osrg/gobgp/packet/bgp -run ^Test_RaceCondition$; else echo 'skip'; fi
     - go build -o ./gobgp/gobgp   ./gobgp/
     - go build -o ./gobgpd/gobgpd ./gobgpd/

--- a/config/default.go
+++ b/config/default.go
@@ -30,7 +30,7 @@ var configuredFields map[string]interface{}
 
 func RegisterConfiguredFields(addr string, n interface{}) {
 	if configuredFields == nil {
-		configuredFields = make(map[string]interface{}, 0)
+		configuredFields = make(map[string]interface{})
 	}
 	configuredFields[addr] = n
 }

--- a/config/default_linux.go
+++ b/config/default_linux.go
@@ -53,3 +53,20 @@ func GetIPv6LinkLocalNeighborAddress(ifname string) (string, error) {
 
 	return fmt.Sprintf("%s%%%s", addr, ifname), nil
 }
+
+func isLocalLinkLocalAddress(ifindex int, addr net.IP) (bool, error) {
+	ifi, err := net.InterfaceByIndex(ifindex)
+	if err != nil {
+		return false, err
+	}
+	addrs, err := ifi.Addrs()
+	if err != nil {
+		return false, err
+	}
+	for _, a := range addrs {
+		if ip, _, _ := net.ParseCIDR(a.String()); addr.Equal(ip) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/config/serve.go
+++ b/config/serve.go
@@ -68,12 +68,10 @@ func ReadConfigfileServe(path, format string, configCh chan *BgpConfigSet) {
 			}).Warningf("Can't read config file %s", path)
 		}
 	NEXT:
-		select {
-		case <-sigCh:
-			log.WithFields(log.Fields{
-				"Topic": "Config",
-			}).Info("Reload the config file")
-		}
+		<-sigCh
+		log.WithFields(log.Fields{
+			"Topic": "Config",
+		}).Info("Reload the config file")
 	}
 }
 

--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -97,23 +97,6 @@ var neighborsOpts struct {
 	Transport string `short:"t" long:"transport" description:"specifying a transport protocol"`
 }
 
-var conditionOpts struct {
-	Prefix       string `long:"prefix" description:"specifying a prefix set name of policy"`
-	Neighbor     string `long:"neighbor" description:"specifying a neighbor set name of policy"`
-	AsPath       string `long:"aspath" description:"specifying an as set name of policy"`
-	Community    string `long:"community" description:"specifying a community set name of policy"`
-	ExtCommunity string `long:"extcommunity" description:"specifying a extended community set name of policy"`
-	AsPathLength string `long:"aspath-len" description:"specifying an as path length of policy (<operator>,<numeric>)"`
-}
-
-var actionOpts struct {
-	RouteAction         string `long:"route-action" description:"specifying a route action of policy (accept | reject)"`
-	CommunityAction     string `long:"community" description:"specifying a community action of policy"`
-	MedAction           string `long:"med" description:"specifying a med action of policy"`
-	AsPathPrependAction string `long:"as-prepend" description:"specifying a as-prepend action of policy"`
-	NexthopAction       string `long:"next-hop" description:"specifying a next-hop action of policy"`
-}
-
 var mrtOpts struct {
 	OutputDir   string
 	FileFormat  string
@@ -216,10 +199,7 @@ func (n neighbors) Less(i, j int) bool {
 	p1Isv4 := !strings.Contains(p1, ":")
 	p2Isv4 := !strings.Contains(p2, ":")
 	if p1Isv4 != p2Isv4 {
-		if p1Isv4 {
-			return true
-		}
-		return false
+		return p1Isv4
 	}
 	addrlen := 128
 	if p1Isv4 {

--- a/gobgp/cmd/neighbor.go
+++ b/gobgp/cmd/neighbor.go
@@ -129,11 +129,11 @@ func showNeighbors(vrf string) error {
 		}
 		timedelta = append(timedelta, timeStr)
 	}
-	var format string
-	format = "%-" + fmt.Sprint(maxaddrlen) + "s" + " %" + fmt.Sprint(maxaslen) + "s" + " %" + fmt.Sprint(maxtimelen) + "s"
+
+	format := "%-" + fmt.Sprint(maxaddrlen) + "s" + " %" + fmt.Sprint(maxaslen) + "s" + " %" + fmt.Sprint(maxtimelen) + "s"
 	format += " %-11s |%9s %9s\n"
 	fmt.Printf(format, "Peer", "AS", "Up/Down", "State", "#Received", "Accepted")
-	format_fsm := func(admin config.AdminState, fsm config.SessionState) string {
+	formatFsm := func(admin config.AdminState, fsm config.SessionState) string {
 		switch admin {
 		case config.ADMIN_STATE_DOWN:
 			return "Idle(Admin)"
@@ -164,7 +164,7 @@ func showNeighbors(vrf string) error {
 		if n.Config.NeighborInterface != "" {
 			neigh = n.Config.NeighborInterface
 		}
-		fmt.Printf(format, neigh, getASN(n), timedelta[i], format_fsm(n.State.AdminState, n.State.SessionState), fmt.Sprint(n.State.AdjTable.Received), fmt.Sprint(n.State.AdjTable.Accepted))
+		fmt.Printf(format, neigh, getASN(n), timedelta[i], formatFsm(n.State.AdminState, n.State.SessionState), fmt.Sprint(n.State.AdjTable.Received), fmt.Sprint(n.State.AdjTable.Accepted))
 	}
 
 	return nil
@@ -422,11 +422,7 @@ func showNeighbor(args []string) error {
 	return nil
 }
 
-type AsPathFormat struct {
-	start     string
-	end       string
-	separator string
-}
+type AsPathFormat struct{}
 
 func getPathSymbolString(p *table.Path, idx int, showBest bool) string {
 	symbols := ""
@@ -825,9 +821,7 @@ func showNeighborRib(r string, name string, args []string) error {
 			var ps []*table.Path
 			switch r {
 			case CMD_ACCEPTED:
-				for _, p := range d.GetAllKnownPathList() {
-					ps = append(ps, p)
-				}
+				ps = append(ps, d.GetAllKnownPathList()...)
 			case CMD_REJECTED:
 				// always nothing
 			default:

--- a/gobgp/cmd/policy.go
+++ b/gobgp/cmd/policy.go
@@ -31,6 +31,8 @@ import (
 	"github.com/osrg/gobgp/table"
 )
 
+var _regexpCommunity = regexp.MustCompile(`\^\^(\S+)\$\$`)
+
 func formatDefinedSet(head bool, typ string, indent int, list []table.DefinedSet) string {
 	if len(list) == 0 {
 		return "Nothing defined yet\n"
@@ -59,8 +61,7 @@ func formatDefinedSet(head bool, typ string, indent int, list []table.DefinedSet
 		}
 		for i, x := range l {
 			if typ == "COMMUNITY" || typ == "EXT-COMMUNITY" || typ == "LARGE-COMMUNITY" {
-				exp := regexp.MustCompile("\\^\\^(\\S+)\\$\\$")
-				x = exp.ReplaceAllString(x, "$1")
+				x = _regexpCommunity.ReplaceAllString(x, "$1")
 			}
 			if i == 0 {
 				buff.WriteString(fmt.Sprintf(format, s.Name(), x))
@@ -778,6 +779,9 @@ func modAction(name, op string, args []string) error {
 		stmt.Actions.BgpActions.SetNextHop = config.BgpNextHopType(args[0])
 	}
 	t, err := table.NewStatement(stmt)
+	if err != nil {
+		return err
+	}
 	switch op {
 	case CMD_ADD:
 		err = client.AddStatement(t)

--- a/gobgp/cmd/root.go
+++ b/gobgp/cmd/root.go
@@ -37,7 +37,6 @@ var globalOpts struct {
 	CaFile       string
 }
 
-var cmds []string
 var client *cli.Client
 
 func NewRootCmd() *cobra.Command {

--- a/gobgp/cmd/rpki.go
+++ b/gobgp/cmd/rpki.go
@@ -36,36 +36,37 @@ func showRPKIServer(args []string) error {
 		for _, r := range servers {
 			s := "Down"
 			uptime := "never"
-			if r.State.Up == true {
+			if r.State.Up {
 				s = "Up"
-				uptime = fmt.Sprint(formatTimedelta(int64(time.Now().Sub(time.Unix(r.State.Uptime, 0)).Seconds())))
+				uptime = fmt.Sprint(formatTimedelta(int64(time.Since(time.Unix(r.State.Uptime, 0)).Seconds())))
 			}
 
 			fmt.Printf(format, net.JoinHostPort(r.Config.Address, fmt.Sprintf("%d", r.Config.Port)), s, uptime, fmt.Sprintf("%d/%d", r.State.RecordsV4, r.State.RecordsV6))
 		}
-	} else {
-		for _, r := range servers {
-			if r.Config.Address == args[0] {
-				up := "Down"
-				if r.State.Up == true {
-					up = "Up"
-				}
-				fmt.Printf("Session: %s, State: %s\n", r.Config.Address, up)
-				fmt.Println("  Port:", r.Config.Port)
-				fmt.Println("  Serial:", r.State.SerialNumber)
-				fmt.Printf("  Prefix: %d/%d\n", r.State.PrefixesV4, r.State.PrefixesV6)
-				fmt.Printf("  Record: %d/%d\n", r.State.RecordsV4, r.State.RecordsV6)
-				fmt.Println("  Message statistics:")
-				fmt.Printf("    Receivedv4:    %10d\n", r.State.RpkiMessages.RpkiReceived.Ipv4Prefix)
-				fmt.Printf("    Receivedv6:    %10d\n", r.State.RpkiMessages.RpkiReceived.Ipv4Prefix)
-				fmt.Printf("    SerialNotify:  %10d\n", r.State.RpkiMessages.RpkiReceived.SerialNotify)
-				fmt.Printf("    CacheReset:    %10d\n", r.State.RpkiMessages.RpkiReceived.CacheReset)
-				fmt.Printf("    CacheResponse: %10d\n", r.State.RpkiMessages.RpkiReceived.CacheResponse)
-				fmt.Printf("    EndOfData:     %10d\n", r.State.RpkiMessages.RpkiReceived.EndOfData)
-				fmt.Printf("    Error:         %10d\n", r.State.RpkiMessages.RpkiReceived.Error)
-				fmt.Printf("    SerialQuery:   %10d\n", r.State.RpkiMessages.RpkiSent.SerialQuery)
-				fmt.Printf("    ResetQuery:    %10d\n", r.State.RpkiMessages.RpkiSent.ResetQuery)
+		return nil
+	}
+
+	for _, r := range servers {
+		if r.Config.Address == args[0] {
+			up := "Down"
+			if r.State.Up {
+				up = "Up"
 			}
+			fmt.Printf("Session: %s, State: %s\n", r.Config.Address, up)
+			fmt.Println("  Port:", r.Config.Port)
+			fmt.Println("  Serial:", r.State.SerialNumber)
+			fmt.Printf("  Prefix: %d/%d\n", r.State.PrefixesV4, r.State.PrefixesV6)
+			fmt.Printf("  Record: %d/%d\n", r.State.RecordsV4, r.State.RecordsV6)
+			fmt.Println("  Message statistics:")
+			fmt.Printf("    Receivedv4:    %10d\n", r.State.RpkiMessages.RpkiReceived.Ipv4Prefix)
+			fmt.Printf("    Receivedv6:    %10d\n", r.State.RpkiMessages.RpkiReceived.Ipv4Prefix)
+			fmt.Printf("    SerialNotify:  %10d\n", r.State.RpkiMessages.RpkiReceived.SerialNotify)
+			fmt.Printf("    CacheReset:    %10d\n", r.State.RpkiMessages.RpkiReceived.CacheReset)
+			fmt.Printf("    CacheResponse: %10d\n", r.State.RpkiMessages.RpkiReceived.CacheResponse)
+			fmt.Printf("    EndOfData:     %10d\n", r.State.RpkiMessages.RpkiReceived.EndOfData)
+			fmt.Printf("    Error:         %10d\n", r.State.RpkiMessages.RpkiReceived.Error)
+			fmt.Printf("    SerialQuery:   %10d\n", r.State.RpkiMessages.RpkiSent.SerialQuery)
+			fmt.Printf("    ResetQuery:    %10d\n", r.State.RpkiMessages.RpkiSent.ResetQuery)
 		}
 	}
 	return nil

--- a/gobgp/cmd/vrf.go
+++ b/gobgp/cmd/vrf.go
@@ -154,7 +154,9 @@ func modVrf(typ string, args []string) error {
 				return err
 			}
 		}
-		err = client.AddVRF(name, int(id), rd, importRt, exportRt)
+		if err := client.AddVRF(name, int(id), rd, importRt, exportRt); err != nil {
+			return err
+		}
 	case CMD_DEL:
 		if len(args) != 1 {
 			return fmt.Errorf("Usage: gobgp vrf del <vrf name>")

--- a/gobgp/cmd/vrf.go
+++ b/gobgp/cmd/vrf.go
@@ -22,12 +22,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/protobuf/ptypes/any"
-
-	"github.com/spf13/cobra"
-
 	api "github.com/osrg/gobgp/api"
 	"github.com/osrg/gobgp/packet/bgp"
+
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/spf13/cobra"
 )
 
 func getVrfs() (vrfs, error) {
@@ -167,7 +166,6 @@ func modVrf(typ string, args []string) error {
 }
 
 func NewVrfCmd() *cobra.Command {
-
 	ribCmd := &cobra.Command{
 		Use: CMD_RIB,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/gobgpd/main.go
+++ b/gobgpd/main.go
@@ -113,7 +113,7 @@ func main() {
 		log.SetLevel(log.InfoLevel)
 	}
 
-	if opts.DisableStdlog == true {
+	if opts.DisableStdlog {
 		log.SetOutput(ioutil.Discard)
 	} else {
 		log.SetOutput(os.Stdout)

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -289,13 +289,13 @@ func (c BGPCapabilityCode) String() string {
 
 var (
 	// Used parsing RouteDistinguisher
-	_regexpRouteDistinguisher = regexp.MustCompile("^((\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)|((\\d+)\\.)?(\\d+)|([\\w]+:[\\w:]*:[\\w]+)):(\\d+)$")
+	_regexpRouteDistinguisher = regexp.MustCompile(`^((\d+)\.(\d+)\.(\d+)\.(\d+)|((\d+)\.)?(\d+)|([\w]+:[\w:]*:[\w]+)):(\d+)$`)
 
 	// Used for operator and value for the FlowSpec numeric type
 	// Example:
 	// re.FindStringSubmatch("&==80")
 	// >>> ["&==80" "&" "==" "80"]
-	_regexpFlowSpecNumericType = regexp.MustCompile("(&?)(==|=|>|>=|<|<=|!|!=|=!)?(\\d+|-\\d|true|false)")
+	_regexpFlowSpecNumericType = regexp.MustCompile(`(&?)(==|=|>|>=|<|<=|!|!=|=!)?(\d+|-\d|true|false)`)
 
 	// - "=!" is used in the old style format of "tcp-flags" and "fragment".
 	// - The value field should be one of the followings:
@@ -303,8 +303,8 @@ var (
 	//     * Combination of the small letters, decimals, "-" and "+"
 	//       (e.g., tcp, ipv4, is-fragment+first-fragment)
 	//     * Capital letters (e.g., SA)
-	_regexpFlowSpecOperator      = regexp.MustCompile("&|=|>|<|!|[\\w\\-+]+")
-	_regexpFlowSpecOperatorValue = regexp.MustCompile("[\\w\\-+]+")
+	_regexpFlowSpecOperator      = regexp.MustCompile(`&|=|>|<|!|[\w\-+]+`)
+	_regexpFlowSpecOperatorValue = regexp.MustCompile(`[\w\-+]+`)
 
 	// Note: "(-*)" and "(.*)" catch the invalid flags
 	// Example: In this case, "Z" is unsupported flag type.
@@ -315,13 +315,13 @@ var (
 	// Note: "(.*)" catches the invalid flags
 	// re.FindStringSubmatch("&!=+first-fragment+last-fragment+invalid-fragment")
 	// >>> ["&!=+first-fragment+last-fragment+invalid-fragment" "&" "!=" "+first-fragment+last-fragment" "+last-fragment" "+" "last" "+invalid-fragment"]
-	_regexpFlowSpecFragment = regexp.MustCompile("(&?)(==|=|!|!=|=!)?(((\\+)?(dont|is|first|last|not-a)-fragment)+)(.*)")
+	_regexpFlowSpecFragment = regexp.MustCompile(`(&?)(==|=|!|!=|=!)?(((\+)?(dont|is|first|last|not-a)-fragment)+)(.*)`)
 
 	// re.FindStringSubmatch("192.168.0.0/24")
 	// >>> ["192.168.0.0/24" "192.168.0.0" "/24" "24"]
 	// re.FindStringSubmatch("192.168.0.1")
 	// >>> ["192.168.0.1" "192.168.0.1" "" ""]
-	_regexpFindIPv4Prefix = regexp.MustCompile("^([\\d.]+)(/(\\d{1,2}))?")
+	_regexpFindIPv4Prefix = regexp.MustCompile(`^([\d.]+)(/(\d{1,2}))?`)
 
 	// re.FindStringSubmatch("2001:dB8::/64")
 	// >>> ["2001:dB8::/64" "2001:dB8::" "/64" "64" "" ""]
@@ -329,7 +329,7 @@ var (
 	// >>> ["2001:dB8::/64/8" "2001:dB8::" "/64" "64" "/8" "8"]
 	// re.FindStringSubmatch("2001:dB8::1")
 	// >>> ["2001:dB8::1" "2001:dB8::1" "" "" "" ""]
-	_regexpFindIPv6Prefix = regexp.MustCompile("^([a-fA-F\\d:.]+)(/(\\d{1,3}))?(/(\\d{1,3}))?")
+	_regexpFindIPv6Prefix = regexp.MustCompile(`^([a-fA-F\d:.]+)(/(\d{1,3}))?(/(\d{1,3}))?`)
 )
 
 type ParameterCapabilityInterface interface {
@@ -1572,7 +1572,8 @@ func (l *MPLSLabelStack) DecodeFromBytes(data []byte) error {
 			break
 		}
 	}
-	if foundBottom == false {
+
+	if foundBottom {
 		l.Labels = []uint32{}
 		return nil
 	}
@@ -2161,7 +2162,7 @@ func ParseEthernetSegmentIdentifier(args []string) (EthernetSegmentIdentifier, e
 	}
 
 	invalidEsiValuesError := fmt.Errorf("invalid esi values for type %s: %s", esi.Type.String(), args[1:])
-	esi.Value = make([]byte, 9, 9)
+	esi.Value = make([]byte, 9)
 	switch esi.Type {
 	case ESI_LACP:
 		fallthrough
@@ -2196,7 +2197,7 @@ func ParseEthernetSegmentIdentifier(args []string) (EthernetSegmentIdentifier, e
 		if err != nil {
 			return esi, invalidEsiValuesError
 		}
-		iBuf := make([]byte, 4, 4)
+		iBuf := make([]byte, 4)
 		binary.BigEndian.PutUint32(iBuf, uint32(i))
 		copy(esi.Value[6:9], iBuf[1:4])
 	case ESI_ROUTERID:
@@ -2278,7 +2279,7 @@ func labelSerialize(label uint32) ([]byte, error) {
 	if label > 0xffffff {
 		return nil, NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, fmt.Sprintf("Out of range Label: %d", label))
 	}
-	buf := make([]byte, 3, 3)
+	buf := make([]byte, 3)
 	buf[0] = byte((label >> 16) & 0xff)
 	buf[1] = byte((label >> 8) & 0xff)
 	buf[2] = byte(label & 0xff)
@@ -3951,13 +3952,10 @@ func (v *FlowSpecComponentItem) Len() int {
 }
 
 func (v *FlowSpecComponentItem) Serialize() ([]byte, error) {
-	if v.Value < 0 {
-		return nil, fmt.Errorf("invalid value size(too small): %d", v.Value)
-	}
-	if v.Op < 0 || v.Op > math.MaxUint8 {
+	if v.Op > math.MaxUint8 {
 		return nil, fmt.Errorf("invalid op size: %d", v.Op)
-
 	}
+
 	order := uint32(math.Log2(float64(v.Len())))
 	buf := make([]byte, 1+(1<<order))
 	buf[0] = byte(uint32(v.Op) | order<<4)
@@ -5488,7 +5486,7 @@ func (p *PathAttributeAsPath) DecodeFromBytes(data []byte, options ...*Marshalli
 	}
 	for len(value) > 0 {
 		var tuple AsPathParamInterface
-		if isAs4 == true {
+		if isAs4 {
 			tuple = &As4PathParam{}
 		} else {
 			tuple = &AsPathParam{}
@@ -5498,9 +5496,6 @@ func (p *PathAttributeAsPath) DecodeFromBytes(data []byte, options ...*Marshalli
 			return err
 		}
 		p.Value = append(p.Value, tuple)
-		if tuple.Len() > len(value) {
-
-		}
 		value = value[tuple.Len():]
 	}
 	return nil
@@ -5877,19 +5872,19 @@ type WellKnownCommunity uint32
 
 const (
 	COMMUNITY_INTERNET                   WellKnownCommunity = 0x00000000
-	COMMUNITY_PLANNED_SHUT                                  = 0xffff0000
-	COMMUNITY_ACCEPT_OWN                                    = 0xffff0001
-	COMMUNITY_ROUTE_FILTER_TRANSLATED_v4                    = 0xffff0002
-	COMMUNITY_ROUTE_FILTER_v4                               = 0xffff0003
-	COMMUNITY_ROUTE_FILTER_TRANSLATED_v6                    = 0xffff0004
-	COMMUNITY_ROUTE_FILTER_v6                               = 0xffff0005
-	COMMUNITY_LLGR_STALE                                    = 0xffff0006
-	COMMUNITY_NO_LLGR                                       = 0xffff0007
-	COMMUNITY_BLACKHOLE                                     = 0xffff029a
-	COMMUNITY_NO_EXPORT                                     = 0xffffff01
-	COMMUNITY_NO_ADVERTISE                                  = 0xffffff02
-	COMMUNITY_NO_EXPORT_SUBCONFED                           = 0xffffff03
-	COMMUNITY_NO_PEER                                       = 0xffffff04
+	COMMUNITY_PLANNED_SHUT               WellKnownCommunity = 0xffff0000
+	COMMUNITY_ACCEPT_OWN                 WellKnownCommunity = 0xffff0001
+	COMMUNITY_ROUTE_FILTER_TRANSLATED_v4 WellKnownCommunity = 0xffff0002
+	COMMUNITY_ROUTE_FILTER_v4            WellKnownCommunity = 0xffff0003
+	COMMUNITY_ROUTE_FILTER_TRANSLATED_v6 WellKnownCommunity = 0xffff0004
+	COMMUNITY_ROUTE_FILTER_v6            WellKnownCommunity = 0xffff0005
+	COMMUNITY_LLGR_STALE                 WellKnownCommunity = 0xffff0006
+	COMMUNITY_NO_LLGR                    WellKnownCommunity = 0xffff0007
+	COMMUNITY_BLACKHOLE                  WellKnownCommunity = 0xffff029a
+	COMMUNITY_NO_EXPORT                  WellKnownCommunity = 0xffffff01
+	COMMUNITY_NO_ADVERTISE               WellKnownCommunity = 0xffffff02
+	COMMUNITY_NO_EXPORT_SUBCONFED        WellKnownCommunity = 0xffffff03
+	COMMUNITY_NO_PEER                    WellKnownCommunity = 0xffffff04
 )
 
 var WellKnownCommunityNameMap = map[WellKnownCommunity]string{
@@ -5996,7 +5991,7 @@ func (p *PathAttributeOriginatorId) MarshalJSON() ([]byte, error) {
 }
 
 func (p *PathAttributeOriginatorId) Serialize(options ...*MarshallingOption) ([]byte, error) {
-	buf := make([]byte, 4, 4)
+	buf := make([]byte, 4)
 	copy(buf, p.Value)
 	return p.PathAttribute.Serialize(buf, options...)
 }
@@ -6710,7 +6705,7 @@ type ValidationExtended struct {
 }
 
 func (e *ValidationExtended) Serialize() ([]byte, error) {
-	buf := make([]byte, 8, 8)
+	buf := make([]byte, 8)
 	typ, subType := e.GetTypes()
 	buf[0] = byte(typ)
 	buf[1] = byte(subType)
@@ -6750,7 +6745,7 @@ type ColorExtended struct {
 }
 
 func (e *ColorExtended) Serialize() ([]byte, error) {
-	buf := make([]byte, 8, 8)
+	buf := make([]byte, 8)
 	typ, subType := e.GetTypes()
 	buf[0] = byte(typ)
 	buf[1] = byte(subType)
@@ -6790,7 +6785,7 @@ type EncapExtended struct {
 }
 
 func (e *EncapExtended) Serialize() ([]byte, error) {
-	buf := make([]byte, 8, 8)
+	buf := make([]byte, 8)
 	typ, subType := e.GetTypes()
 	buf[0] = byte(typ)
 	buf[1] = byte(subType)
@@ -6850,7 +6845,7 @@ type DefaultGatewayExtended struct {
 }
 
 func (e *DefaultGatewayExtended) Serialize() ([]byte, error) {
-	buf := make([]byte, 8, 8)
+	buf := make([]byte, 8)
 	typ, subType := e.GetTypes()
 	buf[0] = byte(typ)
 	buf[1] = byte(subType)
@@ -6889,7 +6884,7 @@ func (e *OpaqueExtended) Serialize() ([]byte, error) {
 	if len(e.Value) != 7 {
 		return nil, fmt.Errorf("invalid value length for opaque extended community: %d", len(e.Value))
 	}
-	buf := make([]byte, 8, 8)
+	buf := make([]byte, 8)
 	if e.IsTransitive {
 		buf[0] = byte(EC_TYPE_TRANSITIVE_OPAQUE)
 	} else {
@@ -6900,7 +6895,7 @@ func (e *OpaqueExtended) Serialize() ([]byte, error) {
 }
 
 func (e *OpaqueExtended) String() string {
-	buf := make([]byte, 8, 8)
+	buf := make([]byte, 8)
 	copy(buf[1:], e.Value)
 	return fmt.Sprintf("%d", binary.BigEndian.Uint64(buf))
 }
@@ -6931,7 +6926,7 @@ func (e *OpaqueExtended) MarshalJSON() ([]byte, error) {
 }
 
 func NewOpaqueExtended(isTransitive bool, value []byte) *OpaqueExtended {
-	v := make([]byte, 7, 7)
+	v := make([]byte, 7)
 	copy(v, value)
 	return &OpaqueExtended{
 		IsTransitive: isTransitive,
@@ -7552,7 +7547,7 @@ func (e *UnknownExtended) Serialize() ([]byte, error) {
 	if len(e.Value) != 7 {
 		return nil, fmt.Errorf("invalid value length for unknown extended community: %d", len(e.Value))
 	}
-	buf := make([]byte, 8, 8)
+	buf := make([]byte, 8)
 	buf[0] = uint8(e.Type)
 	copy(buf[1:], e.Value)
 	return buf, nil
@@ -7587,7 +7582,7 @@ func (e *UnknownExtended) GetTypes() (ExtendedCommunityAttrType, ExtendedCommuni
 }
 
 func NewUnknownExtended(typ ExtendedCommunityAttrType, value []byte) *UnknownExtended {
-	v := make([]byte, 7, 7)
+	v := make([]byte, 7)
 	copy(v, value)
 	return &UnknownExtended{
 		Type:  typ,
@@ -7731,9 +7726,11 @@ func (p *PathAttributeAs4Path) DecodeFromBytes(data []byte, options ...*Marshall
 	if err != nil {
 		return err
 	}
-	if isAs4 == false {
+
+	if !isAs4 {
 		return NewMessageError(eCode, eSubCode, nil, "AS4 PATH param is malformed")
 	}
+
 	for len(value) > 0 {
 		tuple := &As4PathParam{}
 		tuple.DecodeFromBytes(value)
@@ -8149,7 +8146,7 @@ func (p *TunnelEncapTLV) Serialize() ([]byte, error) {
 }
 
 func (p *TunnelEncapTLV) String() string {
-	tlvList := make([]string, len(p.Value), len(p.Value))
+	tlvList := make([]string, len(p.Value))
 	for i, v := range p.Value {
 		tlvList[i] = v.String()
 	}
@@ -8208,7 +8205,7 @@ func (p *PathAttributeTunnelEncap) Serialize(options ...*MarshallingOption) ([]b
 }
 
 func (p *PathAttributeTunnelEncap) String() string {
-	tlvList := make([]string, len(p.Value), len(p.Value))
+	tlvList := make([]string, len(p.Value))
 	for i, v := range p.Value {
 		tlvList[i] = v.String()
 	}

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -1573,7 +1573,7 @@ func (l *MPLSLabelStack) DecodeFromBytes(data []byte) error {
 		}
 	}
 
-	if foundBottom {
+	if !foundBottom {
 		l.Labels = []uint32{}
 		return nil
 	}
@@ -1850,13 +1850,13 @@ func (l *LabeledIPAddrPrefix) DecodeFromBytes(data []byte, options ...*Marshalli
 	l.Length = uint8(data[0])
 	data = data[1:]
 	l.Labels.DecodeFromBytes(data)
+
 	if int(l.Length)-8*(l.Labels.Len()) < 0 {
 		l.Labels.Labels = []uint32{}
 	}
 	restbits := int(l.Length) - 8*(l.Labels.Len())
 	data = data[l.Labels.Len():]
-	l.decodePrefix(data, uint8(restbits), l.addrlen)
-	return nil
+	return l.decodePrefix(data, uint8(restbits), l.addrlen)
 }
 
 func (l *LabeledIPAddrPrefix) Serialize(options ...*MarshallingOption) ([]byte, error) {
@@ -9258,10 +9258,12 @@ func (msg *BGPHeader) DecodeFromBytes(data []byte, options ...*MarshallingOption
 	if uint16(len(data)) < BGP_HEADER_LENGTH {
 		return NewMessageError(BGP_ERROR_MESSAGE_HEADER_ERROR, BGP_ERROR_SUB_BAD_MESSAGE_LENGTH, nil, "not all BGP message header")
 	}
+
 	msg.Len = binary.BigEndian.Uint16(data[16:18])
 	if int(msg.Len) < BGP_HEADER_LENGTH {
 		return NewMessageError(BGP_ERROR_MESSAGE_HEADER_ERROR, BGP_ERROR_SUB_BAD_MESSAGE_LENGTH, nil, "unknown message type")
 	}
+
 	msg.Type = data[18]
 	return nil
 }

--- a/packet/bgp/bgp_test.go
+++ b/packet/bgp/bgp_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"net"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -53,15 +54,17 @@ func Test_Message(t *testing.T) {
 
 	for _, m1 := range l {
 		buf1, err := m1.Serialize()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		t.Log("LEN =", len(buf1))
 		m2, err := ParseBGPMessage(buf1)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		// FIXME: shouldn't but workaround for some structs.
+		_, err = m2.Serialize()
+		assert.NoError(t, err)
 
-		assert.Equal(t, m1, m2)
+		assert.True(t, reflect.DeepEqual(m1, m2))
 	}
 }
 

--- a/packet/bgp/validate.go
+++ b/packet/bgp/validate.go
@@ -274,7 +274,7 @@ func validateAsPathValueBytes(data []byte) (bool, error) {
 				return false, NewMessageError(eCode, eSubCode, nil, "AS PATH the number of AS is incorrect")
 			}
 			segLength := int(asNum)
-			if use4byte == true {
+			if use4byte {
 				segLength *= 4
 			} else {
 				segLength *= 2

--- a/packet/bgp/validate_test.go
+++ b/packet/bgp/validate_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func bgpupdate() *BGPMessage {
@@ -47,6 +48,7 @@ func Test_Validate_CapV4(t *testing.T) {
 	assert.Error(err)
 
 	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
+	require.NoError(t, err)
 	assert.Equal(true, res)
 }
 
@@ -58,6 +60,7 @@ func Test_Validate_CapV6(t *testing.T) {
 	assert.NoError(err)
 
 	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
+	require.NoError(t, err)
 	assert.Equal(false, res)
 }
 
@@ -295,12 +298,12 @@ func Test_Validate_unrecognized_well_known(t *testing.T) {
 }
 
 func Test_Validate_aspath(t *testing.T) {
-
 	assert := assert.New(t)
 	message := bgpupdate().Body.(*BGPUpdate)
 
 	// VALID AS_PATH
 	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, false)
+	require.NoError(t, err)
 	assert.Equal(true, res)
 
 	// CONFED_SET
@@ -360,6 +363,7 @@ func Test_Validate_aspath(t *testing.T) {
 	assert.Nil(e.Data)
 
 	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, true)
+	require.NoError(t, err)
 	assert.Equal(true, res)
 }
 

--- a/packet/bgp/validate_test.go
+++ b/packet/bgp/validate_test.go
@@ -56,12 +56,12 @@ func Test_Validate_CapV6(t *testing.T) {
 	assert := assert.New(t)
 	message := bgpupdateV6().Body.(*BGPUpdate)
 	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv6_UC: BGP_ADD_PATH_BOTH}, false, false)
-	assert.Equal(true, res)
 	assert.NoError(err)
+	assert.True(res)
 
 	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false)
-	require.NoError(t, err)
-	assert.Equal(false, res)
+	assert.Error(err)
+	assert.False(res)
 }
 
 func Test_Validate_OK(t *testing.T) {

--- a/packet/bmp/bmp_test.go
+++ b/packet/bmp/bmp_test.go
@@ -16,27 +16,21 @@
 package bmp
 
 import (
-	"github.com/osrg/gobgp/packet/bgp"
-	"github.com/stretchr/testify/assert"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/osrg/gobgp/packet/bgp"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func verify(t *testing.T, m1 *BMPMessage) {
 	buf1, _ := m1.Serialize()
 	m2, err := ParseBMPMessage(buf1)
-	if err != nil {
-		t.Error(err)
-	}
-	buf2, _ := m2.Serialize()
+	require.NoError(t, err)
 
-	if reflect.DeepEqual(m1, m2) == true {
-		t.Log("OK")
-	} else {
-		t.Error("Something wrong")
-		t.Error(len(buf1), m1, buf1)
-		t.Error(len(buf2), m2, buf2)
-	}
+	assert.Equal(t, m1, m2)
 }
 
 func Test_Initiation(t *testing.T) {

--- a/packet/rtr/rtr_test.go
+++ b/packet/rtr/rtr_test.go
@@ -19,26 +19,22 @@ import (
 	"encoding/hex"
 	"math/rand"
 	"net"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func verifyRTRMessage(t *testing.T, m1 RTRMessage) {
 	buf1, _ := m1.Serialize()
 	m2, err := ParseRTR(buf1)
-	if err != nil {
-		t.Error(err)
-	}
-	buf2, _ := m2.Serialize()
+	require.NoError(t, err)
 
-	if reflect.DeepEqual(buf1, buf2) == true {
-		t.Log("OK")
-	} else {
-		t.Errorf("Something wrong")
-		t.Error(len(buf1), m1, hex.EncodeToString(buf1))
-		t.Error(len(buf2), m2, hex.EncodeToString(buf2))
-	}
+	buf2, err := m2.Serialize()
+	require.NoError(t, err)
+
+	assert.Equal(t, buf1, buf2, "buf1: %v buf2: %v", hex.EncodeToString(buf1), hex.EncodeToString(buf2))
 }
 
 func randUint32() uint32 {

--- a/server/fsm.go
+++ b/server/fsm.go
@@ -23,14 +23,14 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/eapache/channels"
-	log "github.com/sirupsen/logrus"
-	"gopkg.in/tomb.v2"
-
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
 	"github.com/osrg/gobgp/packet/bmp"
 	"github.com/osrg/gobgp/table"
+
+	"github.com/eapache/channels"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/tomb.v2"
 )
 
 type PeerDownReason int
@@ -1048,9 +1048,7 @@ func open2Cap(open *bgp.BGPOpen, n *config.Neighbor) (map[bgp.BGPCapabilityCode]
 	if caps, y := capMap[bgp.BGP_CAP_ADD_PATH]; y {
 		items := make([]*bgp.CapAddPathTuple, 0, len(caps))
 		for _, c := range caps {
-			for _, i := range c.(*bgp.CapAddPath).Tuples {
-				items = append(items, i)
-			}
+			items = append(items, c.(*bgp.CapAddPath).Tuples...)
 		}
 		capMap[bgp.BGP_CAP_ADD_PATH] = []bgp.ParameterCapabilityInterface{bgp.NewCapAddPath(items)}
 	}

--- a/server/peer.go
+++ b/server/peer.go
@@ -42,8 +42,8 @@ type PeerGroup struct {
 func NewPeerGroup(c *config.PeerGroup) *PeerGroup {
 	return &PeerGroup{
 		Conf:             c,
-		members:          make(map[string]config.Neighbor, 0),
-		dynamicNeighbors: make(map[string]*config.DynamicNeighbor, 0),
+		members:          make(map[string]config.Neighbor),
+		dynamicNeighbors: make(map[string]*config.DynamicNeighbor),
 	}
 }
 
@@ -293,7 +293,7 @@ func (peer *Peer) markLLGRStale(fs []bgp.RouteFamily) []*table.Path {
 	for i, p := range paths {
 		doStale := true
 		for _, c := range p.GetCommunities() {
-			if c == bgp.COMMUNITY_NO_LLGR {
+			if c == uint32(bgp.COMMUNITY_NO_LLGR) {
 				doStale = false
 				p = p.Clone(true)
 				break
@@ -301,7 +301,7 @@ func (peer *Peer) markLLGRStale(fs []bgp.RouteFamily) []*table.Path {
 		}
 		if doStale {
 			p = p.Clone(false)
-			p.SetCommunities([]uint32{bgp.COMMUNITY_LLGR_STALE}, false)
+			p.SetCommunities([]uint32{uint32(bgp.COMMUNITY_LLGR_STALE)}, false)
 		}
 		paths[i] = p
 	}
@@ -315,10 +315,6 @@ func (peer *Peer) stopPeerRestarting() {
 	}
 	peer.llgrEndChs = make([]chan struct{}, 0)
 
-}
-
-func (peer *Peer) getAccepted(rfList []bgp.RouteFamily) []*table.Path {
-	return peer.adjRibIn.PathList(rfList, true)
 }
 
 func (peer *Peer) filterPathFromSourcePeer(path, old *table.Path) *table.Path {

--- a/server/server.go
+++ b/server/server.go
@@ -1711,8 +1711,8 @@ func (s *BgpServer) AddVrf(name string, id uint32, rd bgp.RouteDistinguisherInte
 			AS:      s.bgpConfig.Global.Config.As,
 			LocalID: net.ParseIP(s.bgpConfig.Global.Config.RouterId).To4(),
 		}
-		if pathList, e := s.globalRib.AddVrf(name, id, rd, im, ex, pi); e != nil {
-			return e
+		if pathList, err := s.globalRib.AddVrf(name, id, rd, im, ex, pi); err != nil {
+			return err
 		} else if len(pathList) > 0 {
 			s.propagateUpdate(nil, pathList)
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -594,7 +594,7 @@ func TestGracefulRestartTimerExpired(t *testing.T) {
 		GracefulRestart: config.GracefulRestart{
 			Config: config.GracefulRestartConfig{
 				Enabled:     true,
-				RestartTime: 10,
+				RestartTime: 1,
 			},
 		},
 	}
@@ -610,7 +610,7 @@ func TestGracefulRestartTimerExpired(t *testing.T) {
 			Port:     -1,
 		},
 	})
-	assert.Nil(err)
+	require.NoError(t, err)
 	defer s2.Stop()
 
 	m := &config.Neighbor{
@@ -626,7 +626,7 @@ func TestGracefulRestartTimerExpired(t *testing.T) {
 		GracefulRestart: config.GracefulRestart{
 			Config: config.GracefulRestartConfig{
 				Enabled:     true,
-				RestartTime: 10,
+				RestartTime: 1,
 			},
 		},
 	}
@@ -658,7 +658,8 @@ func TestGracefulRestartTimerExpired(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	// this seems to take around 22 seconds... need to address this whole thing
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// Waiting for Graceful Restart timer expired and moving on to IDLE state.

--- a/server/zclient.go
+++ b/server/zclient.go
@@ -283,10 +283,6 @@ type zebraClient struct {
 	dead         chan struct{}
 }
 
-func (z *zebraClient) stop() {
-	close(z.dead)
-}
-
 func (z *zebraClient) getPathListWithNexthopUpdate(body *zebra.NexthopUpdateBody) []*table.Path {
 	rib := &table.TableManager{
 		Tables: make(map[bgp.RouteFamily]*table.Table),
@@ -326,7 +322,6 @@ func (z *zebraClient) updatePathByNexthopCache(paths []*table.Path) {
 			}).Error("failed to update nexthop reachability")
 		}
 	}
-	return
 }
 
 func (z *zebraClient) loop() {

--- a/table/destination.go
+++ b/table/destination.go
@@ -255,18 +255,6 @@ func (dd *Destination) GetMultiBestPath(id string) []*Path {
 	return getMultiBestPath(id, dd.knownPathList)
 }
 
-func (dd *Destination) validatePath(path *Path) {
-	if path == nil || path.GetRouteFamily() != dd.routeFamily {
-
-		log.WithFields(log.Fields{
-			"Topic":      "Table",
-			"Key":        dd.GetNlri().String(),
-			"Path":       path,
-			"ExpectedRF": dd.routeFamily,
-		}).Error("path is nil or invalid route family")
-	}
-}
-
 // Calculates best-path among known paths for this destination.
 //
 // Modifies destination's state related to stored paths. Removes withdrawn
@@ -530,10 +518,7 @@ func (dst *Destination) sort() {
 
 		better.reason = reason
 
-		if better == path1 {
-			return true
-		}
-		return false
+		return better == path1
 	})
 }
 

--- a/table/message.go
+++ b/table/message.go
@@ -201,9 +201,7 @@ func UpdatePathAttrs4ByteAs(msg *bgp.BGPUpdate) error {
 	}
 
 	newIntfParams := make([]bgp.AsPathParamInterface, 0, len(asAttr.Value))
-	for _, p := range newParams {
-		newIntfParams = append(newIntfParams, p)
-	}
+	newIntfParams = append(newIntfParams, newParams...)
 
 	msg.PathAttributes[asAttrPos] = bgp.NewPathAttributeAsPath(newIntfParams)
 	return nil
@@ -384,7 +382,7 @@ func (p *packerV4) add(path *Path) {
 	if cages, y := p.hashmap[key]; y {
 		added := false
 		for _, c := range cages {
-			if bytes.Compare(c.attrsBytes, attrsB.Bytes()) == 0 {
+			if bytes.Equal(c.attrsBytes, attrsB.Bytes()) {
 				c.paths = append(c.paths, path)
 				added = true
 				break

--- a/table/message_test.go
+++ b/table/message_test.go
@@ -578,9 +578,7 @@ func TestMergeV4NLRIs(t *testing.T) {
 	for _, msg := range msgs {
 		u := msg.Body.(*bgp.BGPUpdate)
 		assert.Equal(t, len(u.PathAttributes), 3)
-		for _, n := range u.NLRI {
-			l = append(l, n)
-		}
+		l = append(l, u.NLRI...)
 	}
 
 	assert.Equal(t, len(l), nr)
@@ -651,9 +649,7 @@ func TestMergeV4Withdraw(t *testing.T) {
 	for _, msg := range msgs {
 		u := msg.Body.(*bgp.BGPUpdate)
 		assert.Equal(t, len(u.PathAttributes), 0)
-		for _, n := range u.WithdrawnRoutes {
-			l = append(l, n)
-		}
+		l = append(l, u.WithdrawnRoutes...)
 	}
 	assert.Equal(t, len(l), nr)
 	for i, addr := range addrs {

--- a/table/policy.go
+++ b/table/policy.go
@@ -26,12 +26,11 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
-
-	radix "github.com/armon/go-radix"
-
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
+
+	radix "github.com/armon/go-radix"
+	log "github.com/sirupsen/logrus"
 )
 
 type PolicyOptions struct {
@@ -310,6 +309,8 @@ func (p *Prefix) PrefixString() string {
 	return p.Prefix.String()
 }
 
+var _regexpPrefixRange = regexp.MustCompile(`(\d+)\.\.(\d+)`)
+
 func NewPrefix(c config.Prefix) (*Prefix, error) {
 	_, prefix, err := net.ParseCIDR(c.IpPrefix)
 	if err != nil {
@@ -325,28 +326,30 @@ func NewPrefix(c config.Prefix) (*Prefix, error) {
 		AddressFamily: rf,
 	}
 	maskRange := c.MasklengthRange
+
 	if maskRange == "" {
 		l, _ := prefix.Mask.Size()
 		maskLength := uint8(l)
 		p.MasklengthRangeMax = maskLength
 		p.MasklengthRangeMin = maskLength
-	} else {
-		exp := regexp.MustCompile("(\\d+)\\.\\.(\\d+)")
-		elems := exp.FindStringSubmatch(maskRange)
-		if len(elems) != 3 {
-			log.WithFields(log.Fields{
-				"Topic":           "Policy",
-				"Type":            "Prefix",
-				"MaskRangeFormat": maskRange,
-			}).Warn("mask length range format is invalid.")
-			return nil, fmt.Errorf("mask length range format is invalid")
-		}
-		// we've already checked the range is sane by regexp
-		min, _ := strconv.ParseUint(elems[1], 10, 8)
-		max, _ := strconv.ParseUint(elems[2], 10, 8)
-		p.MasklengthRangeMin = uint8(min)
-		p.MasklengthRangeMax = uint8(max)
+		return p, nil
 	}
+
+	elems := _regexpPrefixRange.FindStringSubmatch(maskRange)
+	if len(elems) != 3 {
+		log.WithFields(log.Fields{
+			"Topic":           "Policy",
+			"Type":            "Prefix",
+			"MaskRangeFormat": maskRange,
+		}).Warn("mask length range format is invalid.")
+		return nil, fmt.Errorf("mask length range format is invalid")
+	}
+
+	// we've already checked the range is sane by regexp
+	min, _ := strconv.ParseUint(elems[1], 10, 8)
+	max, _ := strconv.ParseUint(elems[2], 10, 8)
+	p.MasklengthRangeMin = uint8(min)
+	p.MasklengthRangeMax = uint8(max)
 	return p, nil
 }
 
@@ -817,32 +820,35 @@ func (m *singleAsPathMatch) Match(aspath []uint32) bool {
 	return false
 }
 
+var (
+	_regexpLeftMostRe = regexp.MustCompile(`$\^([0-9]+)_^`)
+	_regexpOriginRe   = regexp.MustCompile(`^_([0-9]+)\$$`)
+	_regexpIncludeRe  = regexp.MustCompile("^_([0-9]+)_$")
+	_regexpOnlyRe     = regexp.MustCompile(`^\^([0-9]+)\$$`)
+)
+
 func NewSingleAsPathMatch(arg string) *singleAsPathMatch {
-	leftMostRe := regexp.MustCompile("$\\^([0-9]+)_^")
-	originRe := regexp.MustCompile("^_([0-9]+)\\$$")
-	includeRe := regexp.MustCompile("^_([0-9]+)_$")
-	onlyRe := regexp.MustCompile("^\\^([0-9]+)\\$$")
 	switch {
-	case leftMostRe.MatchString(arg):
-		asn, _ := strconv.ParseUint(leftMostRe.FindStringSubmatch(arg)[1], 10, 32)
+	case _regexpLeftMostRe.MatchString(arg):
+		asn, _ := strconv.ParseUint(_regexpLeftMostRe.FindStringSubmatch(arg)[1], 10, 32)
 		return &singleAsPathMatch{
 			asn:  uint32(asn),
 			mode: LEFT_MOST,
 		}
-	case originRe.MatchString(arg):
-		asn, _ := strconv.ParseUint(originRe.FindStringSubmatch(arg)[1], 10, 32)
+	case _regexpOriginRe.MatchString(arg):
+		asn, _ := strconv.ParseUint(_regexpOriginRe.FindStringSubmatch(arg)[1], 10, 32)
 		return &singleAsPathMatch{
 			asn:  uint32(asn),
 			mode: ORIGIN,
 		}
-	case includeRe.MatchString(arg):
-		asn, _ := strconv.ParseUint(includeRe.FindStringSubmatch(arg)[1], 10, 32)
+	case _regexpIncludeRe.MatchString(arg):
+		asn, _ := strconv.ParseUint(_regexpIncludeRe.FindStringSubmatch(arg)[1], 10, 32)
 		return &singleAsPathMatch{
 			asn:  uint32(asn),
 			mode: INCLUDE,
 		}
-	case onlyRe.MatchString(arg):
-		asn, _ := strconv.ParseUint(onlyRe.FindStringSubmatch(arg)[1], 10, 32)
+	case _regexpOnlyRe.MatchString(arg):
+		asn, _ := strconv.ParseUint(_regexpOnlyRe.FindStringSubmatch(arg)[1], 10, 32)
 		return &singleAsPathMatch{
 			asn:  uint32(asn),
 			mode: ONLY,
@@ -1085,13 +1091,15 @@ func (s *CommunitySet) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.ToConfig())
 }
 
+var _regexpCommunity = regexp.MustCompile(`(\d+):(\d+)`)
+
 func ParseCommunity(arg string) (uint32, error) {
 	i, err := strconv.ParseUint(arg, 10, 32)
 	if err == nil {
 		return uint32(i), nil
 	}
-	exp := regexp.MustCompile("(\\d+):(\\d+)")
-	elems := exp.FindStringSubmatch(arg)
+
+	elems := _regexpCommunity.FindStringSubmatch(arg)
 	if len(elems) == 3 {
 		fst, _ := strconv.ParseUint(elems[1], 10, 16)
 		snd, _ := strconv.ParseUint(elems[2], 10, 16)
@@ -1136,24 +1144,25 @@ func ParseExtCommunity(arg string) (bgp.ExtendedCommunityInterface, error) {
 	return bgp.ParseExtendedCommunity(subtype, value)
 }
 
+var _regexpCommunity2 = regexp.MustCompile(`(\d+.)*\d+:\d+`)
+
 func ParseCommunityRegexp(arg string) (*regexp.Regexp, error) {
 	i, err := strconv.ParseUint(arg, 10, 32)
 	if err == nil {
-		return regexp.MustCompile(fmt.Sprintf("^%d:%d$", i>>16, i&0x0000ffff)), nil
+		return regexp.Compile(fmt.Sprintf("^%d:%d$", i>>16, i&0x0000ffff))
 	}
-	if regexp.MustCompile("(\\d+.)*\\d+:\\d+").MatchString(arg) {
-		return regexp.MustCompile(fmt.Sprintf("^%s$", arg)), nil
+
+	if _regexpCommunity2.MatchString(arg) {
+		return regexp.Compile(fmt.Sprintf("^%s$", arg))
 	}
+
 	for i, v := range bgp.WellKnownCommunityNameMap {
 		if strings.Replace(strings.ToLower(arg), "_", "-", -1) == v {
-			return regexp.MustCompile(fmt.Sprintf("^%d:%d$", i>>16, i&0x0000ffff)), nil
+			return regexp.Compile(fmt.Sprintf("^%d:%d$", i>>16, i&0x0000ffff))
 		}
 	}
-	exp, err := regexp.Compile(arg)
-	if err != nil {
-		return nil, fmt.Errorf("invalid community format: %s", arg)
-	}
-	return exp, nil
+
+	return regexp.Compile(arg)
 }
 
 func ParseExtCommunityRegexp(arg string) (bgp.ExtendedCommunityAttrSubType, *regexp.Regexp, error) {
@@ -1304,14 +1313,17 @@ func (s *LargeCommunitySet) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.ToConfig())
 }
 
+var _regexpCommunityLarge = regexp.MustCompile(`\d+:\d+:\d+`)
+
 func ParseLargeCommunityRegexp(arg string) (*regexp.Regexp, error) {
-	if regexp.MustCompile("\\d+:\\d+:\\d+").MatchString(arg) {
-		return regexp.MustCompile(fmt.Sprintf("^%s$", arg)), nil
+	if _regexpCommunityLarge.MatchString(arg) {
+		return regexp.Compile(fmt.Sprintf("^%s$", arg))
 	}
 	exp, err := regexp.Compile(arg)
 	if err != nil {
-		return nil, fmt.Errorf("invalid large-community format: %s", arg)
+		return nil, fmt.Errorf("invalid large-community format: %v", err)
 	}
+
 	return exp, nil
 }
 
@@ -2072,7 +2084,7 @@ func RegexpRemoveCommunities(path *Path, exps []*regexp.Regexp) {
 				break
 			}
 		}
-		if match == false {
+		if !match {
 			newComms = append(newComms, comm)
 		}
 	}
@@ -2095,7 +2107,7 @@ func RegexpRemoveExtCommunities(path *Path, exps []*regexp.Regexp, subtypes []bg
 				break
 			}
 		}
-		if match == false {
+		if !match {
 			newComms = append(newComms, comm)
 		}
 	}
@@ -2114,7 +2126,7 @@ func RegexpRemoveLargeCommunities(path *Path, exps []*regexp.Regexp) {
 				break
 			}
 		}
-		if match == false {
+		if !match {
 			newComms = append(newComms, comm)
 		}
 	}
@@ -2156,10 +2168,12 @@ func (a *CommunityAction) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a.ToConfig())
 }
 
+// TODO: this is not efficient use of regexp, probably slow
+var _regexpCommunityReplaceString = regexp.MustCompile(`[\^\$]`)
+
 func (a *CommunityAction) String() string {
 	list := a.ToConfig().SetCommunityMethod.CommunitiesList
-	exp := regexp.MustCompile("[\\^\\$]")
-	l := exp.ReplaceAllString(strings.Join(list, ", "), "")
+	l := _regexpCommunityReplaceString.ReplaceAllString(strings.Join(list, ", "), "")
 	return fmt.Sprintf("%s[%s]", a.action, l)
 }
 
@@ -2253,8 +2267,7 @@ func (a *ExtCommunityAction) ToConfig() *config.SetExtCommunity {
 
 func (a *ExtCommunityAction) String() string {
 	list := a.ToConfig().SetExtCommunityMethod.CommunitiesList
-	exp := regexp.MustCompile("[\\^\\$]")
-	l := exp.ReplaceAllString(strings.Join(list, ", "), "")
+	l := _regexpCommunityReplaceString.ReplaceAllString(strings.Join(list, ", "), "")
 	return fmt.Sprintf("%s[%s]", a.action, l)
 }
 
@@ -2342,8 +2355,7 @@ func (a *LargeCommunityAction) ToConfig() *config.SetLargeCommunity {
 
 func (a *LargeCommunityAction) String() string {
 	list := a.ToConfig().SetLargeCommunityMethod.CommunitiesList
-	exp := regexp.MustCompile("[\\^\\$]")
-	l := exp.ReplaceAllString(strings.Join(list, ", "), "")
+	l := _regexpCommunityReplaceString.ReplaceAllString(strings.Join(list, ", "), "")
 	return fmt.Sprintf("%s[%s]", a.action, l)
 }
 
@@ -2432,12 +2444,14 @@ func (a *MedAction) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a.ToConfig())
 }
 
+var _regexpParseMedAction = regexp.MustCompile(`^(\+|\-)?(\d+)$`)
+
 func NewMedAction(c config.BgpSetMedType) (*MedAction, error) {
 	if string(c) == "" {
 		return nil, nil
 	}
-	exp := regexp.MustCompile("^(\\+|\\-)?(\\d+)$")
-	elems := exp.FindStringSubmatch(string(c))
+
+	elems := _regexpParseMedAction.FindStringSubmatch(string(c))
 	if len(elems) != 3 {
 		return nil, fmt.Errorf("invalid med action format")
 	}

--- a/table/policy_test.go
+++ b/table/policy_test.go
@@ -24,11 +24,12 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/packet/bgp"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPrefixCalcurateNoRange(t *testing.T) {
@@ -3060,6 +3061,7 @@ func TestLargeCommunityMatchAction(t *testing.T) {
 
 func TestAfiSafiInMatchPath(t *testing.T) {
 	condition, err := NewAfiSafiInCondition([]config.AfiSafiType{config.AFI_SAFI_TYPE_L3VPN_IPV4_UNICAST, config.AFI_SAFI_TYPE_L3VPN_IPV6_UNICAST})
+	require.NoError(t, err)
 
 	rtExtCom, err := bgp.ParseExtendedCommunity(bgp.EC_SUBTYPE_ROUTE_TARGET, "100:100")
 	assert.NoError(t, err)

--- a/table/table_manager.go
+++ b/table/table_manager.go
@@ -57,9 +57,7 @@ func ProcessMessage(m *bgp.BGPMessage, peerInfo *PeerInfo, timestamp time.Time) 
 			reach = a
 		case *bgp.PathAttributeMpUnreachNLRI:
 			l := make([]bgp.AddrPrefixInterface, 0, len(a.Value))
-			for _, nlri := range a.Value {
-				l = append(l, nlri)
-			}
+			l = append(l, a.Value...)
 			dels = append(dels, l...)
 		default:
 			attrs = append(attrs, attr)

--- a/table/table_manager_test.go
+++ b/table/table_manager_test.go
@@ -18,12 +18,10 @@ package table
 import (
 	_ "fmt"
 	"net"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/osrg/gobgp/packet/bgp"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,16 +38,6 @@ func (manager *TableManager) ProcessUpdate(fromPeer *PeerInfo, message *bgp.BGPM
 		pathList = append(pathList, b)
 	}
 	return pathList, nil
-}
-
-func getLogger(lv log.Level) *log.Logger {
-	var l *log.Logger = &log.Logger{
-		Out:       os.Stderr,
-		Formatter: new(log.JSONFormatter),
-		Hooks:     make(map[log.Level][]log.Hook),
-		Level:     lv,
-	}
-	return l
 }
 
 func peerR1() *PeerInfo {

--- a/table/vrf.go
+++ b/table/vrf.go
@@ -30,10 +30,7 @@ type Vrf struct {
 func (v *Vrf) Clone() *Vrf {
 	f := func(rt []bgp.ExtendedCommunityInterface) []bgp.ExtendedCommunityInterface {
 		l := make([]bgp.ExtendedCommunityInterface, 0, len(rt))
-		for _, v := range rt {
-			l = append(l, v)
-		}
-		return l
+		return append(l, rt...)
 	}
 	return &Vrf{
 		Name:     v.Name,

--- a/test/scenario_test/route_reflector_test.py
+++ b/test/scenario_test/route_reflector_test.py
@@ -241,7 +241,6 @@ class GoBGPTestBase(unittest.TestCase):
 
     def test_12_routes_from_separate_rts_peers_are_isolated_by_rr(self):
         self.tyrell1.local("gobgp vrf add a1 rd 100:100 rt both 100:100")
-        self.tyrell1.local("gobgp vrf add a1 rd 100:100 rt both 100:100")
         self.tyrell1.local("gobgp vrf a1 rib add 10.10.0.0/16 local-pref 200")
         self.tyrell1.local("gobgp vrf a1 rib add 10.30.0.0/16")
         time.sleep(1)

--- a/tools/route-server/quagga-rsconfig.go
+++ b/tools/route-server/quagga-rsconfig.go
@@ -45,8 +45,6 @@ func (qt *QuaggaConfig) Config() *bytes.Buffer {
 }
 
 func create_config_files(nr int, outputDir string) {
-	quaggaConfigList := make([]*QuaggaConfig, 0)
-
 	gobgpConf := config.Bgp{}
 	gobgpConf.Global.Config.As = 65000
 	gobgpConf.Global.Config.RouterId = "192.168.255.1"
@@ -60,21 +58,24 @@ func create_config_files(nr int, outputDir string) {
 
 		gobgpConf.Neighbors = append(gobgpConf.Neighbors, c)
 		q := NewQuaggaConfig(i, &gobgpConf.Global, &c, net.ParseIP("10.0.255.1"))
-		quaggaConfigList = append(quaggaConfigList, q)
-		os.Mkdir(fmt.Sprintf("%s/q%d", outputDir, i), 0755)
-		err := ioutil.WriteFile(fmt.Sprintf("%s/q%d/bgpd.conf", outputDir, i), q.Config().Bytes(), 0644)
-		if err != nil {
+
+		if err := os.Mkdir(fmt.Sprintf("%s/q%d", outputDir, i), 0755); err != nil {
+			log.Fatalf("failed to make directory: %v", err)
+		}
+
+		if err := ioutil.WriteFile(fmt.Sprintf("%s/q%d/bgpd.conf", outputDir, i), q.Config().Bytes(), 0644); err != nil {
 			log.Fatal(err)
 		}
 	}
 
 	var buffer bytes.Buffer
 	encoder := toml.NewEncoder(&buffer)
-	encoder.Encode(gobgpConf)
+	if err := encoder.Encode(gobgpConf); err != nil {
+		log.Fatalf("failed to encode config: %v", err)
+	}
 
-	err := ioutil.WriteFile(fmt.Sprintf("%s/gobgpd.conf", outputDir), buffer.Bytes(), 0644)
-	if err != nil {
-		log.Fatal(err)
+	if err := ioutil.WriteFile(fmt.Sprintf("%s/gobgpd.conf", outputDir), buffer.Bytes(), 0644); err != nil {
+		log.Fatalf("failed to write config file: %v", err)
 	}
 }
 

--- a/zebra/zapi.go
+++ b/zebra/zapi.go
@@ -907,7 +907,7 @@ func (b *HelloBody) Serialize(version uint8) ([]byte, error) {
 	if version <= 3 {
 		return []byte{uint8(b.RedistDefault)}, nil
 	} else { // version >= 4
-		buf := make([]byte, 3, 3)
+		buf := make([]byte, 3)
 		buf[0] = uint8(b.RedistDefault)
 		binary.BigEndian.PutUint16(buf[1:3], b.Instance)
 		return buf, nil
@@ -942,7 +942,7 @@ func (b *RedistributeBody) Serialize(version uint8) ([]byte, error) {
 	if version <= 3 {
 		return []byte{uint8(b.Redist)}, nil
 	} else { // version >= 4
-		buf := make([]byte, 4, 4)
+		buf := make([]byte, 4)
 		buf[0] = uint8(b.Afi)
 		buf[1] = uint8(b.Redist)
 		binary.BigEndian.PutUint16(buf[2:4], b.Instance)
@@ -1405,71 +1405,6 @@ func (n *Nexthop) String() string {
 		"type: %s, addr: %s, ifindex: %d, ifname: %s",
 		n.Type.String(), n.Addr.String(), n.Ifindex, n.Ifname)
 	return s
-}
-
-func serializeNexthops(nexthops []*Nexthop, isV4 bool, version uint8) ([]byte, error) {
-	buf := make([]byte, 0)
-	if len(nexthops) == 0 {
-		return buf, nil
-	}
-	buf = append(buf, byte(len(nexthops)))
-
-	nhIfindex := NEXTHOP_IFINDEX
-	nhIfname := NEXTHOP_IFNAME
-	nhIPv4 := NEXTHOP_IPV4
-	nhIPv4Ifindex := NEXTHOP_IPV4_IFINDEX
-	nhIPv4Ifname := NEXTHOP_IPV4_IFNAME
-	nhIPv6 := NEXTHOP_IPV6
-	nhIPv6Ifindex := NEXTHOP_IPV6_IFINDEX
-	nhIPv6Ifname := NEXTHOP_IPV6_IFNAME
-	if version >= 4 {
-		nhIfindex = FRR_NEXTHOP_IFINDEX
-		nhIfname = NEXTHOP_FLAG(0)
-		nhIPv4 = FRR_NEXTHOP_IPV4
-		nhIPv4Ifindex = FRR_NEXTHOP_IPV4_IFINDEX
-		nhIPv4Ifname = NEXTHOP_FLAG(0)
-		nhIPv6 = FRR_NEXTHOP_IPV6
-		nhIPv6Ifindex = FRR_NEXTHOP_IPV6_IFINDEX
-		nhIPv6Ifname = NEXTHOP_FLAG(0)
-	}
-
-	for _, nh := range nexthops {
-		buf = append(buf, byte(nh.Type))
-
-		switch nh.Type {
-		case nhIfindex, nhIfname:
-			bbuf := make([]byte, 4)
-			binary.BigEndian.PutUint32(bbuf, nh.Ifindex)
-			buf = append(buf, bbuf...)
-
-		case nhIPv4, nhIPv6:
-			if isV4 {
-				buf = append(buf, nh.Addr.To4()...)
-			} else {
-				buf = append(buf, nh.Addr.To16()...)
-			}
-			if version >= 4 {
-				// On FRRouting version 3.0 or later, NEXTHOP_IPV4 and
-				// NEXTHOP_IPV6 have the same structure with
-				// NEXTHOP_TYPE_IPV4_IFINDEX and NEXTHOP_TYPE_IPV6_IFINDEX.
-				bbuf := make([]byte, 4)
-				binary.BigEndian.PutUint32(bbuf, nh.Ifindex)
-				buf = append(buf, bbuf...)
-			}
-
-		case nhIPv4Ifindex, nhIPv4Ifname, nhIPv6Ifindex, nhIPv6Ifname:
-			if isV4 {
-				buf = append(buf, nh.Addr.To4()...)
-			} else {
-				buf = append(buf, nh.Addr.To16()...)
-			}
-			bbuf := make([]byte, 4)
-			binary.BigEndian.PutUint32(bbuf, nh.Ifindex)
-			buf = append(buf, bbuf...)
-		}
-	}
-
-	return buf, nil
 }
 
 func decodeNexthopsFromBytes(nexthops *[]*Nexthop, data []byte, isV4 bool, version uint8) (int, error) {

--- a/zebra/zapi.go
+++ b/zebra/zapi.go
@@ -546,7 +546,7 @@ func NewClient(network, address string, typ ROUTE_TYPE, version uint8) (*Client,
 				if err != nil {
 					log.WithFields(log.Fields{
 						"Topic": "Zebra",
-					}).Warnf("failed to serialize: %s", m)
+					}).Warnf("failed to serialize: %v", m)
 					continue
 				}
 

--- a/zebra/zapi_test.go
+++ b/zebra/zapi_test.go
@@ -21,6 +21,8 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -113,6 +115,8 @@ func Test_InterfaceAddressUpdateBody(t *testing.T) {
 
 	b := &InterfaceAddressUpdateBody{}
 	err := b.DecodeFromBytes(buf, 2)
+	require.NoError(t, err)
+
 	assert.Equal(uint32(0), b.Index)
 	assert.Equal(INTERFACE_ADDRESS_FLAG(1), b.Flags)
 	assert.Equal("192.168.100.1", b.Prefix.String())


### PR DESCRIPTION
This fixes all the check issues on the master branch. 

notable changes
- returning errors where we were not before (could behave slightly differently)
- python test change since it might be a bug in the test. not sure but seems like it.

```
gobgp/cmd/policy.go:780:5: this value of err is never used (SA4006)
gobgp/cmd/vrf.go:157:3: this value of err is never used (SA4006)
packet/bgp/bgp.go:3954:5: unsigned values are never < 0 (SA4003)
packet/bgp/bgp.go:3957:5: unsigned values are never < 0 (SA4003)
packet/bgp/bgp.go:5501:3: empty branch (SA9003)
packet/bgp/bgp.go:5878:1: only the first constant has an explicit type (SA9004)
packet/bgp/validate_test.go:49:7: this value of err is never used (SA4006)
packet/bgp/validate_test.go:60:7: this value of err is never used (SA4006)
packet/bgp/validate_test.go:303:7: this value of err is never used (SA4006)
packet/bgp/validate_test.go:362:7: this value of err is never used (SA4006)
server/server_test.go:285:3: the surrounding loop is unconditionally terminated (SA4004)
server/server_test.go:666:3: the surrounding loop is unconditionally terminated (SA4004)
table/path.go:984:3: this value of newMed is never used (SA4006)
table/policy_test.go:3062:13: this value of err is never used (SA4006)
tools/route-server/quagga-rsconfig.go:63:28: this result of append is never used, except maybe in other appends (SA4010)
zebra/zapi_test.go:115:2: this value of err is never used (SA4006)
api/grpc_server.go:690:3: should use for range instead of for { select {} } (S1000)
api/grpc_server.go:726:3: should use for range instead of for { select {} } (S1000)
api/grpc_server.go:902:6: should omit comparison to bool constant, can be simplified to !path.IsWithdraw (S1002)
api/grpc_server.go:1663:3: should replace loop with a.List = append(a.List, c.NeighborInfoList...) (S1011)
api/grpc_server.go:1669:3: should replace loop with a.List = append(a.List, c.AsPathList...) (S1011)
api/grpc_server.go:1675:3: should replace loop with a.List = append(a.List, c.CommunityList...) (S1011)
api/grpc_server.go:1681:3: should replace loop with a.List = append(a.List, c.ExtCommunityList...) (S1011)
api/grpc_server.go:1687:3: should replace loop with a.List = append(a.List, c.LargeCommunityList...) (S1011)
api/grpc_server.go:1890:13: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
api/grpc_server.go:2069:10: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
config/default.go:33:51: should use make(map[string]interface{}) instead (S1019)
config/serve.go:71:3: should use a simple channel send/receive instead of select with a single case (S1000)
config/util.go:252:9: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
gobgp/cmd/common.go:219:3: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008)
gobgp/cmd/global.go:886:8: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
gobgp/cmd/global.go:1253:5: should omit nil check; len() for nil slices is defined as zero (S1009)
gobgp/cmd/neighbor.go:132:2: should merge variable declaration with assignment on next line (S1021)
gobgp/cmd/neighbor.go:828:5: should replace loop with ps = append(ps, d.GetAllKnownPathList()...) (S1011)
gobgp/cmd/policy.go:62:12: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
gobgp/cmd/rpki.go:39:7: should omit comparison to bool constant, can be simplified to r.State.Up (S1002)
gobgp/cmd/rpki.go:41:47: should use time.Since instead of time.Now().Sub (S1012)
gobgp/cmd/rpki.go:50:8: should omit comparison to bool constant, can be simplified to r.State.Up (S1002)
gobgpd/main.go:116:5: should omit comparison to bool constant, can be simplified to opts.DisableStdlog (S1002)
packet/bgp/bgp.go:292:30: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
packet/bgp/bgp.go:298:31: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
packet/bgp/bgp.go:306:33: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
packet/bgp/bgp.go:307:33: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
packet/bgp/bgp.go:318:28: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
packet/bgp/bgp.go:324:26: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
packet/bgp/bgp.go:332:26: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
packet/bgp/bgp.go:1575:5: should omit comparison to bool constant, can be simplified to !foundBottom (S1002)
packet/bgp/bgp.go:2164:27: should use make([]byte, 9) instead (S1019)
packet/bgp/bgp.go:2199:24: should use make([]byte, 4) instead (S1019)
packet/bgp/bgp.go:2281:22: should use make([]byte, 3) instead (S1019)
packet/bgp/bgp.go:5491:6: should omit comparison to bool constant, can be simplified to isAs4 (S1002)
packet/bgp/bgp.go:5999:22: should use make([]byte, 4) instead (S1019)
packet/bgp/bgp.go:6713:22: should use make([]byte, 8) instead (S1019)
packet/bgp/bgp.go:6753:22: should use make([]byte, 8) instead (S1019)
packet/bgp/bgp.go:6793:22: should use make([]byte, 8) instead (S1019)
packet/bgp/bgp.go:6853:22: should use make([]byte, 8) instead (S1019)
packet/bgp/bgp.go:6892:22: should use make([]byte, 8) instead (S1019)
packet/bgp/bgp.go:6903:22: should use make([]byte, 8) instead (S1019)
packet/bgp/bgp.go:6934:20: should use make([]byte, 7) instead (S1019)
packet/bgp/bgp.go:7555:22: should use make([]byte, 8) instead (S1019)
packet/bgp/bgp.go:7590:20: should use make([]byte, 7) instead (S1019)
packet/bgp/bgp.go:7734:5: should omit comparison to bool constant, can be simplified to !isAs4 (S1002)
packet/bgp/bgp.go:8152:28: should use make([]string, len(p.Value)) instead (S1019)
packet/bgp/bgp.go:8211:28: should use make([]string, len(p.Value)) instead (S1019)
packet/bgp/bgp_test.go:63:6: should omit comparison to bool constant, can be simplified to reflect.DeepEqual(m1, m2) (S1002)
packet/bgp/bgp_test.go:410:5: should omit comparison to bool constant, can be simplified to reflect.DeepEqual(n1, n2) (S1002)
packet/bgp/bgp_test.go:436:5: should omit comparison to bool constant, can be simplified to reflect.DeepEqual(m1, m2) (S1002)
packet/bgp/bgp_test.go:456:5: should omit comparison to bool constant, can be simplified to reflect.DeepEqual(m1, m2) (S1002)
packet/bgp/bgp_test.go:497:5: should omit comparison to bool constant, can be simplified to reflect.DeepEqual(n1, n2) (S1002)
packet/bgp/bgp_test.go:517:5: should omit comparison to bool constant, can be simplified to reflect.DeepEqual(a1, a2) (S1002)
packet/bgp/bgp_test.go:544:5: should omit comparison to bool constant, can be simplified to reflect.DeepEqual(n1, n2) (S1002)
packet/bgp/bgp_test.go:577:5: should omit comparison to bool constant, can be simplified to reflect.DeepEqual(n1, n2) (S1002)
packet/bgp/bgp_test.go:1136:25: should use make([]string, 0) instead (S1019)
packet/bgp/validate.go:277:7: should omit comparison to bool constant, can be simplified to use4byte (S1002)
packet/bmp/bmp_test.go:33:5: should omit comparison to bool constant, can be simplified to reflect.DeepEqual(m1, m2) (S1002)
packet/rtr/rtr_test.go:35:5: should omit comparison to bool constant, can be simplified to reflect.DeepEqual(buf1, buf2) (S1002)
server/fsm.go:1051:4: should replace loop with items = append(items, c.(*bgp.CapAddPath).Tuples...) (S1011)
server/peer.go:45:54: should use make(map[string]config.Neighbor) instead (S1019)
server/peer.go:46:62: should use make(map[string]*config.DynamicNeighbor) instead (S1019)
server/server.go:245:8: should omit comparison to bool constant, can be simplified to !localAddrValid (S1002)
server/server.go:1378:2: redundant return statement (S1023)
server/server.go:1831:6: should omit comparison to bool constant, can be simplified to !deferral (S1002)
server/server.go:2296:7: should omit comparison to bool constant, can be simplified to !c.Config.AdminDown (S1002)
server/server.go:2862:2: should use for range instead of for { select {} } (S1000)
server/zclient.go:329:2: redundant return statement (S1023)
table/destination.go:533:3: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008)
table/message.go:204:2: should replace loop with newIntfParams = append(newIntfParams, newParams...) (S1011)
table/message.go:387:7: should use bytes.Equal(c.attrsBytes, attrsB.Bytes()) instead (S1004)
table/message_test.go:581:3: should replace loop with l = append(l, u.NLRI...) (S1011)
table/message_test.go:654:3: should replace loop with l = append(l, u.WithdrawnRoutes...) (S1011)
table/path.go:801:2: redundant return statement (S1023)
table/path.go:928:3: should replace loop with eCommunityList = append(eCommunityList, eCommunities...) (S1011)
table/path.go:954:3: should replace loop with ret = append(ret, v...) (S1011)
table/policy.go:334:10: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
table/policy.go:821:16: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
table/policy.go:822:14: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
table/policy.go:824:12: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
table/policy.go:1093:9: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
table/policy.go:1144:5: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
table/policy.go:1308:5: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
table/policy.go:2075:6: should omit comparison to bool constant, can be simplified to !match (S1002)
table/policy.go:2098:6: should omit comparison to bool constant, can be simplified to !match (S1002)
table/policy.go:2117:6: should omit comparison to bool constant, can be simplified to !match (S1002)
table/policy.go:2161:9: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
table/policy.go:2256:9: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
table/policy.go:2345:9: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
table/policy.go:2439:9: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)
table/table_manager.go:60:4: should replace loop with l = append(l, a.Value...) (S1011)
table/vrf.go:33:3: should replace loop with l = append(l, rt...) (S1011)
zebra/zapi.go:910:23: should use make([]byte, 3) instead (S1019)
zebra/zapi.go:945:23: should use make([]byte, 4) instead (S1019)
config/util.go:84:6: func isLocalLinkLocalAddress is unused (U1000)
gobgp/cmd/common.go:100:5: var conditionOpts is unused (U1000)
gobgp/cmd/common.go:109:5: var actionOpts is unused (U1000)
gobgp/cmd/global.go:1074:6: func extractRouteDistinguisher is unused (U1000)
gobgp/cmd/neighbor.go:426:2: field start is unused (U1000)
gobgp/cmd/neighbor.go:427:2: field end is unused (U1000)
gobgp/cmd/neighbor.go:428:2: field separator is unused (U1000)
gobgp/cmd/root.go:40:5: var cmds is unused (U1000)
server/peer.go:320:19: func (*Peer).getAccepted is unused (U1000)
server/server.go:2737:2: field sentMessage is unused (U1000)
server/zclient.go:286:23: func (*zebraClient).stop is unused (U1000)
table/destination.go:258:24: func (*Destination).validatePath is unused (U1000)
table/table_manager_test.go:45:6: func getLogger is unused (U1000)
zebra/zapi.go:1410:6: func serializeNexthops is unused (U1000)
```