### PR TITLE
zebra: fix unit test failure on non linux

### DIFF
--- a/internal/pkg/zebra/zapi_test.go
+++ b/internal/pkg/zebra/zapi_test.go
@@ -864,9 +864,9 @@ func Test_NexthopRegisterBody(t *testing.T) {
 
 	// Input binary
 	bufIn := []byte{
-		0x01, 0x00, 0x02, 0x20, // connected(1 byte)=1, afi(2 bytes)=AF_INET, prefix_len(1 byte)=32
+		0x01, uint8(syscall.AF_INET >> 8), uint8(syscall.AF_INET & 0xff), 0x20, // connected(1 byte)=1, afi(2 bytes)=AF_INET, prefix_len(1 byte)=32
 		0xc0, 0xa8, 0x01, 0x01, // prefix(4 bytes)="192.168.1.1"
-		0x00, 0x00, 0x0a, 0x80, // connected(1 byte)=0, afi(2 bytes)=AF_INET6, prefix_len(1 byte)=128
+		0x00, uint8(syscall.AF_INET6 >> 8), uint8(syscall.AF_INET6 & 0xff), 0x80, // connected(1 byte)=0, afi(2 bytes)=AF_INET6, prefix_len(1 byte)=128
 		0x20, 0x01, 0x0d, 0xb8, // prefix(16 bytes)="2001:db8:1:1::1"
 		0x00, 0x01, 0x00, 0x01,
 		0x00, 0x00, 0x00, 0x00,


### PR DESCRIPTION
syscall.AF_INET/AF_INET6 are os/architecture specific. On some non
Linux x86 architectures, failures like the following happen:

--- FAIL: Test_NexthopRegisterBody (0.00s)
        Error Trace:    zapi_test.go:893
        Error:			Not equal: 0x1e (expected)
        			        != 0xa (actual)

        Error Trace:    zapi_test.go:894
        Error:			Not equal: net.IP{0x20, 0x1, 0xd, 0xb8, 0x0, 0x1, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1} (expected)
        			        != net.IP(nil) (actual)

        				Diff:
        				--- Expected
        				+++ Actual
        				@@ -1,2 +1,2 @@
        				-(net.IP) (len=16 cap=16) 2001:db8:1:1::1
        				+(net.IP) <nil>

looks like that frr uses os/os/architecture specific values in the
zapi message.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>