### PR TITLE
scenario_test: Make BusyBox based container available

### DIFF
--- a/test/lib/bird.py
+++ b/test/lib/bird.py
@@ -41,7 +41,7 @@ class BirdContainer(BGPContainer):
 
     def _start_bird(self):
         c = CmdBuffer()
-        c << '#!/bin/bash'
+        c << '#!/bin/sh'
         c << 'bird'
         cmd = 'echo "{0:s}" > {1}/start.sh'.format(c, self.config_dir)
         local(cmd)

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -572,8 +572,8 @@ class GoBGPContainer(BGPContainer):
 
     def reload_config(self):
         for daemon in self._get_enabled_quagga_daemons():
-            self.local('pkill {0} -SIGHUP'.format(daemon), capture=True)
-        self.local('pkill gobgpd -SIGHUP', capture=True)
+            self.local('pkill -SIGHUP {0}'.format(daemon), capture=True)
+        self.local('pkill -SIGHUP gobgpd', capture=True)
         self._wait_for_boot()
 
     def add_route(self, route, rf='ipv4', attribute=None, aspath=None,

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -108,7 +108,7 @@ class GoBGPContainer(BGPContainer):
 
     def _start_gobgp(self, graceful_restart=False):
         c = CmdBuffer()
-        c << '#!/bin/bash'
+        c << '#!/bin/sh'
         c << '/go/bin/gobgpd -f {0}/gobgpd.conf -l {1} -p {2} -t {3} > ' \
              '{0}/gobgpd.log 2>&1'.format(self.SHARED_VOLUME, self.log_level, '-r' if graceful_restart else '', self.config_format)
 

--- a/test/lib/quagga.py
+++ b/test/lib/quagga.py
@@ -273,7 +273,7 @@ class QuaggaBGPContainer(BGPContainer):
 
     def reload_config(self):
         for daemon in self._get_enabled_daemons():
-            self.local('pkill {0} -SIGHUP'.format(daemon), capture=True)
+            self.local('pkill -SIGHUP {0}'.format(daemon), capture=True)
         self._wait_for_boot()
 
     def _vtysh_add_route_map(self, path):


### PR DESCRIPTION
This PR enable us to use container images which contain BusyBox for scenario test.

When we want to do scenario test with our own container image, for example which is based on alpine, we can specify own image like `GOBGP_IMAGE=my/image:tag ./run_all_tests.sh`.