### PR TITLE
Exclude bgp.RF_RTC_UC from address farmily in soft reset in and out.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1762,6 +1762,16 @@ func (s *BgpServer) Stop() error {
 	}, true)
 }
 
+func filterFamilyList(families []bgp.RouteFamily, f bgp.RouteFamily) []bgp.RouteFamily {
+	l := make([]bgp.RouteFamily, 0, len(families))
+	for _, family := range families {
+		if family != f {
+			l = append(l, family)
+		}
+	}
+	return l
+}
+
 func (s *BgpServer) softResetIn(addr string, family bgp.RouteFamily) error {
 	peers, err := s.addrToPeers(addr)
 	if err != nil {
@@ -1772,6 +1782,7 @@ func (s *BgpServer) softResetIn(addr string, family bgp.RouteFamily) error {
 		if family == bgp.RouteFamily(0) {
 			families = peer.configuredRFlist()
 		}
+		families = filterFamilyList(families, bgp.RF_RTC_UC)
 		pathList := make([]*table.Path, 0, peer.adjRibIn.Count(families))
 		for _, path := range peer.adjRibIn.PathList(families, false) {
 			// RFC4271 9.1.2 Phase 2: Route Selection
@@ -1812,6 +1823,7 @@ func (s *BgpServer) softResetOut(addr string, family bgp.RouteFamily, deferral b
 		if family == bgp.RouteFamily(0) {
 			families = peer.negotiatedRFList()
 		}
+		families = filterFamilyList(families, bgp.RF_RTC_UC)
 
 		if deferral {
 			_, y := peer.fsm.rfMap[bgp.RF_RTC_UC]

--- a/server/server.go
+++ b/server/server.go
@@ -1782,7 +1782,9 @@ func (s *BgpServer) softResetIn(addr string, family bgp.RouteFamily) error {
 		if family == bgp.RouteFamily(0) {
 			families = peer.configuredRFlist()
 		}
-		families = filterFamilyList(families, bgp.RF_RTC_UC)
+		if family != bgp.RF_RTC_UC {
+			families = filterFamilyList(families, bgp.RF_RTC_UC)
+		}
 		pathList := make([]*table.Path, 0, peer.adjRibIn.Count(families))
 		for _, path := range peer.adjRibIn.PathList(families, false) {
 			// RFC4271 9.1.2 Phase 2: Route Selection
@@ -1823,7 +1825,9 @@ func (s *BgpServer) softResetOut(addr string, family bgp.RouteFamily, deferral b
 		if family == bgp.RouteFamily(0) {
 			families = peer.negotiatedRFList()
 		}
-		families = filterFamilyList(families, bgp.RF_RTC_UC)
+		if family != bgp.RF_RTC_UC {
+			families = filterFamilyList(families, bgp.RF_RTC_UC)
+		}
 
 		if deferral {
 			_, y := peer.fsm.rfMap[bgp.RF_RTC_UC]

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -676,3 +676,16 @@ func TestGracefulRestartTimerExpired(t *testing.T) {
 		}
 	}
 }
+
+func TestFilterFamilyList(t *testing.T) {
+	families := []bgp.RouteFamily{bgp.RF_IPv4_UC, bgp.RF_RTC_UC}
+	families = filterFamilyList(families, bgp.RF_RTC_UC)
+	assert.Equal(t, len(families), 1)
+	assert.Equal(t, families[0], bgp.RF_IPv4_UC)
+
+	families = []bgp.RouteFamily{bgp.RF_IPv4_UC, bgp.RF_RTC_UC, bgp.RF_IPv6_UC}
+	families = filterFamilyList(families, bgp.RF_RTC_UC)
+	families = filterFamilyList(families, bgp.RF_IPv4_UC)
+	assert.Equal(t, len(families), 1)
+	assert.Equal(t, families[0], bgp.RF_IPv6_UC)
+}


### PR DESCRIPTION
When RTC and AddPath both are enabled.   Issuing softreset command to Route Reflector with many Client cause route update storm.