### PR TITLE
Fix bgp update error handling

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -12318,15 +12318,12 @@ func (msg *BGPUpdate) DecodeFromBytes(data []byte, options ...*MarshallingOption
 			if e.(*MessageError).Stronger(strongestError) {
 				strongestError = e
 			}
-			break
+			return strongestError
 		}
 		data = data[p.Len(options...):]
 		if e == nil || e.(*MessageError).ErrorHandling != ERROR_HANDLING_ATTRIBUTE_DISCARD {
 			msg.PathAttributes = append(msg.PathAttributes, p)
 		}
-	}
-	if strongestError != nil {
-		return strongestError
 	}
 
 	msg.NLRI = make([]*IPAddrPrefix, 0)
@@ -12347,7 +12344,7 @@ func (msg *BGPUpdate) DecodeFromBytes(data []byte, options ...*MarshallingOption
 		msg.NLRI = append(msg.NLRI, n)
 	}
 
-	return nil
+	return strongestError
 }
 
 func (msg *BGPUpdate) Serialize(options ...*MarshallingOption) ([]byte, error) {

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -12318,11 +12318,15 @@ func (msg *BGPUpdate) DecodeFromBytes(data []byte, options ...*MarshallingOption
 			if e.(*MessageError).Stronger(strongestError) {
 				strongestError = e
 			}
+			break
 		}
 		data = data[p.Len(options...):]
 		if e == nil || e.(*MessageError).ErrorHandling != ERROR_HANDLING_ATTRIBUTE_DISCARD {
 			msg.PathAttributes = append(msg.PathAttributes, p)
 		}
+	}
+	if strongestError != nil {
+		return strongestError
 	}
 
 	msg.NLRI = make([]*IPAddrPrefix, 0)
@@ -12343,7 +12347,7 @@ func (msg *BGPUpdate) DecodeFromBytes(data []byte, options ...*MarshallingOption
 		msg.NLRI = append(msg.NLRI, n)
 	}
 
-	return strongestError
+	return nil
 }
 
 func (msg *BGPUpdate) Serialize(options ...*MarshallingOption) ([]byte, error) {


### PR DESCRIPTION
I've encountered gobgpd crash with the following logs: 

```
Feb 20 02:52:26 bugyo gobgpd[11502]: panic: runtime error: slice bounds out of range
Feb 20 02:52:26 bugyo gobgpd[11502]: goroutine 285 [running]:
Feb 20 02:52:26 bugyo gobgpd[11502]: github.com/osrg/gobgp/pkg/packet/bgp.(*BGPUpdate).DecodeFromBytes(0xc220c08b40, 0xc1dbe6ed04, 0x86f, 0x873, 0xc0ff968c50, 0x1, 0x1, 0x0, 0xc0004c4e00)
Feb 20 02:52:26 bugyo gobgpd[11502]: #011/usr/local/opt/go/src/github.com/osrg/gobgp/pkg/packet/bgp/bgp.go:9105 +0x162e
Feb 20 02:52:26 bugyo gobgpd[11502]: github.com/osrg/gobgp/pkg/packet/bgp.parseBody(0xc299ead8c8, 0xc1dbe6ed00, 0x873, 0x873, 0xc0ff968c50, 0x1, 0x1, 0xaecbc0, 0x1faa3d01, 0xc0ff968c50)
Feb 20 02:52:26 bugyo gobgpd[11502]: #011/usr/local/opt/go/src/github.com/osrg/gobgp/pkg/packet/bgp/bgp.go:9378 +0x2e8
Feb 20 02:52:26 bugyo gobgpd[11502]: github.com/osrg/gobgp/pkg/packet/bgp.ParseBGPBody(0xc299ead8c8, 0xc1dbe6ed00, 0x873, 0x873, 0xc0ff968c50, 0x1, 0x1, 0x0, 0x0, 0x0)
Feb 20 02:52:26 bugyo gobgpd[11502]: #011/usr/local/opt/go/src/github.com/osrg/gobgp/pkg/packet/bgp/bgp.go:9397 +0x74
Feb 20 02:52:26 bugyo gobgpd[11502]: github.com/osrg/gobgp/pkg/server.(*fsmHandler).recvMessageWithError(0xc05da67ab0, 0xc299eadf90, 0x0, 0x0)
Feb 20 02:52:26 bugyo gobgpd[11502]: #011/usr/local/opt/go/src/github.com/osrg/gobgp/pkg/server/fsm.go:970 +0x7a1
Feb 20 02:52:26 bugyo gobgpd[11502]: github.com/osrg/gobgp/pkg/server.(*fsmHandler).recvMessageloop(0xc05da67ab0, 0xd1e880, 0xc05dcde300, 0xc05dcaa534, 0x0, 0x0)
Feb 20 02:52:26 bugyo gobgpd[11502]: #011/usr/local/opt/go/src/github.com/osrg/gobgp/pkg/server/fsm.go:1722 +0x5d
Feb 20 02:52:26 bugyo gobgpd[11502]: created by github.com/osrg/gobgp/pkg/server.(*fsmHandler).established
Feb 20 02:52:26 bugyo gobgpd[11502]: #011/usr/local/opt/go/src/github.com/osrg/gobgp/pkg/server/fsm.go:1744 +0x1fc
```

After my investigation, I realized it was due to receiving invalid update from a peer.
However I expect gobgp should not to be crash in such cases.

This PR includes a test code and a fix code. 