### PR TITLE
Python3 support to gobgp tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ _node_js: &_node_js
 
 _python: &_python
   language: python
-  python: "2.7"
+  python: "3.6"
 
 _docker: &_docker
   <<: *_python
@@ -31,9 +31,9 @@ _docker: &_docker
     - test $TRAVIS_OS_NAME == "linux" && sudo sysctl -w net.ipv6.conf.docker0.disable_ipv6=1
   install:
     - pip install -r test/pip-requires.txt
-    - fab -f test/lib/base.py make_gobgp_ctn:tag=$DOCKER_IMAGE,from_image=$FROM_IMAGE
+    - fab2 -f test/lib/base.py make_gobgp_ctn:tag=$DOCKER_IMAGE,from_image=$FROM_IMAGE
   script:
-    - PYTHONPATH=test python test/scenario_test/$TEST --gobgp-image $DOCKER_IMAGE -x -s
+    - PYTHONPATH=test python3 test/scenario_test/$TEST --gobgp-image $DOCKER_IMAGE -x -s
   services:
     - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ _docker: &_docker
     - test $TRAVIS_OS_NAME == "linux" && sudo sysctl -w net.ipv6.conf.default.disable_ipv6=0
     - test $TRAVIS_OS_NAME == "linux" && sudo sysctl -w net.ipv6.conf.docker0.disable_ipv6=1
   install:
-    - pip install -r test/pip-requires.txt
+    - pip3 install -r test/pip-requires.txt
     - fab2 -f test/lib/base.py make_gobgp_ctn:tag=$DOCKER_IMAGE,from_image=$FROM_IMAGE
   script:
     - PYTHONPATH=test python3 test/scenario_test/$TEST --gobgp-image $DOCKER_IMAGE -x -s

--- a/test/lib/bagpipe.py
+++ b/test/lib/bagpipe.py
@@ -13,14 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
-from fabric import colors
-from fabric.api import local
 
 from lib.base import (
     BGPContainer,
     CmdBuffer,
+    yellow,
+    local,
 )
 
 
@@ -49,7 +47,7 @@ class BagpipeContainer(BGPContainer):
         c << '[BGP]'
         if len(self.ip_addrs) > 0:
             c << 'local_address={0}'.format(self.ip_addrs[0][1].split('/')[0])
-        for info in self.peers.values():
+        for info in list(self.peers.values()):
             c << 'peers={0}'.format(info['neigh_addr'].split('/')[0])
         c << 'my_as={0}'.format(self.asn)
         c << 'enable_rtc=True'
@@ -62,7 +60,7 @@ class BagpipeContainer(BGPContainer):
         c << 'dataplane_driver = DummyDataplaneDriver'
 
         with open('{0}/bgp.conf'.format(self.config_dir), 'w') as f:
-            print colors.yellow(str(c))
+            print(yellow(str(c)))
             f.writelines(str(c))
 
     def reload_config(self):

--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -13,20 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 import os
 import time
 import itertools
 
-from fabric.api import local, lcd
-from fabric import colors
-from fabric.state import env, output
+from invoke import run
+
+import textwrap
+from colored import fg, attr
+
 try:
     from docker import Client
 except ImportError:
     from docker import APIClient as Client
 import netaddr
+
 
 DEFAULT_TEST_PREFIX = ''
 DEFAULT_TEST_BASE_DIR = '/tmp/gobgp'
@@ -82,8 +84,19 @@ FLOWSPEC_NAME_TO_TYPE = {
 TEST_CONTAINER_LABEL = 'gobgp-test'
 TEST_NETWORK_LABEL = TEST_CONTAINER_LABEL
 
-env.abort_exception = RuntimeError
-output.stderr = False
+
+def local(s, capture=False):
+    print('[localhost] local:', s)
+    _env = {'NOSE_NOLOGCAPTURE': '1' if capture else '0'}
+    return run(s, hide=True, env=_env).stdout.strip()
+
+
+def yellow(s):
+    return fg('yellow') + str(s) + attr('reset')
+
+
+def indent(s):
+    return textwrap.indent(str(s), ' '*4, lambda line: True)
 
 
 def community_str(i):
@@ -158,27 +171,6 @@ class CmdBuffer(list):
         return self.delim.join(self)
 
 
-def make_gobgp_ctn(tag='gobgp', local_gobgp_path='', from_image='osrg/quagga'):
-    if local_gobgp_path == '':
-        local_gobgp_path = os.getcwd()
-
-    c = CmdBuffer()
-    c << 'FROM {0}'.format(from_image)
-    c << 'ENV GO111MODULE on'
-    c << 'ADD gobgp /tmp/gobgp'
-    c << 'RUN cd /tmp/gobgp && go install ./cmd/gobgpd ./cmd/gobgp'
-
-    rindex = local_gobgp_path.rindex('gobgp')
-    if rindex < 0:
-        raise Exception('{0} seems not gobgp dir'.format(local_gobgp_path))
-
-    workdir = local_gobgp_path[:rindex]
-    with lcd(workdir):
-        local('echo \'{0}\' > Dockerfile'.format(str(c)))
-        local('docker build -t {0} .'.format(tag))
-        local('rm Dockerfile')
-
-
 class Bridge(object):
     def __init__(self, name, subnet='', with_ip=True, self_ip=False):
         self.name = name
@@ -222,7 +214,7 @@ class Bridge(object):
                       capture=True)
 
     def next_ip_address(self):
