### PR TITLE
server: fix ListPolicyAssignment to handle empty policy

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3492,9 +3492,6 @@ func (s *BgpServer) ListPolicyAssignment(ctx context.Context, r *api.ListPolicyA
 				if err != nil {
 					return err
 				}
-				if len(policies) == 0 {
-					continue
-				}
 				t := &table.PolicyAssignment{
 					Name:     name,
 					Type:     dir,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -194,19 +194,19 @@ func TestListPolicyAssignment(t *testing.T) {
 		Name: table.GLOBAL_RIB_NAME,
 	}, func(p *api.PolicyAssignment) { ps = append(ps, p) })
 	assert.Nil(err)
-	assert.Equal(len(ps), 0)
+	assert.Equal(2, len(ps))
 
 	ps = []*api.PolicyAssignment{}
 	err = s.ListPolicyAssignment(context.Background(), &api.ListPolicyAssignmentRequest{}, func(p *api.PolicyAssignment) { ps = append(ps, p) })
 	assert.Nil(err)
-	assert.Equal(len(ps), 3)
+	assert.Equal(8, len(ps))
 
 	ps = []*api.PolicyAssignment{}
 	err = s.ListPolicyAssignment(context.Background(), &api.ListPolicyAssignmentRequest{
 		Direction: api.PolicyDirection_EXPORT,
 	}, func(p *api.PolicyAssignment) { ps = append(ps, p) })
 	assert.Nil(err)
-	assert.Equal(len(ps), 0)
+	assert.Equal(4, len(ps))
 }
 
 func TestListPathEnableFiltered(test *testing.T) {


### PR DESCRIPTION
fix ListPolicyAssignment() return an assignment response even if the
response doesn't have any policy. The assignment has default action
policy so it's useful without any policy.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>