### PR TITLE
server: Fix some values are all off by one in MRT TABLEDUMP_V2

### DIFF
--- a/pkg/server/mrt.go
+++ b/pkg/server/mrt.go
@@ -137,12 +137,12 @@ func (m *mrtWriter) loop() error {
 				}
 
 				idx := func(p *table.Path) uint16 {
-					for i, pconf := range e.Neighbor {
-						if p.GetSource().Address.String() == pconf.State.NeighborAddress {
+					for i, peer := range peers {
+						if peer.IpAddress.String() == p.GetSource().Address.String() {
 							return uint16(i)
 						}
 					}
-					return uint16(len(e.Neighbor))
+					return uint16(len(peers))
 				}
 
 				subtype := func(p *table.Path, isAddPath bool) mrt.MRTSubTypeTableDumpv2 {


### PR DESCRIPTION
The values of Peer information and BGP Message in MRT TABLE_DUMP_V2 output are all off by one. Not sure, but I guess it is due to 04f36f09a17c45f09f103dc167caf0fbdb721578.