### PR TITLE
goreleaser: improve portability

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,10 @@ builds:
   - id: gobgp
     main: ./cmd/gobgp/
     binary: gobgp
-    ldflags: -s -extldflags "-static"
+    flags:
+      - -a
+      - -tags=netgo
+    ldflags: -s
     goos:
       - linux
     goarch:
@@ -21,7 +24,10 @@ builds:
   - id: gobgpd
     main: ./cmd/gobgpd/
     binary: gobgpd
-    ldflags: -s -extldflags "-static"
+    flags:
+      - -a
+      - -tags=netgo
+    ldflags: -s
     goos:
       - linux
     goarch:


### PR DESCRIPTION
- Use tags=netgo to ensure net package won't use cgo
- Rebuild stdlib (go build -a) to really disable cgo as it was
  tried in https://github.com/osrg/gobgp/pull/2300
- Remove static ldflags as it would statically compile cgo