### PR TITLE
cmd/gobgp: remove in policy debris

### DIFF
--- a/cmd/gobgp/common.go
+++ b/cmd/gobgp/common.go
@@ -59,7 +59,6 @@ const (
 	cmdExtcommunity   = "ext-community"
 	cmdImport         = "import"
 	cmdExport         = "export"
-	cmdIn             = "in"
 	cmdMonitor        = "monitor"
 	cmdMRT            = "mrt"
 	cmdInject         = "inject"

--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -1052,7 +1052,7 @@ func showNeighborPolicy(remoteIP, policyType string, indent int) error {
 	case "export":
 		dir = api.PolicyDirection_EXPORT
 	default:
-		return fmt.Errorf("invalid policy type: choose from (in|import|export)")
+		return fmt.Errorf("invalid policy type: choose from (import|export)")
 	}
 	if remoteIP == "" {
 		remoteIP = globalRIBName
@@ -1417,7 +1417,7 @@ func newNeighborCmd() *cobra.Command {
 				exitWithError(err)
 			}
 			remoteIP := peer.State.NeighborAddress
-			for _, v := range []string{cmdIn, cmdImport, cmdExport} {
+			for _, v := range []string{cmdImport, cmdExport} {
 				if err := showNeighborPolicy(remoteIP, v, 4); err != nil {
 					exitWithError(err)
 				}
@@ -1425,7 +1425,7 @@ func newNeighborCmd() *cobra.Command {
 		},
 	}
 
-	for _, v := range []string{cmdIn, cmdImport, cmdExport} {
+	for _, v := range []string{cmdImport, cmdExport} {
 		cmd := &cobra.Command{
 			Use: v,
 			Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
$ gobgp n 10.0.255.1 p
invalid policy type: choose from (in|import|export)

The in policy was removed long ago.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>