### PR TITLE
Support AdminDown from config

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -2958,6 +2958,7 @@ type PeerConf struct {
 	Vrf               string                 `protobuf:"bytes,15,opt,name=vrf" json:"vrf,omitempty"`
 	AllowOwnAs        uint32                 `protobuf:"varint,16,opt,name=allow_own_as,json=allowOwnAs" json:"allow_own_as,omitempty"`
 	ReplacePeerAs     bool                   `protobuf:"varint,17,opt,name=replace_peer_as,json=replacePeerAs" json:"replace_peer_as,omitempty"`
+	AdminDown         bool                   `protobuf:"varint,18,opt,name=admin_down,json=adminDown" json:"admin_down,omitempty"`
 }
 
 func (m *PeerConf) Reset()                    { *m = PeerConf{} }

--- a/api/gobgp.proto
+++ b/api/gobgp.proto
@@ -622,6 +622,7 @@ message PeerConf {
   string vrf = 15;
   uint32 allow_own_as = 16;
   bool replace_peer_as = 17;
+  bool admin_down = 18;
 }
 
 message PeerGroupConf {

--- a/internal/pkg/config/util.go
+++ b/internal/pkg/config/util.go
@@ -456,6 +456,7 @@ func NewPeerFromConfigStruct(pconf *Neighbor) *api.Peer {
 			AllowOwnAs:        uint32(pconf.AsPathOptions.Config.AllowOwnAs),
 			RemovePrivateAs:   removePrivateAs,
 			ReplacePeerAs:     pconf.AsPathOptions.Config.ReplacePeerAs,
+			AdminDown:         pconf.Config.AdminDown,
 		},
 		State: &api.PeerState{
 			SessionState: api.PeerState_SessionState(api.PeerState_SessionState_value[strings.ToUpper(string(s.SessionState))]),

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -565,6 +565,7 @@ func newNeighborFromAPIStruct(a *api.Peer) (*config.Neighbor, error) {
 		pconf.Config.PeerGroup = a.Conf.PeerGroup
 		pconf.Config.PeerType = config.IntToPeerTypeMap[int(a.Conf.PeerType)]
 		pconf.Config.NeighborAddress = a.Conf.NeighborAddress
+		pconf.Config.AdminDown = a.Conf.AdminDown
 		pconf.Config.NeighborInterface = a.Conf.NeighborInterface
 		pconf.Config.Vrf = a.Conf.Vrf
 		pconf.AsPathOptions.Config.AllowOwnAs = uint8(a.Conf.AllowOwnAs)


### PR DESCRIPTION
Currently, `gobgp neighbor x.x.x.x enable/disable` command enables to control the peer.
However it doesn't work the same thing from config using `admin-down = true/false`. This PR will fix it.