### PR TITLE
fix nil pointer error when create pmsitunnel

### DIFF
--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -8444,7 +8444,13 @@ func (p *PathAttributePmsiTunnel) MarshalJSON() ([]byte, error) {
 
 func NewPathAttributePmsiTunnel(typ PmsiTunnelType, isLeafInfoRequired bool, label uint32, id PmsiTunnelIDInterface) *PathAttributePmsiTunnel {
 	// Flags(1) + TunnelType(1) + Label(3) + TunnelID(variable)
-	l := 5 + id.Len()
+	l := 5
+	if id != nil {
+		l += id.Len()
+	} else {
+		l += net.IPv4len
+	}
+
 	t := BGP_ATTR_TYPE_PMSI_TUNNEL
 	return &PathAttributePmsiTunnel{
 		PathAttribute: PathAttribute{


### PR DESCRIPTION
fix error:
# gobgp global rib -a evpn add multicast 172.31.9.12 etag 10 rd 1:10 rt 1:1000 encap vxlan nexthop 172.31.9.12 pmsi ingress-repl 10 172.31.9.12
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6190bf]

goroutine 1 [running]:
github.com/osrg/gobgp/packet/bgp.NewPathAttributePmsiTunnel(0x1010000, 0x0, 0x0, 0x0)