### PR TITLE
Add missing marshal of Prefix SID path attribute

### DIFF
--- a/internal/pkg/apiutil/attribute.go
+++ b/internal/pkg/apiutil/attribute.go
@@ -1455,6 +1455,9 @@ func MarshalPathAttributes(attrList []bgp.PathAttributeInterface) []*any.Any {
 		case *bgp.PathAttributeLs:
 			n, _ := ptypes.MarshalAny(NewLsAttributeFromNative(a))
 			anyList = append(anyList, n)
+		case *bgp.PathAttributePrefixSID:
+			n, _ := ptypes.MarshalAny(NewPrefixSIDAttributeFromNative(a))
+			anyList = append(anyList, n)
 		case *bgp.PathAttributeUnknown:
 			n, _ := ptypes.MarshalAny(NewUnknownAttributeFromNative(a))
 			anyList = append(anyList, n)


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Currently when API call is issued to List for L3VPN prefix with Prefix SID, prefix sid info has not been returned along with other path attributes. This PR add marshalling Prefix SID into the reply to List call.