### PR TITLE
zebra: close the incoming channel

### DIFF
--- a/internal/pkg/zebra/zapi.go
+++ b/internal/pkg/zebra/zapi.go
@@ -1377,7 +1377,7 @@ func NewClient(network, address string, typ RouteType, version uint8, software s
 
 	// Start receive loop only when the first message successfully received.
 	go func() {
-		defer closeChannel(incoming)
+		defer close(incoming)
 		for {
 			if m, err := receiveSingleMsg(); err != nil {
 				return


### PR DESCRIPTION
In general the writer should close the channel, thus we can close the channel here directly.
If zebra has disconnected the `closeChannel` method will in most cases not even close the channel
because no more messages can be received on it.