### PR TITLE
Fix intervals for MRT

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -2258,9 +2258,10 @@ func (m *EnableZebraRequest) GetNexthopTriggerDelay() uint32 {
 }
 
 type EnableMrtRequest struct {
-	DumpType int32  `protobuf:"varint,1,opt,name=dump_type,json=dumpType" json:"dump_type,omitempty"`
-	Filename string `protobuf:"bytes,2,opt,name=filename" json:"filename,omitempty"`
-	Interval uint64 `protobuf:"varint,3,opt,name=interval" json:"interval,omitempty"`
+	DumpType         int32  `protobuf:"varint,1,opt,name=dump_type,json=dumpType" json:"dump_type,omitempty"`
+	Filename         string `protobuf:"bytes,2,opt,name=filename" json:"filename,omitempty"`
+	DumpInterval     uint64 `protobuf:"varint,3,opt,name=dump_interval" json:"dump_interval,omitempty"`
+	RotationInterval uint64 `protobuf:"varint,4,opt,name=rotation_interval" json:"rotation_interval,omitempty"`
 }
 
 func (m *EnableMrtRequest) Reset()                    { *m = EnableMrtRequest{} }
@@ -2282,9 +2283,16 @@ func (m *EnableMrtRequest) GetFilename() string {
 	return ""
 }
 
-func (m *EnableMrtRequest) GetInterval() uint64 {
+func (m *EnableMrtRequest) GetDumpInterval() uint64 {
 	if m != nil {
-		return m.Interval
+		return m.DumpInterval
+	}
+	return 0
+}
+
+func (m *EnableMrtRequest) GetRotationInterval() uint64 {
+	if m != nil {
+		return m.RotationInterval
 	}
 	return 0
 }

--- a/api/gobgp.proto
+++ b/api/gobgp.proto
@@ -413,7 +413,8 @@ message EnableZebraRequest {
 message EnableMrtRequest {
   int32 dump_type = 1;
   string filename = 2;
-  uint64 interval = 3;
+  uint64 dump_interval = 3;
+  uint64 rotation_interval = 4;
 }
 
 message DisableMrtRequest {

--- a/cmd/gobgpd/main.go
+++ b/cmd/gobgpd/main.go
@@ -255,9 +255,10 @@ func main() {
 							continue
 						}
 						if err := bgpServer.EnableMrt(context.Background(), &api.EnableMrtRequest{
-							DumpType: int32(c.Config.DumpType.ToInt()),
-							Filename: c.Config.FileName,
-							Interval: c.Config.DumpInterval,
+							DumpType:         int32(c.Config.DumpType.ToInt()),
+							Filename:         c.Config.FileName,
+							DumpInterval:     c.Config.DumpInterval,
+							RotationInterval: c.Config.RotationInterval,
 						}); err != nil {
 							log.Fatalf("failed to set mrt config: %s", err)
 						}

--- a/pkg/server/mrt.go
+++ b/pkg/server/mrt.go
@@ -282,15 +282,15 @@ func (m *mrtWriter) loop() error {
 	}
 }
 
-func mrtFileOpen(filename string, interval uint64) (*os.File, error) {
+func mrtFileOpen(filename string, rInterval uint64) (*os.File, error) {
 	realname := filename
-	if interval != 0 {
+	if rInterval != 0 {
 		realname = time.Now().Format(filename)
 	}
 	log.WithFields(log.Fields{
-		"Topic":         "mrt",
-		"Filename":      realname,
-		"Dump Interval": interval,
+		"Topic":            "mrt",
+		"Filename":         realname,
+		"RotationInterval": rInterval,
 	}).Debug("Setting new MRT destination file")
 
 	i := len(realname)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3280,7 +3280,8 @@ func (s *BgpServer) SetPolicyAssignment(ctx context.Context, r *api.SetPolicyAss
 func (s *BgpServer) EnableMrt(ctx context.Context, r *api.EnableMrtRequest) error {
 	return s.mgmtOperation(func() error {
 		return s.mrtManager.enable(&config.MrtConfig{
-			RotationInterval: r.Interval,
+			DumpInterval:     r.DumpInterval,
+			RotationInterval: r.RotationInterval,
 			DumpType:         config.IntToMrtTypeMap[int(r.DumpType)],
 			FileName:         r.Filename,
 		})


### PR DESCRIPTION
In spite of having 2 fields for MRT interval(dump-interval, rotation-interval), EnableMrtRequest() in api has only one field.