### PR TITLE
pkg/packet/bgp: Fix NewEVPNMacIPAdvertisementRoute() to use correct MAC length

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -2559,7 +2559,7 @@ func NewEVPNMacIPAdvertisementRoute(rd RouteDistinguisherInterface, esi Ethernet
 		RD:               rd,
 		ESI:              esi,
 		ETag:             etag,
-		MacAddressLength: 6,
+		MacAddressLength: 48,
 		MacAddress:       mac,
 		IPAddressLength:  ipLen,
 		IPAddress:        ip,


### PR DESCRIPTION
According to the implementation, the MacAddressLength seems to be in bit, not byte. So fixing it...