### PR TITLE
server: propagate local routes to neighbour with policy

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1070,7 +1070,7 @@ func (server *BgpServer) propagateUpdateToNeighbors(source *peer, newPath *table
 	}
 	family := newPath.GetRouteFamily()
 	for _, targetPeer := range server.neighborMap {
-		if (source == nil && targetPeer.isRouteServerClient()) || (source != nil && source.isRouteServerClient() != targetPeer.isRouteServerClient()) {
+		if source != nil && source.isRouteServerClient() != targetPeer.isRouteServerClient() {
 			continue
 		}
 		f := func() bgp.RouteFamily {


### PR DESCRIPTION
This fix remove the limit of not sending local routes to neighbour
when it has policy and enabled router-server-client, in order to
be used as bgp speaker to inject route to specified neighbours.