### PR TITLE
server: make MonitorTable callback usable with UseMultiplePaths

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -170,12 +170,14 @@ func (s *server) ListPath(r *api.ListPathRequest, stream api.GobgpApi_ListPathSe
 func (s *server) MonitorTable(arg *api.MonitorTableRequest, stream api.GobgpApi_MonitorTableServer) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	var err error
-	s.bgpServer.MonitorTable(ctx, arg, func(p *api.Path) {
-		if err = stream.Send(&api.MonitorTableResponse{
-			Path: p,
-		}); err != nil {
-			cancel()
-			return
+	s.bgpServer.MonitorTable(ctx, arg, func(pl []*api.Path) {
+		for _, p := range pl {
+			if err = stream.Send(&api.MonitorTableResponse{
+				Path: p,
+			}); err != nil {
+				cancel()
+				return
+			}
 		}
 	})
 	<-ctx.Done()


### PR DESCRIPTION
#1958 

I believe it would be better for the UseMultiplePaths option to pass all paths at once to the callback function and not trickle them down so you would have to implement a state tracking inside the callback function.