### PR TITLE
README: use now.sh instead of bluemix.net for slackin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GoBGP: BGP implementation in Go
 
 [![Build Status](https://travis-ci.org/osrg/gobgp.svg?branch=master)](https://travis-ci.org/osrg/gobgp/builds)
-[![Slack Status](https://slackin-gobgp.mybluemix.net/badge.svg)](https://slackin-gobgp.mybluemix.net/)
+[![Slack Status](https://slackin-gobgp.now.sh/badge.svg)](https://slackin-gobgp.now.sh/)
 
 GoBGP is an open source BGP implementation designed from scratch for
 modern environment and implemented in a modern programming language,


### PR DESCRIPTION
Seems that bluemix.net is unstable nowadays.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>