### PR TITLE
docs: update bmp verification section

### DIFF
--- a/docs/sources/bmp.md
+++ b/docs/sources/bmp.md
@@ -79,24 +79,4 @@ Please note this option is mainly for debugging purpose.
 
 ## Verification
 
-Let's check if BMP works with a bmp server. GoBGP also supports BMP server (currently, just shows received BMP messages in the json format).
-
-```bash
-$ go get github.com/osrg/gobgp/gobmpd
-$ gobmpd
-...(snip)...
-```
-
-Once the BMP server accepts a connection from gobgpd, then you see
-below on the BMP server side.
-
-```bash
-INFO[0013] Accepted a new connection from 127.0.0.1:33685
-{"Header":{"Version":3,"Length":6,"Type":4},"PeerHeader":{"PeerType":0,"IsPostPolicy":false,"PeerDistinguisher":0,"PeerAddress":"","PeerAS":0,"PeerBGPID":"","Timestamp":0},"Body":{"Info":null}}
-```
-
-You also see below on the BGP server side:
-
-```bash
-{"level":"info","msg":"bmp server is connected, 127.0.0.1:11019","time":"2015-09-15T10:29:03+09:00"}
-```
+Let's check if BMP works with a bmp server. You can find some OSS BMP server implementations such as [yambp](https://github.com/smartbgp/yabmp), [OpenBMP](https://github.com/SNAS/openbmp), etc.


### PR DESCRIPTION
gobgmp was removed long ago. Add a pointer to other BMP server
implementations.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>