### PR TITLE
Consolidate duplicate code blocks both updating peer groups

### DIFF
--- a/cmd/gobgpd/main.go
+++ b/cmd/gobgpd/main.go
@@ -391,21 +391,13 @@ func main() {
 					}
 				}
 				for _, pg := range updatedPg {
-					log.Infof("PeerGroup %v is updated", pg.State.PeerGroupName)
+					log.Infof("PeerGroup %s is updated", pg.Config.PeerGroupName)
 					if u, err := bgpServer.UpdatePeerGroup(context.Background(), &api.UpdatePeerGroupRequest{
 						PeerGroup: config.NewPeerGroupFromConfigStruct(&pg),
 					}); err != nil {
 						log.Warn(err)
 					} else {
 						updatePolicy = updatePolicy || u.NeedsSoftResetIn
-					}
-				}
-				for _, pg := range updatedPg {
-					log.Infof("PeerGroup %s is updated", pg.Config.PeerGroupName)
-					if _, err := bgpServer.UpdatePeerGroup(context.Background(), &api.UpdatePeerGroupRequest{
-						PeerGroup: config.NewPeerGroupFromConfigStruct(&pg),
-					}); err != nil {
-						log.Warn(err)
 					}
 				}
 				for _, dn := range newConfig.DynamicNeighbors {


### PR DESCRIPTION
I can only see two differences: 1) the first block updates
`updatePolicy` and 2) the log statements are a little bit different
(`pg.State` vs `pg.Config` and `%v` vs `%s`).

From the other blocks above it, it seems that `pg.Config` is the right
thing to use in the log statement rather than `pg.State`.