### PR TITLE
Add support for tunnel encap in gobgp policy

### DIFF
--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -206,6 +206,8 @@ func encapParser(args []string) ([]bgp.ExtendedCommunityInterface, error) {
 		typ = bgp.TUNNEL_TYPE_MPLS_IN_UDP
 	case "vxlan-gre":
 		typ = bgp.TUNNEL_TYPE_VXLAN_GRE
+	case "geneve":
+		typ = bgp.TUNNEL_TYPE_GENEVE
 	default:
 		return nil, fmt.Errorf("invalid encap type")
 	}

--- a/docs/sources/policy.md
+++ b/docs/sources/policy.md
@@ -410,6 +410,19 @@ subtype of extended community and subtypes that can be used are as follows:
 
 - RT: mean the route target.
 - SoO: mean the site of origin(route origin).
+- encap: mean the encapsulation tunnel type, currently gobgp supports the following encap tunnels:
+    l2tp3
+    gre
+    ip-in-ip
+    vxlan
+    nvgre
+    mpls
+    mpls-in-gre
+    vxlan-gre
+    mpls-in-udp
+    sr-policy
+    geneve
+
 
 ##### Examples
 

--- a/internal/pkg/table/policy.go
+++ b/internal/pkg/table/policy.go
@@ -1116,7 +1116,7 @@ func ParseExtCommunity(arg string) (bgp.ExtendedCommunityInterface, error) {
 		return r || s == bgp.VALIDATION_STATE_INVALID.String()
 	}
 	if len(elems) < 2 && (len(elems) < 1 && !isValidationState(elems[0])) {
-		return nil, fmt.Errorf("invalid ext-community (rt|soo):<value> | valid | not-found | invalid")
+		return nil, fmt.Errorf("invalid ext-community (rt|soo|encap):<value> | valid | not-found | invalid")
 	}
 	if isValidationState(elems[0]) {
 		subtype = bgp.EC_SUBTYPE_ORIGIN_VALIDATION
@@ -1127,8 +1127,10 @@ func ParseExtCommunity(arg string) (bgp.ExtendedCommunityInterface, error) {
 			subtype = bgp.EC_SUBTYPE_ROUTE_TARGET
 		case "soo":
 			subtype = bgp.EC_SUBTYPE_ROUTE_ORIGIN
+		case "encap":
+			subtype = bgp.EC_SUBTYPE_ENCAPSULATION
 		default:
-			return nil, fmt.Errorf("invalid ext-community (rt|soo):<value> | valid | not-found | invalid")
+			return nil, fmt.Errorf("invalid ext-community (rt|soo|encap):<value> | valid | not-found | invalid")
 		}
 		value = elems[1]
 	}
