### PR TITLE
fix panic if Family == nil

### DIFF
--- a/internal/pkg/apiutil/util.go
+++ b/internal/pkg/apiutil/util.go
@@ -17,6 +17,7 @@ package apiutil
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"time"
 
@@ -90,6 +91,9 @@ func getNLRI(family bgp.RouteFamily, buf []byte) (bgp.AddrPrefixInterface, error
 }
 
 func GetNativeNlri(p *api.Path) (bgp.AddrPrefixInterface, error) {
+	if p.Family == nil {
+		return nil, fmt.Errorf("family cannot be nil")
+	}
 	if len(p.NlriBinary) > 0 {
 		return getNLRI(ToRouteFamily(p.Family), p.NlriBinary)
 	}


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

There is no check for the case if Family == nil, as a result there is a panic triggered in this case.
This PR handles this condition by returning the error instead.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x960403]

goroutine 23 [running]:
github.com/osrg/gobgp/internal/pkg/apiutil.ToRouteFamily(...)
	/home/sbezverk/projects/go/workspace/gobgp/internal/pkg/apiutil/util.go:120
github.com/osrg/gobgp/internal/pkg/apiutil.GetNativeNlri(0xc0001e21e0, 0x5, 0x3, 0xe1fd79, 0x0)
	/home/sbezverk/projects/go/workspace/gobgp/internal/pkg/apiutil/util.go:96 +0xa3
github.com/osrg/gobgp/pkg/server.api2Path(0xc000000000, 0xc0001e21e0, 0xc00001e000, 0x60, 0xe0, 0xd68700)
	/home/sbezverk/projects/go/workspace/gobgp/pkg/server/grpc_server.go:273 +0x57
github.com/osrg/gobgp/pkg/server.(*BgpServer).AddPath.func1(0x494231, 0xc71a20)
	/home/sbezverk/projects/go/workspace/gobgp/pkg/server/server.go:1994 +0x54
github.com/osrg/gobgp/pkg/server.(*BgpServer).handleMGMTOp(0xc0001a2d80, 0xc0001149a0)
	/home/sbezverk/projects/go/workspace/gobgp/pkg/server/server.go:218 +0x47
github.com/osrg/gobgp/pkg/server.(*BgpServer).Serve(0xc0001a2d80)
	/home/sbezverk/projects/go/workspace/gobgp/pkg/server/server.go:400 +0x6f2
created by main.main
	/home/sbezverk/projects/go/workspace/gobgp/cmd/gobgpd/main.go:153 +0x394
```