### PR TITLE
Release read lock before calling llgrFamilies

### DIFF
--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -282,8 +282,9 @@ func (peer *Peer) llgrFamilies() ([]bgp.RouteFamily, []bgp.RouteFamily) {
 
 func (peer *Peer) isLLGREnabledFamily(family bgp.RouteFamily) bool {
 	peer.fsm.lock.RLock()
-	defer peer.fsm.lock.RUnlock()
-	if !peer.fsm.pConf.GracefulRestart.Config.LongLivedEnabled {
+	llgrEnabled := peer.fsm.pConf.GracefulRestart.Config.LongLivedEnabled
+	peer.fsm.lock.RUnlock()
+	if !llgrEnabled {
 		return false
 	}
 	fs, _ := peer.llgrFamilies()


### PR DESCRIPTION
llgrFamilies attempts to obtain a read lock on its own but the caller already
has one. This results in deadlock.

Addresses #1818