### PR TITLE
Fix error in BGP Confederation syntax

### DIFF
--- a/docs/sources/bgp-confederation.md
+++ b/docs/sources/bgp-confederation.md
@@ -22,13 +22,14 @@ must also configure `member-as-list` with a list of other ASNs which compose the
 example, AS65001 would configure this attribute as `member-as-list = [ 65002 ]`.
 
 ```toml
-[global.config]
-as = 65001
-router-id = "10.0.0.1"
-  [confederation.config]
-  enabled = true
-  identifier = 30
-  member-as-list = [ 65002 ]
+[global]
+  [global.config]
+    as = 65001
+    router-id = "10.0.0.1"
+  [global.confederation.config]
+    enabled = true
+    identifier = 30
+    member-as-list = [ 65002 ]
 
 [[neighbors]]
   [neighbors.config]


### PR DESCRIPTION
Sorry about this, I had forgot that TOML subtables require the name of the parent table in their path's. I've validated this configuration:

```
root@kkirsche-dev:/home/kkirsche# ./gobgpd -f config.toml
{"level":"info","msg":"gobgpd started","time":"2019-08-28T18:32:23Z"}
{"Topic":"Config","level":"info","msg":"Finished reading the config file","time":"2019-08-28T18:32:23Z"}
{"level":"info","msg":"Peer 10.0.0.2 is added","time":"2019-08-28T18:32:23Z"}
{"Topic":"Peer","level":"info","msg":"Add a peer configuration for:10.0.0.2","time":"2019-08-28T18:32:23Z"}
```

```
root@kkirsche-dev:# cat config.toml
[global]
  [global.config]
    as = 65001
    router-id = "10.0.0.1"
  [global.confederation.config]
    enabled = true
    identifier = 30
    member-as-list = [ 65002 ]
```