### PR TITLE
Update adjrib for LLGR and preserve aslooped attr

### DIFF
--- a/internal/pkg/table/adj_test.go
+++ b/internal/pkg/table/adj_test.go
@@ -69,14 +69,19 @@ func TestStale(t *testing.T) {
 	p1 := NewPath(pi, nlri1, false, attrs, time.Now(), false)
 	nlri2 := bgp.NewIPAddrPrefix(24, "20.20.20.0")
 	p2 := NewPath(pi, nlri2, false, attrs, time.Now(), false)
+	p2.SetAsLooped(true)
+
 	family := p1.GetRouteFamily()
 	families := []bgp.RouteFamily{family}
 
 	adj := NewAdjRib(families)
 	adj.Update([]*Path{p1, p2})
 	assert.Equal(t, adj.Count([]bgp.RouteFamily{family}), 2)
+	assert.Equal(t, adj.Accepted([]bgp.RouteFamily{family}), 1)
 
-	adj.StaleAll(families)
+	stalePathList := adj.StaleAll(families)
+	// As looped path should not be returned
+	assert.Equal(t, 1, len(stalePathList))
 
 	for _, p := range adj.PathList([]bgp.RouteFamily{family}, false) {
 		assert.True(t, p.IsStale())
@@ -86,7 +91,45 @@ func TestStale(t *testing.T) {
 	p3 := NewPath(pi, nlri3, false, attrs, time.Now(), false)
 	adj.Update([]*Path{p1, p3})
 
-	adj.DropStale(families)
+	droppedPathList := adj.DropStale(families)
+	assert.Equal(t, 2, len(droppedPathList))
 	assert.Equal(t, adj.Count([]bgp.RouteFamily{family}), 1)
 	assert.Equal(t, 1, len(adj.table[family].destinations))
+}
+
+func TestLLGRStale(t *testing.T) {
+	pi := &PeerInfo{}
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
+
+	nlri1 := bgp.NewIPAddrPrefix(24, "20.20.10.0")
+	p1 := NewPath(pi, nlri1, false, attrs, time.Now(), false)
+
+	nlri2 := bgp.NewIPAddrPrefix(24, "20.20.20.0")
+	p2 := NewPath(pi, nlri2, false, attrs, time.Now(), false)
+	p2.SetAsLooped(true) // Not accepted
+
+	nlri3 := bgp.NewIPAddrPrefix(24, "20.20.30.0")
+	p3 := NewPath(pi, nlri3, false, attrs, time.Now(), false)
+	p3.SetAsLooped(true)
+	// Not accepted and then dropped on MarkLLGRStaleOrDrop
+	p3.SetCommunities([]uint32{uint32(bgp.COMMUNITY_NO_LLGR)}, false)
+
+	nlri4 := bgp.NewIPAddrPrefix(24, "20.20.40.0")
+	p4 := NewPath(pi, nlri4, false, attrs, time.Now(), false)
+	// dropped on MarkLLGRStaleOrDrop
+	p4.SetCommunities([]uint32{uint32(bgp.COMMUNITY_NO_LLGR)}, false)
+
+	family := p1.GetRouteFamily()
+	families := []bgp.RouteFamily{family}
+
+	adj := NewAdjRib(families)
+	adj.Update([]*Path{p1, p2, p3, p4})
+	assert.Equal(t, adj.Count([]bgp.RouteFamily{family}), 4)
+	assert.Equal(t, adj.Accepted([]bgp.RouteFamily{family}), 2)
+
+	pathList := adj.MarkLLGRStaleOrDrop(families)
+	assert.Equal(t, 3, len(pathList)) // Does not return aslooped path that is retained in adjrib
+	assert.Equal(t, adj.Count([]bgp.RouteFamily{family}), 2)
+	assert.Equal(t, adj.Accepted([]bgp.RouteFamily{family}), 1)
+	assert.Equal(t, 2, len(adj.table[family].destinations))
 }

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -398,6 +398,15 @@ func (path *Path) SetDropped(y bool) {
 	path.dropped = y
 }
 
+func (path *Path) HasNoLLGR() bool {
+	for _, c := range path.GetCommunities() {
+		if c == uint32(bgp.COMMUNITY_NO_LLGR) {
+			return true
+		}
+	}
+	return false
+}
+
 func (path *Path) IsLLGRStale() bool {
 	for _, c := range path.GetCommunities() {
 		if c == uint32(bgp.COMMUNITY_LLGR_STALE) {

--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -333,23 +333,7 @@ func (peer *peer) llgrRestartTimerExpired(family bgp.RouteFamily) bool {
 }
 
 func (peer *peer) markLLGRStale(fs []bgp.RouteFamily) []*table.Path {
-	paths := peer.adjRibIn.PathList(fs, true)
-	for i, p := range paths {
-		doStale := true
-		for _, c := range p.GetCommunities() {
-			if c == uint32(bgp.COMMUNITY_NO_LLGR) {
-				doStale = false
-				p = p.Clone(true)
-				break
-			}
-		}
-		if doStale {
-			p = p.Clone(false)
-			p.SetCommunities([]uint32{uint32(bgp.COMMUNITY_LLGR_STALE)}, false)
-		}
-		paths[i] = p
-	}
-	return paths
+	return peer.adjRibIn.MarkLLGRStaleOrDrop(fs)
 }
 
 func (peer *peer) stopPeerRestarting() {


### PR DESCRIPTION
Fixes LLGR community cleared on softreset.
Fixes AS Path looped routes added back to rib on Graceful Restart.