### PR TITLE
README: remove slack status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # GoBGP: BGP implementation in Go
 
 [![Build Status](https://travis-ci.org/osrg/gobgp.svg?branch=master)](https://travis-ci.org/osrg/gobgp/builds)
-[![Slack Status](https://slackin-gobgp.now.sh/badge.svg)](https://slackin-gobgp.now.sh/)
 
 GoBGP is an open source BGP implementation designed from scratch for
 modern environment and implemented in a modern programming language,


### PR DESCRIPTION
It shows the status of slackin web server. We don't need it anymore.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>