### PR TITLE
github: workaround for action trigger bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,11 @@ name: release
 
 on:
   create:
-    tags:
-      - v*.*.*
+    branches:
+      - refs/tags/*
+#  create:
+#    tags:
+#      - v*.*.*
 
 jobs:
   build:


### PR DESCRIPTION
https://github.community/t5/GitHub-API-Development-and/How-to-restrict-execution-of-GitHub-Actions-workflow-on-tags/td-p/29567

'tags' doesn't work; the action is executed when anything (tag,
branch, etc) is created. Let's work around.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>