### PR TITLE
scenario_test: Make static ip address available

### DIFF
--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -232,10 +232,13 @@ class Bridge(object):
         local("docker network connect {0} {1}".format(self.name, ctn.docker_name()))
         i = [x for x in Client(timeout=60, version='auto').inspect_network(self.id)['Containers'].values() if x['Name'] == ctn.docker_name()][0]
         if self.subnet.version == 4:
+            eth = 'eth{0}'.format(len(ctn.ip_addrs))
             addr = i['IPv4Address']
+            ctn.ip_addrs.append((eth, addr, self.name))
         else:
+            eth = 'eth{0}'.format(len(ctn.ip6_addrs))
             addr = i['IPv6Address']
-        ctn.ip_addrs.append(('eth1', addr, self.name))
+            ctn.ip6_addrs.append((eth, addr, self.name))
 
     def delete(self):
         try_several_times(lambda: local("docker network rm {0}".format(self.name)))

--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -226,10 +226,15 @@ class Bridge(object):
         return "{0}/{1}".format(self._ip_generator.next(),
                                 self.subnet.prefixlen)
 
-    def addif(self, ctn):
+    def addif(self, ctn, ip_addr=''):
         _name = ctn.next_if_name()
         self.ctns.append(ctn)
-        local("docker network connect {0} {1}".format(self.name, ctn.docker_name()))
+        ip = ''
+        if not ip_addr == '':
+            ip = '--ip {0}'.format(ip_addr)
+            if self.subnet.version == 6:
+                ip = '--ip6 {0}'.format(ip_addr)
+        local("docker network connect {0} {1} {2}".format(ip, self.name, ctn.docker_name()))
         i = [x for x in Client(timeout=60, version='auto').inspect_network(self.id)['Containers'].values() if x['Name'] == ctn.docker_name()][0]
         if self.subnet.version == 4:
             eth = 'eth{0}'.format(len(ctn.ip_addrs))

--- a/test/scenario_test/bgp_zebra_test.py
+++ b/test/scenario_test/bgp_zebra_test.py
@@ -173,8 +173,8 @@ class GoBGPTestBase(unittest.TestCase):
         [self.bridges['br02_v6'].addif(ctn) for ctn in [g1, q1]]
         [self.bridges['br03_v6'].addif(ctn) for ctn in [q1, o2]]
 
-        g1.add_peer(q1, bridge=self.bridges['br02_v6'].name)
-        q1.add_peer(g1, bridge=self.bridges['br02_v6'].name)
+        g1.add_peer(q1, bridge=self.bridges['br02_v6'].name, v6=True)
+        q1.add_peer(g1, bridge=self.bridges['br02_v6'].name, v6=True)
 
         g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=q1)
 
@@ -190,15 +190,15 @@ class GoBGPTestBase(unittest.TestCase):
         o2 = self.others['ipv6'][1]
 
         # set o1's default gateway as g1
-        g1_addr = g1.ip_addrs[1][1].split('/')[0]
+        g1_addr = [a for a in g1.ip6_addrs if a[2] == self.bridges['br01_v6'].name][0][1].split('/')[0]
         o1.add_static_route(self.bridges['br03_v6'].subnet, g1_addr)
 
         # set o2's default gateway as q1
-        q1_addr = q1.ip_addrs[2][1].split('/')[0]
+        q1_addr = [a for a in q1.ip6_addrs if a[2] == self.bridges['br03_v6'].name][0][1].split('/')[0]
         o2.add_static_route(self.bridges['br01_v6'].subnet, q1_addr)
 
         # test reachability between o1 and o2
-        addrs = [e[1] for e in o2.ip_addrs if 'br03_v6' in e[2]]
+        addrs = [e[1] for e in o2.ip6_addrs if 'br03_v6' in e[2]]
         self.assertTrue(len(addrs) == 1)
         o2_addr = addrs[0]
         o1.get_reachability(o2_addr)


### PR DESCRIPTION
This RP enable us to use static IP address in scenario test.

Basically, GoBGP's container based scenario test is executed with dynamic IP address allocation by docker. In some case, for example when we use static configuration file, static IP address is help us to keep a consistency of our test.

Usage:
```
br01 = Bridge(name='br01', subnet='192.168.0.0/24', self_ip=False)
g1 = GoBGPContainer(name='g1', asn=64512 router_id='10.0.0.1')
br01.addif(g1, ip_addr='192.168.0.11')
```

P.S. I'm going to send other PR that include a change for static configuration.