### PR TITLE
table: fix SingleAsPathMatch pre compiled pattern

### DIFF
--- a/internal/pkg/table/policy.go
+++ b/internal/pkg/table/policy.go
@@ -825,7 +825,7 @@ func (m *singleAsPathMatch) Match(aspath []uint32) bool {
 }
 
 var (
-	_regexpLeftMostRe = regexp.MustCompile(`$\^([0-9]+)_^`)
+	_regexpLeftMostRe = regexp.MustCompile(`^\^([0-9]+)_$`)
 	_regexpOriginRe   = regexp.MustCompile(`^_([0-9]+)\$$`)
 	_regexpIncludeRe  = regexp.MustCompile("^_([0-9]+)_$")
 	_regexpOnlyRe     = regexp.MustCompile(`^\^([0-9]+)\$$`)


### PR DESCRIPTION
This fixes a pre-compiled pattern for SingleAsPathMatch though this didn't affect actual behavior much because it always fails and falls back to a regexp match against an AS Path text representation.