### PR TITLE
travis: fix go vet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ matrix:
       before_script: go get -u honnef.co/go/tools/cmd/megacheck
       script:
         - test -z "$(go fmt $(go list ./... | grep -v '/vendor/'))"
-        - test -z "$(go vet $(go list ./... | grep -v '/vendor/'))"
+        - go vet $(go list ./... | grep -v '/vendor/')
         - megacheck $(go list ./... | grep -v '/vendor/')
     - <<: *_dep_ensure
       env:


### PR DESCRIPTION
The error message of 'go vet' goes to stderr so the length of the
stdout is zero. Always the test passes successfully.

'go vet' exits with non zero when something wrong happens.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>