### PR TITLE
docs: remove obsolete rpki command

### DIFF
--- a/docs/sources/rpki.md
+++ b/docs/sources/rpki.md
@@ -194,13 +194,3 @@ Target Prefix: 2.1.0.0/16, AS: 65001
 
 From this, we can notice that 2.1.0.0/16 (Origin AS: 65001) is invalid due to its origin AS,
 the origin AS should be 3215.
-
-## Force Re-validation
-
-Validation is executed every time bgp update messages arrive. The
-changes of ROAs doesn't trigger off validation. The following command
-enables you to validate all the routes.
-
-```bash
-$ gobgp rpki validate
-```


### PR DESCRIPTION
Long ago gobgp stored the validation results in memory but for reduce
memory usage, the cache was removed. Currently, every time you request
the validation result, gobgp validates paths with the latest ROAs.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>