### PR TITLE
api: add GwAddress to EVPNIPPrefixRoute

### DIFF
--- a/internal/pkg/apiutil/attribute.go
+++ b/internal/pkg/apiutil/attribute.go
@@ -391,6 +391,7 @@ func MarshalNLRI(value bgp.AddrPrefixInterface) *any.Any {
 				IpPrefix:    r.IPPrefix.String(),
 				IpPrefixLen: uint32(r.IPPrefixLength),
 				Label:       r.Label,
+				GwAddress:   r.GWIPAddress.String(),
 			}
 		}
 	case *bgp.LabeledVPNIPAddrPrefix:

--- a/internal/pkg/apiutil/attribute_test.go
+++ b/internal/pkg/apiutil/attribute_test.go
@@ -652,6 +652,7 @@ func Test_MpReachNLRIAttribute_EVPN_Prefix_Route(t *testing.T) {
 		IpPrefixLen: 24,
 		IpPrefix:    "192.168.101.0",
 		Label:       200,
+		GwAddress:   "172.16.101.1",
 	})
 	assert.Nil(err)
 	nlris = append(nlris, a)


### PR DESCRIPTION
Fix error that GwAddress attr is missing in EVPNIPPrefixRoute.

Updated testcase.