### PR TITLE
enable ebgp-multihop if configured

### DIFF
--- a/api/grpc_server.go
+++ b/api/grpc_server.go
@@ -279,6 +279,10 @@ func NewPeerFromConfigStruct(pconf *config.Neighbor) *Peer {
 			RemovePrivateAs:   removePrivateAs,
 			ReplacePeerAs:     pconf.AsPathOptions.Config.ReplacePeerAs,
 		},
+		EbgpMultihop: &EbgpMultihop{
+			Enabled:     pconf.EbgpMultihop.Config.Enabled,
+			MultihopTtl: uint32(pconf.EbgpMultihop.Config.MultihopTtl),
+		},
 		Info: &PeerState{
 			BgpState:   string(s.SessionState),
 			AdminState: PeerState_AdminState(s.AdminState.ToInt()),


### PR DESCRIPTION
- neighbors.ebgp-multihop.config configuration is ignored without this patch, meaning ebgp multihop peer can't be established because ttl is set to 1.
- this bug seems to have crept in since commit [0c334f5](https://github.com/osrg/gobgp/commit/0c334f5b3f8d330ced71649316c894119b2432d3).