### PR TITLE
bugfix: fix a panic when delete neighborset (all) by name directly

### DIFF
--- a/cmd/gobgp/policy.go
+++ b/cmd/gobgp/policy.go
@@ -323,7 +323,7 @@ func parseNeighborSet(args []string) (*api.DefinedSet, error) {
 	}
 	name := args[0]
 	args = args[1:]
-	list := make([]string, 0, len(args[1:]))
+	list := make([]string, 0, len(args))
 	for _, arg := range args {
 		address := net.ParseIP(arg)
 		if address.To4() != nil {


### PR DESCRIPTION
```
╰─$ gobgp policy nei del ns2                                                                                                                                                                                                                         2 ↵
panic: runtime error: slice bounds out of range [1:0]

goroutine 1 [running]:
main.parseNeighborSet(0xc000092660, 0x1, 0x1, 0x2, 0xc0000a4ea0, 0x0)
	/Users/ij0151/go/src/github.com/osrg/gobgp/cmd/gobgp/policy.go:326 +0x70f
main.parseDefinedSet(0x1749b4c, 0x8, 0xc000092660, 0x1, 0x1, 0x174a070, 0xc0001d5d38, 0xc0000a4ea0)
	/Users/ij0151/go/src/github.com/osrg/gobgp/cmd/gobgp/policy.go:429 +0x205
main.modDefinedSet(0x1749b4c, 0x8, 0x1745750, 0x3, 0xc000092660, 0x1, 0x1, 0x0, 0xc000096050)
	/Users/ij0151/go/src/github.com/osrg/gobgp/cmd/gobgp/policy.go:458 +0x6d
main.newPolicyCmd.func3(0xc0000befc0, 0xc000092660, 0x1, 0x1)
	/Users/ij0151/go/src/github.com/osrg/gobgp/cmd/gobgp/policy.go:1073 +0x6e
github.com/spf13/cobra.(*Command).execute(0xc0000befc0, 0xc000092610, 0x1, 0x1, 0xc0000befc0, 0xc000092610)
	/Users/ij0151/go/pkg/mod/github.com/spf13/cobra@v0.0.0-20170731170427-b26b538f6930/command.go:653 +0x277
```
This commit fixes the above issue when delete a neighborset from `gobgp` command line solely by name
