### PR TITLE
packet/bgp: Support SR TE Policy

### DIFF
--- a/config/bgp_configs.go
+++ b/config/bgp_configs.go
@@ -259,6 +259,8 @@ const (
 	AFI_SAFI_TYPE_L3VPN_IPV6_FLOWSPEC   AfiSafiType = "l3vpn-ipv6-flowspec"
 	AFI_SAFI_TYPE_L2VPN_FLOWSPEC        AfiSafiType = "l2vpn-flowspec"
 	AFI_SAFI_TYPE_OPAQUE                AfiSafiType = "opaque"
+	AFI_SAFI_TYPE_IPV4_SR_TE            AfiSafiType = "ipv4-sr-te"
+	AFI_SAFI_TYPE_IPV6_SR_TE            AfiSafiType = "ipv6-sr-te"
 )
 
 var AfiSafiTypeToIntMap = map[AfiSafiType]int{
@@ -283,6 +285,8 @@ var AfiSafiTypeToIntMap = map[AfiSafiType]int{
 	AFI_SAFI_TYPE_L3VPN_IPV6_FLOWSPEC:   18,
 	AFI_SAFI_TYPE_L2VPN_FLOWSPEC:        19,
 	AFI_SAFI_TYPE_OPAQUE:                20,
+	AFI_SAFI_TYPE_IPV4_SR_TE:            21,
+	AFI_SAFI_TYPE_IPV6_SR_TE:            22,
 }
 
 func (v AfiSafiType) ToInt() int {
@@ -315,6 +319,8 @@ var IntToAfiSafiTypeMap = map[int]AfiSafiType{
 	18: AFI_SAFI_TYPE_L3VPN_IPV6_FLOWSPEC,
 	19: AFI_SAFI_TYPE_L2VPN_FLOWSPEC,
 	20: AFI_SAFI_TYPE_OPAQUE,
+	21: AFI_SAFI_TYPE_IPV4_SR_TE,
+	22: AFI_SAFI_TYPE_IPV6_SR_TE,
 }
 
 func (v AfiSafiType) Validate() error {

--- a/config/default.go
+++ b/config/default.go
@@ -2,12 +2,14 @@ package config
 
 import (
 	"fmt"
+	"net"
+	"reflect"
+
+	"github.com/spf13/viper"
+
 	"github.com/osrg/gobgp/packet/bgp"
 	"github.com/osrg/gobgp/packet/bmp"
 	"github.com/osrg/gobgp/packet/rtr"
-	"github.com/spf13/viper"
-	"net"
-	"reflect"
 )
 
 const (

--- a/gobgp/cmd/common.go
+++ b/gobgp/cmd/common.go
@@ -288,6 +288,10 @@ func checkAddressFamily(def bgp.RouteFamily) (bgp.RouteFamily, error) {
 		rf = bgp.RF_IPv6_MPLS
 	case "evpn":
 		rf = bgp.RF_EVPN
+	case "ipv4-sr-te":
+		rf = bgp.RF_IPv4_SR_TE
+	case "ipv6-sr-te":
+		rf = bgp.RF_IPv6_SR_TE
 	case "encap", "ipv4-encap":
 		rf = bgp.RF_IPv4_ENCAP
 	case "ipv6-encap":

--- a/packet/bgp/bgp.go
+++ b/packet/bgp/bgp.go
@@ -63,6 +63,7 @@ const (
 	SAFI_ENCAPSULATION            = 7
 	SAFI_VPLS                     = 65
 	SAFI_EVPN                     = 70
+	SAFI_SR_TE_POLICY             = 73
 	SAFI_MPLS_VPN                 = 128
 	SAFI_MPLS_VPN_MULTICAST       = 129
 	SAFI_ROUTE_TARGET_CONSTRAINTS = 132
@@ -159,16 +160,47 @@ const (
 type TunnelType uint16
 
 const (
-	TUNNEL_TYPE_L2TP3       TunnelType = 1
-	TUNNEL_TYPE_GRE         TunnelType = 2
-	TUNNEL_TYPE_IP_IN_IP    TunnelType = 7
-	TUNNEL_TYPE_VXLAN       TunnelType = 8
-	TUNNEL_TYPE_NVGRE       TunnelType = 9
-	TUNNEL_TYPE_MPLS        TunnelType = 10
-	TUNNEL_TYPE_MPLS_IN_GRE TunnelType = 11
-	TUNNEL_TYPE_VXLAN_GRE   TunnelType = 12
-	TUNNEL_TYPE_MPLS_IN_UDP TunnelType = 13
+	TUNNEL_TYPE_L2TP3        TunnelType = 1
+	TUNNEL_TYPE_GRE          TunnelType = 2
+	TUNNEL_TYPE_IP_IN_IP     TunnelType = 7
+	TUNNEL_TYPE_VXLAN        TunnelType = 8
+	TUNNEL_TYPE_NVGRE        TunnelType = 9
+	TUNNEL_TYPE_MPLS         TunnelType = 10
+	TUNNEL_TYPE_MPLS_IN_GRE  TunnelType = 11
+	TUNNEL_TYPE_VXLAN_GRE    TunnelType = 12
+	TUNNEL_TYPE_MPLS_IN_UDP  TunnelType = 13
+	TUNNEL_TYPE_IPv6         TunnelType = 14
+	TUNNEL_TYPE_SR_TE_Policy TunnelType = 15
 )
+
+func (p TunnelType) String() string {
+	switch p {
+	case TUNNEL_TYPE_L2TP3:
+		return "l2tp3"
+	case TUNNEL_TYPE_GRE:
+		return "gre"
+	case TUNNEL_TYPE_IP_IN_IP:
+		return "ip-in-ip"
+	case TUNNEL_TYPE_VXLAN:
+		return "vxlan"
+	case TUNNEL_TYPE_NVGRE:
+		return "nvgre"
+	case TUNNEL_TYPE_MPLS:
+		return "mpls"
+	case TUNNEL_TYPE_MPLS_IN_GRE:
+		return "mpls-ingre"
+	case TUNNEL_TYPE_VXLAN_GRE:
+		return "vxlan-gre"
+	case TUNNEL_TYPE_MPLS_IN_UDP:
+		return "mpls-in-udp"
+	case TUNNEL_TYPE_IPv6:
+		return "ipv6"
+	case TUNNEL_TYPE_SR_TE_Policy:
+		return "sr-te-policy"
+	default:
+		return fmt.Sprintf("TunnelType(%d)", uint8(p))
+	}
+}
 
 type PmsiTunnelType uint8
 
@@ -209,9 +241,13 @@ func (p PmsiTunnelType) String() string {
 type EncapSubTLVType uint8
 
 const (
-	ENCAP_SUBTLV_TYPE_ENCAPSULATION EncapSubTLVType = 1
-	ENCAP_SUBTLV_TYPE_PROTOCOL      EncapSubTLVType = 2
-	ENCAP_SUBTLV_TYPE_COLOR         EncapSubTLVType = 4
+	ENCAP_SUBTLV_TYPE_ENCAPSULATION   EncapSubTLVType = 1
+	ENCAP_SUBTLV_TYPE_PROTOCOL        EncapSubTLVType = 2
+	ENCAP_SUBTLV_TYPE_COLOR           EncapSubTLVType = 4
+	ENCAP_SUBTLV_TYPE_REMOTE_ENDPOINT EncapSubTLVType = 6
+	ENCAP_SUBTLV_TYPE_PREFERENCE      EncapSubTLVType = 12
+	ENCAP_SUBTLV_TYPE_BINDING_SID     EncapSubTLVType = 13
+	ENCAP_SUBTLV_TYPE_SEGMENT_LIST    EncapSubTLVType = 128
 )
 
 const (
@@ -4503,6 +4539,8 @@ const (
 	RF_IPv6_MPLS   RouteFamily = AFI_IP6<<16 | SAFI_MPLS_LABEL
 	RF_VPLS        RouteFamily = AFI_L2VPN<<16 | SAFI_VPLS
 	RF_EVPN        RouteFamily = AFI_L2VPN<<16 | SAFI_EVPN
+	RF_IPv4_SR_TE  RouteFamily = AFI_IP<<16 | SAFI_SR_TE_POLICY
+	RF_IPv6_SR_TE  RouteFamily = AFI_IP6<<16 | SAFI_SR_TE_POLICY
 	RF_RTC_UC      RouteFamily = AFI_IP<<16 | SAFI_ROUTE_TARGET_CONSTRAINTS
 	RF_IPv4_ENCAP  RouteFamily = AFI_IP<<16 | SAFI_ENCAPSULATION
 	RF_IPv6_ENCAP  RouteFamily = AFI_IP6<<16 | SAFI_ENCAPSULATION
@@ -4527,6 +4565,8 @@ var AddressFamilyNameMap = map[RouteFamily]string{
 	RF_IPv6_VPN_MC: "l3vpn-ipv6-multicast",
 	RF_VPLS:        "l2vpn-vpls",
 	RF_EVPN:        "l2vpn-evpn",
+	RF_IPv4_SR_TE:  "ipv4-sr-te",
+	RF_IPv6_SR_TE:  "ipv6-sr-te",
 	RF_RTC_UC:      "rtc",
 	RF_IPv4_ENCAP:  "ipv4-encap",
 	RF_IPv6_ENCAP:  "ipv6-encap",
@@ -4551,6 +4591,8 @@ var AddressFamilyValueMap = map[string]RouteFamily{
 	AddressFamilyNameMap[RF_IPv6_VPN_MC]: RF_IPv6_VPN_MC,
 	AddressFamilyNameMap[RF_VPLS]:        RF_VPLS,
 	AddressFamilyNameMap[RF_EVPN]:        RF_EVPN,
+	AddressFamilyNameMap[RF_IPv4_SR_TE]:  RF_IPv4_SR_TE,
+	AddressFamilyNameMap[RF_IPv6_SR_TE]:  RF_IPv6_SR_TE,
 	AddressFamilyNameMap[RF_RTC_UC]:      RF_RTC_UC,
 	AddressFamilyNameMap[RF_IPv4_ENCAP]:  RF_IPv4_ENCAP,
 	AddressFamilyNameMap[RF_IPv6_ENCAP]:  RF_IPv6_ENCAP,
@@ -4585,6 +4627,10 @@ func NewPrefixFromRouteFamily(afi uint16, safi uint8) (prefix AddrPrefixInterfac
 		prefix = NewLabeledIPv6AddrPrefix(0, "", *NewMPLSLabelStack())
 	case RF_EVPN:
 		prefix = NewEVPNNLRI(0, 0, nil)
+	case RF_IPv4_SR_TE:
+		prefix = NewIPv4SRTEPolicyNLRI(0, 0, nil)
+	case RF_IPv6_SR_TE:
+		prefix = NewIPv6SRTEPolicyNLRI(0, 0, nil)
 	case RF_RTC_UC:
 		prefix = &RouteTargetMembershipNLRI{}
 	case RF_IPv4_ENCAP:
@@ -5633,6 +5679,15 @@ func (p *PathAttributeCommunities) Serialize(options ...*MarshallingOption) ([]b
 	return p.PathAttribute.Serialize(options...)
 }
 
+func (p *PathAttributeCommunities) hasCommunity(community uint32) bool {
+	for _, value := range p.Value {
+		if value == community {
+			return true
+		}
+	}
+	return false
+}
+
 type WellKnownCommunity uint32
 
 const (
@@ -6457,19 +6512,77 @@ func (e *ValidationExtended) String() string {
 	return e.Value.String()
 }
 
+type ColorExtendedFlag uint16
+
+const (
+	COLOR_EXT_FLAG_COLOR ColorExtendedFlag = 0x8000 // draft-ietf-idr-segment-routing-te-policy
+	COLOR_EXT_FLAG_ONLY  ColorExtendedFlag = 0x4000 // draft-ietf-idr-segment-routing-te-policy
+)
+
+var ColorExtendedFlagNameMap = map[ColorExtendedFlag]string{
+	COLOR_EXT_FLAG_COLOR: "C",
+	COLOR_EXT_FLAG_ONLY:  "O",
+}
+
+var ColorExtendedSortedFlags = []ColorExtendedFlag{
+	COLOR_EXT_FLAG_COLOR,
+	COLOR_EXT_FLAG_ONLY,
+}
+
+func (f *ColorExtendedFlag) String() string {
+	s := make([]string, 0, len(ColorExtendedSortedFlags))
+	for _, flag := range ColorExtendedSortedFlags {
+		if *f&flag > 0 {
+			s = append(s, ColorExtendedFlagNameMap[flag])
+		}
+	}
+	return strings.Join(s, "")
+}
+
 type ColorExtended struct {
+	Flags ColorExtendedFlag
 	Value uint32
 }
 
 func (e *ColorExtended) Serialize() ([]byte, error) {
 	buf := make([]byte, 7)
 	buf[0] = byte(EC_SUBTYPE_COLOR)
-	binary.BigEndian.PutUint32(buf[3:], uint32(e.Value))
+	binary.BigEndian.PutUint16(buf[1:3], uint16(e.Flags))
+	binary.BigEndian.PutUint32(buf[3:7], uint32(e.Value))
 	return buf, nil
 }
 
 func (e *ColorExtended) String() string {
+	if e.Flags > 0 {
+		return fmt.Sprintf("%s:%d", e.Flags.String(), e.Value)
+	}
 	return fmt.Sprintf("%d", e.Value)
+}
+
+func ParseColorExtended(arg string) (*ColorExtended, error) {
+	re := regexp.MustCompile("(CO)*:?(\\d+)")
+	m := re.FindStringSubmatch(arg)
+	// re.FindStringSubmatch("CO:100")
+	// >> ["CO:100" "CO" "100"]
+	// re.FindStringSubmatch("100")
+	// >> ["100" "" "100"]
+	if len(m) < 3 {
+		return nil, fmt.Errorf("invalid color extended community string: %s", arg)
+	}
+	var flags ColorExtendedFlag
+	for flag, name := range ColorExtendedFlagNameMap {
+		if strings.Contains(m[1], name) {
+			flags |= flag
+		}
+	}
+	value, err := strconv.ParseUint(m[2], 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid color extended community value: %s", m[2])
+	}
+	return &ColorExtended{
+		Flags: flags,
+		Value: uint32(value),
+	}, nil
 }
 
 type EncapExtended struct {
@@ -6536,9 +6649,9 @@ func (e *OpaqueExtended) DecodeFromBytes(data []byte) error {
 	if e.IsTransitive {
 		switch e.SubType {
 		case EC_SUBTYPE_COLOR:
-			v := binary.BigEndian.Uint32(data[3:7])
 			e.Value = &ColorExtended{
-				Value: v,
+				Flags: ColorExtendedFlag(binary.BigEndian.Uint16(data[1:3])),
+				Value: binary.BigEndian.Uint32(data[3:7]),
 			}
 		case EC_SUBTYPE_ENCAPSULATION:
 			t := TunnelType(binary.BigEndian.Uint16(data[5:7]))
@@ -7431,16 +7544,44 @@ func NewPathAttributeAs4Aggregator(as uint32, address string) *PathAttributeAs4A
 	}
 }
 
-type TunnelEncapSubTLVValue interface {
-	Serialize() ([]byte, error)
+type TunnelEncapSubTLVInterface interface {
+	Type() EncapSubTLVType
+	decodeValue([]byte) error
+	serializeValue() ([]byte, error)
+	String() string
+	MarshalJSON() ([]byte, error)
 }
 
-type TunnelEncapSubTLVDefault struct {
+type TunnelEncapSubTLVUnkown struct {
+	typ   EncapSubTLVType
 	Value []byte
 }
 
-func (t *TunnelEncapSubTLVDefault) Serialize() ([]byte, error) {
+func (t *TunnelEncapSubTLVUnkown) Type() EncapSubTLVType {
+	return t.typ
+}
+
+func (t *TunnelEncapSubTLVUnkown) decodeValue(data []byte) error {
+	t.Value = data
+	return nil
+}
+
+func (t *TunnelEncapSubTLVUnkown) serializeValue() ([]byte, error) {
 	return t.Value, nil
+}
+
+func (t *TunnelEncapSubTLVUnkown) String() string {
+	return fmt.Sprintf("[Type: %d, Value: %x]", t.typ, t.Value)
+}
+
+func (t *TunnelEncapSubTLVUnkown) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  EncapSubTLVType `json:"type"`
+		Value []byte          `json:"value"`
+	}{
+		Type:  t.typ,
+		Value: t.Value,
+	})
 }
 
 type TunnelEncapSubTLVEncapsulation struct {
@@ -7448,86 +7589,341 @@ type TunnelEncapSubTLVEncapsulation struct {
 	Cookie []byte
 }
 
-func (t *TunnelEncapSubTLVEncapsulation) Serialize() ([]byte, error) {
+func (t *TunnelEncapSubTLVEncapsulation) Type() EncapSubTLVType {
+	return ENCAP_SUBTLV_TYPE_ENCAPSULATION
+}
+
+func (t *TunnelEncapSubTLVEncapsulation) decodeValue(data []byte) error {
+	if len(data) < 4 {
+		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLVEncapsulation bytes available")
+	}
+	t.Key = binary.BigEndian.Uint32(data[0:4])
+	t.Cookie = data[4:]
+	return nil
+}
+
+func (t *TunnelEncapSubTLVEncapsulation) serializeValue() ([]byte, error) {
 	buf := make([]byte, 4)
 	binary.BigEndian.PutUint32(buf, t.Key)
 	return append(buf, t.Cookie...), nil
+}
+
+func (t *TunnelEncapSubTLVEncapsulation) String() string {
+	return fmt.Sprintf("[Key: %d, Cookie: %x]", t.Key, t.Cookie)
+}
+
+func (t *TunnelEncapSubTLVEncapsulation) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type   EncapSubTLVType `json:"type"`
+		Key    uint32          `json:"key"`
+		Cookie []byte          `json:"cookie"`
+	}{
+		Type:   t.Type(),
+		Key:    t.Key,
+		Cookie: t.Cookie,
+	})
 }
 
 type TunnelEncapSubTLVProtocol struct {
 	Protocol uint16
 }
 
-func (t *TunnelEncapSubTLVProtocol) Serialize() ([]byte, error) {
+func (t *TunnelEncapSubTLVProtocol) Type() EncapSubTLVType {
+	return ENCAP_SUBTLV_TYPE_PROTOCOL
+}
+
+func (t *TunnelEncapSubTLVProtocol) decodeValue(data []byte) error {
+	if len(data) < 2 {
+		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLVProtocol bytes available")
+	}
+	t.Protocol = binary.BigEndian.Uint16(data[0:2])
+	return nil
+}
+
+func (t *TunnelEncapSubTLVProtocol) serializeValue() ([]byte, error) {
 	buf := make([]byte, 2)
 	binary.BigEndian.PutUint16(buf, t.Protocol)
 	return buf, nil
+}
+
+func (t *TunnelEncapSubTLVProtocol) String() string {
+	return fmt.Sprintf("[Protocol: %d]", t.Protocol)
+}
+
+func (t *TunnelEncapSubTLVProtocol) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type     EncapSubTLVType `json:"type"`
+		Protocol uint16          `json:"protocol"`
+	}{
+		Type:     t.Type(),
+		Protocol: t.Protocol,
+	})
 }
 
 type TunnelEncapSubTLVColor struct {
 	Color uint32
 }
 
-func (t *TunnelEncapSubTLVColor) Serialize() ([]byte, error) {
+func (t *TunnelEncapSubTLVColor) Type() EncapSubTLVType {
+	return ENCAP_SUBTLV_TYPE_COLOR
+}
+
+func (t *TunnelEncapSubTLVColor) decodeValue(data []byte) error {
+	if len(data) < 8 {
+		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLVColor bytes available")
+	}
+	t.Color = binary.BigEndian.Uint32(data[4:8])
+	return nil
+}
+
+func (t *TunnelEncapSubTLVColor) serializeValue() ([]byte, error) {
 	buf := make([]byte, 8)
 	buf[0] = byte(EC_TYPE_TRANSITIVE_OPAQUE)
 	buf[1] = byte(EC_SUBTYPE_COLOR)
-	binary.BigEndian.PutUint32(buf[4:], t.Color)
+	binary.BigEndian.PutUint32(buf[4:8], t.Color)
 	return buf, nil
 }
 
-type TunnelEncapSubTLV struct {
-	Type  EncapSubTLVType
-	Len   int
-	Value TunnelEncapSubTLVValue
+func (t *TunnelEncapSubTLVColor) String() string {
+	return fmt.Sprintf("[Color: %d]", t.Color)
 }
 
-func (p *TunnelEncapSubTLV) Serialize() ([]byte, error) {
-	buf := make([]byte, 2)
-	bbuf, err := p.Value.Serialize()
-	if err != nil {
-		return nil, err
+func (t *TunnelEncapSubTLVColor) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  EncapSubTLVType `json:"type"`
+		Color uint32          `json:"color"`
+	}{
+		Type:  t.Type(),
+		Color: t.Color,
+	})
+}
+
+type TunnelEncapSubTLVRemoteEndpoint struct {
+	AS      uint32
+	AFI     int
+	Address net.IP
+}
+
+func (t *TunnelEncapSubTLVRemoteEndpoint) Type() EncapSubTLVType {
+	return ENCAP_SUBTLV_TYPE_REMOTE_ENDPOINT
+}
+
+func (t *TunnelEncapSubTLVRemoteEndpoint) decodeValue(data []byte) error {
+	if len(data) < 10 {
+		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLVRemoteEndpoint bytes available")
 	}
-	buf = append(buf, bbuf...)
-	buf[0] = byte(p.Type)
-	p.Len = len(buf) - 2
-	buf[1] = byte(p.Len)
-	return buf, nil
-}
-
-func (p *TunnelEncapSubTLV) DecodeFromBytes(data []byte) error {
-	switch p.Type {
-	case ENCAP_SUBTLV_TYPE_ENCAPSULATION:
-		if len(data) < 4 {
-			return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLV bytes available")
+	t.AS = binary.BigEndian.Uint32(data[0:4])
+	t.AFI = int(binary.BigEndian.Uint16(data[4:6]))
+	switch t.AFI {
+	case AFI_IP:
+		t.Address = net.IP(data[6:10]).To4()
+		if t.Address == nil {
+			return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "invalid ipv4 address for TunnelEncapSubTLVRemoteEndpoint")
 		}
-		key := binary.BigEndian.Uint32(data[:4])
-		p.Value = &TunnelEncapSubTLVEncapsulation{
-			Key:    key,
-			Cookie: data[4:],
+	case AFI_IP6:
+		if len(data) < 22 {
+			return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLVColor bytes available")
 		}
-	case ENCAP_SUBTLV_TYPE_PROTOCOL:
-		if len(data) < 2 {
-			return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLV bytes available")
+		t.Address = net.IP(data[6:22]).To16()
+		if t.Address == nil {
+			return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "invalid ipv6 address for TunnelEncapSubTLVRemoteEndpoint")
 		}
-		protocol := binary.BigEndian.Uint16(data[:2])
-		p.Value = &TunnelEncapSubTLVProtocol{protocol}
-	case ENCAP_SUBTLV_TYPE_COLOR:
-		if len(data) < 8 {
-			return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLV bytes available")
-		}
-		color := binary.BigEndian.Uint32(data[4:])
-		p.Value = &TunnelEncapSubTLVColor{color}
 	default:
-		p.Value = &TunnelEncapSubTLVDefault{data}
+		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "invalid address family for TunnelEncapSubTLVRemoteEndpoint")
 	}
 	return nil
 }
 
+func (t *TunnelEncapSubTLVRemoteEndpoint) serializeValue() ([]byte, error) {
+	var buf []byte
+	switch t.AFI {
+	case AFI_IP:
+		buf = make([]byte, 10)
+		addr := t.Address.To4()
+		if addr == nil {
+			return nil, fmt.Errorf("invalid ipv4 address: %s", t.Address.String())
+		}
+		copy(buf[6:], addr)
+	case AFI_IP6:
+		buf = make([]byte, 22)
+		addr := t.Address.To16()
+		if addr == nil {
+			return nil, fmt.Errorf("invalid ipv6 address: %s", t.Address.String())
+		}
+		copy(buf[6:], addr)
+	default:
+		return nil, fmt.Errorf("invalid address family: %d", t.AFI)
+	}
+	binary.BigEndian.PutUint32(buf[0:4], t.AS)
+	binary.BigEndian.PutUint16(buf[4:6], uint16(t.AFI))
+	return buf, nil
+}
+
+func (t *TunnelEncapSubTLVRemoteEndpoint) String() string {
+	return fmt.Sprintf("[RemoteEndpoint: %d:%s]", t.AS, t.Address.String())
+}
+
+func (t *TunnelEncapSubTLVRemoteEndpoint) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type    EncapSubTLVType `json:"type"`
+		AS      uint32          `json:"as"`
+		AFI     int             `json:"afi"`
+		Address net.IP          `json:"address"`
+	}{
+		Type:    t.Type(),
+		AS:      t.AS,
+		AFI:     t.AFI,
+		Address: t.Address,
+	})
+}
+
+type TunnelEncapSubTLVPreference struct {
+	Flags      uint8 // None are defined at this stage
+	Preference uint32
+}
+
+func (t *TunnelEncapSubTLVPreference) Type() EncapSubTLVType {
+	return ENCAP_SUBTLV_TYPE_PREFERENCE
+}
+
+func (t *TunnelEncapSubTLVPreference) decodeValue(data []byte) error {
+	if len(data) < 6 {
+		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLVPreference bytes available")
+	}
+	t.Flags = data[2]
+	t.Preference = binary.BigEndian.Uint32(data[2:6])
+	return nil
+}
+
+func (t *TunnelEncapSubTLVPreference) serializeValue() ([]byte, error) {
+	buf := make([]byte, 6)
+	buf[0] = t.Flags
+	binary.BigEndian.PutUint32(buf[2:], t.Preference)
+	return buf, nil
+}
+
+func (t *TunnelEncapSubTLVPreference) String() string {
+	return fmt.Sprintf("[Preference: %d]", t.Preference)
+}
+
+func (t *TunnelEncapSubTLVPreference) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type       EncapSubTLVType `json:"type"`
+		Flags      uint8           `json:"flags"`
+		Preference uint32          `json:"preference"`
+	}{
+		Type:       t.Type(),
+		Flags:      t.Flags,
+		Preference: t.Preference,
+	})
+}
+
+type TunnelEncapSubTLVBindingSID struct {
+	Flags uint8 // None are defined at this stage
+	SID   SegmentID
+}
+
+func (t *TunnelEncapSubTLVBindingSID) Type() EncapSubTLVType {
+	return ENCAP_SUBTLV_TYPE_BINDING_SID
+}
+
+func (t *TunnelEncapSubTLVBindingSID) decodeValue(data []byte) error {
+	if len(data) < 2 {
+		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLV bytes available")
+	}
+	t.Flags = data[1]
+	t.SID = data[2:]
+	return nil
+}
+
+func (t *TunnelEncapSubTLVBindingSID) serializeValue() ([]byte, error) {
+	sidLen := t.SID.Len()
+	switch sidLen {
+	case 0, 4, 16:
+	default:
+		return nil, fmt.Errorf("invalid segment id length")
+	}
+	buf := make([]byte, 2+sidLen)
+	buf[0] = t.Flags
+	copy(buf[2:], t.SID)
+	return buf, nil
+}
+
+func (t *TunnelEncapSubTLVBindingSID) String() string {
+	return fmt.Sprintf("[Binding-SID: %s]", t.SID.String())
+}
+
+func (t *TunnelEncapSubTLVBindingSID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  EncapSubTLVType `json:"type"`
+		Flags uint8           `json:"flags"`
+		SID   SegmentID       `json:"sid"`
+	}{
+		Type:  t.Type(),
+		Flags: t.Flags,
+		SID:   t.SID,
+	})
+}
+
+type TunnelEncapSubTLVSegmentList struct {
+	Value []SegmentListSubTLVInterface
+}
+
+func (t *TunnelEncapSubTLVSegmentList) Type() EncapSubTLVType {
+	return ENCAP_SUBTLV_TYPE_SEGMENT_LIST
+}
+
+func (t *TunnelEncapSubTLVSegmentList) decodeValue(data []byte) error {
+	if len(data) < 3 {
+		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLVSegmentList bytes available")
+	}
+	tlvsLen := len(data) - 1 // excluding RESERVED field
+	if tlvsLen > 2 {         // Type + Length
+		var err error
+		if t.Value, err = decodeSegmentListSubTLVs(data[1:]); err != nil {
+			return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, err.Error())
+		}
+	}
+	return nil
+}
+
+func (t *TunnelEncapSubTLVSegmentList) serializeValue() ([]byte, error) {
+	buf := []byte{0x00} // RESERVED field
+	for _, tlv := range t.Value {
+		tBuf, err := tlv.serializeValue()
+		if err != nil {
+			return nil, err
+		}
+		length := len(tBuf)
+		tBuf = append(make([]byte, 2), tBuf...)
+		tBuf[0] = byte(tlv.Type())
+		tBuf[1] = byte(length)
+		buf = append(buf, tBuf...)
+	}
+	return buf, nil
+}
+
+func (t *TunnelEncapSubTLVSegmentList) String() string {
+	tlvList := make([]string, len(t.Value), len(t.Value))
+	for i, v := range t.Value {
+		tlvList[i] = v.String()
+	}
+	return fmt.Sprintf("[Segment-List: %s]", strings.Join(tlvList, ", "))
+}
+
+func (t *TunnelEncapSubTLVSegmentList) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  EncapSubTLVType              `json:"type"`
+		Value []SegmentListSubTLVInterface `json:"value"`
+	}{
+		Type:  t.Type(),
+		Value: t.Value,
+	})
+}
+
 type TunnelEncapTLV struct {
 	Type  TunnelType
-	Len   int
-	Value []*TunnelEncapSubTLV
+	Value []TunnelEncapSubTLVInterface
 }
 
 func (t *TunnelEncapTLV) DecodeFromBytes(data []byte) error {
@@ -7537,37 +7933,109 @@ func (t *TunnelEncapTLV) DecodeFromBytes(data []byte) error {
 			break
 		}
 		subType := EncapSubTLVType(data[curr])
-		l := int(data[curr+1])
-		if len(data) < curr+2+l {
+		curr++
+		length := int(data[curr])
+		curr++
+		if subType >= 0x80 {
+			length = int(binary.BigEndian.Uint16(data[curr-1 : curr+1]))
+			curr++
+		}
+		if len(data) < curr+length {
 			return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLV bytes available")
 		}
-		v := data[curr+2 : curr+2+l]
-		subTlv := &TunnelEncapSubTLV{
-			Type: subType,
+		v := data[curr : curr+length]
+		var subTlv TunnelEncapSubTLVInterface
+		switch subType {
+		case ENCAP_SUBTLV_TYPE_ENCAPSULATION:
+			subTlv = &TunnelEncapSubTLVEncapsulation{}
+		case ENCAP_SUBTLV_TYPE_PROTOCOL:
+			subTlv = &TunnelEncapSubTLVProtocol{}
+		case ENCAP_SUBTLV_TYPE_COLOR:
+			subTlv = &TunnelEncapSubTLVColor{}
+		case ENCAP_SUBTLV_TYPE_REMOTE_ENDPOINT:
+			subTlv = &TunnelEncapSubTLVRemoteEndpoint{}
+		case ENCAP_SUBTLV_TYPE_PREFERENCE:
+			subTlv = &TunnelEncapSubTLVPreference{}
+		case ENCAP_SUBTLV_TYPE_BINDING_SID:
+			subTlv = &TunnelEncapSubTLVBindingSID{}
+		case ENCAP_SUBTLV_TYPE_SEGMENT_LIST:
+			subTlv = &TunnelEncapSubTLVSegmentList{}
+		default:
+			subTlv = &TunnelEncapSubTLVUnkown{typ: subType}
 		}
-		err := subTlv.DecodeFromBytes(v)
+		err := subTlv.decodeValue(v)
 		if err != nil {
 			return err
 		}
 		t.Value = append(t.Value, subTlv)
-		curr += 2 + l
+		curr += length
 	}
 	return nil
 }
 
 func (p *TunnelEncapTLV) Serialize() ([]byte, error) {
 	buf := make([]byte, 4)
-	for _, s := range p.Value {
-		bbuf, err := s.Serialize()
+	for _, t := range p.Value {
+		tBuf, err := t.serializeValue()
 		if err != nil {
 			return nil, err
 		}
-		buf = append(buf, bbuf...)
+		length := len(tBuf)
+		if t.Type() >= 0x80 {
+			tBuf = append(make([]byte, 3), tBuf...)
+			binary.BigEndian.PutUint16(tBuf[1:3], uint16(length))
+		} else {
+			tBuf = append(make([]byte, 2), tBuf...)
+			tBuf[1] = byte(length)
+		}
+		tBuf[0] = byte(t.Type())
+		buf = append(buf, tBuf...)
 	}
 	binary.BigEndian.PutUint16(buf, uint16(p.Type))
-	p.Len = len(buf) - 4
-	binary.BigEndian.PutUint16(buf[2:], uint16(p.Len))
+	binary.BigEndian.PutUint16(buf[2:], uint16(len(buf)-4))
 	return buf, nil
+}
+
+func (p *TunnelEncapTLV) String() string {
+	tlvList := make([]string, len(p.Value), len(p.Value))
+	for i, v := range p.Value {
+		tlvList[i] = v.String()
+	}
+	return fmt.Sprintf("[%s: %s]", p.Type.String(), strings.Join(tlvList, ", "))
+}
+
+func (p *TunnelEncapTLV) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  TunnelType                   `json:"type"`
+		Value []TunnelEncapSubTLVInterface `json:"value"`
+	}{
+		Type:  p.Type,
+		Value: p.Value,
+	})
+}
+
+func (p *TunnelEncapTLV) validate() bool {
+	switch p.Type {
+	case TUNNEL_TYPE_SR_TE_Policy:
+		// draft-ietf-idr-segment-routing-te-policy-01
+		// 4.2.1. Acceptance of an SR Policy NLRI
+		// o Within the SR Policy NLRI, at least one Segment List sub-TLV MUST
+		//   be present.
+		// o Within the Segment List sub-TLV at least one Segment sub-TLV MUST
+		//   be present.
+		for _, v := range p.Value {
+			switch t := v.(type) {
+			case *TunnelEncapSubTLVSegmentList:
+				for _, subTlv := range t.Value {
+					if 0 < subTlv.Type() && subTlv.Type() < SEGMENT_LIST_SUB_TLV_TYPE_WEIGHT {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}
+	return true
 }
 
 type PathAttributeTunnelEncap struct {
@@ -7592,10 +8060,7 @@ func (p *PathAttributeTunnelEncap) DecodeFromBytes(data []byte, options ...*Mars
 			return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, fmt.Sprintf("Not all TunnelEncapTLV bytes available. %d < %d", len(p.PathAttribute.Value), curr+4+l))
 		}
 		v := p.PathAttribute.Value[curr+4 : curr+4+l]
-		tlv := &TunnelEncapTLV{
-			Type: tunnelType,
-			Len:  l,
-		}
+		tlv := &TunnelEncapTLV{Type: tunnelType}
 		err = tlv.DecodeFromBytes(v)
 		if err != nil {
 			return err
@@ -7617,6 +8082,40 @@ func (p *PathAttributeTunnelEncap) Serialize(options ...*MarshallingOption) ([]b
 	}
 	p.PathAttribute.Value = buf
 	return p.PathAttribute.Serialize(options...)
+}
+
+func (p *PathAttributeTunnelEncap) String() string {
+	tlvList := make([]string, len(p.Value), len(p.Value))
+	for i, v := range p.Value {
+		tlvList[i] = v.String()
+	}
+	return fmt.Sprintf("{TunnelEncap: %s}", strings.Join(tlvList, ", "))
+}
+
+func (p *PathAttributeTunnelEncap) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  BGPAttrType       `json:"type"`
+		Value []*TunnelEncapTLV `json:"value"`
+	}{
+		Type:  p.Type,
+		Value: p.Value,
+	})
+}
+
+func (p *PathAttributeTunnelEncap) validate(required []TunnelType) bool {
+	if len(required) == 0 {
+		return true
+	}
+	for _, typ := range required {
+		for _, tlv := range p.Value {
+			if tlv.Type == typ {
+				if !tlv.validate() {
+					return false
+				}
+			}
+		}
+	}
+	return true
 }
 
 func NewPathAttributeTunnelEncap(value []*TunnelEncapTLV) *PathAttributeTunnelEncap {
@@ -8712,7 +9211,9 @@ func (e *TwoOctetAsSpecificExtended) Flat() map[string]string {
 }
 
 func (e *OpaqueExtended) Flat() map[string]string {
-	if e.SubType == EC_SUBTYPE_ENCAPSULATION {
+	if e.SubType == EC_SUBTYPE_COLOR {
+		return map[string]string{"color": e.String()}
+	} else if e.SubType == EC_SUBTYPE_ENCAPSULATION {
 		return map[string]string{"encaspulation": e.Value.String()}
 	}
 	return map[string]string{}

--- a/packet/bgp/segment_routing.go
+++ b/packet/bgp/segment_routing.go
@@ -1,0 +1,1065 @@
+// Copyright (C) 2018 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bgp
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strconv"
+)
+
+// SegmentID represents the Segment Identifier used in the Segment Routing.
+type SegmentID []byte
+
+// Len returns the length of the Segment Identifier in bytes.
+func (i *SegmentID) Len() int {
+	return len(*i)
+}
+
+// 4-octet SID Format:
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |          Label                        | TC  |S|       TTL     |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+func (i *SegmentID) is4Octet() bool {
+	return len(*i) == 4
+}
+
+// 16-octet IPv6 SID Format:
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// //                       IPv6 SID (16 octets)                  //
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+func (i *SegmentID) is16Octet() bool {
+	return len(*i) == 16
+}
+
+// Label returns the significant 20 bits which represents MPLS label field if
+// SegmentID is a 4-octet SID, otherwise 0.
+func (i *SegmentID) Label() uint32 {
+	if !i.is4Octet() {
+		return 0
+	}
+	return binary.BigEndian.Uint32(*i) >> 12
+}
+
+// TrafficClass returns the MPLS TrafficClass (Experimental) field (3 bits) if
+// SegmentID is a 4-octet SID, otherwise 0.
+func (i *SegmentID) TrafficClass() uint8 {
+	if !i.is4Octet() {
+		return 0
+	}
+	b := []byte(*i)
+	return (b[2] >> 1) & 0x7
+}
+
+// isBoS returns true if SegmentID is a 4-octet SID and the MPLS BoS bit is
+// set, otherwise false.
+func (i *SegmentID) isBoS() bool {
+	if !i.is4Octet() {
+		return false
+	}
+	b := []byte(*i)
+	return (b[2] & 0x1) == 1
+}
+
+// TTL returns the MPLS TTL field (1 byte) if SegmentID is a 4-octet SID,
+// otherwise 0.
+func (i *SegmentID) TTL() uint8 {
+	if !i.is4Octet() {
+		return 0
+	}
+	b := []byte(*i)
+	return b[3]
+}
+
+func (i *SegmentID) String() string {
+	switch i.Len() {
+	case 0:
+		return "<nil>"
+	case 4:
+		// 4-octet SID
+		return fmt.Sprint(binary.BigEndian.Uint32(*i))
+	case 16:
+		// 16-octet IPv6 SID
+		return net.IP(*i).String()
+	default:
+		return fmt.Sprint([]byte(*i))
+	}
+}
+
+func (i SegmentID) MarshalJSON() ([]byte, error) {
+	switch i.Len() {
+	case 0:
+		return nil, nil
+	case 4:
+		// 4-octet SID
+		return json.Marshal(binary.BigEndian.Uint32(i))
+	case 16:
+		// 16-octet IPv6 SID
+		return json.Marshal(net.IP(i))
+	default:
+		return []byte(i), nil
+	}
+}
+
+func ParseSegmentID(s string) (sid SegmentID, err error) {
+	// Case of 4-octet SID
+	if n, err := strconv.ParseUint(s, 10, 32); err == nil {
+		sid = make([]byte, 4, 4)
+		binary.BigEndian.PutUint32(sid, uint32(n))
+	}
+
+	// Case of 16-octet IPv6 SID
+	ip := net.ParseIP(s)
+	if ip.To16() != nil {
+		sid = SegmentID(ip)
+	}
+
+	if sid == nil {
+		return nil, fmt.Errorf("invalid sid: %s", s)
+	}
+	return sid, nil
+}
+
+// SRTEPolicyNLRI represents SR TE Policy NLRI.
+type SRTEPolicyNLRI struct {
+	PrefixDefault
+	Length        uint8 // length of Distinguisher + Color + Endpoint in bits
+	Distinguisher uint32
+	Color         uint32
+	Endpoint      net.IP
+	// rf has no correpsonding NLRI field and it is used to determine AFI/SAFI
+	rf RouteFamily
+}
+
+func (n *SRTEPolicyNLRI) DecodeFromBytes(data []byte, options ...*MarshallingOption) error {
+	if n.rf == 0 {
+		n.rf = RF_IPv4_SR_TE
+	}
+	if IsAddPathEnabled(true, n.rf, options) {
+		var err error
+		data, err = n.decodePathIdentifier(data)
+		if err != nil {
+			return err
+		}
+	}
+	if len(data) < 1 {
+		return NewMessageError(
+			uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR),
+			uint8(BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST), nil,
+			"sr te policy nlri misses length field")
+	}
+	n.Length = data[0]
+	invalidLengthError := NewMessageError(
+		uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR),
+		uint8(BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST), nil,
+		fmt.Sprintf("sr te policy nlri length invalid for %s: %x", n.rf.String(), data))
+	switch n.Length {
+	case 96: // Distinguisher + Color + Endpoint(IPv4)
+		if n.rf != RF_IPv4_SR_TE {
+			return invalidLengthError
+		}
+		n.Endpoint = net.IP(data[9:13]).To4()
+	case 192: // Distinguisher + Color + Endpoint(IPv6)
+		if n.rf != RF_IPv6_SR_TE {
+			return invalidLengthError
+		}
+		n.Endpoint = net.IP(data[9:25]).To16()
+	default:
+		return invalidLengthError
+	}
+	n.Distinguisher = binary.BigEndian.Uint32(data[1:5])
+	n.Color = binary.BigEndian.Uint32(data[5:9])
+	return nil
+}
+
+func (n *SRTEPolicyNLRI) Serialize(options ...*MarshallingOption) ([]byte, error) {
+	var buf []byte
+	if IsAddPathEnabled(false, n.rf, options) {
+		var err error
+		buf, err = n.serializeIdentifier()
+		if err != nil {
+			return nil, err
+		}
+	}
+	tmpBuf := make([]byte, 8, 8)
+	binary.BigEndian.PutUint32(tmpBuf[0:4], n.Distinguisher)
+	binary.BigEndian.PutUint32(tmpBuf[4:8], n.Color)
+	tmpBuf = append(tmpBuf, n.Endpoint...)
+	n.Length = uint8(len(tmpBuf) * 8)
+	buf = append(buf, n.Length)
+	return append(buf, tmpBuf...), nil
+}
+
+func (n *SRTEPolicyNLRI) AFI() uint16 {
+	afi, _ := RouteFamilyToAfiSafi(n.rf)
+	return afi
+}
+
+func (n *SRTEPolicyNLRI) SAFI() uint8 {
+	return SAFI_SR_TE_POLICY
+}
+
+func (n *SRTEPolicyNLRI) Len(options ...*MarshallingOption) int {
+	return 1 + ((int(n.Length) + 7) / 8)
+}
+
+func (n *SRTEPolicyNLRI) String() string {
+	return fmt.Sprintf("[distinguisher:%d][color:%d][endpoint:%s]", n.Distinguisher, n.Color, n.Endpoint.String())
+}
+
+func (n *SRTEPolicyNLRI) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Distinguisher uint32 `json:"distinguisher"`
+		Color         uint32 `json:"color"`
+		Endpoint      string `json:"endpoint"`
+	}{
+		Distinguisher: n.Distinguisher,
+		Color:         n.Color,
+		Endpoint:      n.Endpoint.String(),
+	})
+}
+
+func (n *SRTEPolicyNLRI) Flat() map[string]string {
+	return map[string]string{
+		"Length":        fmt.Sprintf("%d", n.Length),
+		"Distinguisher": fmt.Sprintf("%d", n.Distinguisher),
+		"Color":         fmt.Sprintf("%d", n.Color),
+		"Endpoint":      n.Endpoint.String(),
+	}
+}
+
+func NewIPv4SRTEPolicyNLRI(distinguisher uint32, color uint32, endpoint net.IP) *SRTEPolicyNLRI {
+	return &SRTEPolicyNLRI{
+		Distinguisher: distinguisher,
+		Color:         color,
+		Endpoint:      endpoint.To4(),
+		rf:            RF_IPv4_SR_TE,
+	}
+}
+
+func NewIPv6SRTEPolicyNLRI(distinguisher uint32, color uint32, endpoint net.IP) *SRTEPolicyNLRI {
+	return &SRTEPolicyNLRI{
+		Distinguisher: distinguisher,
+		Color:         color,
+		Endpoint:      endpoint.To16(),
+		rf:            RF_IPv6_SR_TE,
+	}
+}
+
+// SegmentListSubTLVInterface is the interface type for the Sub-TLVs for the Segment
+// List Sub-TLV.
+type SegmentListSubTLVInterface interface {
+	Type() SegmentListSubTLVType
+	decodeValue([]byte) error
+	serializeValue() ([]byte, error)
+	String() string
+	MarshalJSON() ([]byte, error)
+}
+
+// SegmentListSubTLVType represents the types for the Sub-TLVs for the Segment
+// List Sub-TLV.
+type SegmentListSubTLVType uint8
+
+const (
+	SEGMENT_LIST_SUB_TLV_TYPE_MPLS_LABEL_SID                SegmentListSubTLVType = 1
+	SEGMENT_LIST_SUB_TLV_TYPE_IPv6_ADDRESS_SID              SegmentListSubTLVType = 2
+	SEGMENT_LIST_SUB_TLV_TYPE_IPv4_NODE_ADDRESS_SID         SegmentListSubTLVType = 3
+	SEGMENT_LIST_SUB_TLV_TYPE_IPv6_NODE_ADDRESS_SID         SegmentListSubTLVType = 4
+	SEGMENT_LIST_SUB_TLV_TYPE_IPv4_ADDRESS_INDEX_SID        SegmentListSubTLVType = 5
+	SEGMENT_LIST_SUB_TLV_TYPE_IPv4_LOCAL_REMOTE_ADDRESS_SID SegmentListSubTLVType = 6
+	SEGMENT_LIST_SUB_TLV_TYPE_IPv6_ADDRESS_INDEX_SID        SegmentListSubTLVType = 7
+	SEGMENT_LIST_SUB_TLV_TYPE_IPv6_LOCAL_REMOTE_ADDRESS_SID SegmentListSubTLVType = 8
+	SEGMENT_LIST_SUB_TLV_TYPE_WEIGHT                        SegmentListSubTLVType = 9
+)
+
+func decodeSegmentListSubTLVs(data []byte) ([]SegmentListSubTLVInterface, error) {
+	tlvs := make([]SegmentListSubTLVInterface, 0)
+	for len(data) > 2 {
+		typ := SegmentListSubTLVType(data[0])
+		length := data[1]
+		var tlv SegmentListSubTLVInterface
+		switch typ {
+		case SEGMENT_LIST_SUB_TLV_TYPE_MPLS_LABEL_SID:
+			tlv = &SegmentListSubTLVMPLSLabelSID{}
+		case SEGMENT_LIST_SUB_TLV_TYPE_IPv6_ADDRESS_SID:
+			tlv = &SegmentListSubTLVIPv6AddressSID{}
+		case SEGMENT_LIST_SUB_TLV_TYPE_IPv4_NODE_ADDRESS_SID:
+			tlv = &SegmentListSubTLVIPv4NodeAddressSID{}
+		case SEGMENT_LIST_SUB_TLV_TYPE_IPv6_NODE_ADDRESS_SID:
+			tlv = &SegmentListSubTLVIPv6NodeAddressSID{}
+		case SEGMENT_LIST_SUB_TLV_TYPE_IPv4_ADDRESS_INDEX_SID:
+			tlv = &SegmentListSubTLVIPv4AddressIndexSID{}
+		case SEGMENT_LIST_SUB_TLV_TYPE_IPv4_LOCAL_REMOTE_ADDRESS_SID:
+			tlv = &SegmentListSubTLVIPv4LocalRemoteAddressSID{}
+		case SEGMENT_LIST_SUB_TLV_TYPE_IPv6_ADDRESS_INDEX_SID:
+			tlv = &SegmentListSubTLVIPv6AddressIndexSID{}
+		case SEGMENT_LIST_SUB_TLV_TYPE_IPv6_LOCAL_REMOTE_ADDRESS_SID:
+			tlv = &SegmentListSubTLVIPv6LocalRemoteAddressSID{}
+		case SEGMENT_LIST_SUB_TLV_TYPE_WEIGHT:
+			tlv = &SegmentListSubTLVWeight{}
+		default:
+			tlv = &SegmentListSubTLVUnknown{typ: typ}
+		}
+		if err := tlv.decodeValue(data[2 : 2+length]); err != nil {
+			return nil, err
+		}
+		tlvs = append(tlvs, tlv)
+		data = data[2+length:]
+	}
+	return tlvs, nil
+}
+
+type SegmentListSubTLVUnknown struct {
+	typ   SegmentListSubTLVType
+	Value []byte
+}
+
+func (t *SegmentListSubTLVUnknown) Type() SegmentListSubTLVType {
+	return t.typ
+}
+
+func (t *SegmentListSubTLVUnknown) decodeValue(data []byte) error {
+	t.Value = data
+	return nil
+}
+
+func (t *SegmentListSubTLVUnknown) serializeValue() ([]byte, error) {
+	return t.Value, nil
+}
+
+func (t *SegmentListSubTLVUnknown) String() string {
+	return fmt.Sprintf("%x", t.Value)
+}
+
+func (t *SegmentListSubTLVUnknown) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  SegmentListSubTLVType `json:"type"`
+		Value []byte                `json:"value"`
+	}{
+		Type:  t.Type(),
+		Value: t.Value,
+	})
+}
+
+type SegmentListSubTLVMPLSLabelSID struct {
+	Flags uint8
+	SID   SegmentID
+}
+
+func (t *SegmentListSubTLVMPLSLabelSID) Type() SegmentListSubTLVType {
+	return SEGMENT_LIST_SUB_TLV_TYPE_MPLS_LABEL_SID
+}
+
+func (t *SegmentListSubTLVMPLSLabelSID) decodeValue(data []byte) error {
+	if len(data) < 6 {
+		return fmt.Errorf("not all SegmentListSubTLVMPLSLabelSID bytes available")
+	}
+	t.Flags = data[0]
+	t.SID = data[2:6]
+	return nil
+}
+
+func (t *SegmentListSubTLVMPLSLabelSID) serializeValue() ([]byte, error) {
+	buf := make([]byte, 6, 6)
+	buf[0] = t.Flags
+	if !t.SID.is4Octet() {
+		return nil, fmt.Errorf("invalid Segment ID for SegmentListSubTLVMPLSLabelSID: %s", t.SID.String())
+	}
+	copy(buf[2:6], t.SID)
+	return buf, nil
+}
+
+func (t *SegmentListSubTLVMPLSLabelSID) String() string {
+	return fmt.Sprintf("[SID: %s]", t.SID.String())
+}
+
+func (t *SegmentListSubTLVMPLSLabelSID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type SegmentListSubTLVType `json:"type"`
+		SID  SegmentID             `json:"sid"`
+	}{
+		Type: t.Type(),
+		SID:  t.SID,
+	})
+}
+
+type SegmentListSubTLVIPv6AddressSID struct {
+	Flags uint8
+	SID   SegmentID
+}
+
+func (t *SegmentListSubTLVIPv6AddressSID) Type() SegmentListSubTLVType {
+	return SEGMENT_LIST_SUB_TLV_TYPE_IPv6_ADDRESS_SID
+}
+
+func (t *SegmentListSubTLVIPv6AddressSID) decodeValue(data []byte) error {
+	if len(data) < 18 {
+		return fmt.Errorf("not all SegmentListSubTLVIPv6AddressSID bytes available")
+	}
+	t.Flags = data[0]
+	t.SID = data[2:18]
+	return nil
+}
+
+func (t *SegmentListSubTLVIPv6AddressSID) serializeValue() ([]byte, error) {
+	buf := make([]byte, 18, 18)
+	buf[0] = t.Flags
+	if !t.SID.is16Octet() {
+		return nil, fmt.Errorf("invalid Segment ID for SegmentListSubTLVIPv6AddressSID: %s", t.SID.String())
+	}
+	copy(buf[2:18], t.SID)
+	return buf, nil
+}
+
+func (t *SegmentListSubTLVIPv6AddressSID) String() string {
+	return fmt.Sprintf("[SID: %s]", t.SID.String())
+}
+
+func (t *SegmentListSubTLVIPv6AddressSID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type SegmentListSubTLVType `json:"type"`
+		SID  SegmentID             `json:"sid"`
+	}{
+		Type: t.Type(),
+		SID:  t.SID,
+	})
+}
+
+type SegmentListSubTLVIPv4NodeAddressSID struct {
+	Flags   uint8
+	Address net.IP
+	SID     SegmentID
+}
+
+func (t *SegmentListSubTLVIPv4NodeAddressSID) Type() SegmentListSubTLVType {
+	return SEGMENT_LIST_SUB_TLV_TYPE_IPv4_NODE_ADDRESS_SID
+}
+
+func (t *SegmentListSubTLVIPv4NodeAddressSID) decodeValue(data []byte) error {
+	if len(data) < 6 {
+		return fmt.Errorf("not all SegmentListSubTLVIPv4NodeAddressSID bytes available")
+	}
+	t.Flags = data[0]
+	t.Address = data[2:6]
+	switch len(data) {
+	case 6:
+	case 10, 22:
+		t.SID = data[6:]
+	default:
+		return fmt.Errorf("invalid byte length for SegmentListSubTLVIPv4NodeAddressSID")
+	}
+	return nil
+}
+
+func (t *SegmentListSubTLVIPv4NodeAddressSID) serializeValue() ([]byte, error) {
+	length := 6 + t.SID.Len()
+	switch length {
+	case 6, 10, 22:
+	default:
+		return nil, fmt.Errorf("invalid Segment ID for SegmentListSubTLVIPv4NodeAddressSID: %s", t.SID.String())
+	}
+	buf := make([]byte, length, length)
+	buf[0] = t.Flags
+	addr := t.Address.To4()
+	if addr == nil {
+		return nil, fmt.Errorf("invalid IP Address for SegmentListSubTLVIPv4NodeAddressSID: %s", t.Address)
+	}
+	copy(buf[2:6], addr)
+	copy(buf[6:], t.SID)
+	return buf, nil
+}
+
+func (t *SegmentListSubTLVIPv4NodeAddressSID) String() string {
+	return fmt.Sprintf("[Address: %s SID: %s]", t.Address.String(), t.SID.String())
+}
+
+func (t *SegmentListSubTLVIPv4NodeAddressSID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type    SegmentListSubTLVType `json:"type"`
+		Flags   uint8                 `json:"flags"`
+		Address net.IP                `json:"address"`
+		SID     SegmentID             `json:"sid"`
+	}{
+		Type:    t.Type(),
+		Flags:   t.Flags,
+		Address: t.Address,
+		SID:     t.SID,
+	})
+}
+
+type SegmentListSubTLVIPv6NodeAddressSID struct {
+	Flags   uint8
+	Address net.IP
+	SID     SegmentID
+}
+
+func (t *SegmentListSubTLVIPv6NodeAddressSID) Type() SegmentListSubTLVType {
+	return SEGMENT_LIST_SUB_TLV_TYPE_IPv6_NODE_ADDRESS_SID
+}
+
+func (t *SegmentListSubTLVIPv6NodeAddressSID) decodeValue(data []byte) error {
+	if len(data) < 18 {
+		return fmt.Errorf("not all SegmentListSubTLVIPv6NodeAddressSID bytes available")
+	}
+	t.Flags = data[0]
+	t.Address = data[2:18]
+	switch len(data) {
+	case 18:
+	case 22, 34:
+		t.SID = data[18:]
+	default:
+		return fmt.Errorf("invalid byte length for SegmentListSubTLVIPv6NodeAddressSID")
+	}
+	return nil
+}
+
+func (t *SegmentListSubTLVIPv6NodeAddressSID) serializeValue() ([]byte, error) {
+	length := 18 + t.SID.Len()
+	switch length {
+	case 18, 22, 34:
+	default:
+		return nil, fmt.Errorf("invalid Segment ID for SegmentListSubTLVIPv6NodeAddressSID: %s", t.SID.String())
+	}
+	buf := make([]byte, length, length)
+	buf[0] = t.Flags
+	addr := t.Address.To16()
+	if addr == nil {
+		return nil, fmt.Errorf("invalid IP Address for SegmentListSubTLVIPv6NodeAddressSID: %s", t.Address)
+	}
+	copy(buf[2:18], addr)
+	copy(buf[18:], t.SID)
+	return buf, nil
+}
+
+func (t *SegmentListSubTLVIPv6NodeAddressSID) String() string {
+	return fmt.Sprintf("[Address: %s SID: %s]", t.Address.String(), t.SID.String())
+}
+
+func (t *SegmentListSubTLVIPv6NodeAddressSID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type    SegmentListSubTLVType `json:"type"`
+		Flags   uint8                 `json:"flags"`
+		Address net.IP                `json:"address"`
+		SID     SegmentID             `json:"sid"`
+	}{
+		Type:    t.Type(),
+		Flags:   t.Flags,
+		Address: t.Address,
+		SID:     t.SID,
+	})
+}
+
+type SegmentListSubTLVIPv4AddressIndexSID struct {
+	Flags       uint8
+	InterfaceID uint32
+	Address     net.IP
+	SID         SegmentID
+}
+
+func (t *SegmentListSubTLVIPv4AddressIndexSID) Type() SegmentListSubTLVType {
+	return SEGMENT_LIST_SUB_TLV_TYPE_IPv4_ADDRESS_INDEX_SID
+}
+
+func (t *SegmentListSubTLVIPv4AddressIndexSID) decodeValue(data []byte) error {
+	if len(data) < 10 {
+		return fmt.Errorf("not all SegmentListSubTLVIPv4AddressIndexSID bytes available")
+	}
+	t.Flags = data[0]
+	t.InterfaceID = binary.BigEndian.Uint32(data[2:6])
+	t.Address = data[6:10]
+	switch len(data) {
+	case 10:
+	case 14, 26:
+		t.SID = data[10:]
+	default:
+		return fmt.Errorf("invalid byte length for SegmentListSubTLVIPv4AddressIndexSID")
+	}
+	return nil
+}
+
+func (t *SegmentListSubTLVIPv4AddressIndexSID) serializeValue() ([]byte, error) {
+	length := 10 + t.SID.Len()
+	switch length {
+	case 10, 14, 26:
+	default:
+		return nil, fmt.Errorf("invalid Segment ID for SegmentListSubTLVIPv4AddressIndexSID: %s", t.SID.String())
+	}
+	buf := make([]byte, length, length)
+	buf[0] = t.Flags
+	binary.BigEndian.PutUint32(buf[2:6], t.InterfaceID)
+	addr := t.Address.To4()
+	if addr == nil {
+		return nil, fmt.Errorf("invalid IP Address for SegmentListSubTLVIPv4AddressIndexSID: %s", t.Address)
+	}
+	copy(buf[6:10], addr)
+	copy(buf[10:], t.SID)
+	return buf, nil
+}
+
+func (t *SegmentListSubTLVIPv4AddressIndexSID) String() string {
+	return fmt.Sprintf("[InterfaceID: %d Address: %s SID: %s]", t.InterfaceID, t.Address.String(), t.SID.String())
+}
+
+func (t *SegmentListSubTLVIPv4AddressIndexSID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type        SegmentListSubTLVType `json:"type"`
+		Flags       uint8                 `json:"flags"`
+		InterfaceID uint32                `json:"interface-id"`
+		Address     net.IP                `json:"address"`
+		SID         SegmentID             `json:"sid"`
+	}{
+		Type:        t.Type(),
+		Flags:       t.Flags,
+		InterfaceID: t.InterfaceID,
+		Address:     t.Address,
+		SID:         t.SID,
+	})
+}
+
+type SegmentListSubTLVIPv4LocalRemoteAddressSID struct {
+	Flags         uint8
+	LocalAddress  net.IP
+	RemoteAddress net.IP
+	SID           SegmentID
+}
+
+func (t *SegmentListSubTLVIPv4LocalRemoteAddressSID) Type() SegmentListSubTLVType {
+	return SEGMENT_LIST_SUB_TLV_TYPE_IPv4_LOCAL_REMOTE_ADDRESS_SID
+}
+
+func (t *SegmentListSubTLVIPv4LocalRemoteAddressSID) decodeValue(data []byte) error {
+	if len(data) < 10 {
+		return fmt.Errorf("not all SegmentListSubTLVIPv4LocalRemoteAddressSID bytes available")
+	}
+	t.Flags = data[0]
+	t.LocalAddress = data[2:6]
+	t.RemoteAddress = data[6:10]
+	switch len(data) {
+	case 10:
+	case 14, 26:
+		t.SID = data[10:]
+	default:
+		return fmt.Errorf("invalid byte length for SegmentListSubTLVIPv4LocalRemoteAddressSID")
+	}
+	return nil
+}
+
+func (t *SegmentListSubTLVIPv4LocalRemoteAddressSID) serializeValue() ([]byte, error) {
+	length := 10 + t.SID.Len()
+	switch length {
+	case 10, 14, 26:
+	default:
+		return nil, fmt.Errorf("invalid Segment ID for SegmentListSubTLVIPv4LocalRemoteAddressSID: %s", t.SID.String())
+	}
+	buf := make([]byte, length, length)
+	buf[0] = t.Flags
+	localAddr := t.LocalAddress.To4()
+	if localAddr == nil {
+		return nil, fmt.Errorf("invalid Local IP Address for SegmentListSubTLVIPv4LocalRemoteAddressSID: %s", t.LocalAddress)
+	}
+	copy(buf[2:6], localAddr)
+	remoteAddr := t.RemoteAddress.To4()
+	if remoteAddr == nil {
+		return nil, fmt.Errorf("invalid Remote IP Address for SegmentListSubTLVIPv4LocalRemoteAddressSID: %s", t.RemoteAddress)
+	}
+	copy(buf[6:10], remoteAddr)
+	copy(buf[10:], t.SID)
+	return buf, nil
+}
+
+func (t *SegmentListSubTLVIPv4LocalRemoteAddressSID) String() string {
+	return fmt.Sprintf("[LocalAddress: %s RemoteAddress: %s SID: %s]", t.LocalAddress.String(), t.RemoteAddress.String(), t.SID.String())
+}
+
+func (t *SegmentListSubTLVIPv4LocalRemoteAddressSID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type          SegmentListSubTLVType `json:"type"`
+		Flags         uint8                 `json:"flags"`
+		LocalAddress  net.IP                `json:"local-address"`
+		RemoteAddress net.IP                `json:"remote-address"`
+		SID           SegmentID             `json:"sid"`
+	}{
+		Type:          t.Type(),
+		Flags:         t.Flags,
+		LocalAddress:  t.LocalAddress,
+		RemoteAddress: t.RemoteAddress,
+		SID:           t.SID,
+	})
+}
+
+type SegmentListSubTLVIPv6AddressIndexSID struct {
+	Flags       uint8
+	InterfaceID uint32
+	Address     net.IP
+	SID         SegmentID
+}
+
+func (t *SegmentListSubTLVIPv6AddressIndexSID) Type() SegmentListSubTLVType {
+	return SEGMENT_LIST_SUB_TLV_TYPE_IPv6_ADDRESS_INDEX_SID
+}
+
+func (t *SegmentListSubTLVIPv6AddressIndexSID) decodeValue(data []byte) error {
+	if len(data) < 22 {
+		return fmt.Errorf("not all SegmentListSubTLVIPv6AddressIndexSID bytes available")
+	}
+	t.Flags = data[0]
+	t.InterfaceID = binary.BigEndian.Uint32(data[2:6])
+	t.Address = data[6:22]
+	switch len(data) {
+	case 22:
+	case 26, 38:
+		t.SID = data[22:]
+	default:
+		return fmt.Errorf("invalid byte length for SegmentListSubTLVIPv6AddressIndexSID")
+	}
+	return nil
+}
+
+func (t *SegmentListSubTLVIPv6AddressIndexSID) serializeValue() ([]byte, error) {
+	length := 22 + t.SID.Len()
+	switch length {
+	case 22, 26, 38:
+	default:
+		return nil, fmt.Errorf("invalid Segment ID for SegmentListSubTLVIPv6AddressIndexSID: %s", t.SID.String())
+	}
+	buf := make([]byte, length, length)
+	buf[0] = t.Flags
+	binary.BigEndian.PutUint32(buf[2:6], t.InterfaceID)
+	addr := t.Address.To16()
+	if addr == nil {
+		return nil, fmt.Errorf("invalid IP Address for SegmentListSubTLVIPv6AddressIndexSID: %s", t.Address)
+	}
+	copy(buf[6:22], addr)
+	copy(buf[22:], t.SID)
+	return buf, nil
+}
+
+func (t *SegmentListSubTLVIPv6AddressIndexSID) String() string {
+	return fmt.Sprintf("[InterfaceID: %d Address: %s SID: %s]", t.InterfaceID, t.Address.String(), t.SID.String())
+}
+
+func (t *SegmentListSubTLVIPv6AddressIndexSID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type        SegmentListSubTLVType `json:"type"`
+		Flags       uint8                 `json:"flags"`
+		InterfaceID uint32                `json:"interface-id"`
+		Address     net.IP                `json:"address"`
+		SID         SegmentID             `json:"sid"`
+	}{
+		Type:        t.Type(),
+		Flags:       t.Flags,
+		InterfaceID: t.InterfaceID,
+		Address:     t.Address,
+		SID:         t.SID,
+	})
+}
+
+type SegmentListSubTLVIPv6LocalRemoteAddressSID struct {
+	Flags         uint8
+	LocalAddress  net.IP
+	RemoteAddress net.IP
+	SID           SegmentID
+}
+
+func (t *SegmentListSubTLVIPv6LocalRemoteAddressSID) Type() SegmentListSubTLVType {
+	return SEGMENT_LIST_SUB_TLV_TYPE_IPv6_LOCAL_REMOTE_ADDRESS_SID
+}
+
+func (t *SegmentListSubTLVIPv6LocalRemoteAddressSID) decodeValue(data []byte) error {
+	if len(data) < 34 {
+		return fmt.Errorf("not all SegmentListSubTLVIPv6LocalRemoteAddressSID bytes available")
+	}
+	t.Flags = data[0]
+	t.LocalAddress = data[2:18]
+	t.RemoteAddress = data[18:34]
+	switch len(data) {
+	case 34:
+	case 38, 50:
+		t.SID = data[34:]
+	default:
+		return fmt.Errorf("invalid byte length for SegmentListSubTLVIPv6LocalRemoteAddressSID")
+	}
+	return nil
+}
+
+func (t *SegmentListSubTLVIPv6LocalRemoteAddressSID) serializeValue() ([]byte, error) {
+	length := 34 + t.SID.Len()
+	switch length {
+	case 34, 38, 50:
+	default:
+		return nil, fmt.Errorf("invalid Segment ID for SegmentListSubTLVIPv6LocalRemoteAddressSID: %s", t.SID.String())
+	}
+	buf := make([]byte, length, length)
+	buf[0] = t.Flags
+	localAddr := t.LocalAddress.To16()
+	if localAddr == nil {
+		return nil, fmt.Errorf("invalid Local IP Address for SegmentListSubTLVIPv6LocalRemoteAddressSID: %s", t.LocalAddress)
+	}
+	copy(buf[2:18], localAddr)
+	remoteAddr := t.RemoteAddress.To16()
+	if remoteAddr == nil {
+		return nil, fmt.Errorf("invalid Remote IP Address for SegmentListSubTLVIPv6LocalRemoteAddressSID: %s", t.RemoteAddress)
+	}
+	copy(buf[18:34], remoteAddr)
+	copy(buf[34:], t.SID)
+	return buf, nil
+}
+
+func (t *SegmentListSubTLVIPv6LocalRemoteAddressSID) String() string {
+	return fmt.Sprintf("[LocalAddress: %s RemoteAddress: %s SID: %s]", t.LocalAddress.String(), t.RemoteAddress.String(), t.SID.String())
+}
+
+func (t *SegmentListSubTLVIPv6LocalRemoteAddressSID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type          SegmentListSubTLVType `json:"type"`
+		Flags         uint8                 `json:"flags"`
+		LocalAddress  net.IP                `json:"local-address"`
+		RemoteAddress net.IP                `json:"remote-address"`
+		SID           SegmentID             `json:"sid"`
+	}{
+		Type:          t.Type(),
+		Flags:         t.Flags,
+		LocalAddress:  t.LocalAddress,
+		RemoteAddress: t.RemoteAddress,
+		SID:           t.SID,
+	})
+}
+
+type SegmentListSubTLVWeight struct {
+	Flags  uint8
+	Weight uint32
+}
+
+func (t *SegmentListSubTLVWeight) Type() SegmentListSubTLVType {
+	return SEGMENT_LIST_SUB_TLV_TYPE_WEIGHT
+}
+
+func (t *SegmentListSubTLVWeight) decodeValue(data []byte) error {
+	if len(data) < 6 {
+		return fmt.Errorf("not all SegmentListSubTLVWeight bytes available")
+	}
+	t.Flags = data[0]
+	t.Weight = binary.BigEndian.Uint32(data[2:6])
+	return nil
+}
+
+func (t *SegmentListSubTLVWeight) serializeValue() ([]byte, error) {
+	buf := make([]byte, 6, 6)
+	buf[0] = t.Flags
+	binary.BigEndian.PutUint32(buf[2:6], t.Weight)
+	return buf, nil
+}
+
+func (t *SegmentListSubTLVWeight) String() string {
+	return fmt.Sprintf("[Weight: %d]", t.Weight)
+}
+
+func (t *SegmentListSubTLVWeight) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type   SegmentListSubTLVType `json:"type"`
+		Flags  uint8                 `json:"flags"`
+		Weight uint32                `json:"weight"`
+	}{
+		Type:   t.Type(),
+		Flags:  t.Flags,
+		Weight: t.Weight,
+	})
+}
+
+func ParseSegmentListSubTLV(args []string) (tlvs []SegmentListSubTLVInterface, err error) {
+	// Format:
+	// args := []string{"weight", "100", "segment", "<TYPE>", "<ARGS>"...}
+	pos := 0
+	argsLen := len(args)
+	parseOptionalSid := func(typ uint64) (sid SegmentID, err error) {
+		switch args[pos] {
+		case "segment", "weight":
+			return nil, nil
+		default:
+			if args[pos] != "segment" {
+				sid, err = ParseSegmentID(args[pos])
+				if err != nil {
+					return nil, fmt.Errorf("invalid sid for segment type %d: %s", typ, args[pos])
+				}
+				pos++
+			}
+			return sid, nil
+		}
+	}
+	for pos < argsLen {
+		switch args[pos] {
+		case "segment":
+			pos++
+			typ, err := strconv.ParseUint(args[pos], 10, 8)
+			if err != nil {
+				return nil, fmt.Errorf("invalid segment type for segment-list: %s", err.Error())
+			}
+			pos++
+			switch SegmentListSubTLVType(typ) {
+			case SEGMENT_LIST_SUB_TLV_TYPE_MPLS_LABEL_SID:
+				id, err := strconv.ParseUint(args[pos], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("invalid sid for segment type %d: %s", typ, args[pos])
+				}
+				pos++
+				sid := make([]byte, 4, 4)
+				binary.BigEndian.PutUint32(sid, uint32(id))
+				tlvs = append(tlvs, &SegmentListSubTLVMPLSLabelSID{
+					SID: sid,
+				})
+			case SEGMENT_LIST_SUB_TLV_TYPE_IPv6_ADDRESS_SID:
+				sid := net.ParseIP(args[pos])
+				if sid.To16() == nil {
+					return nil, fmt.Errorf("invalid sid for segment type %d: %s", typ, args[pos])
+				}
+				pos++
+				tlvs = append(tlvs, &SegmentListSubTLVIPv6AddressSID{
+					SID: SegmentID(sid),
+				})
+			case SEGMENT_LIST_SUB_TLV_TYPE_IPv4_NODE_ADDRESS_SID:
+				ip := net.ParseIP(args[pos])
+				if ip.To4() == nil {
+					return nil, fmt.Errorf("invalid ipv4 address for segment type %d: %s", typ, args[pos])
+				}
+				pos++
+				sid, err := parseOptionalSid(typ)
+				if err != nil {
+					return nil, err
+				}
+				tlvs = append(tlvs, &SegmentListSubTLVIPv4NodeAddressSID{
+					Address: ip,
+					SID:     sid,
+				})
+			case SEGMENT_LIST_SUB_TLV_TYPE_IPv6_NODE_ADDRESS_SID:
+				ip := net.ParseIP(args[pos])
+				if ip.To16() == nil {
+					return nil, fmt.Errorf("invalid ipv6 address for segment type %d: %s", typ, args[pos])
+				}
+				pos++
+				sid, err := parseOptionalSid(typ)
+				if err != nil {
+					return nil, err
+				}
+				tlvs = append(tlvs, &SegmentListSubTLVIPv6NodeAddressSID{
+					Address: ip,
+					SID:     sid,
+				})
+			case SEGMENT_LIST_SUB_TLV_TYPE_IPv4_ADDRESS_INDEX_SID:
+				idx, err := strconv.ParseUint(args[pos], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("invalid interface id for segment type %d: %s", typ, args[pos])
+				}
+				pos++
+				ip := net.ParseIP(args[pos])
+				if ip.To4() == nil {
+					return nil, fmt.Errorf("invalid ipv4 address for segment type %d: %s", typ, args[pos])
+				}
+				pos++
+				sid, err := parseOptionalSid(typ)
+				if err != nil {
+					return nil, err
+				}
+				tlvs = append(tlvs, &SegmentListSubTLVIPv4AddressIndexSID{
+					InterfaceID: uint32(idx),
+					Address:     ip,
+					SID:         sid,
+				})
+			case SEGMENT_LIST_SUB_TLV_TYPE_IPv4_LOCAL_REMOTE_ADDRESS_SID:
+				localIP := net.ParseIP(args[pos])
+				if localIP.To4() == nil {
+					return nil, fmt.Errorf("invalid local ipv4 address for segment type %d: %s", typ, args[pos])
+				}
+				pos++
+				remoteIP := net.ParseIP(args[pos])
+				if remoteIP.To4() == nil {
+					return nil, fmt.Errorf("invalid ipv4 address for segment type %d: %s", typ, args[pos])
+				}
+				pos++
+				sid, err := parseOptionalSid(typ)
+				if err != nil {
+					return nil, err
+				}
+				tlvs = append(tlvs, &SegmentListSubTLVIPv4LocalRemoteAddressSID{
+					LocalAddress:  localIP,
+					RemoteAddress: remoteIP,
+					SID:           sid,
+				})
+			case SEGMENT_LIST_SUB_TLV_TYPE_IPv6_ADDRESS_INDEX_SID:
+				idx, err := strconv.ParseUint(args[pos], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("invalid interface id for segment type %d: %s", typ, args[pos])
+				}
+				pos++
+				ip := net.ParseIP(args[pos])
+				if ip.To16() == nil {
+					return nil, fmt.Errorf("invalid ipv6 address for segment type %d: %s", typ, args[pos])
+				}
+				pos++
+				sid, err := parseOptionalSid(typ)
+				if err != nil {
+					return nil, err
+				}
+				tlvs = append(tlvs, &SegmentListSubTLVIPv6AddressIndexSID{
+					InterfaceID: uint32(idx),
+					Address:     ip,
+					SID:         sid,
+				})
+			case SEGMENT_LIST_SUB_TLV_TYPE_IPv6_LOCAL_REMOTE_ADDRESS_SID:
+				localIP := net.ParseIP(args[pos])
+				if localIP.To16() == nil {
+					return nil, fmt.Errorf("invalid local ipv16 address for segment type %d: %s", typ, args[pos])
+				}
+				pos++
+				remoteIP := net.ParseIP(args[pos])
+				if remoteIP.To16() == nil {
+					return nil, fmt.Errorf("invalid ipv16 address for segment type %d: %s", typ, args[pos])
+				}
+				pos++
+				var sid SegmentID
+				sid, err := parseOptionalSid(typ)
+				if err != nil {
+					return nil, err
+				}
+				tlvs = append(tlvs, &SegmentListSubTLVIPv6LocalRemoteAddressSID{
+					LocalAddress:  localIP,
+					RemoteAddress: remoteIP,
+					SID:           sid,
+				})
+			default:
+				return nil, fmt.Errorf("unsupported segment type: %d", typ)
+			}
+		case "weight":
+			pos++
+			weight, err := strconv.ParseUint(args[pos], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid weight: %s", args[pos])
+			}
+			pos++
+			tlvs = append(tlvs, &SegmentListSubTLVWeight{
+				Weight: uint32(weight),
+			})
+		default:
+			return nil, fmt.Errorf("invalid segment-list arguments: %s in %s", args[pos], args)
+		}
+	}
+	return tlvs, nil
+}

