### PR TITLE
reset eor state on graceful-restart peer down

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1187,6 +1187,9 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 			if graceful {
 				peer.fsm.lock.Lock()
 				peer.fsm.pConf.GracefulRestart.State.PeerRestarting = true
+				for i := range peer.fsm.pConf.AfiSafis {
+					peer.fsm.pConf.AfiSafis[i].MpGracefulRestart.State.EndOfRibReceived = false
+				}
 				peer.fsm.lock.Unlock()
 				var p []bgp.RouteFamily
 				p, drop = peer.forwardingPreservedFamilies()


### PR DESCRIPTION
eor state was not reset during peer restarting, and after peer re-established, it will withdraw all stale routes as soon as first update is received regardless of eor