### PR TITLE
remove neighbors.transport.config.ttl option

### DIFF
--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -76,7 +76,6 @@
         passive-mode = true
         local-address = "192.168.10.1"
         remote-port = 2016
-        ttl = 64  # default value on Linux
     [neighbors.ebgp-multihop.config]
         enabled = true
         multihop-ttl = 100

--- a/internal/pkg/config/bgp_configs.go
+++ b/internal/pkg/config/bgp_configs.go
@@ -2515,9 +2515,6 @@ type TransportConfig struct {
 	// original -> gobgp:remote-port
 	// gobgp:remote-port's original type is inet:port-number.
 	RemotePort uint16 `mapstructure:"remote-port" json:"remote-port,omitempty"`
-	// original -> gobgp:ttl
-	// TTL value for BGP packets.
-	Ttl uint8 `mapstructure:"ttl" json:"ttl,omitempty"`
 }
 
 func (lhs *TransportConfig) Equal(rhs *TransportConfig) bool {
@@ -2537,9 +2534,6 @@ func (lhs *TransportConfig) Equal(rhs *TransportConfig) bool {
 		return false
 	}
 	if lhs.RemotePort != rhs.RemotePort {
-		return false
-	}
-	if lhs.Ttl != rhs.Ttl {
 		return false
 	}
 	return true

--- a/tools/pyang_plugins/README.rst
+++ b/tools/pyang_plugins/README.rst
@@ -37,4 +37,4 @@ Generate config/bgp_configs.go from yang files::
    $HOME/public/release/models/bgp/openconfig-bgp.yang \
    $HOME/public/release/models/policy/openconfig-routing-policy.yang \
    $GOBGP_PATH/tools/pyang_plugins/gobgp.yang \
-   | gofmt > $GOBGP_PATH/config/bgp_configs.go
+   | gofmt > $GOBGP_PATH/internal/pkg/config/bgp_configs.go

--- a/tools/pyang_plugins/bgpyang2golang.py
+++ b/tools/pyang_plugins/bgpyang2golang.py
@@ -766,7 +766,7 @@ def generate_header(ctx, fd):
     print('import (', file=fd)
     print('"fmt"', file=fd)
     print('', file=fd)
-    print('"github.com/osrg/gobgp/packet/bgp"', file=fd)
+    print('"github.com/osrg/gobgp/pkg/packet/bgp"', file=fd)
     print(')', file=fd)
     print('', file=fd)
 

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -887,11 +887,6 @@ module gobgp {
     leaf remote-port {
       type inet:port-number;
     }
-
-    leaf ttl {
-      description "TTL value for BGP packets";
-      type uint8;
-    }
   }
 
   augment "/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:timers/bgp:config" {


### PR DESCRIPTION
use neighbors.ebgp-multihop.config.multihop-ttl instead.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>