--- a/packet/bgp/segment_routing_test.go
+++ b/packet/bgp/segment_routing_test.go
@@ -1,0 +1,657 @@
+// Copyright (C) 2018 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bgp
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test4OctetSegmentID(t *testing.T) {
+	assert := assert.New(t)
+
+	bufIn := []byte{
+		0x00, 0x06, 0x47, 0x40, // Label=100, TC=3, S=1, TTL=64
+	}
+	nStr := fmt.Sprint(0x064740)
+
+	// Test parser
+	sid, err := ParseSegmentID(nStr)
+	assert.Nil(err)
+
+	// Test decoded values
+	assert.Equal(4, sid.Len())
+	assert.True(sid.is4Octet())
+	assert.Equal(uint32(100), sid.Label())
+	assert.Equal(uint8(3), sid.TrafficClass())
+	assert.True(sid.isBoS())
+	assert.Equal(uint8(64), sid.TTL())
+
+	// Test binary and string representation
+	assert.Equal(bufIn, []byte(sid))
+	assert.Equal(nStr, sid.String())
+}
+
+func Test16OctetIPv6SegmentID(t *testing.T) {
+	assert := assert.New(t)
+
+	ip := net.ParseIP("2001:db8::1")
+
+	// Test parser
+	sid, err := ParseSegmentID(ip.String())
+	assert.Nil(err)
+
+	// Test decoded values
+	assert.Equal(16, sid.Len())
+	assert.True(sid.is16Octet())
+	assert.Equal(uint32(0), sid.Label())
+	assert.Equal(uint8(0), sid.TrafficClass())
+	assert.False(sid.isBoS())
+	assert.Equal(uint8(0), sid.TTL())
+	assert.Equal("2001:db8::1", sid.String())
+
+	// Test binary and string representation
+	assert.Equal([]byte(ip), []byte(sid))
+	assert.Equal(ip.String(), sid.String())
+}
+
+func TestIPv4SRTEPolicyNLRI(t *testing.T) {
+	assert := assert.New(t)
+
+	bufIn := []byte{
+		0x60,                   // NLRI Length = 96
+		0x11, 0x11, 0x11, 0x11, // Distinguisher
+		0x22, 0x22, 0x22, 0x22, // Policy Color
+		0xc0, 0xa8, 0x00, 0x01, // Endpoint = "192.168.0.1"
+	}
+
+	// Test DecodeFromBytes()
+	n := NewIPv4SRTEPolicyNLRI(0, 0, nil)
+	err := n.DecodeFromBytes(bufIn)
+	assert.Nil(err)
+
+	// Test decoded values
+	assert.Equal(uint8(96), n.Length)
+	assert.Equal(uint32(0x11111111), n.Distinguisher)
+	assert.Equal(uint32(0x22222222), n.Color)
+	assert.Equal(net.ParseIP("192.168.0.1").To4(), n.Endpoint)
+
+	// Test String()
+	assert.Equal("[distinguisher:286331153][color:572662306][endpoint:192.168.0.1]", n.String())
+
+	// Test Serialize()
+	bufOut, err := n.Serialize()
+	assert.Nil(err)
+
+	// Test serialized value
+	assert.Equal(bufIn, bufOut)
+}
+
+func TestIPv6SRTEPolicyNLRI(t *testing.T) {
+	assert := assert.New(t)
+
+	bufIn := []byte{
+		0xc0,                   // NLRI Length = 192
+		0x11, 0x11, 0x11, 0x11, // Distinguisher
+		0x22, 0x22, 0x22, 0x22, // Policy Color
+		0x20, 0x01, 0x0d, 0xb8, // Endpoint = "2001:db8::1"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+	}
+
+	// Test DecodeFromBytes()
+	n := NewIPv6SRTEPolicyNLRI(0, 0, nil)
+	err := n.DecodeFromBytes(bufIn)
+	assert.Nil(err)
+
+	// Test decoded values
+	assert.Equal(uint8(192), n.Length)
+	assert.Equal(uint32(0x11111111), n.Distinguisher)
+	assert.Equal(uint32(0x22222222), n.Color)
+	assert.Equal(net.ParseIP("2001:db8::1").To16(), n.Endpoint)
+
+	// Test String()
+	assert.Equal("[distinguisher:286331153][color:572662306][endpoint:2001:db8::1]", n.String())
+
+	// Test Serialize()
+	bufOut, err := n.Serialize()
+	assert.Nil(err)
+	assert.Equal(bufIn, bufOut)
+}
+
+func TestSegmentListSubTLVUnknown(t *testing.T) {
+	assert := assert.New(t)
+
+	bufIn := []byte{
+		0x00,                   // RESERVED field of TunnelEncapSubTLVSegmentList
+		0x00, 0x02, 0xff, 0xff, // Type=0, Length=2
+	}
+
+	// Test decoding
+	segListTlv := &TunnelEncapSubTLVSegmentList{}
+	err := segListTlv.decodeValue(bufIn)
+	assert.Nil(err)
+	tlvs := segListTlv.Value
+	assert.Equal(1, len(tlvs))
+
+	// Test decoded values
+	tlv, ok := tlvs[0].(*SegmentListSubTLVUnknown)
+	assert.True(ok)
+	assert.Equal(SegmentListSubTLVType(0), tlv.Type())
+	assert.Equal([]byte{0xff, 0xff}, tlv.Value)
+
+	// Test serializing
+	bufOut, err := segListTlv.serializeValue()
+	assert.Nil(err)
+	assert.Equal(bufIn, bufOut)
+}
+
+func TestSegmentListSubTLVMPLSLabelSID(t *testing.T) {
+	assert := assert.New(t)
+
+	bufIn := []byte{
+		0x00,                   // RESERVED field of TunnelEncapSubTLVSegmentList
+		0x01, 0x06, 0x00, 0x00, // Type=1, Length=6
+		0x00, 0x06, 0x00, 0xff, // Label=100, TC=0, S=0, TTL=255
+	}
+
+	// Test decoding
+	segListTlv := &TunnelEncapSubTLVSegmentList{}
+	err := segListTlv.decodeValue(bufIn)
+	assert.Nil(err)
+	tlvs := segListTlv.Value
+	assert.Equal(1, len(tlvs))
+
+	// Test decoded values
+	tlv, ok := tlvs[0].(*SegmentListSubTLVMPLSLabelSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal(fmt.Sprint(0x000600ff), tlv.SID.String())
+
+	// Test serializing
+	bufOut, err := segListTlv.serializeValue()
+	assert.Nil(err)
+	assert.Equal(bufIn, bufOut)
+}
+
+func TestSegmentListSubTLVIPv6AddressSID(t *testing.T) {
+	assert := assert.New(t)
+
+	bufIn := []byte{
+		0x00,                   // RESERVED field of TunnelEncapSubTLVSegmentList
+		0x02, 0x12, 0x00, 0x00, // Type=2, Length=18
+		0x20, 0x01, 0x0d, 0xb8, // SID="2001:db8::1"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+	}
+
+	// Test decoding
+	segListTlv := &TunnelEncapSubTLVSegmentList{}
+	err := segListTlv.decodeValue(bufIn)
+	assert.Nil(err)
+	tlvs := segListTlv.Value
+	assert.Equal(1, len(tlvs))
+
+	// Test decoded values
+	tlv, ok := tlvs[0].(*SegmentListSubTLVIPv6AddressSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal("2001:db8::1", tlv.SID.String())
+
+	// Test serializing
+	bufOut, err := segListTlv.serializeValue()
+	assert.Nil(err)
+	assert.Equal(bufIn, bufOut)
+}
+
+func TestSegmentListSubTLVIPv4NodeAddressSID(t *testing.T) {
+	assert := assert.New(t)
+
+	bufIn := []byte{
+		0x00, // RESERVED field of TunnelEncapSubTLVSegmentList
+		// Without SID
+		0x03, 0x06, 0x00, 0x00, // Type=3, Length=6
+		0xc0, 0xa8, 0x00, 0x01, // Address="192.168.0.1"
+		// With 4-octet SID
+		0x03, 0x0a, 0x00, 0x00, // Type=3, Length=10
+		0xc0, 0xa8, 0x00, 0x02, // Address="192.168.0.2"
+		0x00, 0x06, 0x00, 0xff, // Label=100, TC=0, S=0, TTL=255
+		// With 16-octet IPv6 SID
+		0x03, 0x16, 0x00, 0x00, // Type=3, Length=22
+		0xc0, 0xa8, 0x00, 0x03, // Address="192.168.0.3"
+		0x20, 0x01, 0x0d, 0xb8, // SID="2001:db8::1"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+	}
+
+	// Test decoding
+	segListTlv := &TunnelEncapSubTLVSegmentList{}
+	err := segListTlv.decodeValue(bufIn)
+	assert.Nil(err)
+	tlvs := segListTlv.Value
+	assert.Equal(3, len(tlvs))
+
+	// Test decoded values
+	tlv, ok := tlvs[0].(*SegmentListSubTLVIPv4NodeAddressSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal("192.168.0.1", tlv.Address.String())
+	assert.Equal("<nil>", tlv.SID.String())
+	tlv, ok = tlvs[1].(*SegmentListSubTLVIPv4NodeAddressSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal("192.168.0.2", tlv.Address.String())
+	assert.Equal(fmt.Sprint(0x000600ff), tlv.SID.String())
+	tlv, ok = tlvs[2].(*SegmentListSubTLVIPv4NodeAddressSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal("192.168.0.3", tlv.Address.String())
+	assert.Equal("2001:db8::1", tlv.SID.String())
+
+	// Test serializing
+	bufOut, err := segListTlv.serializeValue()
+	assert.Nil(err)
+	assert.Equal(bufIn, bufOut)
+}
+
+func TestSegmentListSubTLVIPv6NodeAddressSID(t *testing.T) {
+	assert := assert.New(t)
+
+	bufIn := []byte{
+		0x00, // RESERVED field of TunnelEncapSubTLVSegmentList
+		// Without SID
+		0x04, 0x12, 0x00, 0x00, // Type=4, Length=18
+		0x20, 0x01, 0x0d, 0xb8, // Address="2001:db8::1"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+		// With 4-octet SID
+		0x04, 0x16, 0x00, 0x00, // Type=4, Length=22
+		0x20, 0x01, 0x0d, 0xb8, // Address="2001:db8::2"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x02,
+		0x00, 0x06, 0x00, 0xff, // Label=100, TC=0, S=0, TTL=255
+		// With 16-octet IPv6 SID
+		0x04, 0x22, 0x00, 0x00, // Type=4, Length=34
+		0x20, 0x01, 0x0d, 0xb8, // Address="2001:db8::3"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x03,
+		0x20, 0x01, 0x0d, 0xb8, // SID="2001:db8::1"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+	}
+
+	// Test decoding
+	segListTlv := &TunnelEncapSubTLVSegmentList{}
+	err := segListTlv.decodeValue(bufIn)
+	assert.Nil(err)
+	tlvs := segListTlv.Value
+	assert.Equal(3, len(tlvs))
+
+	// Test decoded values
+	tlv, ok := tlvs[0].(*SegmentListSubTLVIPv6NodeAddressSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal("2001:db8::1", tlv.Address.String())
+	assert.Equal("<nil>", tlv.SID.String())
+	tlv, ok = tlvs[1].(*SegmentListSubTLVIPv6NodeAddressSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal("2001:db8::2", tlv.Address.String())
+	assert.Equal(fmt.Sprint(0x000600ff), tlv.SID.String())
+	tlv, ok = tlvs[2].(*SegmentListSubTLVIPv6NodeAddressSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal("2001:db8::3", tlv.Address.String())
+	assert.Equal("2001:db8::1", tlv.SID.String())
+
+	// Test serializing
+	bufOut, err := segListTlv.serializeValue()
+	assert.Nil(err)
+	assert.Equal(bufIn, bufOut)
+}
+
+func TestSegmentListSubTLVIPv4AddressIndexSID(t *testing.T) {
+	assert := assert.New(t)
+
+	bufIn := []byte{
+		0x00, // RESERVED field of TunnelEncapSubTLVSegmentList
+		// Without SID
+		0x05, 0x0a, 0x00, 0x00, // Type=5, Length=10
+		0x00, 0x00, 0x00, 0x01, // InterfaceID=1
+		0xc0, 0xa8, 0x00, 0x01, // Address="192.168.0.1"
+		// With 4-octet SID
+		0x05, 0x0e, 0x00, 0x00, // Type=5, Length=14
+		0x00, 0x00, 0x00, 0x02, // InterfaceID=2
+		0xc0, 0xa8, 0x00, 0x02, // Address="192.168.0.2"
+		0x00, 0x06, 0x00, 0xff, // Label=100, TC=0, S=0, TTL=255
+		// With 16-octet IPv6 SID
+		0x05, 0x1a, 0x00, 0x00, // Type=5, Length=26
+		0x00, 0x00, 0x00, 0x03, // InterfaceID=3
+		0xc0, 0xa8, 0x00, 0x03, // Address="192.168.0.3"
+		0x20, 0x01, 0x0d, 0xb8, // SID="2001:db8::1"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+	}
+
+	// Test decoding
+	segListTlv := &TunnelEncapSubTLVSegmentList{}
+	err := segListTlv.decodeValue(bufIn)
+	assert.Nil(err)
+	tlvs := segListTlv.Value
+	assert.Equal(3, len(tlvs))
+
+	// Test decoded values
+	tlv, ok := tlvs[0].(*SegmentListSubTLVIPv4AddressIndexSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal(uint32(1), tlv.InterfaceID)
+	assert.Equal("192.168.0.1", tlv.Address.String())
+	assert.Equal("<nil>", tlv.SID.String())
+	tlv, ok = tlvs[1].(*SegmentListSubTLVIPv4AddressIndexSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal(uint32(2), tlv.InterfaceID)
+	assert.Equal("192.168.0.2", tlv.Address.String())
+	assert.Equal(fmt.Sprint(0x000600ff), tlv.SID.String())
+	tlv, ok = tlvs[2].(*SegmentListSubTLVIPv4AddressIndexSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal(uint32(3), tlv.InterfaceID)
+	assert.Equal("192.168.0.3", tlv.Address.String())
+	assert.Equal("2001:db8::1", tlv.SID.String())
+
+	// Test serializing
+	bufOut, err := segListTlv.serializeValue()
+	assert.Nil(err)
+	assert.Equal(bufIn, bufOut)
+}
+
+func TestSegmentListSubTLVIPv4LocalRemoteAddressSID(t *testing.T) {
+	assert := assert.New(t)
+
+	bufIn := []byte{
+		// Without SID
+		0x00,                   // RESERVED field of TunnelEncapSubTLVSegmentList
+		0x06, 0x0a, 0x00, 0x00, // Type=6, Length=10
+		0xc0, 0xa8, 0x01, 0x01, // LocalAddress="192.168.1.1"
+		0xc0, 0xa8, 0x00, 0x01, // RemoteAddress="192.168.0.1"
+		// With 4-octet SID
+		0x06, 0x0e, 0x00, 0x00, // Type=6, Length=14
+		0xc0, 0xa8, 0x01, 0x02, // LocalAddress="192.168.1.2"
+		0xc0, 0xa8, 0x00, 0x02, // RemoteAddress="192.168.0.2"
+		0x00, 0x06, 0x00, 0xff, // Label=100, TC=0, S=0, TTL=255
+		// With 16-octet IPv6 SID
+		0x06, 0x1a, 0x00, 0x00, // Type=6, Length=26
+		0xc0, 0xa8, 0x01, 0x03, // LocalAddress="192.168.1.3"
+		0xc0, 0xa8, 0x00, 0x03, // RemoteAddress="192.168.0.3"
+		0x20, 0x01, 0x0d, 0xb8, // SID="2001:db8::1"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+	}
+
+	// Test decoding
+	segListTlv := &TunnelEncapSubTLVSegmentList{}
+	err := segListTlv.decodeValue(bufIn)
+	assert.Nil(err)
+	tlvs := segListTlv.Value
+	assert.Equal(3, len(tlvs))
+
+	// Test decoded values
+	tlv, ok := tlvs[0].(*SegmentListSubTLVIPv4LocalRemoteAddressSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal("192.168.1.1", tlv.LocalAddress.String())
+	assert.Equal("192.168.0.1", tlv.RemoteAddress.String())
+	assert.Equal("<nil>", tlv.SID.String())
+	tlv, ok = tlvs[1].(*SegmentListSubTLVIPv4LocalRemoteAddressSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal("192.168.1.2", tlv.LocalAddress.String())
+	assert.Equal("192.168.0.2", tlv.RemoteAddress.String())
+	assert.Equal(fmt.Sprint(0x000600ff), tlv.SID.String())
+	tlv, ok = tlvs[2].(*SegmentListSubTLVIPv4LocalRemoteAddressSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal("192.168.1.3", tlv.LocalAddress.String())
+	assert.Equal("192.168.0.3", tlv.RemoteAddress.String())
+	assert.Equal("2001:db8::1", tlv.SID.String())
+
+	// Test serializing
+	bufOut, err := segListTlv.serializeValue()
+	assert.Nil(err)
+	assert.Equal(bufIn, bufOut)
+}
+
+func TestSegmentListSubTLVIPv6AddressIndexSID(t *testing.T) {
+	assert := assert.New(t)
+
+	bufIn := []byte{
+		0x00, // RESERVED field of TunnelEncapSubTLVSegmentList
+		// Without SID
+		0x07, 0x16, 0x00, 0x00, // Type=7, Length=22
+		0x00, 0x00, 0x00, 0x01, // InterfaceID=1
+		0x20, 0x01, 0x0d, 0xb8, // Address="2001:db8::1"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+		// With 4-octet SID
+		0x07, 0x1a, 0x00, 0x00, // Type=7, Length=26
+		0x00, 0x00, 0x00, 0x02, // InterfaceID=2
+		0x20, 0x01, 0x0d, 0xb8, // Address="2001:db8::2"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x02,
+		0x00, 0x06, 0x00, 0xff, // Label=100, TC=0, S=0, TTL=255
+		// With 16-octet IPv6 SID
+		0x07, 0x26, 0x00, 0x00, // Type=7, Length=38
+		0x00, 0x00, 0x00, 0x03, // InterfaceID=3
+		0x20, 0x01, 0x0d, 0xb8, // Address="2001:db8::3"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x03,
+		0x20, 0x01, 0x0d, 0xb8, // SID="2001:db8::1"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+	}
+
+	// Test decoding
+	segListTlv := &TunnelEncapSubTLVSegmentList{}
+	err := segListTlv.decodeValue(bufIn)
+	assert.Nil(err)
+	tlvs := segListTlv.Value
+	assert.Equal(3, len(tlvs))
+
+	// Test decoded values
+	tlv, ok := tlvs[0].(*SegmentListSubTLVIPv6AddressIndexSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal(uint32(1), tlv.InterfaceID)
+	assert.Equal("2001:db8::1", tlv.Address.String())
+	assert.Equal("<nil>", tlv.SID.String())
+	tlv, ok = tlvs[1].(*SegmentListSubTLVIPv6AddressIndexSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal(uint32(2), tlv.InterfaceID)
+	assert.Equal("2001:db8::2", tlv.Address.String())
+	assert.Equal(fmt.Sprint(0x000600ff), tlv.SID.String())
+	tlv, ok = tlvs[2].(*SegmentListSubTLVIPv6AddressIndexSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal(uint32(3), tlv.InterfaceID)
+	assert.Equal("2001:db8::3", tlv.Address.String())
+	assert.Equal("2001:db8::1", tlv.SID.String())
+
+	// Test serializing
+	bufOut, err := segListTlv.serializeValue()
+	assert.Nil(err)
+	assert.Equal(bufIn, bufOut)
+}
+
+func TestSegmentListSubTLVIPv6LocalRemoteAddressSID(t *testing.T) {
+	assert := assert.New(t)
+
+	bufIn := []byte{
+		0x00, // RESERVED field of TunnelEncapSubTLVSegmentList
+		// Without SID
+		0x08, 0x22, 0x00, 0x00, // Type=8, Length=34
+		0x20, 0x01, 0x0d, 0xb8, // LocalAddress="2001:db8:1::1"
+		0x00, 0x01, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+		0x20, 0x01, 0x0d, 0xb8, // RemoteAddress="2001:db8:2::1"
+		0x00, 0x02, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+		// With 4-octet SID
+		0x08, 0x26, 0x00, 0x00, // Type=8, Length=38
+		0x20, 0x01, 0x0d, 0xb8, // LocalAddress="2001:db8:1::2"
+		0x00, 0x01, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x02,
+		0x20, 0x01, 0x0d, 0xb8, // RemoteAddress="2001:db8:2::2"
+		0x00, 0x02, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x02,
+		0x00, 0x06, 0x00, 0xff, // Label=100, TC=0, S=0, TTL=255
+		// With 16-octet IPv6 SID
+		0x08, 0x32, 0x00, 0x00, // Type=8, Length=50
+		0x20, 0x01, 0x0d, 0xb8, // LocalAddress="2001:db8:1::3"
+		0x00, 0x01, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x03,
+		0x20, 0x01, 0x0d, 0xb8, // RemoteAddress="2001:db8:2::3"
+		0x00, 0x02, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x03,
+		0x20, 0x01, 0x0d, 0xb8, // SID="2001:db8::1"
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+	}
+
+	// Test decoding
+	segListTlv := &TunnelEncapSubTLVSegmentList{}
+	err := segListTlv.decodeValue(bufIn)
+	assert.Nil(err)
+	tlvs := segListTlv.Value
+	assert.Equal(3, len(tlvs))
+
+	// Test decoded values
+	tlv, ok := tlvs[0].(*SegmentListSubTLVIPv6LocalRemoteAddressSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal("2001:db8:1::1", tlv.LocalAddress.String())
+	assert.Equal("2001:db8:2::1", tlv.RemoteAddress.String())
+	assert.Equal("<nil>", tlv.SID.String())
+	tlv, ok = tlvs[1].(*SegmentListSubTLVIPv6LocalRemoteAddressSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal("2001:db8:1::2", tlv.LocalAddress.String())
+	assert.Equal("2001:db8:2::2", tlv.RemoteAddress.String())
+	assert.Equal(fmt.Sprint(0x000600ff), tlv.SID.String())
+	tlv, ok = tlvs[2].(*SegmentListSubTLVIPv6LocalRemoteAddressSID)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal("2001:db8:1::3", tlv.LocalAddress.String())
+	assert.Equal("2001:db8:2::3", tlv.RemoteAddress.String())
+	assert.Equal("2001:db8::1", tlv.SID.String())
+
+	// Test serializing
+	bufOut, err := segListTlv.serializeValue()
+	assert.Nil(err)
+	assert.Equal(bufIn, bufOut)
+}
+
+func TestSegmentListSubTLVWeight(t *testing.T) {
+	assert := assert.New(t)
+
+	bufIn := []byte{
+		0x00,                   // RESERVED field of TunnelEncapSubTLVSegmentList
+		0x09, 0x06, 0x00, 0x00, // Type=1, Length=6
+		0x00, 0x00, 0x00, 0x64, // Weight=100
+	}
+
+	// Test decoding
+	segListTlv := &TunnelEncapSubTLVSegmentList{}
+	err := segListTlv.decodeValue(bufIn)
+	assert.Nil(err)
+	tlvs := segListTlv.Value
+	assert.Equal(1, len(tlvs))
+
+	// Test decoded values
+	tlv, ok := tlvs[0].(*SegmentListSubTLVWeight)
+	assert.True(ok)
+	assert.Equal(uint8(0), tlv.Flags)
+	assert.Equal(uint32(100), tlv.Weight)
+
+	// Test serializing
+	bufOut, err := segListTlv.serializeValue()
+	assert.Nil(err)
+	assert.Equal(bufIn, bufOut)
+}
+
+func TestParseSegmentListSubTLV(t *testing.T) {
+	assert := assert.New(t)
+
+	args := []string{
+		"segment", "1", "100",
+		"segment", "2", "2001:db8:1::1",
+		"segment", "3", "192.168.0.1", "200",
+		"segment", "4", "2001:db8:2::1", "300",
+		"segment", "5", "1", "192.168.1.1", "400",
+		"segment", "6", "192.168.2.1", "192.168.3.1", // <nil>,
+		"segment", "7", "2", "2001:db8:3::1", // <nil>
+		"segment", "8", "2001:db8:4::1", "2001:db8:5::1", "500",
+		"weight", "600",
+	}
+
+	// Test parser
+	tlvs, err := ParseSegmentListSubTLV(args)
+	assert.Nil(err)
+
+	// Test decoded values
+	tlv := tlvs[0]
+	assert.Equal("[SID: 100]", tlv.String())
+	tlv = tlvs[1]
+	assert.Equal("[SID: 2001:db8:1::1]", tlv.String())
+	tlv = tlvs[2]
+	assert.Equal("[Address: 192.168.0.1 SID: 200]", tlv.String())
+	tlv = tlvs[3]
+	assert.Equal("[Address: 2001:db8:2::1 SID: 300]", tlv.String())
+	tlv = tlvs[4]
+	assert.Equal("[InterfaceID: 1 Address: 192.168.1.1 SID: 400]", tlv.String())
+	tlv = tlvs[5]
+	assert.Equal("[LocalAddress: 192.168.2.1 RemoteAddress: 192.168.3.1 SID: <nil>]", tlv.String())
+	tlv = tlvs[6]
+	assert.Equal("[InterfaceID: 2 Address: 2001:db8:3::1 SID: <nil>]", tlv.String())
+	tlv = tlvs[7]
+	assert.Equal("[LocalAddress: 2001:db8:4::1 RemoteAddress: 2001:db8:5::1 SID: 500]", tlv.String())
+	tlv = tlvs[8]
+	assert.Equal("[Weight: 600]", tlv.String())
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1320,6 +1320,21 @@ func (server *BgpServer) fixupApiPath(vrfId string, pathList []*table.Path) erro
 					}
 				}
 			}
+		case *bgp.SRTEPolicyNLRI:
+			// draft-ietf-idr-segment-routing-te-policy-01
+			// 4.2.1. Acceptance of an SR Policy NLRI
+			// The SR Policy update MUST have either the NO_ADVERTISE community
+			// or at least one route-target extended community in IPv4-address
+			// format.
+			found := false
+			for _, extComm := range path.GetExtCommunities() {
+				if _, found = extComm.(*bgp.IPv4AddressSpecificExtended); found {
+					break
+				}
+			}
+			if !found {
+				path.SetCommunities([]uint32{bgp.COMMUNITY_NO_ADVERTISE}, false)
+			}
 		}
 	}
 	return nil

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -148,6 +148,20 @@ module gobgp {
     reference "https://tools.ietf.org/html/draft-lapukhov-bgp-opaque-signaling-01";
   }
 
+  identity IPV4-SR-TE {
+    base bgp-types:afi-safi-type;
+    description
+      "IPv4 SR TE Policy (AFI,SAFI = 1,73)";
+    reference "https://tools.ietf.org/html/draft-ietf-idr-segment-routing-te-policy";
+  }
+
+  identity IPV6-SR-TE {
+    base bgp-types:afi-safi-type;
+    description
+      "IPv6 SR TE Policy (AFI,SAFI = 2,73)";
+    reference "https://tools.ietf.org/html/draft-ietf-idr-segment-routing-te-policy";
+  }
+
   grouping gobgp-message-counter {
     description
       "Counters for all BGPMessage types";
@@ -1248,7 +1262,7 @@ module gobgp {
           uses route-target-membership-config;
       }
     }
-    
+
     uses long-lived-graceful-restart;
   }
 


### PR DESCRIPTION
This patch adds support for the Segment Routing Policy NLRI encoding and
the path attributes encoding defined in
"draft-ietf-idr-segment-routing-te-policy-01".

Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>