### PR TITLE
ci: fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,9 @@
 name: release
 
 on:
-  create:
-    branches:
-      - refs/tags/*
-#  create:
-#    tags:
-#      - v*.*.*
+  push:
+    tags:
+      - v[0-9]+.*
 
 jobs:
   build:


### PR DESCRIPTION
release action should be triggered only when a tag is pushed.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>