### PR TITLE
local CLUSTER_ID check in CLUSTER_LIST.

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -505,6 +505,9 @@ func filterpath(peer *peer, path, old *table.Path) *table.Path {
 			if info.RouteReflectorClient {
 				ignore = false
 			}
+			if peer.isRouteReflectorClient() {
+				ignore = false
+			}
 			// RFC4456 8. Avoiding Routing Information Loops
 			// If the local CLUSTER_ID is found in the CLUSTER_LIST,
 			// the advertisement received SHOULD be ignored.
@@ -522,7 +525,6 @@ func filterpath(peer *peer, path, old *table.Path) *table.Path {
 					return nil
 				}
 			}
-			ignore = false
 		}
 
 		if ignore {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -505,26 +505,24 @@ func filterpath(peer *peer, path, old *table.Path) *table.Path {
 			if info.RouteReflectorClient {
 				ignore = false
 			}
-			if peer.isRouteReflectorClient() {
-				// RFC4456 8. Avoiding Routing Information Loops
-				// If the local CLUSTER_ID is found in the CLUSTER_LIST,
-				// the advertisement received SHOULD be ignored.
-				for _, clusterID := range path.GetClusterList() {
-					peer.fsm.lock.RLock()
-					rrClusterID := peer.fsm.peerInfo.RouteReflectorClusterID
-					peer.fsm.lock.RUnlock()
-					if clusterID.Equal(rrClusterID) {
-						log.WithFields(log.Fields{
-							"Topic":     "Peer",
-							"Key":       peer.ID(),
-							"ClusterID": clusterID,
-							"Data":      path,
-						}).Debug("cluster list path attribute has local cluster id, ignore")
-						return nil
-					}
+			// RFC4456 8. Avoiding Routing Information Loops
+			// If the local CLUSTER_ID is found in the CLUSTER_LIST,
+			// the advertisement received SHOULD be ignored.
+			for _, clusterID := range path.GetClusterList() {
+				peer.fsm.lock.RLock()
+				rrClusterID := peer.fsm.peerInfo.RouteReflectorClusterID
+				peer.fsm.lock.RUnlock()
+				if clusterID.Equal(rrClusterID) {
+					log.WithFields(log.Fields{
+						"Topic":     "Peer",
+						"Key":       peer.ID(),
+						"ClusterID": clusterID,
+						"Data":      path,
+					}).Debug("cluster list path attribute has local cluster id, ignore")
+					return nil
 				}
-				ignore = false
 			}
+			ignore = false
 		}
 
 		if ignore {


### PR DESCRIPTION
local CLUSTER_ID check in CLUSTER_LIST should be performed to non route reflector client as well.
otherwise multi cluster configuration may have routing loop.