### PR TITLE
fixing an issue when gobgp propagates paths from MP peer to non-MP peer

### DIFF
--- a/internal/pkg/table/message.go
+++ b/internal/pkg/table/message.go
@@ -442,6 +442,12 @@ func (p *packerV4) pack(options ...*bgp.MarshallingOption) []*bgp.BGPMessage {
 			paths := c.paths
 
 			attrs := paths[0].GetPathAttrs()
+			// we can apply a fix here when gobgp receives from MP peer
+			// and propagtes to non-MP peer
+			// we should make sure that we next-hop exists in pathattrs
+			// while we build the update message
+			// we do not want to modify the `path` though
+			attrs = append(attrs, bgp.NewPathAttributeNextHop(paths[0].GetNexthop().String()))
 			attrsLen := 0
 			for _, a := range attrs {
 				attrsLen += a.Len()

--- a/internal/pkg/table/message.go
+++ b/internal/pkg/table/message.go
@@ -447,7 +447,9 @@ func (p *packerV4) pack(options ...*bgp.MarshallingOption) []*bgp.BGPMessage {
 			// we should make sure that we next-hop exists in pathattrs
 			// while we build the update message
 			// we do not want to modify the `path` though
-			attrs = append(attrs, bgp.NewPathAttributeNextHop(paths[0].GetNexthop().String()))
+			if paths[0].getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP) == nil {
+				attrs = append(attrs, bgp.NewPathAttributeNextHop(paths[0].GetNexthop().String()))
+			}
 			attrsLen := 0
 			for _, a := range attrs {
 				attrsLen += a.Len()


### PR DESCRIPTION
…P-capable peer

whereby MP-capable peer uses MP_REACH_NLRI to send updates to gobgp
gobgp accepts it but without setting NEXT_HOP pathattr
then gobgp propagates the paths to the non-MP-capable peer with update.NLRI set but without NEXT_HOP
the non-MP-capable peer will treat the update as withdraw message cause routes cannot propagate properly