### PR TITLE
test: fix the versions of fabric and invoke

### DIFF
--- a/test/pip-requires.txt
+++ b/test/pip-requires.txt
@@ -1,10 +1,10 @@
 nose
 toml
 pyyaml
-fabric
+fabric == 2.4.0
 netaddr
 nsenter
 docker-py
 ryu
 colored
-invoke
+invoke == 1.2.0


### PR DESCRIPTION
Seems that the latest versions change the APIs so CI tests fails.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>