-        return "{0}/{1}".format(self._ip_generator.next(),
+        return "{0}/{1}".format(next(self._ip_generator),
                                 self.subnet.prefixlen)
 
     def addif(self, ctn, ip_addr=''):
@@ -234,7 +226,7 @@ class Bridge(object):
             if self.subnet.version == 6:
                 ip = '--ip6 {0}'.format(ip_addr)
         local("docker network connect {0} {1} {2}".format(ip, self.name, ctn.docker_name()))
-        i = [x for x in Client(timeout=60, version='auto').inspect_network(self.id)['Containers'].values() if x['Name'] == ctn.docker_name()][0]
+        i = [x for x in list(Client(timeout=60, version='auto').inspect_network(self.id)['Containers'].values()) if x['Name'] == ctn.docker_name()][0]
         if self.subnet.version == 4:
             eth = 'eth{0}'.format(len(ctn.ip_addrs))
             addr = i['IPv4Address']
@@ -302,7 +294,7 @@ class Container(object):
 
     def pipework(self, bridge, ip_addr, intf_name=""):
         if not self.is_running:
-            print colors.yellow('call run() before pipeworking')
+            print(yellow('call run() before pipeworking'))
             return
         c = CmdBuffer(' ')
         c << "pipework {0}".format(bridge.name)
@@ -460,7 +452,7 @@ class BGPContainer(Container):
 
     def _extract_routes(self, families):
         routes = {}
-        for prefix, paths in self.routes.items():
+        for prefix, paths in list(self.routes.items()):
             if paths and paths[0]['rf'] in families:
                 routes[prefix] = paths
         return routes
@@ -550,7 +542,7 @@ class BGPContainer(Container):
         count = 0
         while True:
             res = self.local(cmd, capture=True)
-            print colors.yellow(res)
+            print(yellow(res))
             if ('1 packets received' in res or '1 received' in res) and '0% packet loss' in res:
                 break
             time.sleep(interval)
@@ -564,10 +556,9 @@ class BGPContainer(Container):
         count = 0
         while True:
             state = self.get_neighbor_state(peer)
-            y = colors.yellow
-            print y("{0}'s peer {1} state: {2}".format(self.router_id,
-                                                       peer.router_id,
-                                                       state))
+            print(yellow("{0}'s peer {1} state: {2}".format(self.router_id,
+                                                            peer.router_id,
+                                                            state)))
             if state == expected_state:
                 return
 

--- a/test/lib/bird.py
+++ b/test/lib/bird.py
@@ -13,19 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import time
-
-from fabric import colors
-from fabric.api import local
-from fabric.utils import indent
 
 from lib.base import (
     BGPContainer,
     CmdBuffer,
     try_several_times,
     wait_for_completion,
+    yellow,
+    indent,
+    local,
 )
 
 
@@ -64,7 +63,7 @@ class BirdContainer(BGPContainer):
     def create_config(self):
         c = CmdBuffer()
         c << 'router id {0};'.format(self.router_id)
-        for peer, info in self.peers.iteritems():
+        for peer, info in self.peers.items():
             c << 'protocol bgp {'
             c << '  local as {0};'.format(self.asn)
             n_addr = info['neigh_addr'].split('/')[0]
@@ -73,8 +72,8 @@ class BirdContainer(BGPContainer):
             c << '}'
 
         with open('{0}/bird.conf'.format(self.config_dir), 'w') as f:
-            print colors.yellow('[{0}\'s new bird.conf]'.format(self.name))
-            print colors.yellow(indent(str(c)))
+            print(yellow('[{0}\'s new bird.conf]'.format(self.name)))
+            print(yellow(indent(str(c))))
             f.writelines(str(c))
 
     def reload_config(self):
@@ -122,6 +121,6 @@ class RawBirdContainer(BirdContainer):
 
     def create_config(self):
         with open('{0}/bird.conf'.format(self.config_dir), 'w') as f:
-            print colors.yellow('[{0}\'s new bird.conf]'.format(self.name))
-            print colors.yellow(indent(self.config))
+            print(yellow('[{0}\'s new bird.conf]'.format(self.name)))
+            print(yellow(indent(self.config)))
             f.writelines(self.config)

--- a/test/lib/exabgp.py
+++ b/test/lib/exabgp.py
@@ -13,15 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
-from fabric import colors
 
 from lib.base import (
     BGPContainer,
     CmdBuffer,
     try_several_times,
     wait_for_completion,
+    yellow,
 )
 
 
@@ -68,7 +66,7 @@ class ExaBGPContainer(BGPContainer):
         # Manpage of exabgp.conf(5):
         # https://github.com/Exa-Networks/exabgp/blob/master/doc/man/exabgp.conf.5
         cmd = CmdBuffer('\n')
-        for peer, info in self.peers.iteritems():
+        for peer, info in self.peers.items():
             cmd << 'neighbor {0} {{'.format(info['neigh_addr'].split('/')[0])
             cmd << '    router-id {0};'.format(self.router_id)
             cmd << '    local-address {0};'.format(info['local_addr'].split('/')[0])
@@ -94,8 +92,8 @@ class ExaBGPContainer(BGPContainer):
             cmd << '}'
 
         with open('{0}/exabgpd.conf'.format(self.config_dir), 'w') as f:
-            print colors.yellow('[{0}\'s new exabgpd.conf]'.format(self.name))
-            print colors.yellow(str(cmd))
+            print(yellow('[{0}\'s new exabgpd.conf]'.format(self.name)))
+            print(yellow(str(cmd)))
             f.write(str(cmd))
 
     def _is_running(self):
@@ -306,6 +304,6 @@ class RawExaBGPContainer(ExaBGPContainer):
 
     def create_config(self):
         with open('{0}/exabgpd.conf'.format(self.config_dir), 'w') as f:
-            print colors.yellow('[{0}\'s new exabgpd.conf]'.format(self.name))
-            print colors.yellow(self.config)
+            print(yellow('[{0}\'s new exabgpd.conf]'.format(self.name)))
+            print(yellow(self.config))
             f.write(self.config)

--- a/test/lib/fabfile.py
+++ b/test/lib/fabfile.py
@@ -1,0 +1,28 @@
+import os
+from fabric2 import task
+from invoke import run as local
+from base import CmdBuffer
+
+
+@task
+def make_gobgp_ctn(ctx, tag='gobgp',
+                   local_gobgp_path='',
+                   from_image='osrg/quagga'):
+    if local_gobgp_path == '':
+        local_gobgp_path = os.getcwd()
+
+    c = CmdBuffer()
+    c << 'FROM {0}'.format(from_image)
+    c << 'ENV GO111MODULE on'
+    c << 'ADD gobgp /tmp/gobgp'
+    c << 'RUN cd /tmp/gobgp && go install ./cmd/gobgpd ./cmd/gobgp'
+
+    rindex = local_gobgp_path.rindex('gobgp')
+    if rindex < 0:
+        raise Exception('{0} seems not gobgp dir'.format(local_gobgp_path))
+
+    workdir = local_gobgp_path[:rindex]
+    os.chdir(workdir)
+    local('echo \'{0}\' > Dockerfile'.format(str(c)))
+    local('docker build -t {0} .'.format(tag))
+    local('rm Dockerfile')

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import collections
 import json
@@ -22,9 +22,6 @@ from threading import Thread
 import subprocess
 import os
 
-from fabric import colors
-from fabric.api import local
-from fabric.utils import indent
 import netaddr
 import toml
 import yaml
@@ -45,6 +42,9 @@ from lib.base import (
     BGP_FSM_IDLE,
     BGP_FSM_ACTIVE,
     BGP_FSM_ESTABLISHED,
+    yellow,
+    indent,
+    local,
 )
 
 
@@ -111,8 +111,7 @@ class GoBGPContainer(BGPContainer):
         c << '#!/bin/sh'
         c << '/go/bin/gobgpd -f {0}/gobgpd.conf -l {1} -p {2} -t {3} > ' \
              '{0}/gobgpd.log 2>&1'.format(self.SHARED_VOLUME, self.log_level, '-r' if graceful_restart else '', self.config_format)
-
-        cmd = 'echo "{0:s}" > {1}/start.sh'.format(c, self.config_dir)
+        cmd = 'echo "{0:s}" > {1}/start.sh'.format(str(c), self.config_dir)
         local(cmd, capture=True)
         cmd = "chmod 755 {0}/start.sh".format(self.config_dir)
         local(cmd, capture=True)
@@ -212,7 +211,7 @@ class GoBGPContainer(BGPContainer):
 
     def _get_rib(self, dests_dict):
         dests = []
-        for k, v in dests_dict.items():
+        for k, v in list(dests_dict.items()):
             for p in v:
                 p["nexthop"] = self._get_nexthop(p)
                 p["aspath"] = self._get_as_path(p)
@@ -282,7 +281,7 @@ class GoBGPContainer(BGPContainer):
                                                                 adj_type,
                                                                 prefix, rf)
         output = self.local(cmd, capture=True)
