### PR TITLE
set shutdownWG to nil after stopBGP finished

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1770,6 +1770,7 @@ func (s *BgpServer) StopBgp(ctx context.Context, r *api.StopBgpRequest) error {
 
 	if s.shutdownWG != nil {
 		s.shutdownWG.Wait()
+		s.shutdownWG = nil
 	}
 	return nil
 }


### PR DESCRIPTION
otherwise gobgp will panic in handlefsmMsg when handle error condition

Signed-off-by: Duan Jiong <duanjiong@yunify.com>