### PR TITLE
Restore NeighborInterface check related to nexthop

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -757,17 +757,19 @@ func capabilitiesFromConfig(pConf *config.Neighbor) []bgp.ParameterCapabilityInt
 		}
 	}
 
-	// Extended Nexthop Capability (Code 5)
-	tuples := []*bgp.CapExtendedNexthopTuple{}
-	families, _ := config.AfiSafis(pConf.AfiSafis).ToRfList()
-	for _, family := range families {
-		if family == bgp.RF_IPv6_UC {
-			continue
+	// unnumbered BGP
+	if pConf.Config.NeighborInterface != "" {
+		tuples := []*bgp.CapExtendedNexthopTuple{}
+		families, _ := config.AfiSafis(pConf.AfiSafis).ToRfList()
+		for _, family := range families {
+			if family == bgp.RF_IPv6_UC {
+				continue
+			}
+			tuple := bgp.NewCapExtendedNexthopTuple(family, bgp.AFI_IP6)
+			tuples = append(tuples, tuple)
 		}
-		tuple := bgp.NewCapExtendedNexthopTuple(family, bgp.AFI_IP6)
-		tuples = append(tuples, tuple)
+		caps = append(caps, bgp.NewCapExtendedNexthop(tuples))
 	}
-	caps = append(caps, bgp.NewCapExtendedNexthop(tuples))
 
 	// ADD-PATH Capability
 	if c := capAddPathFromConfig(pConf); c != nil {


### PR DESCRIPTION
* Establishing IPv6 peers was affected by fsm.go changes in 833188f52610dcf47c57250788b36625b10a8925, revert
* Fix https://github.com/osrg/gobgp/issues/2294