-        ret = [p[0] for p in json.loads(output).itervalues()]
+        ret = [p[0] for p in json.loads(output).values()]
         for p in ret:
             p["nexthop"] = self._get_nexthop(p)
             p["aspath"] = self._get_as_path(p)
@@ -313,7 +312,7 @@ class GoBGPContainer(BGPContainer):
 
     def clear_policy(self):
         self.policies = {}
-        for info in self.peers.itervalues():
+        for info in self.peers.values():
             info['policies'] = {}
         self.prefix_set = []
         self.neighbor_set = []
@@ -352,7 +351,7 @@ class GoBGPContainer(BGPContainer):
                 self._create_config_ospfd()
 
     def _merge_dict(self, dct, merge_dct):
-        for k, v in merge_dct.iteritems():
+        for k, v in merge_dct.items():
             if (k in dct and isinstance(dct[k], dict)
                     and isinstance(merge_dct[k], collections.Mapping)):
                 self._merge_dict(dct[k], merge_dct[k])
@@ -380,7 +379,7 @@ class GoBGPContainer(BGPContainer):
         if self.zebra and self.zapi_version == 2:
             config['global']['use-multiple-paths'] = {'config': {'enabled': True}}
 
-        for peer, info in self.peers.iteritems():
+        for peer, info in self.peers.items():
             afi_safi_list = []
             if info['interface'] != '':
                 afi_safi_list.append({'config': {'afi-safi-name': 'ipv4-unicast'}})
@@ -481,7 +480,7 @@ class GoBGPContainer(BGPContainer):
             if len(info.get('default-policy', [])) + len(info.get('policies', [])) > 0:
                 n['apply-policy'] = {'config': {}}
 
-            for typ, p in info.get('policies', {}).iteritems():
+            for typ, p in info.get('policies', {}).items():
                 n['apply-policy']['config']['{0}-policy-list'.format(typ)] = [p['name']]
 
             def _f(v):
@@ -491,7 +490,7 @@ class GoBGPContainer(BGPContainer):
                     return 'accept-route'
                 raise Exception('invalid default policy type {0}'.format(v))
 
-            for typ, d in info.get('default-policy', {}).iteritems():
+            for typ, d in info.get('default-policy', {}).items():
                 n['apply-policy']['config']['default-{0}-policy'.format(typ)] = _f(d)
 
             if info['treat_as_withdraw']:
@@ -510,7 +509,7 @@ class GoBGPContainer(BGPContainer):
             config['defined-sets']['bgp-defined-sets'] = self.bgp_set
 
         policy_list = []
-        for p in self.policies.itervalues():
+        for p in self.policies.values():
             policy = {'name': p['name']}
             if 'statements' in p:
                 policy['statements'] = p['statements']
@@ -525,7 +524,7 @@ class GoBGPContainer(BGPContainer):
                                           'version': self.zapi_version}}
 
         with open('{0}/gobgpd.conf'.format(self.config_dir), 'w') as f:
-            print colors.yellow('[{0}\'s new gobgpd.conf]'.format(self.name))
+            print(yellow('[{0}\'s new gobgpd.conf]'.format(self.name)))
             if self.config_format is 'toml':
                 raw = toml.dumps(config)
             elif self.config_format is 'yaml':
@@ -534,7 +533,8 @@ class GoBGPContainer(BGPContainer):
                 raw = json.dumps(config)
             else:
                 raise Exception('invalid config_format {0}'.format(self.config_format))
-            print colors.yellow(indent(raw))
+            raw = raw.strip()
+            print(yellow(indent(raw)))
             f.write(raw)
 
     def _create_config_zebra(self):
@@ -549,9 +549,10 @@ class GoBGPContainer(BGPContainer):
         c << ''
 
         with open('{0}/zebra.conf'.format(self.quagga_config_dir), 'w') as f:
-            print colors.yellow('[{0}\'s new zebra.conf]'.format(self.name))
-            print colors.yellow(indent(str(c)))
-            f.writelines(str(c))
+            print(yellow('[{0}\'s new zebra.conf]'.format(self.name)))
+            c = str(c).strip()
+            print(yellow(indent(c)))
+            f.writelines(c)
 
     def _create_config_ospfd(self):
         c = CmdBuffer()
@@ -560,14 +561,14 @@ class GoBGPContainer(BGPContainer):
         c << 'router ospf'
         for redistribute in self.ospfd_config.get('redistributes', []):
             c << ' redistribute {0}'.format(redistribute)
-        for network, area in self.ospfd_config.get('networks', {}).items():
+        for network, area in list(self.ospfd_config.get('networks', {}).items()):
             c << ' network {0} area {1}'.format(network, area)
         c << 'log file {0}/ospfd.log'.format(self.QUAGGA_VOLUME)
         c << ''
 
         with open('{0}/ospfd.conf'.format(self.quagga_config_dir), 'w') as f:
-            print colors.yellow('[{0}\'s new ospfd.conf]'.format(self.name))
-            print colors.yellow(indent(str(c)))
+            print(yellow('[{0}\'s new ospfd.conf]'.format(self.name)))
+            print(yellow(indent(str(c))))
             f.writelines(str(c))
 
     def reload_config(self):
@@ -671,6 +672,6 @@ class RawGoBGPContainer(GoBGPContainer):
 
     def create_config(self):
         with open('{0}/gobgpd.conf'.format(self.config_dir), 'w') as f:
-            print colors.yellow('[{0}\'s new gobgpd.conf]'.format(self.name))
-            print colors.yellow(indent(self.config))
+            print(yellow('[{0}\'s new gobgpd.conf]'.format(self.name)))
+            print(yellow(indent(self.config)))
             f.write(self.config)

--- a/test/lib/yabgp_helper.py
+++ b/test/lib/yabgp_helper.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import absolute_import
-from __future__ import print_function
 
 import json
 import logging

--- a/test/pip-requires.txt
+++ b/test/pip-requires.txt
@@ -1,8 +1,10 @@
 nose
 toml
 pyyaml
-fabric<2.0.0
+fabric
 netaddr
 nsenter
 docker-py
 ryu
+colored
+invoke

--- a/test/scenario_test/README.md
+++ b/test/scenario_test/README.md
@@ -57,7 +57,7 @@ Execute the following commands inside the VM to install the dependencies:
 
     ```shell
     $ sudo apt-get update
-    $ sudo apt-get install git python-pip python-dev iputils-arping bridge-utils lv
+    $ sudo apt-get install git python3-pip python3-dev iputils-arping bridge-utils lv
     $ sudo wget https://raw.github.com/jpetazzo/pipework/master/pipework -O /usr/local/bin/pipework
     $ sudo chmod 755 /usr/local/bin/pipework
     ```
