### PR TITLE
Fix Statistics Report in BMP

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -2306,9 +2306,10 @@ func (*DisableMrtRequest) ProtoMessage()               {}
 func (*DisableMrtRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{64} }
 
 type AddBmpRequest struct {
-	Address string                         `protobuf:"bytes,1,opt,name=address" json:"address,omitempty"`
-	Port    uint32                         `protobuf:"varint,2,opt,name=port" json:"port,omitempty"`
-	Type    AddBmpRequest_MonitoringPolicy `protobuf:"varint,3,opt,name=type,enum=gobgpapi.AddBmpRequest_MonitoringPolicy" json:"type,omitempty"`
+	Address           string                         `protobuf:"bytes,1,opt,name=address" json:"address,omitempty"`
+	Port              uint32                         `protobuf:"varint,2,opt,name=port" json:"port,omitempty"`
+	Type              AddBmpRequest_MonitoringPolicy `protobuf:"varint,3,opt,name=type,enum=gobgpapi.AddBmpRequest_MonitoringPolicy" json:"type,omitempty"`
+	StatisticsTimeout int32                          `protobuf:"varint,4,opt,name=statistics_timeout" json:"statistics_timeout,omitempty"`
 }
 
 func (m *AddBmpRequest) Reset()                    { *m = AddBmpRequest{} }
@@ -2335,6 +2336,13 @@ func (m *AddBmpRequest) GetType() AddBmpRequest_MonitoringPolicy {
 		return m.Type
 	}
 	return AddBmpRequest_PRE
+}
+
+func (m *AddBmpRequest) GetStatisticsTimeout() int32 {
+	if m != nil {
+		return m.StatisticsTimeout
+	}
+	return 0
 }
 
 type DeleteBmpRequest struct {

--- a/api/gobgp.proto
+++ b/api/gobgp.proto
@@ -431,6 +431,7 @@ message AddBmpRequest {
     ALL = 4;
   }
   MonitoringPolicy type = 3;
+  int32 StatisticsTimeout = 4;
 }
 
 message DeleteBmpRequest {

--- a/cmd/gobgp/bmp.go
+++ b/cmd/gobgp/bmp.go
@@ -49,6 +49,13 @@ func modBmpServer(cmdType string, args []string) error {
 	var err error
 	switch cmdType {
 	case cmdAdd:
+		statisticsTimeout := 0
+		if bmpOpts.StatisticsTimeout >= 0 && bmpOpts.StatisticsTimeout <= 65535 {
+			statisticsTimeout = bmpOpts.StatisticsTimeout
+		} else {
+			return fmt.Errorf("invalid statistics-timeout value. it must be in the range 0-65535. default value is 0 and means disabled.")
+		}
+
 		policyType := api.AddBmpRequest_PRE
 		if len(args) > 1 {
 			switch args[1] {
@@ -65,9 +72,10 @@ func modBmpServer(cmdType string, args []string) error {
 			}
 		}
 		_, err = client.AddBmp(ctx, &api.AddBmpRequest{
-			Address: address,
-			Port:    port,
-			Type:    policyType,
+			Address:           address,
+			Port:              port,
+			Type:              policyType,
+			StatisticsTimeout: int32(statisticsTimeout),
 		})
 	case cmdDel:
 		_, err = client.DeleteBmp(ctx, &api.DeleteBmpRequest{
@@ -92,6 +100,9 @@ func newBmpCmd() *cobra.Command {
 					exitWithError(err)
 				}
 			},
+		}
+		if w == cmdAdd {
+			subcmd.PersistentFlags().IntVarP(&bmpOpts.StatisticsTimeout, "statistics-timeout", "s", 0, "Timeout of statistics report")
 		}
 		bmpCmd.AddCommand(subcmd)
 	}

--- a/cmd/gobgp/common.go
+++ b/cmd/gobgp/common.go
@@ -104,6 +104,10 @@ var mrtOpts struct {
 	NextHop     net.IP `long:"nexthop" description:"Rewrite nexthop"`
 }
 
+var bmpOpts struct {
+	StatisticsTimeout int `short:s long:"statistics-timeout" description:"Interval for Statistics Report"`
+}
+
 func formatTimedelta(d int64) string {
 	u := uint64(d)
 	neg := d < 0

--- a/cmd/gobgpd/main.go
+++ b/cmd/gobgpd/main.go
@@ -216,9 +216,10 @@ func main() {
 					}
 					for _, c := range newConfig.BmpServers {
 						if err := bgpServer.AddBmp(context.Background(), &api.AddBmpRequest{
-							Address: c.Config.Address,
-							Port:    c.Config.Port,
-							Type:    api.AddBmpRequest_MonitoringPolicy(c.Config.RouteMonitoringPolicy.ToInt()),
+							Address:           c.Config.Address,
+							Port:              c.Config.Port,
+							Type:              api.AddBmpRequest_MonitoringPolicy(c.Config.RouteMonitoringPolicy.ToInt()),
+							StatisticsTimeout: int32(c.Config.StatisticsTimeout),
 						}); err != nil {
 							log.Fatalf("failed to set bmp config: %s", err)
 						}

--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -230,7 +230,7 @@ func (b *bmpClient) loop() {
 						if n.State.SessionState != config.SESSION_STATE_ESTABLISHED {
 							continue
 						}
-						if err := write(bmpPeerStats(bmp.BMP_PEER_TYPE_GLOBAL, 0, 0, n)); err != nil {
+						if err := write(bmpPeerStats(bmp.BMP_PEER_TYPE_GLOBAL, 0, time.Now().Unix(), n)); err != nil {
 							return false
 						}
 					}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1607,6 +1607,7 @@ func (s *BgpServer) AddBmp(ctx context.Context, r *api.AddBmpRequest) error {
 			Address: r.Address,
 			Port:    r.Port,
 			RouteMonitoringPolicy: config.IntToBmpRouteMonitoringPolicyTypeMap[int(r.Type)],
+			StatisticsTimeout:     uint16(r.StatisticsTimeout),
 		})
 	}, true)
 }


### PR DESCRIPTION
BMP Statistics Report hasn't been sent since the code structure changed. This commit will fix it.