### PR TITLE
Fix typo

### DIFF
--- a/internal/pkg/config/bgp_configs.go
+++ b/internal/pkg/config/bgp_configs.go
@@ -2212,7 +2212,7 @@ type RouteReflectorState struct {
 }
 
 // struct for container bgp:config.
-// Configuraton parameters relating to route reflection
+// Configuration parameters relating to route reflection
 // for the BGP neighbor or group.
 type RouteReflectorConfig struct {
 	// original -> bgp:route-reflector-cluster-id
@@ -2244,7 +2244,7 @@ func (lhs *RouteReflectorConfig) Equal(rhs *RouteReflectorConfig) bool {
 // Route reflector parameters for the BGP neighbor or group.
 type RouteReflector struct {
 	// original -> bgp:route-reflector-config
-	// Configuraton parameters relating to route reflection
+	// Configuration parameters relating to route reflection
 	// for the BGP neighbor or group.
 	Config RouteReflectorConfig `mapstructure:"config" json:"config,omitempty"`
 	// original -> bgp:route-reflector-state
@@ -2625,7 +2625,7 @@ type TimersState struct {
 	// BGP last transitioned out of the Established state.
 	Downtime int64 `mapstructure:"downtime" json:"downtime,omitempty"`
 	// original -> gobgp:update-recv-time
-	// The number of seconds elasped since January 1, 1970 UTC
+	// The number of seconds elapsed since January 1, 1970 UTC
 	// last time the BGP session received an UPDATE message.
 	UpdateRecvTime int64 `mapstructure:"update-recv-time" json:"update-recv-time,omitempty"`
 }

--- a/internal/pkg/config/bgp_configs.go
+++ b/internal/pkg/config/bgp_configs.go
@@ -2212,7 +2212,7 @@ type RouteReflectorState struct {
 }
 
 // struct for container bgp:config.
-// Configuration parameters relating to route reflection
+// Configuraton parameters relating to route reflection
 // for the BGP neighbor or group.
 type RouteReflectorConfig struct {
 	// original -> bgp:route-reflector-cluster-id
@@ -2244,7 +2244,7 @@ func (lhs *RouteReflectorConfig) Equal(rhs *RouteReflectorConfig) bool {
 // Route reflector parameters for the BGP neighbor or group.
 type RouteReflector struct {
 	// original -> bgp:route-reflector-config
-	// Configuration parameters relating to route reflection
+	// Configuraton parameters relating to route reflection
 	// for the BGP neighbor or group.
 	Config RouteReflectorConfig `mapstructure:"config" json:"config,omitempty"`
 	// original -> bgp:route-reflector-state
@@ -2625,7 +2625,7 @@ type TimersState struct {
 	// BGP last transitioned out of the Established state.
 	Downtime int64 `mapstructure:"downtime" json:"downtime,omitempty"`
 	// original -> gobgp:update-recv-time
-	// The number of seconds elapsed since January 1, 1970 UTC
+	// The number of seconds elasped since January 1, 1970 UTC
 	// last time the BGP session received an UPDATE message.
 	UpdateRecvTime int64 `mapstructure:"update-recv-time" json:"update-recv-time,omitempty"`
 }

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -12452,7 +12452,7 @@ type BGPNotification struct {
 
 func (msg *BGPNotification) DecodeFromBytes(data []byte, options ...*MarshallingOption) error {
 	if len(data) < 2 {
-		return NewMessageError(BGP_ERROR_MESSAGE_HEADER_ERROR, BGP_ERROR_SUB_BAD_MESSAGE_LENGTH, nil, "Not all Notificaiton bytes available")
+		return NewMessageError(BGP_ERROR_MESSAGE_HEADER_ERROR, BGP_ERROR_SUB_BAD_MESSAGE_LENGTH, nil, "Not all Notification bytes available")
 	}
 	msg.ErrorCode = data[0]
 	msg.ErrorSubcode = data[1]

--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -1865,7 +1865,7 @@ func (h *fsmHandler) loop(ctx context.Context, wg *sync.WaitGroup) error {
 	}
 
 	if oldState == bgp.BGP_FSM_ESTABLISHED {
-		// The main goroutine sent the notificaiton due to
+		// The main goroutine sent the notification due to
 		// deconfiguration or something.
 		reason := fsm.reason
 		if fsm.h.sentNotification != nil {

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -263,7 +263,7 @@ module gobgp {
     leaf update-recv-time {
       type int64;
       description
-        "The number of seconds elasped since January 1, 1970 UTC
+        "The number of seconds elapsed since January 1, 1970 UTC
         last time the BGP session received an UPDATE message";
     }
   }


### PR DESCRIPTION
Misspell Finds commonly misspelled English words

 - gobgp/server/fsm.go
   - Line 1592: warning: "notificaiton" is a misspelling of "notification" (misspell)
 - gobgp/packet/bgp/bgp.go
   - Line 8432: warning: "Notificaiton" is a misspelling of "Notification" (misspell)
 - gobgp/config/bgp_configs.go
   - Line 2104: warning: "Configuraton" is a misspelling of "Configuration" (misspell)
   - Line 2136: warning: "Configuraton" is a misspelling of "Configuration" (misspell)
   - Line 2517: warning: "elasped" is a misspelling of "elapsed" (misspell)