### PR TITLE
server: fix nil pointer error when apply policy

### DIFF
--- a/internal/pkg/table/policy.go
+++ b/internal/pkg/table/policy.go
@@ -2542,7 +2542,7 @@ func (a *AsPathPrependAction) Apply(path *Path, option *PolicyOptions) *Path {
 		asn = a.asn
 	}
 
-	confed := option != nil && option.Info.Confederation
+	confed := option != nil && option.Info != nil && option.Info.Confederation
 	path.PrependAsn(asn, a.repeat, confed)
 
 	return path


### PR DESCRIPTION
this error can be reproduced by:
gobgp p statement s1 add action as-prepend 65001 1
gobgp p add p1 s1
gobgp n 192.168.0.5 p import add p1
gobgp n 192.168.0.5 softresetin

then:
panic: runtime error: invalid memory address or nil pointer dereference