### PR TITLE
tools: don't use a shebang for bash completion

### DIFF
--- a/tools/completion/gobgp-completion.bash
+++ b/tools/completion/gobgp-completion.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+# bash completion for gobgp                                -*- shell-script -*-
 
 . `dirname $BASH_SOURCE`/gobgp-static-completion.bash
 . `dirname $BASH_SOURCE`/gobgp-dynamic-completion.bash

--- a/tools/completion/gobgp-dynamic-completion.bash
+++ b/tools/completion/gobgp-dynamic-completion.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+# bash completion for gobgp                                -*- shell-script -*-
 
 __gobgp_q()
 {

--- a/tools/completion/gobgp-static-completion.bash
+++ b/tools/completion/gobgp-static-completion.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+# bash completion for gobgp                                -*- shell-script -*-
 
 _gobgp_global_rib_add()
 {


### PR DESCRIPTION
They are not expected to be executed. This seems a silly path, but
some people bother filing bug reports about it, so if you are OK with
it, it could be "fixed".