### PR TITLE
Avoid panic by receiving vpnv6 prefixes with zebra reported in is…

### DIFF
--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -925,7 +925,8 @@ func showNeighborRib(r string, name string, args []string) error {
 			for _, dst := range rib {
 				prefix := dst.Prefix
 				if t == api.TableType_VRF {
-					s := strings.Split(prefix, ":")
+					// extract prefix from original which is RD(AS:VRF):IPv4 or IPv6 address
+					s := strings.SplitN(prefix, ":", 3)
 					prefix = s[len(s)-1]
 				}
 				_, p, _ := net.ParseCIDR(prefix)

--- a/docs/sources/zebra.md
+++ b/docs/sources/zebra.md
@@ -15,11 +15,11 @@ version 4), 5.0.x (Zebra API version 5), and 7.0.x (Zebra API version
 6) are supported as default. FRRouting version 5.0.x changes zebra
 message and it doesn't keep backward compatibility for FRRouting
 version 4.0.x although FRRouting version 4.0.x and 5.0.x use Zebra API
-version 5. Also, FRRouting version 7.0.x changes zebra message and it
-doesn't keep backward compatibility for FRRouting version 6.0.x
-although FRRouting version 6.0.x and 7.0.x use Zebra API version 6. If
-you need to integrate with FRRouting version 4.0.x or 6.0x, please use
-`software-name` configuration.
+version 5. Also, FRRouting version 7.0.x and 7.1.x changes zebra
+message and it doesn't keep backward compatibility for FRRouting
+version 6.0.x although FRRouting version 6.0.x, 7.0.x and 7.1.x use
+Zebra API version 6. If you need to integrate with FRRouting version
+4.0.x or 6.0x, please use `software-name` configuration.
 
 ## Contents
 
@@ -59,15 +59,17 @@ You need to enable the zebra feature in the Global configuration as follows.
   For connecting to FRRouting 7.0.x, please specify `6`.
 
 - `mpls-label-range-size` specifies mpls label range size for
-  requesting to Zebra. It works with FRRouting 5.0.x, FRRouting
-  6.0.x and FRRouting 7.0.x.
+  requesting to Zebra. It works with FRRouting 5.0.x, FRRouting 6.0.x,
+  FRRouting 7.0.x and FRRouting 7.1.x.
 
 - `sotware-name` specifies software name for zebra when only `version`
   configuration cannot specify software uniquely. This configuration
   is used with 'version' configuration. For connecting to FRRouting
-  6.0.x, please specify `6` as `version` and `frr6` as
-  `software-name`.  For connecting to FRRouting 4.0.x, please specify
-  `5` as `version` and `frr4` as `software-name`.
+  7.1.x, please specify `6` as `version` and `frr7.1` as
+  `software-name`. For connecting to FRRouting 6.0.x, please specify
+  `6` as `version` and `frr6` as `software-name`.  For connecting to
+  FRRouting 4.0.x, please specify `5` as `version` and `frr4` as
+  `software-name`.
 
 ## Check Routes from zebra
 

--- a/internal/pkg/config/default.go
+++ b/internal/pkg/config/default.go
@@ -422,7 +422,7 @@ func setDefaultConfigValuesWithViper(v *viper.Viper, b *BgpConfigSet) error {
 	}
 
 	//SoftwareName for Zebra
-	allowableZebraSoftwareName := []string{"", "quagga", "frr3", "frr4", "frr5", "frr6", "frr7"}
+	allowableZebraSoftwareName := []string{"", "quagga", "frr3", "frr4", "frr5", "frr6", "frr7", "frr7.1"}
 	isAllowable := false
 	for _, allowable := range allowableZebraSoftwareName {
 		if b.Zebra.Config.SoftwareName == allowable {

--- a/internal/pkg/zebra/zapi_test.go
+++ b/internal/pkg/zebra/zapi_test.go
@@ -127,12 +127,12 @@ func Test_InterfaceUpdateBody(t *testing.T) {
 			pos += 1
 		}
 		b := &InterfaceUpdateBody{}
-		err := b.DecodeFromBytes(buf, v)
+		err := b.DecodeFromBytes(buf, v, "")
 		assert.Equal(nil, err)
 		assert.Equal("01:23:45:67:89:ab", b.HardwareAddr.String())
 		buf = make([]byte, INTERFACE_NAMSIZ+32) //size mismatch
 		b = &InterfaceUpdateBody{}
-		err = b.DecodeFromBytes(buf, v)
+		err = b.DecodeFromBytes(buf, v, "")
 		assert.NotEqual(nil, err)
 	}
 }
@@ -159,7 +159,7 @@ func Test_InterfaceAddressUpdateBody(t *testing.T) {
 		copy(buf[pos:pos+4], []byte(dst))
 
 		b := &InterfaceAddressUpdateBody{}
-		err := b.DecodeFromBytes(buf, v)
+		err := b.DecodeFromBytes(buf, v, "")
 		require.NoError(t, err)
 
 		assert.Equal(uint32(0), b.Index)
@@ -172,7 +172,7 @@ func Test_InterfaceAddressUpdateBody(t *testing.T) {
 		buf[5] = 0x4
 		pos += 1
 		b = &InterfaceAddressUpdateBody{}
-		err = b.DecodeFromBytes(buf, v)
+		err = b.DecodeFromBytes(buf, v, "")
 		assert.NotEqual(nil, err)
 	}
 }
@@ -192,7 +192,7 @@ func Test_RouterIDUpdateBody(t *testing.T) {
 		buf[pos] = byte(32)
 
 		b := &RouterIDUpdateBody{}
-		err := b.DecodeFromBytes(buf, v)
+		err := b.DecodeFromBytes(buf, v, "")
 		assert.Equal(nil, err)
 		assert.Equal("192.168.100.1", b.Prefix.String())
 		assert.Equal(uint8(32), b.Length)
@@ -201,7 +201,7 @@ func Test_RouterIDUpdateBody(t *testing.T) {
 		buf[0] = 0x4
 		pos += 1
 		b = &RouterIDUpdateBody{}
-		err = b.DecodeFromBytes(buf, v)
+		err = b.DecodeFromBytes(buf, v, "")
 		assert.NotEqual(nil, err)
 	}
 }
@@ -294,7 +294,7 @@ func Test_IPRouteBody_IPv4(t *testing.T) {
 		binary.BigEndian.PutUint32(buf[pos:], 1) // mtu
 		pos += 4
 		r := &IPRouteBody{Api: command[v]}
-		err := r.DecodeFromBytes(buf, v)
+		err := r.DecodeFromBytes(buf, v, "")
 		assert.Equal(nil, err)
 		assert.Equal("192.168.100.0", r.Prefix.Prefix.String())
 		assert.Equal(uint8(0x18), r.Prefix.PrefixLen)
@@ -311,7 +311,7 @@ func Test_IPRouteBody_IPv4(t *testing.T) {
 		assert.Equal(uint32(1), r.Mtu)
 
 		//Serialize
-		buf, err = r.Serialize(v)
+		buf, err = r.Serialize(v, "")
 		assert.Equal(nil, err)
 		switch v {
 		case 2, 3:
@@ -416,7 +416,7 @@ func Test_IPRouteBody_IPv4(t *testing.T) {
 		pos += 4
 
 		r = &IPRouteBody{Api: command[v]}
-		err = r.DecodeFromBytes(buf, v)
+		err = r.DecodeFromBytes(buf, v, "")
 		switch v {
 		case 2, 3, 4:
 			assert.Equal("MESSAGE_METRIC message length invalid pos:14 rest:14", err.Error())
@@ -461,7 +461,7 @@ func Test_IPRouteBody_IPv4(t *testing.T) {
 		binary.BigEndian.PutUint32(buf[pos:], 0) //metric
 		pos += 4
 		r = &IPRouteBody{Api: command[v]}
-		err = r.DecodeFromBytes(buf, v)
+		err = r.DecodeFromBytes(buf, v, "")
 		assert.Equal(nil, err)
 	}
 }
@@ -560,7 +560,7 @@ func Test_IPRouteBody_IPv6(t *testing.T) {
 		binary.BigEndian.PutUint32(buf[pos:], 1) // mtu
 		pos += 4
 		r := &IPRouteBody{Api: command[v]}
-		err := r.DecodeFromBytes(buf, v)
+		err := r.DecodeFromBytes(buf, v, "")
 		assert.Equal(nil, err)
 		assert.Equal("2001:db8:0:f101::", r.Prefix.Prefix.String())
 		assert.Equal(uint8(64), r.Prefix.PrefixLen)
@@ -577,7 +577,7 @@ func Test_IPRouteBody_IPv6(t *testing.T) {
 		assert.Equal(uint32(1), r.Mtu)
 
 		//Serialize
-		buf, err = r.Serialize(v)
+		buf, err = r.Serialize(v, "")
 		assert.Equal(nil, err)
 		switch v {
 		case 2, 3:
@@ -683,7 +683,7 @@ func Test_IPRouteBody_IPv6(t *testing.T) {
 		pos += 4
 
 		r = &IPRouteBody{Api: command[v]}
-		err = r.DecodeFromBytes(buf, v)
+		err = r.DecodeFromBytes(buf, v, "")
 		switch v {
 		case 2, 3, 4:
 			assert.Equal("message length invalid pos:39 rest:46", err.Error())
@@ -726,7 +726,7 @@ func Test_IPRouteBody_IPv6(t *testing.T) {
 		buf[pos] = 1                             //distance
 		binary.BigEndian.PutUint32(buf[pos:], 0) //metic
 		r = &IPRouteBody{Api: command[v]}
-		err = r.DecodeFromBytes(buf, v)
+		err = r.DecodeFromBytes(buf, v, "")
 		assert.Equal(nil, err)
 	}
 }
@@ -754,7 +754,7 @@ func Test_NexthopLookupBody(t *testing.T) {
 	binary.BigEndian.PutUint32(buf[pos:], 3)
 
 	b := &NexthopLookupBody{Api: IPV4_NEXTHOP_LOOKUP}
-	err := b.DecodeFromBytes(buf, 2)
+	err := b.DecodeFromBytes(buf, 2, "")
 	assert.Equal(nil, err)
 	assert.Equal("192.168.50.0", b.Addr.String())
 	assert.Equal(uint32(10), b.Metric)
@@ -763,7 +763,7 @@ func Test_NexthopLookupBody(t *testing.T) {
 	assert.Equal("172.16.1.101", b.Nexthops[0].Gate.String())
 
 	//Serialize
-	buf, err = b.Serialize(2)
+	buf, err = b.Serialize(2, "")
 	ip = net.ParseIP("192.168.50.0").To4()
 	assert.Equal(nil, err)
 	assert.Equal([]byte(ip)[0:4], buf[0:4])
@@ -771,7 +771,7 @@ func Test_NexthopLookupBody(t *testing.T) {
 	// length invalid
 	buf = make([]byte, 3)
 	b = &NexthopLookupBody{Api: IPV4_NEXTHOP_LOOKUP}
-	err = b.DecodeFromBytes(buf, 2)
+	err = b.DecodeFromBytes(buf, 2, "")
 	assert.NotEqual(nil, err)
 
 	//ipv6
@@ -793,7 +793,7 @@ func Test_NexthopLookupBody(t *testing.T) {
 	binary.BigEndian.PutUint32(buf[pos:], 3)
 
 	b = &NexthopLookupBody{Api: IPV6_NEXTHOP_LOOKUP}
-	err = b.DecodeFromBytes(buf, 2)
+	err = b.DecodeFromBytes(buf, 2, "")
 	assert.Equal(nil, err)
 	assert.Equal("2001:db8:0:f101::", b.Addr.String())
 	assert.Equal(uint32(10), b.Metric)
@@ -802,7 +802,7 @@ func Test_NexthopLookupBody(t *testing.T) {
 	assert.Equal("2001:db8:0:1111::1", b.Nexthops[0].Gate.String())
 
 	//Serialize
-	buf, err = b.Serialize(2)
+	buf, err = b.Serialize(2, "")
 	ip = net.ParseIP("2001:db8:0:f101::").To16()
 	assert.Equal(nil, err)
 	assert.Equal([]byte(ip)[0:16], buf[0:16])
@@ -810,7 +810,7 @@ func Test_NexthopLookupBody(t *testing.T) {
 	// length invalid
 	buf = make([]byte, 15)
 	b = &NexthopLookupBody{Api: IPV6_NEXTHOP_LOOKUP}
-	err = b.DecodeFromBytes(buf, 2)
+	err = b.DecodeFromBytes(buf, 2, "")
 	assert.NotEqual(nil, err)
 }
 
@@ -836,7 +836,7 @@ func Test_ImportLookupBody(t *testing.T) {
 	binary.BigEndian.PutUint32(buf[pos:], 3)
 
 	b := &ImportLookupBody{Api: IPV4_IMPORT_LOOKUP}
-	err := b.DecodeFromBytes(buf, 2)
+	err := b.DecodeFromBytes(buf, 2, "")
 	assert.Equal(nil, err)
 	assert.Equal("192.168.50.0", b.Addr.String())
 	assert.Equal(uint32(10), b.Metric)
@@ -846,7 +846,7 @@ func Test_ImportLookupBody(t *testing.T) {
 
 	//Serialize
 	b.PrefixLength = uint8(24)
-	buf, err = b.Serialize(2)
+	buf, err = b.Serialize(2, "")
 	ip = net.ParseIP("192.168.50.0").To4()
 	assert.Equal(nil, err)
 	assert.Equal(uint8(24), buf[0])
@@ -855,7 +855,7 @@ func Test_ImportLookupBody(t *testing.T) {
 	// length invalid
 	buf = make([]byte, 3)
 	b = &ImportLookupBody{Api: IPV4_IMPORT_LOOKUP}
-	err = b.DecodeFromBytes(buf, 2)
+	err = b.DecodeFromBytes(buf, 2, "")
 	assert.NotEqual(nil, err)
 }
 
@@ -882,7 +882,7 @@ func Test_NexthopRegisterBody(t *testing.T) {
 	for v := MinZapiVer; v <= MaxZapiVer; v++ {
 		// Test DecodeFromBytes()
 		b := &NexthopRegisterBody{Api: command[v]}
-		err := b.DecodeFromBytes(bufIn, v)
+		err := b.DecodeFromBytes(bufIn, v, "")
 		assert.Nil(err)
 
 		// Test decoded values
@@ -894,7 +894,7 @@ func Test_NexthopRegisterBody(t *testing.T) {
 		assert.Equal(net.ParseIP("2001:db8:1:1::1").To16(), b.Nexthops[1].Prefix)
 
 		// Test Serialize()
-		bufOut, err := b.Serialize(v)
+		bufOut, err := b.Serialize(v, "")
 		assert.Nil(err)
 
 		// Test serialised value
@@ -950,7 +950,7 @@ func Test_NexthopUpdateBody(t *testing.T) {
 
 		// Test DecodeFromBytes()
 		b := &NexthopUpdateBody{Api: command[v]}
-		err := b.DecodeFromBytes(bufIn, v)
+		err := b.DecodeFromBytes(bufIn, v, "")
 		assert.Nil(err)
 
 		// Test decoded values
@@ -982,12 +982,12 @@ func Test_GetLabelChunkBody(t *testing.T) {
 		binary.BigEndian.PutUint32(buf[8:], 89) //End
 
 		b := &GetLabelChunkBody{}
-		err := b.DecodeFromBytes(buf, v)
+		err := b.DecodeFromBytes(buf, v, "")
 		assert.Equal(nil, err)
 
 		//Serialize
 		b.ChunkSize = 10
-		buf, err = b.Serialize(v)
+		buf, err = b.Serialize(v, "")
 		assert.Equal(nil, err)
 		assert.Equal(byte(routeType[v]), buf[0])
 		bi := make([]byte, 4)
@@ -1006,11 +1006,11 @@ func Test_VrfLabelBody(t *testing.T) {
 		bufIn[4] = byte(AFI_IP)
 		bufIn[5] = byte(LSP_BGP)
 		b := &VrfLabelBody{}
-		err := b.DecodeFromBytes(bufIn, v)
+		err := b.DecodeFromBytes(bufIn, v, "")
 		assert.Equal(nil, err)
 		//Serialize
 		var bufOut []byte
-		bufOut, err = b.Serialize(v)
+		bufOut, err = b.Serialize(v, "")
 		assert.Equal(nil, err)
 		assert.Equal(bufIn, bufOut)
 	}

--- a/pkg/server/zclient.go
+++ b/pkg/server/zclient.go
@@ -121,9 +121,17 @@ func addMessageLabelToIPRouteBody(path *table.Path, vrfId uint32, z *zebraClient
 	rf := path.GetRouteFamily()
 	if v > 4 && (rf == bgp.RF_IPv4_VPN || rf == bgp.RF_IPv6_VPN) {
 		*msgFlags |= zebra.FRR_ZAPI5_MESSAGE_LABEL
-		for _, label := range path.GetNlri().(*bgp.LabeledVPNIPAddrPrefix).Labels.Labels {
-			nexthop.LabelNum++
-			nexthop.MplsLabels = append(nexthop.MplsLabels, label)
+		switch rf {
+		case bgp.RF_IPv4_VPN:
+			for _, label := range path.GetNlri().(*bgp.LabeledVPNIPAddrPrefix).Labels.Labels {
+				nexthop.LabelNum++
+				nexthop.MplsLabels = append(nexthop.MplsLabels, label)
+			}
+		case bgp.RF_IPv6_VPN:
+			for _, label := range path.GetNlri().(*bgp.LabeledVPNIPv6AddrPrefix).Labels.Labels {
+				nexthop.LabelNum++
+				nexthop.MplsLabels = append(nexthop.MplsLabels, label)
+			}
 		}
 	}
 }


### PR DESCRIPTION
…sue #2113

- Additionally bug fix which avoid panic caused by displaying vpnv6 prefixes using gobgp vrf rib
- Supporting FRRouting 7.1.x