### PR TITLE
tests: fix failing tests when using more recent versions of protobuf

### DIFF
--- a/internal/pkg/apiutil/attribute_test.go
+++ b/internal/pkg/apiutil/attribute_test.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	api "github.com/osrg/gobgp/api"
@@ -64,7 +65,9 @@ func Test_AsPathAttribute(t *testing.T) {
 
 	output := NewAsPathAttributeFromNative(n.(*bgp.PathAttributeAsPath))
 	assert.Equal(2, len(output.Segments))
-	assert.Equal(input.Segments, output.Segments)
+	for i := 0; i < 2; i++ {
+		assert.True(proto.Equal(input.Segments[i], output.Segments[i]))
+	}
 }
 
 func Test_NextHopAttribute(t *testing.T) {
@@ -228,7 +231,8 @@ func Test_MpReachNLRIAttribute_IPv4_UC(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(2, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -270,7 +274,8 @@ func Test_MpReachNLRIAttribute_IPv6_UC(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(2, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -314,7 +319,8 @@ func Test_MpReachNLRIAttribute_IPv4_MPLS(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(2, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -358,7 +364,8 @@ func Test_MpReachNLRIAttribute_IPv6_MPLS(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(2, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -398,7 +405,8 @@ func Test_MpReachNLRIAttribute_IPv4_ENCAP(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(2, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -438,7 +446,8 @@ func Test_MpReachNLRIAttribute_IPv6_ENCAP(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(2, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -485,7 +494,8 @@ func Test_MpReachNLRIAttribute_EVPN_AD_Route(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(1, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -534,7 +544,8 @@ func Test_MpReachNLRIAttribute_EVPN_MAC_IP_Route(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(1, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -576,7 +587,8 @@ func Test_MpReachNLRIAttribute_EVPN_MC_Route(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(1, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -622,7 +634,8 @@ func Test_MpReachNLRIAttribute_EVPN_ES_Route(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(1, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -672,7 +685,8 @@ func Test_MpReachNLRIAttribute_EVPN_Prefix_Route(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(1, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -715,7 +729,8 @@ func Test_MpReachNLRIAttribute_IPv4_VPN(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(1, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -758,7 +773,8 @@ func Test_MpReachNLRIAttribute_IPv6_VPN(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(1, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -801,7 +817,8 @@ func Test_MpReachNLRIAttribute_RTC_UC(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(1, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -863,7 +880,8 @@ func Test_MpReachNLRIAttribute_FS_IPv4_UC(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(1, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -932,7 +950,8 @@ func Test_MpReachNLRIAttribute_FS_IPv4_VPN(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(1, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -994,7 +1013,8 @@ func Test_MpReachNLRIAttribute_FS_IPv6_UC(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(1, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -1063,7 +1083,8 @@ func Test_MpReachNLRIAttribute_FS_IPv6_VPN(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(1, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -1130,7 +1151,8 @@ func Test_MpReachNLRIAttribute_FS_L2_VPN(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(input.NextHops, output.NextHops)
 	assert.Equal(1, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
@@ -1171,7 +1193,8 @@ func Test_MpUnreachNLRIAttribute_IPv4_UC(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewMpUnreachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpUnreachNLRI))
-	assert.Equal(input.Family, output.Family)
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
 	assert.Equal(2, len(output.Nlris))
 	for idx, inputNLRI := range input.Nlris {
 		outputNLRI := output.Nlris[idx]
@@ -1339,7 +1362,9 @@ func Test_As4PathAttribute(t *testing.T) {
 
 	output := NewAs4PathAttributeFromNative(n.(*bgp.PathAttributeAs4Path))
 	assert.Equal(2, len(output.Segments))
-	assert.Equal(input.Segments, output.Segments)
+	for i := 0; i < 2; i++ {
+		assert.True(proto.Equal(input.Segments[i], output.Segments[i]))
+	}
 }
 
 func Test_As4AggregatorAttribute(t *testing.T) {
@@ -1530,7 +1555,9 @@ func Test_LargeCommunitiesAttribute(t *testing.T) {
 
 	output := NewLargeCommunitiesAttributeFromNative(n.(*bgp.PathAttributeLargeCommunities))
 	assert.Equal(2, len(output.Communities))
-	assert.Equal(input.Communities, output.Communities)
+	for i := 0; i < 2; i++ {
+		assert.True(proto.Equal(input.Communities[i], output.Communities[i]))
+	}
 }
 
 func Test_UnknownAttribute(t *testing.T) {

--- a/internal/pkg/apiutil/capability_test.go
+++ b/internal/pkg/apiutil/capability_test.go
@@ -18,6 +18,7 @@ package apiutil
 import (
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	api "github.com/osrg/gobgp/api"
 	"github.com/osrg/gobgp/pkg/packet/bgp"
@@ -42,7 +43,7 @@ func Test_MultiProtocolCapability(t *testing.T) {
 	assert.Equal(bgp.RF_IPv4_UC, c.CapValue)
 
 	output := NewMultiProtocolCapability(c)
-	assert.Equal(input, output)
+	assert.True(proto.Equal(input, output))
 }
 
 func Test_RouteRefreshCapability(t *testing.T) {
@@ -56,7 +57,7 @@ func Test_RouteRefreshCapability(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewRouteRefreshCapability(n.(*bgp.CapRouteRefresh))
-	assert.Equal(input, output)
+	assert.True(proto.Equal(input, output))
 }
 
 func Test_CarryingLabelInfoCapability(t *testing.T) {
@@ -70,7 +71,7 @@ func Test_CarryingLabelInfoCapability(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewCarryingLabelInfoCapability(n.(*bgp.CapCarryingLabelInfo))
-	assert.Equal(input, output)
+	assert.True(proto.Equal(input, output))
 }
 
 func Test_ExtendedNexthopCapability(t *testing.T) {
@@ -102,7 +103,7 @@ func Test_ExtendedNexthopCapability(t *testing.T) {
 	assert.Equal(uint16(bgp.AFI_IP6), c.Tuples[0].NexthopAFI)
 
 	output := NewExtendedNexthopCapability(c)
-	assert.Equal(input, output)
+	assert.True(proto.Equal(input, output))
 }
 
 func Test_GracefulRestartCapability(t *testing.T) {
@@ -136,7 +137,7 @@ func Test_GracefulRestartCapability(t *testing.T) {
 	assert.Equal(uint8(0x80), c.Tuples[0].Flags)
 
 	output := NewGracefulRestartCapability(c)
-	assert.Equal(input, output)
+	assert.True(proto.Equal(input, output))
 }
 
 func Test_FourOctetASNumberCapability(t *testing.T) {
@@ -155,7 +156,7 @@ func Test_FourOctetASNumberCapability(t *testing.T) {
 	assert.Equal(uint32(100), c.CapValue)
 
 	output := NewFourOctetASNumberCapability(c)
-	assert.Equal(input, output)
+	assert.True(proto.Equal(input, output))
 }
 
 func Test_AddPathCapability(t *testing.T) {
@@ -184,7 +185,7 @@ func Test_AddPathCapability(t *testing.T) {
 	assert.Equal(bgp.BGP_ADD_PATH_BOTH, c.Tuples[0].Mode)
 
 	output := NewAddPathCapability(c)
-	assert.Equal(input, output)
+	assert.True(proto.Equal(input, output))
 }
 
 func Test_EnhancedRouteRefreshCapability(t *testing.T) {
@@ -198,7 +199,7 @@ func Test_EnhancedRouteRefreshCapability(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewEnhancedRouteRefreshCapability(n.(*bgp.CapEnhancedRouteRefresh))
-	assert.Equal(input, output)
+	assert.True(proto.Equal(input, output))
 }
 
 func Test_LongLivedGracefulRestartCapability(t *testing.T) {
@@ -230,7 +231,7 @@ func Test_LongLivedGracefulRestartCapability(t *testing.T) {
 	assert.Equal(uint32(90), c.Tuples[0].RestartTime)
 
 	output := NewLongLivedGracefulRestartCapability(c)
-	assert.Equal(input, output)
+	assert.True(proto.Equal(input, output))
 }
 
 func Test_RouteRefreshCiscoCapability(t *testing.T) {
@@ -244,7 +245,7 @@ func Test_RouteRefreshCiscoCapability(t *testing.T) {
 	assert.Nil(err)
 
 	output := NewRouteRefreshCiscoCapability(n.(*bgp.CapRouteRefreshCisco))
-	assert.Equal(input, output)
+	assert.True(proto.Equal(input, output))
 }
 
 func Test_UnknownCapability(t *testing.T) {
@@ -265,5 +266,5 @@ func Test_UnknownCapability(t *testing.T) {
 	assert.Equal([]byte{0x11, 0x22, 0x33, 0x44}, c.CapValue)
 
 	output := NewUnknownCapability(c)
-	assert.Equal(input, output)
+	assert.True(proto.Equal(input, output))
 }


### PR DESCRIPTION
When regenerating the `*.pb.go` file, we get many tests failing
because testify is using `reflect.DeepEqual()` under the hood. There
is no option to have a custom comparison function and currently, the
only way around is to use `proto.Equal()` to compare protobuf
messages. The downside of using `proto.Equal()` is that we loose the
expected/actual display in case of a mismatch.

When comparing family, we compare `Api`/`Sapi` in separate asserts
instead of using `proto.Equal()`.

Fix: #1952

If you prefer to keep the more descriptive error messages, I can also maintain the patch myself for Debian use. Hopefully, testify will come with a better solution in the future.