### PR TITLE
Remove MP_REACH_NLRI if the attr exists for IPv4_UC with IPv4 nexthop

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -4853,7 +4853,7 @@ func (n *OpaqueNLRI) Len(options ...*MarshallingOption) int {
 }
 
 func (n *OpaqueNLRI) String() string {
-	return fmt.Sprintf("%s", n.Key)
+	return string(n.Key)
 }
 
 func (n *OpaqueNLRI) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
refactor: nlri/nexthop requires MP will get MP explicitly already. So we can safely remove the MP_REACH_NLRI from ipv4_uc with ipv4 nexthop

However, I am wondering is it safe to discard the MP_REACH_NLRI on the receiving side directly. Since MP_REACH_NLRI is not counted for hash calculation