### PR TITLE
Fix incorrect values in BMP Statistics Report(type 7 and 8)

### DIFF
--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -298,14 +298,17 @@ func bmpPeerRoute(t uint8, policy bool, pd uint64, fourBytesAs bool, peeri *tabl
 func bmpPeerStats(peerType uint8, peerDist uint64, timestamp int64, peer *api.Peer) *bmp.BMPMessage {
 	var peerFlags uint8 = 0
 	ph := bmp.NewBMPPeerHeader(peerType, peerFlags, peerDist, peer.State.NeighborAddress, peer.State.PeerAs, peer.State.RouterId, float64(timestamp))
+	received := uint64(0)
 	accepted := uint64(0)
 	for _, a := range peer.AfiSafis {
+		received += a.State.Received
 		accepted += a.State.Accepted
 	}
 	return bmp.NewBMPStatisticsReport(
 		*ph,
 		[]bmp.BMPStatsTLVInterface{
-			bmp.NewBMPStatsTLV64(bmp.BMP_STAT_TYPE_ADJ_RIB_IN, accepted),
+			bmp.NewBMPStatsTLV64(bmp.BMP_STAT_TYPE_ADJ_RIB_IN, received),
+			bmp.NewBMPStatsTLV64(bmp.BMP_STAT_TYPE_LOC_RIB, accepted),
 			bmp.NewBMPStatsTLV32(bmp.BMP_STAT_TYPE_WITHDRAW_UPDATE, uint32(peer.State.Messages.Received.WithdrawUpdate)),
 			bmp.NewBMPStatsTLV32(bmp.BMP_STAT_TYPE_WITHDRAW_PREFIX, uint32(peer.State.Messages.Received.WithdrawPrefix)),
 		},


### PR DESCRIPTION
The value of `bmp.BMP_STAT_TYPE_ADJ_RIB_IN` corresponds to (*AfiSafiState).Received, not (*AfiSafiState).Accepted.