### PR TITLE
Update the hold timer when a BGP Update message is received

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -1019,6 +1019,13 @@ func (h *fsmHandler) recvMessageWithError() (*fsmMsg, error) {
 			case bgp.BGP_MSG_ROUTE_REFRESH:
 				fmsg.MsgType = fsmMsgRouteRefresh
 			case bgp.BGP_MSG_UPDATE:
+				// if the length of h.holdTimerResetCh
+				// isn't zero, the timer will be reset
+				// soon anyway.
+				select {
+				case h.holdTimerResetCh <- true:
+				default:
+				}
 				body := m.Body.(*bgp.BGPUpdate)
 				isEBGP := h.fsm.pConf.IsEBGPPeer(h.fsm.gConf)
 				isConfed := h.fsm.pConf.IsConfederationMember(h.fsm.gConf)


### PR DESCRIPTION
According to RFC4271,
       The calculated value indicates the maximum number of
         seconds that may elapse between the receipt of successive
         KEEPALIVE and/or UPDATE messages from the sender.

This change will reset the hold timer in the update FSM case.
(note, I am super new with Go. I'm not quite sure how to craft a good test case for this.)
