### PR TITLE
packet/bgp: Fix TunnelEncapSubTLV.DecodeFromBytes

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -11393,7 +11393,7 @@ func (t *TunnelEncapSubTLV) DecodeFromBytes(data []byte) (value []byte, err erro
 	if len(data) < int(t.Length) {
 		return nil, NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all TunnelEncapSubTLV bytes available")
 	}
-	return data, nil
+	return data[:t.Length], nil
 }
 
 func (t *TunnelEncapSubTLV) Serialize(value []byte) (buf []byte, err error) {


### PR DESCRIPTION
Return data of the correct length from TunnelEncapSubTLV.DecodeFromBytes.

This fixes a problem with TunnelEncapSubTLVUnknown which caused it to
contain more bytes in its Value unless it was the last SubTLV.

Signed-off-by: Mikael Magnusson <mikma@users.sourceforge.net>