### PR TITLE
pyang_plugins: Fix an import path

### DIFF
--- a/tools/pyang_plugins/bgpyang2golang.py
+++ b/tools/pyang_plugins/bgpyang2golang.py
@@ -768,7 +768,7 @@ def generate_header(fd):
     print('import (', file=fd)
     print('"fmt"', file=fd)
     print('', file=fd)
-    print('"github.com/osrg/gobgp/packet/bgp"', file=fd)
+    print('"github.com/osrg/gobgp/pkg/packet/bgp"', file=fd)
     print(')', file=fd)
     print('', file=fd)
 


### PR DESCRIPTION
This PR fixes a hard-coded Go import path to "packet/bgp" in `bgpyang2golang.py` as following.
NG: "github.com/osrg/gobgp/packet/bgp"
OK: "github.com/osrg/gobgp/pkg/packet/bgp"

Also improves pylint and pycodestyle results.