### PR TITLE
travis: use longer timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 _unittest: &_unittest
   go: "1.12"
   script:
-    - go test $([ $(go env GOARCH) == 'amd64' ] && echo '-race') -timeout 120s ./...
+    - go test $([ $(go env GOARCH) == 'amd64' ] && echo '-race') -timeout 240s ./...
     - if [ "$(go env GOARCH)" = "amd64" ]; then go test -race github.com/osrg/gobgp/pkg/packet/bgp -run ^Test_RaceCondition$; else echo 'skip'; fi
 
 _build: &_build


### PR DESCRIPTION
sometimes the unittest fails due to 120s timeout. The travis-ci might
be overloaded? Let's see what happens with the longer timeout.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>