### PR TITLE
config: peer groups support add-paths

### DIFF
--- a/internal/pkg/config/default.go
+++ b/internal/pkg/config/default.go
@@ -520,7 +520,7 @@ func OverwriteNeighborConfigWithPeerGroup(c *Neighbor, pg *PeerGroup) error {
 	overwriteConfig(&c.RouteServer.Config, &pg.RouteServer.Config, "neighbor.route-server.config", v)
 	overwriteConfig(&c.TtlSecurity.Config, &pg.TtlSecurity.Config, "neighbor.ttl-security.config", v)
 
-	if !v.IsSet("neighbor.afi-safis") {
+	if !v.IsSet("neighbor.afi-safis") && len(c.AfiSafis) == 0 {
 		c.AfiSafis = append([]AfiSafi{}, pg.AfiSafis...)
 	}
 


### PR DESCRIPTION
Support config '[peer-groups.add-paths.config]'.
Neighbor add-paths is set or from peer-groups and saves to neighbor AfiSafis
after reading config file.
After config->api->config, the AddPaths of neighbor and peer-groups is lost.
Neighbor config is set again in func addNeighbor when a peer is added.
The neighbor AfiSafis will be overwritten in func
OverwriteNeighborConfigWithPeerGroup even though it has values.

Signed-off-by: Faicker Mo <faicker.mo@ucloud.cn>