### PR TITLE
make CI faster

### DIFF
--- a/test/lib/fabfile.py
+++ b/test/lib/fabfile.py
@@ -11,11 +11,13 @@ def make_gobgp_ctn(ctx, tag='gobgp',
     if local_gobgp_path == '':
         local_gobgp_path = os.getcwd()
 
+    local('CGO_ENABLED=0 go build "-ldflags=-s -w -buildid=" ./cmd/gobgp')
+    local('CGO_ENABLED=0 go build "-ldflags=-s -w -buildid=" ./cmd/gobgpd')
+
     c = CmdBuffer()
     c << 'FROM {0}'.format(from_image)
-    c << 'ENV GO111MODULE on'
-    c << 'ADD gobgp /tmp/gobgp'
-    c << 'RUN cd /tmp/gobgp && go install ./cmd/gobgpd ./cmd/gobgp'
+    c << 'COPY gobgp/gobgpd /go/bin/gobgpd'
+    c << 'COPY gobgp/gobgp /go/bin/gobgp'
 
     rindex = local_gobgp_path.rindex('gobgp')
     if rindex < 0:


### PR DESCRIPTION
Build GoBGP binaries of a pull request locally and copy them to the
container to be tested instead of copying the code into the container
and building the binaries inside.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>