### PR TITLE
remove incomingCh when deleting dynamic peer

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1296,6 +1296,7 @@ func (s *BgpServer) deleteDynamicNeighbor(peer *peer, oldState bgp.FSMState, e *
 	peer.fsm.lock.RUnlock()
 	cleanInfiniteChannel(peer.fsm.outgoingCh)
 	cleanInfiniteChannel(peer.fsm.incomingCh)
+	s.delIncoming(peer.fsm.incomingCh)
 	s.broadcastPeerState(peer, oldState, e)
 }
 


### PR DESCRIPTION
When a dynamic neighbor/peer is deleted (i.e. BGP session goes down), its incoming channel is closed, but never removed from the server's list. This results in excessive iterations of the loop in BgpServer.Serve func, as it constantly selects on the closed channel. This in turn causes **very** high CPU utilization, mainly from the repeated creation and garbage collection of the slice being passed to reflect.Select.

This PR fixes the issue by removing the incoming channel from the server's list when the dynamic neighbor is deleted (which also mirrors the behaviour of when a non-dynamic peer is deleted)