### PR TITLE
fix ipv6 next hop

### DIFF
--- a/internal/pkg/apiutil/attribute.go
+++ b/internal/pkg/apiutil/attribute.go
@@ -45,7 +45,9 @@ func UnmarshalAttribute(an *any.Any) (bgp.PathAttributeInterface, error) {
 	case *api.NextHopAttribute:
 		nexthop := net.ParseIP(a.NextHop).To4()
 		if nexthop == nil {
-			return nil, fmt.Errorf("invalid nexthop address: %s", a.NextHop)
+			if nexthop = net.ParseIP(a.NextHop).To16(); nexthop == nil {
+				return nil, fmt.Errorf("invalid nexthop address: %s", a.NextHop)
+			}
 		}
 		return bgp.NewPathAttributeNextHop(a.NextHop), nil
 	case *api.MultiExitDiscAttribute:
@@ -1363,7 +1365,9 @@ func unmarshalAttribute(an *any.Any) (bgp.PathAttributeInterface, error) {
 	case *api.NextHopAttribute:
 		nexthop := net.ParseIP(a.NextHop).To4()
 		if nexthop == nil {
-			return nil, fmt.Errorf("invalid nexthop address: %s", a.NextHop)
+			if nexthop = net.ParseIP(a.NextHop).To16(); nexthop == nil {
+				return nil, fmt.Errorf("invalid nexthop address: %s", a.NextHop)
+			}
 		}
 		return bgp.NewPathAttributeNextHop(a.NextHop), nil
 	case *api.MultiExitDiscAttribute:


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Currently if ipv6 next hop is specified, 
```
	a2, _ := ptypes.MarshalAny(&api.NextHopAttribute{
		NextHop: "2001:222:1111:20::201",
	})
```
AddPath fails with the following error:
```
rpc error: code = Unknown desc = invalid nexthop address: 2001:222:1111:20::201
```
This PR adds missing code to handle ipv6 next hop properly.