### PR TITLE
Add quotes to short option value

### DIFF
--- a/cmd/gobgp/common.go
+++ b/cmd/gobgp/common.go
@@ -105,7 +105,7 @@ var mrtOpts struct {
 }
 
 var bmpOpts struct {
-	StatisticsTimeout int `short:s long:"statistics-timeout" description:"Interval for Statistics Report"`
+	StatisticsTimeout int `short:"s" long:"statistics-timeout" description:"Interval for Statistics Report"`
 }
 
 func formatTimedelta(d int64) string {


### PR DESCRIPTION
This broke vet for me. Not sure why it didn't break in CI.