@@ -91,7 +91,7 @@ You also need this operation at every modification to the source code.
 
 ```shell
 $ cd $GOPATH/src/github.com/osrg/gobgp
-$ sudo fab -f ./test/lib/base.py make_gobgp_ctn --set tag=gobgp
+$ sudo fab2 -r ./test/lib make-gobgp-ctn
 ```
 
 ## Run test
@@ -116,7 +116,7 @@ $ sudo fab -f ./test/lib/base.py make_gobgp_ctn --set tag=gobgp
 
     ```shell
     $ cd $GOPATH/src/github.com/osrg/gobgp/test/scenario_test
-    $ sudo -E PYTHONPATH=$GOBGP/test python <scenario test name>.py
+    $ sudo -E PYTHONPATH=$GOBGP/test python3 <scenario test name>.py
     ...
     OK
     ```

--- a/test/scenario_test/addpath_test.py
+++ b/test/scenario_test/addpath_test.py
@@ -18,12 +18,12 @@ import time
 import unittest
 
 import nose
-from fabric.api import local
 
 from lib import base
 from lib.base import (
     BGP_FSM_ESTABLISHED,
     assert_several_times,
+    local,
 )
 from lib.gobgp import GoBGPContainer
 from lib.exabgp import ExaBGPContainer
@@ -252,7 +252,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/aspath_test.py
+++ b/test/scenario_test/aspath_test.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
@@ -28,6 +27,7 @@ from lib import base
 from lib.base import (
     BGP_FSM_ESTABLISHED,
     assert_several_times,
+    local,
 )
 from lib.gobgp import GoBGPContainer
 from lib.quagga import QuaggaBGPContainer
@@ -173,7 +173,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/bgp_confederation_test.py
+++ b/test/scenario_test/bgp_confederation_test.py
@@ -13,20 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
+
+
 
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
 
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED
+from lib.base import BGP_FSM_ESTABLISHED, local
 from lib.gobgp import GoBGPContainer
 from lib.quagga import QuaggaBGPContainer
 
@@ -113,7 +112,7 @@ class GoBGPTestBase(unittest.TestCase):
             if routes:
                 break
             time.sleep(1)
-        self.failIf(len(routes) == 0)
+        self.assertFalse(len(routes) == 0)
 
         # Confirm AS_PATH in confederation is removed
         self._check_global_rib_first(self.quaggas['q1'], '10.0.0.0/24', [30, 20, 21])
@@ -133,8 +132,8 @@ class GoBGPTestBase(unittest.TestCase):
                 if len(routes[0]['paths']) == 2:
                     break
             time.sleep(1)
-        self.failIf(len(routes) != 1)
-        self.failIf(len(routes[0]['paths']) != 2)
+        self.assertFalse(len(routes) != 1)
+        self.assertFalse(len(routes[0]['paths']) != 2)
 
         # In g1, there are two routes to 10.0.0.0/24
         # confirm the route from q1 is selected as the best path

--- a/test/scenario_test/bgp_malformed_msg_handling_test.py
+++ b/test/scenario_test/bgp_malformed_msg_handling_test.py
@@ -13,19 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
 
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED
+from lib.base import BGP_FSM_ESTABLISHED, local
 from lib.gobgp import GoBGPContainer
 from lib.exabgp import ExaBGPContainer
 
@@ -101,7 +100,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/bgp_unnumbered_test.py
+++ b/test/scenario_test/bgp_unnumbered_test.py
@@ -13,12 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import unittest
-from fabric.api import local
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED
+from lib.base import BGP_FSM_ESTABLISHED, local
 from lib.gobgp import GoBGPContainer
 import sys
 import os
@@ -92,7 +91,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/bgp_zebra_nht_test.py
+++ b/test/scenario_test/bgp_zebra_nht_test.py
@@ -17,7 +17,6 @@ import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
@@ -27,6 +26,7 @@ from lib.base import (
     assert_several_times,
     Bridge,
     BGP_FSM_ESTABLISHED,
+    local,
 )
 from lib.gobgp import GoBGPContainer
 from lib.quagga import QuaggaOSPFContainer
@@ -285,7 +285,7 @@ class ZebraNHTTest(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/bgp_zebra_test.py
+++ b/test/scenario_test/bgp_zebra_test.py
@@ -13,14 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
 
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
@@ -29,6 +26,7 @@ from lib import base
 from lib.base import (
     Bridge,
     BGP_FSM_ESTABLISHED,
+    local,
 )
 from lib.gobgp import GoBGPContainer
 from lib.quagga import QuaggaBGPContainer

--- a/test/scenario_test/ci-scripts/jenkins-build-script.sh
+++ b/test/scenario_test/ci-scripts/jenkins-build-script.sh
@@ -33,7 +33,7 @@ do
 done
 
 sudo docker rmi $GOBGP_IMAGE
-sudo fab -f $GOBGP/test/lib/base.py make_gobgp_ctn:tag=$GOBGP_IMAGE
+sudo fab2 -r $GOBGP/test/lib make-gobgp-ctn
 [ "$?" != 0 ] && exit "$?"
 
 cd $GOBGP/gobgpd

--- a/test/scenario_test/evpn_test.py
+++ b/test/scenario_test/evpn_test.py
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 from itertools import combinations
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
@@ -29,6 +28,7 @@ from lib import base
 from lib.base import (
     BGP_FSM_ESTABLISHED,
     BGP_ATTR_TYPE_EXTENDED_COMMUNITIES,
+    local,
 )
 from lib.gobgp import GoBGPContainer
 
@@ -145,7 +145,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/flow_spec_test.py
+++ b/test/scenario_test/flow_spec_test.py
@@ -13,19 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
 
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED
+from lib.base import BGP_FSM_ESTABLISHED, local
 from lib.gobgp import GoBGPContainer
 from lib.exabgp import ExaBGPContainer
 from lib.yabgp import YABGPContainer
@@ -411,7 +410,7 @@ class FlowSpecTest(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/graceful_restart_test.py
+++ b/test/scenario_test/graceful_restart_test.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
@@ -30,6 +29,7 @@ from lib.base import (
     BGP_FSM_ACTIVE,
     BGP_FSM_ESTABLISHED,
     GRACEFUL_RESTART_TIME,
+    local,
 )
 from lib.gobgp import GoBGPContainer
 
@@ -196,7 +196,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/long_lived_graceful_restart_test.py
+++ b/test/scenario_test/long_lived_graceful_restart_test.py
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 from itertools import chain
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
@@ -30,6 +29,7 @@ from lib.base import (
     BGP_FSM_ACTIVE,
     BGP_FSM_ESTABLISHED,
     LONG_LIVED_GRACEFUL_RESTART_TIME,
+    local,
 )
 from lib.gobgp import GoBGPContainer
 
@@ -166,7 +166,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/route_server_as2_test.py
+++ b/test/scenario_test/route_server_as2_test.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import unittest
 import sys
 import time
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
@@ -28,6 +27,7 @@ from lib import base
 from lib.base import (
     BGP_FSM_IDLE,
     BGP_FSM_ESTABLISHED,
+    local,
 )
 from lib.gobgp import GoBGPContainer
 from lib.exabgp import ExaBGPContainer
@@ -76,11 +76,11 @@ class GoBGPTestBase(unittest.TestCase):
 
     # test each neighbor state is turned establish
     def test_01_neighbor_established(self):
-        for q in self.quaggas.itervalues():
+        for q in self.quaggas.values():
             self.gobgp.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=q)
 
     def test_02_check_gobgp_local_rib(self):
-        for rs_client in self.quaggas.itervalues():
+        for rs_client in self.quaggas.values():
             done = False
             for _ in range(self.retry_limit):
                 if done:
@@ -111,7 +111,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/route_server_ipv4_v6_test.py
+++ b/test/scenario_test/route_server_ipv4_v6_test.py
@@ -13,19 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
 
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED
+from lib.base import BGP_FSM_ESTABLISHED, local
 from lib.gobgp import GoBGPContainer
 from lib.quagga import QuaggaBGPContainer
 
@@ -77,7 +76,7 @@ class GoBGPIPv6Test(unittest.TestCase):
         cls.ipv6s = {'q3': q3, 'q4': q4}
 
     def check_gobgp_local_rib(self, ctns, rf):
-        for rs_client in ctns.itervalues():
+        for rs_client in ctns.values():
             done = False
             for _ in range(self.retry_limit):
                 if done:
@@ -93,7 +92,7 @@ class GoBGPIPv6Test(unittest.TestCase):
 
                 self.assertEqual(len(local_rib), (len(ctns) - 1))
 
-                for c in ctns.itervalues():
+                for c in ctns.values():
                     if rs_client != c:
                         for r in c.routes:
                             self.assertTrue(r in local_rib)
@@ -105,7 +104,7 @@ class GoBGPIPv6Test(unittest.TestCase):
             raise AssertionError
 
     def check_rs_client_rib(self, ctns, rf):
-        for rs_client in ctns.itervalues():
+        for rs_client in ctns.values():
             done = False
             for _ in range(self.retry_limit):
                 if done:
@@ -118,7 +117,7 @@ class GoBGPIPv6Test(unittest.TestCase):
 
                 self.assertEqual(len(global_rib), len(ctns))
 
-                for c in ctns.itervalues():
+                for c in ctns.values():
                     for r in c.routes:
                         self.assertTrue(r in global_rib)
 
@@ -130,7 +129,7 @@ class GoBGPIPv6Test(unittest.TestCase):
 
     # test each neighbor state is turned establish
     def test_01_neighbor_established(self):
-        for q in self.quaggas.itervalues():
+        for q in self.quaggas.values():
             self.gobgp.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=q)
 
     def test_02_check_ipv4_peer_rib(self):
