### PR TITLE
Maintain unique vrf IDs in watchEventBestPath vrf map

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -708,13 +708,13 @@ func (s *BgpServer) notifyBestWatcher(best []*table.Path, multipath [][]*table.P
 		clonedM[i] = clonePathList(pathList)
 	}
 	clonedB := clonePathList(best)
-	m := make(map[string]uint32)
+	m := make(map[uint32]bool)
 	for _, p := range clonedB {
 		switch p.GetRouteFamily() {
 		case bgp.RF_IPv4_VPN, bgp.RF_IPv6_VPN:
 			for _, vrf := range s.globalRib.Vrfs {
 				if vrf.Id != 0 && table.CanImportToVrf(vrf, p) {
-					m[p.GetNlri().String()] = uint32(vrf.Id)
+					m[uint32(vrf.Id)] = true
 				}
 			}
 		}
@@ -3828,7 +3828,7 @@ type watchEventTable struct {
 type watchEventBestPath struct {
 	PathList      []*table.Path
 	MultiPathList [][]*table.Path
-	Vrf           map[string]uint32
+	Vrf           map[uint32]bool
 }
 
 type watchEventMessage struct {

--- a/pkg/server/zclient.go
+++ b/pkg/server/zclient.go
@@ -433,8 +433,8 @@ func (z *zebraClient) loop() {
 					for _, path := range msg.PathList {
 						vrfs := []uint32{0}
 						if msg.Vrf != nil {
-							if v, ok := msg.Vrf[path.GetNlri().String()]; ok {
-								vrfs = append(vrfs, v)
+							for vrfId := range msg.Vrf {
+								vrfs = append(vrfs, vrfId)
 							}
 						}
 						for _, i := range vrfs {


### PR DESCRIPTION
Fixes missing route propagation to proper vrfs in zapi when we have route import/export from different RTs