### PR TITLE
cmd: fix error when delete policy statement

### DIFF
--- a/gobgp/cmd/policy.go
+++ b/gobgp/cmd/policy.go
@@ -490,7 +490,7 @@ func modStatement(op string, args []string) error {
 	case CMD_ADD:
 		err = client.AddStatement(stmt)
 	case CMD_DEL:
-		err = client.DeleteStatement(stmt, false)
+		err = client.DeleteStatement(stmt, true)
 	default:
 		return fmt.Errorf("invalid operation: %s", op)
 	}


### PR DESCRIPTION
fixed bug: `gobgp policy statement del statement1` has no effect