### PR TITLE
table: kill GetPathListByPeer()

### DIFF
--- a/internal/pkg/table/adj.go
+++ b/internal/pkg/table/adj.go
@@ -106,13 +106,18 @@ func (adj *AdjRib) Accepted(rfList []bgp.RouteFamily) int {
 	return count
 }
 
-func (adj *AdjRib) Drop(rfList []bgp.RouteFamily) {
+func (adj *AdjRib) Drop(rfList []bgp.RouteFamily) []*Path {
+	l := make([]*Path, 0, adj.Count(rfList))
 	for _, rf := range rfList {
 		if _, ok := adj.table[rf]; ok {
+			for _, p := range adj.table[rf] {
+				l = append(l, p.Clone(true))
+			}
 			adj.table[rf] = make(map[string]*Path)
 			adj.accepted[rf] = 0
 		}
 	}
+	return l
 }
 
 func (adj *AdjRib) DropStale(rfList []bgp.RouteFamily) []*Path {

--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -190,21 +190,6 @@ func (tm *TableManager) update(newPath *Path) *Update {
 	return u
 }
 
-func (manager *TableManager) GetPathListByPeer(info *PeerInfo, rf bgp.RouteFamily) []*Path {
-	if t, ok := manager.Tables[rf]; ok {
-		pathList := make([]*Path, 0, len(t.destinations))
-		for _, dst := range t.destinations {
-			for _, p := range dst.knownPathList {
-				if p.GetSource().Equal(info) {
-					pathList = append(pathList, p)
-				}
-			}
-		}
-		return pathList
-	}
-	return nil
-}
-
 func (manager *TableManager) Update(newPath *Path) []*Update {
 	if newPath == nil || newPath.IsEOR() {
 		return nil

--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -558,6 +558,6 @@ func (peer *peer) PassConn(conn *net.TCPConn) {
 	}
 }
 
-func (peer *peer) DropAll(rfList []bgp.RouteFamily) {
-	peer.adjRibIn.Drop(rfList)
+func (peer *peer) DropAll(rfList []bgp.RouteFamily) []*table.Path {
+	return peer.adjRibIn.Drop(rfList)
 }


### PR DESCRIPTION
when a peer is down, use paths in its adj table instead of searching
for the global table.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>