### PR TITLE
cmd/gobgp: fix RPKI result in neighbor policy command

### DIFF
--- a/cmd/gobgp/policy.go
+++ b/cmd/gobgp/policy.go
@@ -511,7 +511,7 @@ func printStatement(indent int, s *api.Statement) {
 		fmt.Printf("%sAsPathLength: %s\n", ind, prettyString(c.AsPathLength))
 	}
 	if c.RpkiResult != -1 {
-		fmt.Printf("%sRPKI result: %s\n", ind, strings.TrimLeft(api.Validation_State(c.RpkiResult).String(), "STATE_"))
+		fmt.Printf("%sRPKI result: %s\n", ind, strings.TrimPrefix(api.Validation_State(c.RpkiResult).String(), "STATE_"))
 	}
 	if c.RouteType != api.Conditions_ROUTE_TYPE_NONE {
 		fmt.Printf("%sRoute Type: %s\n", ind, routeTypePrettyString(c.RouteType))

--- a/cmd/gobgp/policy.go
+++ b/cmd/gobgp/policy.go
@@ -511,18 +511,7 @@ func printStatement(indent int, s *api.Statement) {
 		fmt.Printf("%sAsPathLength: %s\n", ind, prettyString(c.AsPathLength))
 	}
 	if c.RpkiResult != -1 {
-		var result string
-		switch c.RpkiResult {
-		case 0:
-			result = "none"
-		case 1:
-			result = "valid"
-		case 2:
-			result = "invalid"
-		case 3:
-			result = "not-found"
-		}
-		fmt.Printf("%sRPKI result: %s\n", ind, result)
+		fmt.Printf("%sRPKI result: %s\n", ind, config.IntToRpkiValidationResultTypeMap[int(c.RpkiResult)])
 	}
 	if c.RouteType != api.Conditions_ROUTE_TYPE_NONE {
 		fmt.Printf("%sRoute Type: %s\n", ind, routeTypePrettyString(c.RouteType))

--- a/cmd/gobgp/policy.go
+++ b/cmd/gobgp/policy.go
@@ -511,7 +511,7 @@ func printStatement(indent int, s *api.Statement) {
 		fmt.Printf("%sAsPathLength: %s\n", ind, prettyString(c.AsPathLength))
 	}
 	if c.RpkiResult != -1 {
-		fmt.Printf("%sRPKI result: %s\n", ind, config.IntToRpkiValidationResultTypeMap[int(c.RpkiResult)])
+		fmt.Printf("%sRPKI result: %s\n", ind, strings.TrimLeft(api.Validation_State(c.RpkiResult).String(), "STATE_"))
 	}
 	if c.RouteType != api.Conditions_ROUTE_TYPE_NONE {
 		fmt.Printf("%sRoute Type: %s\n", ind, routeTypePrettyString(c.RouteType))


### PR DESCRIPTION
This patch fix the output of `gobgp policy` command to show correct `RPKI result:`.