### PR TITLE
chore: general py setting for vscode development; suppress py3 syntax warnings in py test files

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PYTHONPATH=./test

--- a/test/scenario_test/addpath_test.py
+++ b/test/scenario_test/addpath_test.py
@@ -269,7 +269,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/aspath_test.py
+++ b/test/scenario_test/aspath_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -173,7 +172,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/bgp_confederation_test.py
+++ b/test/scenario_test/bgp_confederation_test.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 
-
-
 import sys
 import time
 import unittest
@@ -148,7 +146,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/bgp_malformed_msg_handling_test.py
+++ b/test/scenario_test/bgp_malformed_msg_handling_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -99,7 +98,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/bgp_router_test.py
+++ b/test/scenario_test/bgp_router_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import json
 import sys
 import time
@@ -472,7 +471,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/bgp_unnumbered_test.py
+++ b/test/scenario_test/bgp_unnumbered_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import unittest
 from lib import base
 from lib.base import BGP_FSM_ESTABLISHED, local
@@ -47,6 +46,7 @@ class GoBGPTestBase(unittest.TestCase):
         time.sleep(initial_wait_time + 2)
 
         done = False
+
         def f(ifname, ctn):
             out = ctn.local('ip -6 n', capture=True)
             l = [line for line in out.split('\n') if ifname in line]
@@ -90,7 +90,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/bgp_zebra_nht_test.py
+++ b/test/scenario_test/bgp_zebra_nht_test.py
@@ -284,7 +284,7 @@ class ZebraNHTTest(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/bgp_zebra_test.py
+++ b/test/scenario_test/bgp_zebra_test.py
@@ -303,7 +303,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/evpn_test.py
+++ b/test/scenario_test/evpn_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 from itertools import combinations
 import sys
 import time
@@ -144,7 +143,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/flow_spec_test.py
+++ b/test/scenario_test/flow_spec_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -409,7 +408,7 @@ class FlowSpecTest(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/global_policy_test.py
+++ b/test/scenario_test/global_policy_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -291,7 +290,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/graceful_restart_test.py
+++ b/test/scenario_test/graceful_restart_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -230,7 +229,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/ibgp_router_test.py
+++ b/test/scenario_test/ibgp_router_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 from itertools import combinations
 import sys
 import time
@@ -292,7 +291,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/long_lived_graceful_restart_test.py
+++ b/test/scenario_test/long_lived_graceful_restart_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 from itertools import chain
 import sys
 import time
@@ -251,7 +250,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/route_reflector_test.py
+++ b/test/scenario_test/route_reflector_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -139,7 +138,6 @@ class GoBGPTestBase(unittest.TestCase):
         # | (RR Client) |  | (RR Client) |  | (RR Client) |  | (RR Client) |
         # +-------------+  +-------------+  +-------------+  +-------------+
 
-
         gobgp_ctn_image_name = parser_option.gobgp_image
         rr = GoBGPContainer(name='rr', asn=65000, router_id='192.168.1.1',
                             ctn_image_name=gobgp_ctn_image_name,
@@ -260,7 +258,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/route_server_as2_test.py
+++ b/test/scenario_test/route_server_as2_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import unittest
 import sys
 import time
@@ -110,7 +109,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/route_server_ipv4_v6_test.py
+++ b/test/scenario_test/route_server_ipv4_v6_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -168,7 +167,7 @@ class GoBGPIPv6Test(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/route_server_malformed_test.py
+++ b/test/scenario_test/route_server_malformed_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -543,7 +542,7 @@ class TestGoBGPBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/route_server_policy_grpc_test.py
+++ b/test/scenario_test/route_server_policy_grpc_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -2709,7 +2708,7 @@ class TestGoBGPBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/route_server_policy_test.py
+++ b/test/scenario_test/route_server_policy_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -3184,7 +3183,7 @@ class TestGoBGPBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/route_server_softreset_test.py
+++ b/test/scenario_test/route_server_softreset_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -135,7 +134,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/route_server_test.py
+++ b/test/scenario_test/route_server_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -250,7 +249,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/route_server_test2.py
+++ b/test/scenario_test/route_server_test2.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -101,7 +100,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/rtc_test.py
+++ b/test/scenario_test/rtc_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 from itertools import combinations
 import sys
 import time
@@ -984,7 +983,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/vrf_neighbor_test.py
+++ b/test/scenario_test/vrf_neighbor_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -169,7 +168,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/vrf_neighbor_test2.py
+++ b/test/scenario_test/vrf_neighbor_test2.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-
 import sys
 import time
 import unittest
@@ -137,7 +136,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/zapi_v3_multipath_test.py
+++ b/test/scenario_test/zapi_v3_multipath_test.py
@@ -69,6 +69,7 @@ class GoBGPTestBase(unittest.TestCase):
     # Single nexthop route
     10.0.0.0/24 via 127.0.0.2 dev lo proto zebra metric 20
     """
+
     def parse_ip_route(self, ip_route_output):
         routes = {}
         current_mpath_dest = ""
@@ -254,7 +255,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 

--- a/test/scenario_test/zapi_v3_test.py
+++ b/test/scenario_test/zapi_v3_test.py
@@ -147,7 +147,7 @@ class GoBGPTestBase(unittest.TestCase):
 
 if __name__ == '__main__':
     output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) is not 0:
+    if int(output) != 0:
         print("docker not found")
         sys.exit(1)
 


### PR DESCRIPTION
added `.env` file for vscode to find test/lib module
replace `is not` exp in *_test.py files to suppress python syntax warning with py3