### PR TITLE
Fix cli crash when showing neighbor stats as list.

### DIFF
--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -63,6 +63,9 @@ func getNeighbors(address string, enableAdv bool) ([]*api.Peer, error) {
 		Address:          address,
 		EnableAdvertised: enableAdv,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	l := make([]*api.Peer, 0, 1024)
 	for {


### PR DESCRIPTION
Hi,

so basically - if gobgpd is started with TLS support, but `--tls ...` is not passed to the cli, it crashes when listing neighbors with a segfault due to an unhandled error.