### PR TITLE
config: Copy afi-safi objects from peer group to neighbor instead of …

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -496,7 +496,9 @@ func OverwriteNeighborConfigWithPeerGroup(c *Neighbor, pg *PeerGroup) error {
 	overwriteConfig(&c.TtlSecurity.Config, &pg.TtlSecurity.Config, "neighbor.ttl-security.config", v)
 
 	if !v.IsSet("neighbor.afi-safis") {
-		c.AfiSafis = pg.AfiSafis
+		for _, afiSafi := range pg.AfiSafis {
+			c.AfiSafis = append(c.AfiSafis, afiSafi)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
…share the same array
https://github.com/osrg/gobgp/issues/1765