### PR TITLE
Check AfiSafi Graceful Restart configuration in NeedsResendOpenMessage

### DIFF
--- a/internal/pkg/config/util.go
+++ b/internal/pkg/config/util.go
@@ -221,11 +221,22 @@ func isAfiSafiChanged(x, y []AfiSafi) bool {
 	return false
 }
 
+func isAfiSafiGracefulRestartEnabled(a []AfiSafi) bool {
+	for _, e := range a {
+		if e.MpGracefulRestart.Config.Enabled {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (n *Neighbor) NeedsResendOpenMessage(new *Neighbor) bool {
 	return !n.Config.Equal(&new.Config) ||
 		!n.Transport.Config.Equal(&new.Transport.Config) ||
 		!n.AddPaths.Config.Equal(&new.AddPaths.Config) ||
 		!n.GracefulRestart.Config.Equal(&new.GracefulRestart.Config) ||
+		!isAfiSafiGracefulRestartEnabled(n.AfiSafis) ||
 		isAfiSafiChanged(n.AfiSafis, new.AfiSafis)
 }
 

--- a/internal/pkg/config/util_test.go
+++ b/internal/pkg/config/util_test.go
@@ -56,3 +56,27 @@ func TestIsAfiSafiChanged(t *testing.T) {
 	new = []AfiSafi{v4ap}
 	assert.True(t, isAfiSafiChanged(old, new))
 }
+
+func TestIsAfiSafiGracefulRestartEnabled(t *testing.T) {
+	disabled := []AfiSafi{
+		AfiSafi{
+			MpGracefulRestart: MpGracefulRestart{
+				Config: MpGracefulRestartConfig{
+					Enabled: false,
+				},
+			},
+		},
+	}
+	enabled := []AfiSafi{
+		AfiSafi{
+			MpGracefulRestart: MpGracefulRestart{
+				Config: MpGracefulRestartConfig{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	assert.False(t, isAfiSafiGracefulRestartEnabled(disabled))
+	assert.True(t, isAfiSafiGracefulRestartEnabled(enabled))
+}


### PR DESCRIPTION
Fix #2119

If I understood the issue correctly, this adds a check to see whether the AfiSafi slice contains an entry with enabled graceful restart on it to decide whether or not it should perform the open message resend.

This also adds a corresponding unit test to validate that it correctly identifies true and false scenarios. 

Please let me know if I misunderstood or missed any aspect of what this issue required.