@@ -142,7 +141,7 @@ class GoBGPIPv6Test(unittest.TestCase):
         self.check_rs_client_rib(self.ipv6s, 'ipv6')
 
     def test_04_add_in_policy_to_reject_all(self):
-        for q in self.gobgp.peers.itervalues():
+        for q in self.gobgp.peers.values():
             self.gobgp.local('gobgp neighbor {0} policy import set default reject'.format(q['neigh_addr'].split('/')[0]))
 
     def test_05_check_ipv4_peer_rib(self):
@@ -158,11 +157,11 @@ class GoBGPIPv6Test(unittest.TestCase):
         time.sleep(1)
 
     def test_08_check_rib(self):
-        for q in self.ipv4s.itervalues():
+        for q in self.ipv4s.values():
             self.assertEqual(len(self.gobgp.get_adj_rib_out(q)), 0)
             self.assertEqual(len(q.get_global_rib()), len(q.routes))
 
-        for q in self.ipv6s.itervalues():
+        for q in self.ipv6s.values():
             self.assertEqual(len(self.gobgp.get_adj_rib_out(q, rf='ipv6')), 0)
             self.assertEqual(len(q.get_global_rib(rf='ipv6')), len(q.routes))
 
@@ -170,7 +169,7 @@ class GoBGPIPv6Test(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/route_server_malformed_test.py
+++ b/test/scenario_test/route_server_malformed_test.py
@@ -13,20 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 import inspect
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
 
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED
+from lib.base import BGP_FSM_ESTABLISHED, local
 from lib.gobgp import GoBGPContainer
 from lib.exabgp import ExaBGPContainer
 
@@ -42,7 +41,7 @@ def register_scenario(cls):
 
 
 def lookup_scenario(name):
-    for value in _SCENARIOS.values():
+    for value in list(_SCENARIOS.values()):
         if value.__name__ == name:
             return value
     return None
@@ -522,14 +521,14 @@ class TestGoBGPBase(unittest.TestCase):
         cls.parser_option = parser_option
         cls.executors = []
         if idx == 0:
-            print 'unset test-index. run all test sequential'
-            for _, v in _SCENARIOS.items():
+            print('unset test-index. run all test sequential')
+            for _, v in list(_SCENARIOS.items()):
                 for k, m in inspect.getmembers(v, inspect.isfunction):
                     if k == 'executor':
                         cls.executor = m
                 cls.executors.append(cls.executor)
         elif idx not in _SCENARIOS:
-            print 'invalid test-index. # of scenarios: {0}'.format(len(_SCENARIOS))
+            print('invalid test-index. # of scenarios: {0}'.format(len(_SCENARIOS)))
             sys.exit(1)
         else:
             for k, m in inspect.getmembers(_SCENARIOS[idx], inspect.isfunction):
@@ -545,7 +544,7 @@ class TestGoBGPBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/route_server_policy_grpc_test.py
+++ b/test/scenario_test/route_server_policy_grpc_test.py
@@ -13,18 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 import inspect
 
-from fabric.api import local
 import nose
 from nose.tools import (
     assert_true,
     assert_false,
+    local,
 )
 
 from lib.noseplugin import OptionParser, parser_option
@@ -52,7 +52,7 @@ def register_scenario(cls):
 
 
 def lookup_scenario(name):
-    for value in _SCENARIOS.values():
+    for value in list(_SCENARIOS.values()):
         if value.__name__ == name:
             return value
     return None
@@ -822,9 +822,9 @@ class ImportPolicyAsPathLengthCondition(object):
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
         # this will be blocked
-        e1.add_route('192.168.100.0/24', aspath=range(e1.asn, e1.asn - 10, -1))
+        e1.add_route('192.168.100.0/24', aspath=list(range(e1.asn, e1.asn - 10, -1)))
         # this will pass
-        e1.add_route('192.168.200.0/24', aspath=range(e1.asn, e1.asn - 8, -1))
+        e1.add_route('192.168.200.0/24', aspath=list(range(e1.asn, e1.asn - 8, -1)))
 
         for c in [e1, q1, q2]:
             g1.wait_for(BGP_FSM_ESTABLISHED, c)
@@ -878,9 +878,9 @@ class ImportPolicyAsPathCondition(object):
         g1.local('gobgp neighbor {0} policy import add policy0'.format(g1.peers[q2]['neigh_addr'].split('/')[0]))
 
         # this will be blocked
-        e1.add_route('192.168.100.0/24', aspath=range(e1.asn, e1.asn - 10, -1))
+        e1.add_route('192.168.100.0/24', aspath=list(range(e1.asn, e1.asn - 10, -1)))
         # this will pass
-        e1.add_route('192.168.200.0/24', aspath=range(e1.asn - 1, e1.asn - 10, -1))
+        e1.add_route('192.168.200.0/24', aspath=list(range(e1.asn - 1, e1.asn - 10, -1)))
 
         for c in [e1, q1, q2]:
             g1.wait_for(BGP_FSM_ESTABLISHED, c)
@@ -2687,14 +2687,14 @@ class TestGoBGPBase(unittest.TestCase):
         cls.parser_option = parser_option
         cls.executors = []
         if idx == 0:
-            print 'unset test-index. run all test sequential'
-            for _, v in _SCENARIOS.items():
+            print('unset test-index. run all test sequential')
+            for _, v in list(_SCENARIOS.items()):
                 for k, m in inspect.getmembers(v, inspect.isfunction):
                     if k == 'executor':
                         cls.executor = m
                 cls.executors.append(cls.executor)
         elif idx not in _SCENARIOS:
-            print 'invalid test-index. # of scenarios: {0}'.format(len(_SCENARIOS))
+            print('invalid test-index. # of scenarios: {0}'.format(len(_SCENARIOS)))
             sys.exit(1)
         else:
             for k, m in inspect.getmembers(_SCENARIOS[idx], inspect.isfunction):
@@ -2710,7 +2710,7 @@ class TestGoBGPBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/route_server_policy_test.py
+++ b/test/scenario_test/route_server_policy_test.py
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 import inspect
 
-from fabric.api import local
 import nose
 from nose.tools import (
     assert_true,
@@ -35,6 +34,7 @@ from lib.base import (
     BGP_FSM_ESTABLISHED,
     BGP_ATTR_TYPE_COMMUNITIES,
     BGP_ATTR_TYPE_EXTENDED_COMMUNITIES,
+    local,
 )
 from lib.gobgp import GoBGPContainer
 from lib.quagga import QuaggaBGPContainer
@@ -52,7 +52,7 @@ def register_scenario(cls):
 
 
 def lookup_scenario(name):
-    for value in _SCENARIOS.values():
+    for value in list(_SCENARIOS.values()):
         if value.__name__ == name:
             return value
     return None
@@ -925,9 +925,9 @@ class ImportPolicyAsPathLengthCondition(object):
         g1.add_policy(policy, q2, 'import')
 
         # this will be blocked
-        e1.add_route('192.168.100.0/24', aspath=range(e1.asn, e1.asn - 10, -1))
+        e1.add_route('192.168.100.0/24', aspath=list(range(e1.asn, e1.asn - 10, -1)))
         # this will pass
-        e1.add_route('192.168.200.0/24', aspath=range(e1.asn, e1.asn - 8, -1))
+        e1.add_route('192.168.200.0/24', aspath=list(range(e1.asn, e1.asn - 8, -1)))
 
         for c in [e1, q1, q2]:
             g1.wait_for(BGP_FSM_ESTABLISHED, c)
@@ -985,9 +985,9 @@ class ImportPolicyAsPathCondition(object):
         g1.add_policy(policy, q2, 'import')
 
         # this will be blocked
-        e1.add_route('192.168.100.0/24', aspath=range(e1.asn, e1.asn - 10, -1))
+        e1.add_route('192.168.100.0/24', aspath=list(range(e1.asn, e1.asn - 10, -1)))
         # this will pass
-        e1.add_route('192.168.200.0/24', aspath=range(e1.asn - 1, e1.asn - 10, -1))
+        e1.add_route('192.168.200.0/24', aspath=list(range(e1.asn - 1, e1.asn - 10, -1)))
 
         for c in [e1, q1, q2]:
             g1.wait_for(BGP_FSM_ESTABLISHED, c)
@@ -3162,14 +3162,14 @@ class TestGoBGPBase():
         cls.parser_option = parser_option
         cls.executors = []
         if idx == 0:
-            print 'unset test-index. run all test sequential'
-            for _, v in _SCENARIOS.items():
+            print('unset test-index. run all test sequential')
+            for _, v in list(_SCENARIOS.items()):
                 for k, m in inspect.getmembers(v, inspect.isfunction):
                     if k == 'executor':
                         cls.executor = m
                 cls.executors.append(cls.executor)
         elif idx not in _SCENARIOS:
-            print 'invalid test-index. # of scenarios: {0}'.format(len(_SCENARIOS))
+            print('invalid test-index. # of scenarios: {0}'.format(len(_SCENARIOS)))
             sys.exit(1)
         else:
             for k, m in inspect.getmembers(_SCENARIOS[idx], inspect.isfunction):
@@ -3185,7 +3185,7 @@ class TestGoBGPBase():
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/route_server_softreset_test.py
+++ b/test/scenario_test/route_server_softreset_test.py
@@ -13,19 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
 
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED
+from lib.base import BGP_FSM_ESTABLISHED, local
 from lib.gobgp import GoBGPContainer
 
 
@@ -61,7 +60,7 @@ class GoBGPTestBase(unittest.TestCase):
 
         time.sleep(initial_wait_time)
 
-        for cli in cls.clients.itervalues():
+        for cli in cls.clients.values():
             g1.add_peer(cli, is_rs_client=True, passwd='passwd', passive=True, prefix_limit=10)
             cli.add_peer(g1, passwd='passwd')
 
@@ -69,7 +68,7 @@ class GoBGPTestBase(unittest.TestCase):
 
     # test each neighbor state is turned establish
     def test_01_neighbor_established(self):
-        for cli in self.clients.itervalues():
+        for cli in self.clients.values():
             self.gobgp.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=cli)
 
     def test_02_softresetin_test1(self):
@@ -137,7 +136,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/route_server_test.py
+++ b/test/scenario_test/route_server_test.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
@@ -28,6 +27,7 @@ from lib import base
 from lib.base import (
     BGP_FSM_ACTIVE,
     BGP_FSM_ESTABLISHED,
+    local,
 )
 from lib.gobgp import GoBGPContainer
 from lib.quagga import QuaggaBGPContainer
@@ -74,7 +74,7 @@ class GoBGPTestBase(unittest.TestCase):
         cls.quaggas = {'q1': q1, 'q2': q2, 'q3': q3}
 
     def check_gobgp_local_rib(self):
-        for rs_client in self.quaggas.itervalues():
+        for rs_client in self.quaggas.values():
             done = False
             for _ in range(self.retry_limit):
                 if done:
@@ -90,7 +90,7 @@ class GoBGPTestBase(unittest.TestCase):
 
                 self.assertEqual(len(local_rib), (len(self.quaggas) - 1))
 
-                for c in self.quaggas.itervalues():
+                for c in self.quaggas.values():
                     if rs_client != c:
                         for r in c.routes:
                             self.assertTrue(r in local_rib)
@@ -102,7 +102,7 @@ class GoBGPTestBase(unittest.TestCase):
             raise AssertionError
 
     def check_rs_client_rib(self):
-        for rs_client in self.quaggas.itervalues():
+        for rs_client in self.quaggas.values():
             done = False
             for _ in range(self.retry_limit):
                 if done:
@@ -115,7 +115,7 @@ class GoBGPTestBase(unittest.TestCase):
 
                 self.assertEqual(len(global_rib), len(self.quaggas))
 
-                for c in self.quaggas.itervalues():
+                for c in self.quaggas.values():
                     for r in c.routes:
                         self.assertTrue(r in global_rib)
 
@@ -127,7 +127,7 @@ class GoBGPTestBase(unittest.TestCase):
 
     # test each neighbor state is turned establish
     def test_01_neighbor_established(self):
-        for q in self.quaggas.itervalues():
+        for q in self.quaggas.values():
             self.gobgp.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=q)
 
     # check advertised routes are stored in route-server's local-rib
