### PR TITLE
.github/release: Use goreleaser action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,20 +6,25 @@ on:
       - v[0-9]+.*
 
 jobs:
-  build:
-    runs-on: ubuntu-16.04
-
+  goreleaser:
+    runs-on: ubuntu-latest
     steps:
-      - name: checking out
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: releasing
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          wget https://github.com/goreleaser/goreleaser/releases/download/v0.108.0/goreleaser_amd64.deb
-          sudo dpkg -i goreleaser_amd64.deb
-          rm goreleaser_amd64.deb
-          cd /home/runner/work/gobgp/gobgp && goreleaser release


### PR DESCRIPTION
https://github.com/goreleaser/goreleaser-action#workflow

This simplifies the workflow, allows to define the golang version it is
built with.