### PR TITLE
fix PeerGroup AFI handling

### DIFF
--- a/internal/pkg/config/default.go
+++ b/internal/pkg/config/default.go
@@ -521,7 +521,7 @@ func OverwriteNeighborConfigWithPeerGroup(c *Neighbor, pg *PeerGroup) error {
 	overwriteConfig(&c.TtlSecurity.Config, &pg.TtlSecurity.Config, "neighbor.ttl-security.config", v)
 
 	if !v.IsSet("neighbor.afi-safis") {
-		c.AfiSafis = append(c.AfiSafis, pg.AfiSafis...)
+		c.AfiSafis = append([]AfiSafi{}, pg.AfiSafis...)
 	}
 
 	return nil


### PR DESCRIPTION
This fixes a bug that the duplicated AFI is configured with the peer
group. OverwriteNeighborConfigWithPeerGroup() appends the peer group's
AFI configuration to the existing one instead overwriting.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>