### PR TITLE
bgp: fix dynamic neighbors with prefix "0.0.0.0/0"

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -423,7 +423,8 @@ func (s *BgpServer) matchLongestDynamicNeighborPrefix(a string) *peerGroup {
 		for _, d := range pg.dynamicNeighbors {
 			_, netAddr, _ := net.ParseCIDR(d.Config.Prefix)
 			if netAddr.Contains(ipAddr) {
-				if netAddr.Mask.String() > longestMask {
+				if netAddr.Mask.String() > longestMask ||
+					(netAddr.Mask.String() == longestMask && longestMask == net.CIDRMask(0, 32).String()) {
 					longestMask = netAddr.Mask.String()
 					longestPG = pg
 				}


### PR DESCRIPTION
support prefix "0.0.0.0/0".

Signed-off-by: Faicker Mo <faicker.mo@ucloud.cn>