### PR TITLE
contrib: simplify instructions for systemd

### DIFF
--- a/tools/contrib/centos/README.md
+++ b/tools/contrib/centos/README.md
@@ -1,4 +1,4 @@
-# GoBGP systemd Integration for CentOS
+# GoBGP systemd integration
 
 The following document describes how to manage `gobgp` with `systemd`.
 
@@ -10,25 +10,6 @@ cd /tmp/gobgp && curl -s -L -O https://github.com/osrg/gobgp/releases/download/v
 tar xvzf gobgp_1.31_linux_amd64.tar.gz
 mv gobgp /usr/bin/
 mv gobgpd /usr/bin/
-```
-
-Grant the capability to bind to system or well-known ports, i.e. ports with
-numbers `0–1023`, to `gobgpd` binary:
-
-```bash
-/sbin/setcap cap_net_bind_service=+ep /usr/bin/gobgpd
-/sbin/getcap /usr/bin/gobgpd
-```
-
-First, create a system account for `gobgp` service:
-
-```bash
-groupadd --system gobgpd
-useradd --system -d /var/lib/gobgpd -s /bin/bash -g gobgpd gobgpd
-mkdir -p /var/{lib,run,log}/gobgpd
-chown -R gobgpd:gobgpd /var/{lib,run,log}/gobgpd
-mkdir -p /etc/gobgpd
-chown -R gobgpd:gobgpd /etc/gobgpd
 ```
 
 Paste the below to create `gobgpd` configuration file. The `router-id` in this
@@ -50,7 +31,6 @@ cat << EOF > /etc/gobgpd/gobgpd.conf
     neighbor-address = "$BGP_PEER"
     peer-as = $BGP_AS
 EOF
-chown -R gobgpd:gobgpd /etc/gobgpd/gobgpd.conf
 ```
 
 Next, copy the `systemd` unit file, i.e. `gobgpd.service`, in this directory

--- a/tools/contrib/centos/add_gobgpd_account.sh
+++ b/tools/contrib/centos/add_gobgpd_account.sh
@@ -1,6 +1,0 @@
-groupadd --system gobgpd
-useradd --system -d /var/lib/gobgpd -s /bin/bash -g gobgpd gobgpd
-mkdir -p /var/{lib,run,log}/gobgpd
-chown -R gobgpd:gobgpd /var/{lib,run,log}/gobgpd
-mkdir -p /etc/gobgpd
-chown -R gobgpd:gobgpd /etc/gobgpd

--- a/tools/contrib/centos/gobgpd.service
+++ b/tools/contrib/centos/gobgpd.service
@@ -10,9 +10,8 @@ ExecStart=/usr/bin/gobgpd -f /etc/gobgpd/gobgpd.conf --sdnotify
 ExecReload=/usr/bin/gobgpd -r
 StandardOutput=journal
 StandardError=journal
-User=gobgpd
-Group=gobgpd
-AmbientCapabilities = CAP_NET_BIND_SERVICE
+DynamicUser=true
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
First, using setcap is not used when systemd file contains
AmbientCapabilities=CAP_NET_BIND_SERVICE.

Second, by using DynamicUser= directive, we can avoid creating a user
along with the associated directories. systemd does that itself. This
also has the advantage on working with any distribution based on
systemd.