### PR TITLE
optimized allocations in packet/bgp validations

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -12114,6 +12114,10 @@ func (c *LargeCommunity) String() string {
 	return fmt.Sprintf("%d:%d:%d", c.ASN, c.LocalData1, c.LocalData2)
 }
 
+func (c *LargeCommunity) Eq(rhs *LargeCommunity) bool {
+	return c.ASN == rhs.ASN && c.LocalData1 == rhs.LocalData1 && c.LocalData2 == rhs.LocalData2
+}
+
 func NewLargeCommunity(asn, data1, data2 uint32) *LargeCommunity {
 	return &LargeCommunity{
 		ASN:        asn,

--- a/pkg/packet/bgp/constant.go
+++ b/pkg/packet/bgp/constant.go
@@ -17,6 +17,7 @@ package bgp
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -161,7 +162,7 @@ var BitmaskFlagOpValueMap = map[string]BitmaskFlagOp{
 }
 
 func (f BitmaskFlagOp) String() string {
-	ops := make([]string, 0)
+	ops := make([]string, 0, 3)
 	if f&BITMASK_FLAG_OP_AND > 0 {
 		ops = append(ops, BitmaskFlagOpNameMap[BITMASK_FLAG_OP_AND])
 	} else {
@@ -323,5 +324,5 @@ func (t EthernetType) String() string {
 	if name, ok := EthernetTypeNameMap[t]; ok {
 		return name
 	}
-	return fmt.Sprintf("%d", t)
+	return strconv.Itoa(int(t))
 }

--- a/pkg/packet/bgp/constant.go
+++ b/pkg/packet/bgp/constant.go
@@ -16,7 +16,6 @@
 package bgp
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 )
@@ -74,7 +73,7 @@ var ProtocolNameMap = map[Protocol]string{
 func (p Protocol) String() string {
 	name, ok := ProtocolNameMap[p]
 	if !ok {
-		return fmt.Sprintf("%d", p)
+		return strconv.Itoa(int(p))
 	}
 	return name
 }

--- a/pkg/packet/bgp/validate.go
+++ b/pkg/packet/bgp/validate.go
@@ -33,17 +33,18 @@ func ValidateUpdateMsg(m *BGPUpdate, rfs map[RouteFamily]BGPAddPathMode, isEBGP 
 			//check specific path attribute
 			ok, err := ValidateAttribute(a, rfs, isEBGP, isConfed)
 			if !ok {
-				if err.(*MessageError).ErrorHandling == ERROR_HANDLING_SESSION_RESET {
+				msgErr := err.(*MessageError)
+				if msgErr.ErrorHandling == ERROR_HANDLING_SESSION_RESET {
 					return false, err
-				} else if err.(*MessageError).Stronger(strongestError) {
+				} else if msgErr.Stronger(strongestError) {
 					strongestError = err
 				}
 			}
 		} else if a.GetType() == BGP_ATTR_TYPE_MP_REACH_NLRI || a.GetType() == BGP_ATTR_TYPE_MP_UNREACH_NLRI {
-			eMsg := "the path attribute apears twice. Type : " + strconv.Itoa(int(a.GetType()))
+			eMsg := "the path attribute appears twice. Type : " + strconv.Itoa(int(a.GetType()))
 			return false, NewMessageError(eCode, eSubCodeAttrList, nil, eMsg)
 		} else {
-			eMsg := "the path attribute apears twice. Type : " + strconv.Itoa(int(a.GetType()))
+			eMsg := "the path attribute appears twice. Type : " + strconv.Itoa(int(a.GetType()))
 			e := NewMessageErrorWithErrorHandling(eCode, eSubCodeAttrList, nil, ERROR_HANDLING_ATTRIBUTE_DISCARD, nil, eMsg)
 			if e.(*MessageError).Stronger(strongestError) {
 				strongestError = e
@@ -201,7 +202,7 @@ func ValidateAttribute(a PathAttributeInterface, rfs map[RouteFamily]BGPAddPathM
 		for _, x := range p.Values {
 			found := false
 			for _, y := range uniq {
-				if x.String() == y.String() {
+				if x.Eq(y) {
 					found = true
 					break
 				}


### PR DESCRIPTION
* optimized comparision of LargeCommunities: it compared strings, now it compares uint32 values. I hadn't replaced O(n^2) comparision due to unlikeliness of a significant length of this list.
* got rid of possible double type cast in `ValidateUpdateMsg()`
* used preallocation in `BitmaskFlagOp.String()`
* fixed misspell