### PR TITLE
fix: nil pointer in PrefixSet Append

### DIFF
--- a/internal/pkg/table/policy.go
+++ b/internal/pkg/table/policy.go
@@ -370,6 +370,12 @@ func (lhs *PrefixSet) Append(arg DefinedSet) error {
 	if !ok {
 		return fmt.Errorf("type cast failed")
 	}
+
+	if rhs.tree.Len() == 0 {
+		// if try to append an empty set, then return directly
+		return nil
+	}
+
 	// if either is empty, family can be ignored.
 	if lhs.tree.Len() != 0 && rhs.tree.Len() != 0 {
 		_, w, _ := lhs.tree.Minimum()


### PR DESCRIPTION
When both sets are empty, the Minimum() call will result in nil pointer dereference crash

The fix is to check the new set for append operation, if it is empty, then the function return directly