### PR TITLE
table: fix to avoid setting vacant Large Communities

### DIFF
--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -900,6 +900,12 @@ func (path *Path) GetLargeCommunities() []*bgp.LargeCommunity {
 }
 
 func (path *Path) SetLargeCommunities(cs []*bgp.LargeCommunity, doReplace bool) {
+	if len(cs) == 0 && doReplace {
+		// clear large communities
+		path.delPathAttr(bgp.BGP_ATTR_TYPE_LARGE_COMMUNITY)
+		return
+	}
+
 	a := path.getPathAttr(bgp.BGP_ATTR_TYPE_LARGE_COMMUNITY)
 	if a == nil || doReplace {
 		path.setPathAttr(bgp.NewPathAttributeLargeCommunities(cs))

--- a/internal/pkg/table/policy_test.go
+++ b/internal/pkg/table/policy_test.go
@@ -3076,6 +3076,30 @@ func TestLargeCommunityMatchAction(t *testing.T) {
 	assert.Equal(t, m.Evaluate(p, nil), true)
 }
 
+func TestLargeCommunitiesMatchClearAction(t *testing.T) {
+	coms := []*bgp.LargeCommunity{
+		&bgp.LargeCommunity{ASN: 100, LocalData1: 100, LocalData2: 100},
+		&bgp.LargeCommunity{ASN: 100, LocalData1: 200, LocalData2: 200},
+	}
+	p := NewPath(nil, nil, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeLargeCommunities(coms)}, time.Time{}, false)
+
+	a, err := NewLargeCommunityAction(config.SetLargeCommunity{
+		SetLargeCommunityMethod: config.SetLargeCommunityMethod{
+			CommunitiesList: []string{
+				"100:100:100",
+				"100:200:200",
+			},
+		},
+		Options: config.BGP_SET_COMMUNITY_OPTION_TYPE_REMOVE,
+	})
+
+	assert.Equal(t, err, nil)
+	p = a.Apply(p, nil)
+
+	var lc []*bgp.LargeCommunity
+	assert.Equal(t, lc, p.GetLargeCommunities())
+}
+
 func TestAfiSafiInMatchPath(t *testing.T) {
 	condition, err := NewAfiSafiInCondition([]config.AfiSafiType{config.AFI_SAFI_TYPE_L3VPN_IPV4_UNICAST, config.AFI_SAFI_TYPE_L3VPN_IPV6_UNICAST})
 	require.NoError(t, err)


### PR DESCRIPTION
Currently, GoBGP advertises Large Communities attributes with length of zero when all of them were removed by policy action. Here is a screenshot of a part of packet which was sent from GoBGP.

![vacant-large-communities](https://user-images.githubusercontent.com/7765565/54875443-b9970100-4e42-11e9-82d5-1e6878ae3052.png)

As described in [RFC7606 Section.4](https://tools.ietf.org/html/rfc7606#section-4), most of path attributes having length of zero shall be considered as syntax error. Actually, the above packet caused BGP peer shutdown due to attribute length error (Notification code 3/5).

This patch fix it by checking length of Large Communities and removing it (if necessary), the same as the way of Path.SetCommunities function.