### PR TITLE
config: fix Peer Group AddPath Config

### DIFF
--- a/internal/pkg/config/util.go
+++ b/internal/pkg/config/util.go
@@ -549,6 +549,8 @@ func NewPeerGroupFromConfigStruct(pconf *PeerGroup) *api.PeerGroup {
 	afiSafis := make([]*api.AfiSafi, 0, len(pconf.AfiSafis))
 	for _, f := range pconf.AfiSafis {
 		if afiSafi := newAfiSafiFromConfigStruct(&f); afiSafi != nil {
+			afiSafi.AddPaths.Config.Receive = pconf.AddPaths.Config.Receive
+			afiSafi.AddPaths.Config.SendMax = uint32(pconf.AddPaths.Config.SendMax)
 			afiSafis = append(afiSafis, afiSafi)
 		}
 	}


### PR DESCRIPTION
Peer Group AddPath Config is deprecated but still needs to work.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@lab.ntt.co.jp>