### PR TITLE
Use MonitorTableRequest.Name to filter by peer

### DIFF
--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -122,10 +122,10 @@ func (b *bmpClient) loop() {
 				).Warn("both option for route-monitoring-policy is obsoleted")
 			}
 			if b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY || b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
-				ops = append(ops, watchUpdate(true))
+				ops = append(ops, watchUpdate(true, ""))
 			}
 			if b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY || b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
-				ops = append(ops, watchPostUpdate(true))
+				ops = append(ops, watchPostUpdate(true, ""))
 			}
 			if b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB || b.c.RouteMonitoringPolicy == config.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
 				ops = append(ops, watchBestPath(true))

--- a/pkg/server/mrt.go
+++ b/pkg/server/mrt.go
@@ -51,7 +51,7 @@ func (m *mrtWriter) loop() error {
 	ops := []watchOption{}
 	switch m.c.DumpType {
 	case config.MRT_TYPE_UPDATES:
-		ops = append(ops, watchUpdate(false))
+		ops = append(ops, watchUpdate(false, ""))
 	case config.MRT_TYPE_TABLE:
 		if len(m.c.TableName) > 0 {
 			ops = append(ops, watchTableName(m.c.TableName))

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -581,7 +581,7 @@ func TestMonitor(test *testing.T) {
 	}
 
 	// Test WatchUpdate with "current" flag.
-	w = s.watch(watchUpdate(true))
+	w = s.watch(watchUpdate(true, ""))
 
 	// Test the initial route.
 	ev = <-w.Event()
@@ -1287,7 +1287,7 @@ func TestDoNotReactToDuplicateRTCMemberships(t *testing.T) {
 	if err := peerServers(t, ctx, []*BgpServer{s1, s2}, []config.AfiSafiType{config.AFI_SAFI_TYPE_L3VPN_IPV4_UNICAST, config.AFI_SAFI_TYPE_RTC}); err != nil {
 		t.Fatal(err)
 	}
-	watcher := s1.watch(watchUpdate(true))
+	watcher := s1.watch(watchUpdate(true, ""))
 
 	// Add route to vrf1 on s2
 	attrs := []bgp.PathAttributeInterface{

--- a/pkg/server/zclient.go
+++ b/pkg/server/zclient.go
@@ -364,7 +364,7 @@ func (z *zebraClient) updatePathByNexthopCache(paths []*table.Path) {
 func (z *zebraClient) loop() {
 	w := z.server.watch([]watchOption{
 		watchBestPath(true),
-		watchPostUpdate(true),
+		watchPostUpdate(true, ""),
 	}...)
 	defer w.Stop()
 


### PR DESCRIPTION
It seems that `GetTableRequest.Name` is used to retrieve only the table for the given peer, but while the `MonitorTableRequest.Name` field exists, from what I can tell it is unused.

This uses the `MonitorTableRequest.Name` field to filter returned Paths based on provided peer address (similar to
GetTable). If ADJ_IN is monitored with Current is set, then this filtering is done in the appropriate section of the `watch` method, which should significantly improve performance for users trying to monitor a single peer's table.