### PR TITLE
server: unexport fsm stuff

### DIFF
--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -274,7 +274,7 @@ func bmpPeerDown(ev *WatchEventPeerState, t uint8, policy bool, pd uint64) *bmp.
 		flags |= bmp.BMP_PEER_FLAG_POST_POLICY
 	}
 	ph := bmp.NewBMPPeerHeader(t, flags, pd, ev.PeerAddress.String(), ev.PeerAS, ev.PeerID.String(), float64(ev.Timestamp.Unix()))
-	return bmp.NewBMPPeerDownNotification(*ph, uint8(ev.StateReason.PeerDownReason), ev.StateReason.BGPNotification, ev.StateReason.Data)
+	return bmp.NewBMPPeerDownNotification(*ph, uint8(ev.StateReason.peerDownReason), ev.StateReason.BGPNotification, ev.StateReason.Data)
 }
 
 func bmpPeerRoute(t uint8, policy bool, pd uint64, fourBytesAs bool, peeri *table.PeerInfo, timestamp int64, payload []byte) *bmp.BMPMessage {

--- a/pkg/server/fsm_test.go
+++ b/pkg/server/fsm_test.go
@@ -308,15 +308,15 @@ func TestCheckOwnASLoop(t *testing.T) {
 	assert.False(hasOwnASLoop(65200, 0, aspath))
 }
 
-func makePeerAndHandler() (*peer, *FSMHandler) {
+func makePeerAndHandler() (*peer, *fsmHandler) {
 	p := &peer{
-		fsm:      NewFSM(&config.Global{}, &config.Neighbor{}, table.NewRoutingPolicy()),
+		fsm:      newFSM(&config.Global{}, &config.Neighbor{}, table.NewRoutingPolicy()),
 		outgoing: channels.NewInfiniteChannel(),
 	}
 
-	h := &FSMHandler{
+	h := &fsmHandler{
 		fsm:           p.fsm,
-		stateReasonCh: make(chan FsmStateReason, 2),
+		stateReasonCh: make(chan fsmStateReason, 2),
 		incoming:      channels.NewInfiniteChannel(),
 		outgoing:      p.outgoing,
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -805,7 +805,7 @@ func TestFamiliesForSoftreset(t *testing.T) {
 		}
 	}
 	peer := &peer{
-		fsm: &FSM{
+		fsm: &fsm{
 			pConf: &config.Neighbor{
 				AfiSafis: []config.AfiSafi{f(bgp.RF_RTC_UC), f(bgp.RF_IPv4_UC), f(bgp.RF_IPv6_UC)},
 			},


### PR DESCRIPTION
No need to export the bgp peer internals.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>