@@ -223,8 +223,8 @@ class GoBGPTestBase(unittest.TestCase):
                 time.sleep(self.wait_per_retry)
                 for path in q1.get_global_rib():
                     if path['prefix'] == target_prefix:
-                        print "{0}'s nexthop is {1}".format(path['prefix'],
-                                                            path['nexthop'])
+                        print("{0}'s nexthop is {1}".format(path['prefix'],
+                                                            path['nexthop']))
                         n_addrs = [i[1].split('/')[0] for i in
                                    expected_nexthop.ip_addrs]
                         if path['nexthop'] in n_addrs:
@@ -251,7 +251,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/route_server_test2.py
+++ b/test/scenario_test/route_server_test2.py
@@ -13,19 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
 
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED
+from lib.base import BGP_FSM_ESTABLISHED, local
 from lib.gobgp import GoBGPContainer
 from lib.exabgp import ExaBGPContainer
 
@@ -53,7 +52,7 @@ class GoBGPTestBase(unittest.TestCase):
         initial_wait_time = max(ctn.run() for ctn in ctns)
         time.sleep(initial_wait_time)
 
-        for cli in cls.clients.values():
+        for cli in list(cls.clients.values()):
             # Omit "passwd" to avoid a issue on ExaBGP version 4.0.5:
             # https://github.com/Exa-Networks/exabgp/issues/766
             g1.add_peer(cli, is_rs_client=True, passive=True, prefix_limit=10)