@@ -1160,15 +1162,17 @@ func ParseExtCommunityRegexp(arg string) (bgp.ExtendedCommunityAttrSubType, *reg
 	var subtype bgp.ExtendedCommunityAttrSubType
 	elems := strings.SplitN(arg, ":", 2)
 	if len(elems) < 2 {
-		return subtype, nil, fmt.Errorf("invalid ext-community format([rt|soo]:<value>)")
+		return subtype, nil, fmt.Errorf("invalid ext-community format([rt|soo|encap]:<value>)")
 	}
 	switch strings.ToLower(elems[0]) {
 	case "rt":
 		subtype = bgp.EC_SUBTYPE_ROUTE_TARGET
 	case "soo":
 		subtype = bgp.EC_SUBTYPE_ROUTE_ORIGIN
+	case "encap":
+		subtype = bgp.EC_SUBTYPE_ENCAPSULATION
 	default:
-		return subtype, nil, fmt.Errorf("unknown ext-community subtype. rt, soo is supported")
+		return subtype, nil, fmt.Errorf("unknown ext-community subtype. rt, soo, encap is supported")
 	}
 	exp, err := ParseCommunityRegexp(elems[1])
 	return subtype, exp, err
@@ -1212,6 +1216,8 @@ func (s *ExtCommunitySet) List() []string {
 			return fmt.Sprintf("rt:%s", arg)
 		case bgp.EC_SUBTYPE_ROUTE_ORIGIN:
 			return fmt.Sprintf("soo:%s", arg)
+		case bgp.EC_SUBTYPE_ENCAPSULATION:
+			return fmt.Sprintf("encap:%s", arg)
 		case bgp.EC_SUBTYPE_ORIGIN_VALIDATION:
 			return arg
 		default:
@@ -2221,6 +2227,8 @@ func (a *ExtCommunityAction) ToConfig() *config.SetExtCommunity {
 			return fmt.Sprintf("rt:%s", arg)
 		case bgp.EC_SUBTYPE_ROUTE_ORIGIN:
 			return fmt.Sprintf("soo:%s", arg)
+		case bgp.EC_SUBTYPE_ENCAPSULATION:
+			return fmt.Sprintf("encap:%s", arg)
 		case bgp.EC_SUBTYPE_ORIGIN_VALIDATION:
 			return arg
 		default:

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -10248,6 +10248,55 @@ func NewFourOctetAsSpecificExtended(subtype ExtendedCommunityAttrSubType, as uin
 }
 
 func ParseExtendedCommunity(subtype ExtendedCommunityAttrSubType, com string) (ExtendedCommunityInterface, error) {
+	if subtype == EC_SUBTYPE_ENCAPSULATION {
+		var t TunnelType
+		switch com {
+		case TUNNEL_TYPE_L2TP3.String():
+			t = TUNNEL_TYPE_L2TP3
+		case TUNNEL_TYPE_GRE.String():
+			t = TUNNEL_TYPE_GRE
+		case TUNNEL_TYPE_IP_IN_IP.String():
+			t = TUNNEL_TYPE_IP_IN_IP
+		case TUNNEL_TYPE_VXLAN.String():
+			t = TUNNEL_TYPE_VXLAN
+		case TUNNEL_TYPE_NVGRE.String():
+			t = TUNNEL_TYPE_NVGRE
+		case TUNNEL_TYPE_MPLS.String():
+			t = TUNNEL_TYPE_MPLS
+		case TUNNEL_TYPE_MPLS_IN_GRE.String():
+			t = TUNNEL_TYPE_MPLS_IN_GRE
+		case TUNNEL_TYPE_VXLAN_GRE.String():
+			t = TUNNEL_TYPE_VXLAN_GRE
+		case TUNNEL_TYPE_MPLS_IN_UDP.String():
+			t = TUNNEL_TYPE_MPLS_IN_UDP
+		case TUNNEL_TYPE_GENEVE.String():
+			t = TUNNEL_TYPE_GENEVE
+		case "L2TPv3 over IP":
+			t = TUNNEL_TYPE_L2TP3
+		case "GRE":
+			t = TUNNEL_TYPE_GRE
+		case "IP in IP":
+			t = TUNNEL_TYPE_IP_IN_IP
+		case "VXLAN":
+			t = TUNNEL_TYPE_VXLAN
+		case "NVGRE":
+			t = TUNNEL_TYPE_NVGRE
+		case "MPLS":
+			t = TUNNEL_TYPE_MPLS
+		case "MPLS in GRE":
+			t = TUNNEL_TYPE_MPLS_IN_GRE
+		case "VXLAN GRE":
+			t = TUNNEL_TYPE_VXLAN_GRE
+		case "MPLS in UDP":
+			t = TUNNEL_TYPE_MPLS_IN_UDP
+		case "GENEVE":
+			t = TUNNEL_TYPE_GENEVE
+		default:
+			return nil, fmt.Errorf("invalid encap type %s", com)
+		}
+		return NewEncapExtended(t), nil
+	}
+
 	if subtype == EC_SUBTYPE_ORIGIN_VALIDATION {
 		var state ValidationState
 		switch com {


### PR DESCRIPTION
gobgp now supports adding global rib with encap tunnel type, but tunnel encapsulation is not supported in policy configuration, this pull requests is add add support of tunnel encapsulation in gobgp policy configuration by extending extended community with encap, also add geneve encap in CLI.