### PR TITLE
README: drop the mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ Try [a binary release](https://github.com/osrg/gobgp/releases/latest).
 
 ## Community, discussion and support
 
-We have the [Slack](https://slackin-gobgp.now.sh/) and [mailing
-list](https://lists.sourceforge.net/lists/listinfo/gobgp-devel) for
-questions, discussion, suggestions, etc.
+We have the [Slack](https://slackin-gobgp.now.sh/) for questions, discussion, suggestions, etc.
 
 You have code or documentation for GoBGP? Awesome! Send a pull
 request. No CLA, board members, governance, or other mess. See [`BUILD.md`](BUILD.md) for info on


### PR DESCRIPTION
Seems that the mailing list is unpopular nowadays. Let's focus on
github and slack.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>