@@ -67,7 +66,7 @@ class GoBGPTestBase(unittest.TestCase):
 
     # test each neighbor state is turned establish
     def test_01_neighbor_established(self):
-        for cli in self.clients.values():
+        for cli in list(self.clients.values()):
             self.gobgp.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=cli)
 
     def test_02_add_neighbor(self):
@@ -103,7 +102,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/rtc_test.py
+++ b/test/scenario_test/rtc_test.py
@@ -13,20 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 from itertools import combinations
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
 
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED
+from lib.base import BGP_FSM_ESTABLISHED, local
 from lib.gobgp import GoBGPContainer
 
 
@@ -986,7 +985,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/run_all_tests.sh
+++ b/test/scenario_test/run_all_tests.sh
@@ -34,51 +34,51 @@ PIDS=()
 export PYTHONPATH=$GOBGP/test:$PYTHONPATH
 
 # route server test
-python route_server_test.py --gobgp-image $GOBGP_IMAGE --test-prefix rs -s -x --with-xunit --xunit-file=${WS}/nosetest.xml &
+python3 route_server_test.py --gobgp-image $GOBGP_IMAGE --test-prefix rs -s -x --with-xunit --xunit-file=${WS}/nosetest.xml &
 PIDS=("${PIDS[@]}" $!)
 
 # route server ipv4 ipv6 test
-python route_server_ipv4_v6_test.py --gobgp-image $GOBGP_IMAGE --test-prefix v6 -s -x --with-xunit --xunit-file=${WS}/nosetest_ip.xml &
+python3 route_server_ipv4_v6_test.py --gobgp-image $GOBGP_IMAGE --test-prefix v6 -s -x --with-xunit --xunit-file=${WS}/nosetest_ip.xml &
 PIDS=("${PIDS[@]}" $!)
 
 # bgp router test
-python bgp_router_test.py --gobgp-image $GOBGP_IMAGE --test-prefix bgp -s -x --with-xunit --xunit-file=${WS}/nosetest_bgp.xml &
+python3 bgp_router_test.py --gobgp-image $GOBGP_IMAGE --test-prefix bgp -s -x --with-xunit --xunit-file=${WS}/nosetest_bgp.xml &
 PIDS=("${PIDS[@]}" $!)
 
 # ibgp router test
-python ibgp_router_test.py --gobgp-image $GOBGP_IMAGE --test-prefix ibgp -s -x --with-xunit --xunit-file=${WS}/nosetest_ibgp.xml &
+python3 ibgp_router_test.py --gobgp-image $GOBGP_IMAGE --test-prefix ibgp -s -x --with-xunit --xunit-file=${WS}/nosetest_ibgp.xml &
 PIDS=("${PIDS[@]}" $!)
 
 # evpn router test
-python evpn_test.py --gobgp-image $GOBGP_IMAGE --test-prefix evpn -s -x --with-xunit --xunit-file=${WS}/nosetest_evpn.xml &
+python3 evpn_test.py --gobgp-image $GOBGP_IMAGE --test-prefix evpn -s -x --with-xunit --xunit-file=${WS}/nosetest_evpn.xml &
 PIDS=("${PIDS[@]}" $!)
 
 # flowspec test
-python flow_spec_test.py --gobgp-image $GOBGP_IMAGE --test-prefix flow -s -x --with-xunit --xunit-file=${WS}/nosetest_flow.xml &
+python3 flow_spec_test.py --gobgp-image $GOBGP_IMAGE --test-prefix flow -s -x --with-xunit --xunit-file=${WS}/nosetest_flow.xml &
 PIDS=("${PIDS[@]}" $!)
 
 # route reflector test
-python route_reflector_test.py --gobgp-image $GOBGP_IMAGE --test-prefix rr -s -x --with-xunit --xunit-file=${WS}/nosetest_rr.xml &
+python3 route_reflector_test.py --gobgp-image $GOBGP_IMAGE --test-prefix rr -s -x --with-xunit --xunit-file=${WS}/nosetest_rr.xml &
 PIDS=("${PIDS[@]}" $!)
 
 # zebra test
-python bgp_zebra_test.py --gobgp-image $GOBGP_IMAGE --test-prefix zebra -s -x --with-xunit --xunit-file=${WS}/nosetest_zebra.xml &
+python3 bgp_zebra_test.py --gobgp-image $GOBGP_IMAGE --test-prefix zebra -s -x --with-xunit --xunit-file=${WS}/nosetest_zebra.xml &
 PIDS=("${PIDS[@]}" $!)
 
 # global policy test
-python global_policy_test.py --gobgp-image $GOBGP_IMAGE --test-prefix gpol -s -x --with-xunit --xunit-file=${WS}/nosetest_global_policy.xml &
+python3 global_policy_test.py --gobgp-image $GOBGP_IMAGE --test-prefix gpol -s -x --with-xunit --xunit-file=${WS}/nosetest_global_policy.xml &
 PIDS=("${PIDS[@]}" $!)
 
 # route server as2 test
