### PR TITLE
Add //go:generate stringer directives for public enum types.

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -2102,6 +2102,7 @@ func NewRouteTargetMembershipNLRI(as uint32, target ExtendedCommunityInterface) 
 	}
 }
 
+//go:generate stringer -type=ESIType
 type ESIType uint8
 
 const (
@@ -8284,6 +8285,7 @@ func (f BGPAttrFlag) String() string {
 	return strings.Join(strs, "|")
 }
 
+//go:generate stringer -type=BGPAttrType
 type BGPAttrType uint8
 
 const (

--- a/pkg/packet/bgp/constant.go
+++ b/pkg/packet/bgp/constant.go
@@ -24,6 +24,7 @@ const AS_TRANS = 23456
 
 const BGP_PORT = 179
 
+//go:generate stringer -type=FSMState
 type FSMState int
 
 const (


### PR DESCRIPTION
All such directives can be invoked by running
$ go generate

Stringer itself can be obtained by running
$ go get golang.org/x/tools/cmd/stringer

See https://github.com/osrg/gobgp/issues/2265