### PR TITLE
server: Fix wrong value of RouteMonitoringPolicy from grpc

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1599,14 +1599,14 @@ func (s *BgpServer) EnableZebra(ctx context.Context, r *api.EnableZebraRequest) 
 
 func (s *BgpServer) AddBmp(ctx context.Context, r *api.AddBmpRequest) error {
 	return s.mgmtOperation(func() error {
-		t, ok := api.AddBmpRequest_MonitoringPolicy_name[int32(r.Type)]
+		_, ok := api.AddBmpRequest_MonitoringPolicy_name[int32(r.Type)]
 		if !ok {
 			return fmt.Errorf("invalid bmp route monitoring policy: %v", r.Type)
 		}
 		return s.bmpManager.addServer(&config.BmpServerConfig{
 			Address: r.Address,
 			Port:    r.Port,
-			RouteMonitoringPolicy: config.BmpRouteMonitoringPolicyType(t),
+			RouteMonitoringPolicy: config.IntToBmpRouteMonitoringPolicyTypeMap[int(r.Type)],
 		})
 	}, true)
 }


### PR DESCRIPTION
`config.BmpRouteMonitoringPolicy(t)` returns "PRE" from grpc in the case of using "pre-policy".
and then it doesn't match `config.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY` in https://github.com/osrg/gobgp/blob/master/pkg/server/bmp.go#L122
As a result,  it couldn't send BMP Monitoring messages.
This commit will fix it. and #1831 might be fixed. 