### PR TITLE
packet: fix NewPathAttributeNextHop() to handle ipv6 addresss

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -5654,15 +5654,22 @@ func (p *PathAttributeNextHop) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func NewPathAttributeNextHop(value string) *PathAttributeNextHop {
+func NewPathAttributeNextHop(addr string) *PathAttributeNextHop {
 	t := BGP_ATTR_TYPE_NEXT_HOP
+	ip := net.ParseIP(addr)
+	l := net.IPv4len
+	if ip.To4() == nil {
+		l = net.IPv6len
+	} else {
+		ip = ip.To4()
+	}
 	return &PathAttributeNextHop{
 		PathAttribute: PathAttribute{
 			Flags:  PathAttrFlags[t],
 			Type:   t,
-			Length: 4,
+			Length: uint16(l),
 		},
-		Value: net.ParseIP(value).To4(),
+		Value: ip,
 	}
 }
 

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -1192,3 +1192,14 @@ func TestNormalizeFlowSpecOpValues(t *testing.T) {
 		})
 	}
 }
+
+func Test_PathAttributeNextHop(t *testing.T) {
+	f := func(addr string) {
+		b, _ := NewPathAttributeNextHop(addr).Serialize()
+		p := PathAttributeNextHop{}
+		p.DecodeFromBytes(b)
+		assert.Equal(t, addr, p.Value.String())
+	}
+	f("192.0.2.1")
+	f("2001:db8::68")
+}


### PR DESCRIPTION
NewPathAttributeNextHop struct can handle ipv6 address but
NewPathAttributeNextHop can't.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>