-python route_server_as2_test.py --gobgp-image $GOBGP_IMAGE --test-prefix as2 -s -x --with-xunit --xunit-file=${WS}/nosetest_rs_as2.xml &
+python3 route_server_as2_test.py --gobgp-image $GOBGP_IMAGE --test-prefix as2 -s -x --with-xunit --xunit-file=${WS}/nosetest_rs_as2.xml &
 PIDS=("${PIDS[@]}" $!)
 
 # graceful restart test
-python graceful_restart_test.py --gobgp-image $GOBGP_IMAGE --test-prefix gr -s -x --with-xunit --xunit-file=${WS}/nosetest_rs_gr.xml &
+python3 graceful_restart_test.py --gobgp-image $GOBGP_IMAGE --test-prefix gr -s -x --with-xunit --xunit-file=${WS}/nosetest_rs_gr.xml &
 PIDS=("${PIDS[@]}" $!)
 
 # bgp unnumbered test
-python bgp_unnumbered_test.py --gobgp-image $GOBGP_IMAGE --test-prefix un -s -x --with-xunit --xunit-file=${WS}/nosetest_rs_un.xml &
+python3 bgp_unnumbered_test.py --gobgp-image $GOBGP_IMAGE --test-prefix un -s -x --with-xunit --xunit-file=${WS}/nosetest_rs_un.xml &
 PIDS=("${PIDS[@]}" $!)
 
 for (( i = 0; i < ${#PIDS[@]}; ++i ))
@@ -92,11 +92,11 @@ done
 PIDS=()
 
 # route server malformed message test
-NUM=$(python route_server_malformed_test.py --test-index -1 -s 2> /dev/null | awk '/invalid/{print $NF}')
+NUM=$(python3 route_server_malformed_test.py --test-index -1 -s 2> /dev/null | awk '/invalid/{print $NF}')
 PARALLEL_NUM=10
 for (( i = 1; i < $(( $NUM + 1)); ++i ))
 do
-    python route_server_malformed_test.py --gobgp-image $GOBGP_IMAGE --test-prefix mal$i --test-index $i -s -x --gobgp-log-level debug --with-xunit --xunit-file=${WS}/nosetest_malform${i}.xml &
+    python3 route_server_malformed_test.py --gobgp-image $GOBGP_IMAGE --test-prefix mal$i --test-index $i -s -x --gobgp-log-level debug --with-xunit --xunit-file=${WS}/nosetest_malform${i}.xml &
     PIDS=("${PIDS[@]}" $!)
     sleep 3
 done
@@ -110,14 +110,14 @@ do
 done
 
 # route server policy test
-NUM=$(python route_server_policy_test.py --test-index -1 -s 2> /dev/null | awk '/invalid/{print $NF}')
+NUM=$(python3 route_server_policy_test.py --test-index -1 -s 2> /dev/null | awk '/invalid/{print $NF}')
 PARALLEL_NUM=25
 for (( i = 0; i < $(( NUM / PARALLEL_NUM + 1)); ++i ))
 do
     PIDS=()
     for (( j = $((PARALLEL_NUM * $i + 1)); j < $((PARALLEL_NUM * ($i+1) + 1)); ++j))
     do
-        python route_server_policy_test.py --gobgp-image $GOBGP_IMAGE --test-prefix p$j --test-index $j -s -x --gobgp-log-level debug --with-xunit --xunit-file=${WS}/nosetest_policy${j}.xml &
+        python3 route_server_policy_test.py --gobgp-image $GOBGP_IMAGE --test-prefix p$j --test-index $j -s -x --gobgp-log-level debug --with-xunit --xunit-file=${WS}/nosetest_policy${j}.xml &
         PIDS=("${PIDS[@]}" $!)
         if [ $j -eq $NUM ]; then
             break
@@ -136,14 +136,14 @@ do
 done
 
 # route server policy grpc test
-NUM=$(python route_server_policy_grpc_test.py --test-index -1 -s 2> /dev/null | awk '/invalid/{print $NF}')
+NUM=$(python3 route_server_policy_grpc_test.py --test-index -1 -s 2> /dev/null | awk '/invalid/{print $NF}')
 PARALLEL_NUM=25
 for (( i = 0; i < $(( NUM / PARALLEL_NUM + 1)); ++i ))
 do
     PIDS=()
     for (( j = $((PARALLEL_NUM * $i + 1)); j < $((PARALLEL_NUM * ($i+1) + 1)); ++j))
     do
-        python route_server_policy_grpc_test.py --gobgp-image $GOBGP_IMAGE --test-prefix pg$j --test-index $j -s -x --gobgp-log-level debug --with-xunit --xunit-file=${WS}/nosetest_policy_grpc${j}.xml &
+        python3 route_server_policy_grpc_test.py --gobgp-image $GOBGP_IMAGE --test-prefix pg$j --test-index $j -s -x --gobgp-log-level debug --with-xunit --xunit-file=${WS}/nosetest_policy_grpc${j}.xml &
         PIDS=("${PIDS[@]}" $!)
         if [ $j -eq $NUM ]; then
             break

--- a/test/scenario_test/vrf_neighbor_test.py
+++ b/test/scenario_test/vrf_neighbor_test.py
@@ -13,19 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
 
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED
+from lib.base import BGP_FSM_ESTABLISHED, local
 from lib.gobgp import GoBGPContainer
 
 
@@ -171,7 +170,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/vrf_neighbor_test2.py
+++ b/test/scenario_test/vrf_neighbor_test2.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
@@ -29,6 +28,7 @@ from lib.base import (
     BGP_FSM_ACTIVE,
     BGP_FSM_ESTABLISHED,
     wait_for_completion,
+    local,
 )
 from lib.gobgp import GoBGPContainer
 
@@ -138,7 +138,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],

--- a/test/scenario_test/zapi_v3_test.py
+++ b/test/scenario_test/zapi_v3_test.py
@@ -13,19 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
+
 
 import sys
 import time
 import unittest
 
-from fabric.api import local
 import nose
 
 from lib.noseplugin import OptionParser, parser_option
 
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED
+from lib.base import BGP_FSM_ESTABLISHED, local
 from lib.gobgp import GoBGPContainer
 
 
@@ -97,7 +96,7 @@ class GoBGPTestBase(unittest.TestCase):
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
     if int(output) is not 0:
-        print "docker not found"
+        print("docker not found")
         sys.exit(1)
 
     nose.main(argv=sys.argv, addplugins=[OptionParser()],


### PR DESCRIPTION
This PR removes dependencies on old Fabric version, as it's not
supported by Python3.

The current Fabric versions don't support the colors and indent
used previously, so we found substitute methods from other
libraries and defined these in the library files.

The local function from fabric is now just a wrapper to invoke's
run function. All the files were processed through 2to3 command.

All the tests were executed and we don't see any difference on
the outputs when running Python2 or Python3.

The creation of gobgp container is removed from base.py into
fabfile.py, in order to comply with Fabric2 changes and simplify
dependencies.