### PR TITLE
server: fix deadlock regression

### DIFF
--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -497,8 +497,8 @@ func (peer *peer) handleUpdate(e *fsmMsg) ([]*table.Path, []bgp.RouteFamily, *bg
 			// RFC4456 8. Avoiding Routing Information Loops
 			// A router that recognizes the ORIGINATOR_ID attribute SHOULD
 			// ignore a route received with its BGP Identifier as the ORIGINATOR_ID.
-			peer.fsm.lock.RLock()
 			isIBGPPeer := peer.isIBGPPeer()
+			peer.fsm.lock.RLock()
 			routerId := peer.fsm.gConf.Config.RouterId
 			peer.fsm.lock.RUnlock()
 			if isIBGPPeer {


### PR DESCRIPTION
introduced by 433440067d8084556a31ffd4b8bfa8671bfcaab2

Reported-by: Eiichiro Watanabe <a16tochjp@gmail.com>
Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>