### PR TITLE
Remove policy from FSM

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -189,7 +189,6 @@ type fsm struct {
 	capMap               map[bgp.BGPCapabilityCode][]bgp.ParameterCapabilityInterface
 	recvOpen             *bgp.BGPMessage
 	peerInfo             *table.PeerInfo
-	policy               *table.RoutingPolicy
 	gracefulRestartTimer *time.Timer
 	twoByteAsTrans       bool
 	marshallingOptions   *bgp.MarshallingOption
@@ -261,7 +260,7 @@ func (fsm *fsm) bmpStatsUpdate(statType uint16, increment int) {
 	}
 }
 
-func newFSM(gConf *config.Global, pConf *config.Neighbor, policy *table.RoutingPolicy) *fsm {
+func newFSM(gConf *config.Global, pConf *config.Neighbor) *fsm {
 	adminState := adminStateUp
 	if pConf.Config.AdminDown {
 		adminState = adminStateDown
@@ -281,7 +280,6 @@ func newFSM(gConf *config.Global, pConf *config.Neighbor, policy *table.RoutingP
 		rfMap:                make(map[bgp.RouteFamily]bgp.BGPAddPathMode),
 		capMap:               make(map[bgp.BGPCapabilityCode][]bgp.ParameterCapabilityInterface),
 		peerInfo:             table.NewPeerInfo(gConf, pConf),
-		policy:               policy,
 		gracefulRestartTimer: time.NewTimer(time.Hour),
 		notification:         make(chan *bgp.BGPMessage, 1),
 	}

--- a/pkg/server/fsm_test.go
+++ b/pkg/server/fsm_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/eapache/channels"
 	"github.com/osrg/gobgp/internal/pkg/config"
-	"github.com/osrg/gobgp/internal/pkg/table"
 	"github.com/osrg/gobgp/pkg/packet/bgp"
 
 	log "github.com/sirupsen/logrus"
@@ -311,7 +310,7 @@ func TestCheckOwnASLoop(t *testing.T) {
 
 func makePeerAndHandler() (*peer, *fsmHandler) {
 	p := &peer{
-		fsm: newFSM(&config.Global{}, &config.Neighbor{}, table.NewRoutingPolicy()),
+		fsm: newFSM(&config.Global{}, &config.Neighbor{}),
 	}
 
 	h := &fsmHandler{

--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -106,7 +106,7 @@ func newPeer(g *config.Global, conf *config.Neighbor, loc *table.TableManager, p
 	peer := &peer{
 		localRib:          loc,
 		policy:            policy,
-		fsm:               newFSM(g, conf, policy),
+		fsm:               newFSM(g, conf),
 		prefixLimitWarned: make(map[bgp.RouteFamily]bool),
 	}
 	if peer.isRouteServerClient() {


### PR DESCRIPTION
The `policy` member of fsm is apparently never used. Clean it up to
avoid confusion. Policy is still set on the server and peers.