### PR TITLE
cmd/gobgp: don't use timeout context for requests

### DIFF
--- a/cmd/gobgp/root.go
+++ b/cmd/gobgp/root.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
-	"time"
 
 	api "github.com/osrg/gobgp/api"
 	"github.com/spf13/cobra"
@@ -58,8 +57,8 @@ func newRootCmd() *cobra.Command {
 
 			if !globalOpts.GenCmpl {
 				var err error
-				ctx, cancel = context.WithTimeout(context.Background(), time.Second)
-				client, err = newClient(ctx)
+				ctx = context.Background()
+				client, cancel, err = newClient(ctx)
 				if err != nil {
 					cancel()
 					exitWithError(err)


### PR DESCRIPTION
timeout context is for only connecting. We should refactor the code to
avoid global context variant.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>