### PR TITLE
.github/ci: Replace staticcheck with golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,20 +24,14 @@ jobs:
           go env GOARCH
           go test -timeout 240s ./...
 
-  staticcheck:
-    name: staticcheck
+  golangci:
+    name: lint
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-go@v2
-        with:
-          go-version: '^1.17.4'
-      - run: |
-          test -z "$(go fmt ./...)"
-          go vet ./...
-          export PATH=${PATH}:`go env GOPATH`/bin
-          go install honnef.co/go/tools/cmd/staticcheck@2021.1.2
-          staticcheck ./...
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
 
   embeded:
     name: embeded

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+run:
+  deadline: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - misspell
+    - staticcheck
+    - typecheck

--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -948,7 +948,7 @@ func extractOrigin(args []string) ([]string, bgp.PathAttributeInterface, error) 
 			break
 		}
 	}
-	return args, bgp.NewPathAttributeOrigin(uint8(typ)), nil
+	return args, bgp.NewPathAttributeOrigin(typ), nil
 }
 
 func toAs4Value(s string) (uint32, error) {
@@ -994,7 +994,7 @@ func newAsPath(aspath string) (bgp.PathAttributeInterface, error) {
 			if asn, err := toAs4Value(n); err != nil {
 				return nil, err
 			} else {
-				asNums = append(asNums, uint32(asn))
+				asNums = append(asNums, asn)
 			}
 		}
 		// Assumes "idx" is even, the given "segment" is of type AS_SEQUENCE,
@@ -1137,7 +1137,7 @@ func extractAigp(args []string) ([]string, bgp.PathAttributeInterface, error) {
 				if err != nil {
 					return nil, nil, err
 				}
-				aigp := bgp.NewPathAttributeAigp([]bgp.AigpTLVInterface{bgp.NewAigpTLVIgpMetric(uint64(metric))})
+				aigp := bgp.NewPathAttributeAigp([]bgp.AigpTLVInterface{bgp.NewAigpTLVIgpMetric(metric)})
 				return append(args[:idx], args[idx+3:]...), aigp, nil
 			default:
 				return nil, nil, fmt.Errorf("unknown aigp type: %s", typ)

--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -844,7 +844,7 @@ func showNeighborRib(r string, name string, args []string) error {
 			}
 			args = args[1:]
 		}
-		filter = []*api.TableLookupPrefix{&api.TableLookupPrefix{
+		filter = []*api.TableLookupPrefix{{
 			Prefix:       target,
 			LookupOption: option,
 		},

--- a/internal/pkg/table/policy_test.go
+++ b/internal/pkg/table/policy_test.go
@@ -2895,7 +2895,7 @@ func createPrefixSet(name string, prefix string, maskLength string) config.Prefi
 	ps := config.PrefixSet{
 		PrefixSetName: name,
 		PrefixList: []config.Prefix{
-			config.Prefix{
+			{
 				IpPrefix:        prefix,
 				MasklengthRange: maskLength,
 			}},
@@ -3052,8 +3052,8 @@ func TestPrefixSetMatchV6LabeledwithV6Prefix(t *testing.T) {
 
 func TestLargeCommunityMatchAction(t *testing.T) {
 	coms := []*bgp.LargeCommunity{
-		&bgp.LargeCommunity{ASN: 100, LocalData1: 100, LocalData2: 100},
-		&bgp.LargeCommunity{ASN: 100, LocalData1: 200, LocalData2: 200},
+		{ASN: 100, LocalData1: 100, LocalData2: 100},
+		{ASN: 100, LocalData1: 200, LocalData2: 200},
 	}
 	p := NewPath(nil, nil, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeLargeCommunities(coms)}, time.Time{}, false)
 
@@ -3133,8 +3133,8 @@ func TestLargeCommunityMatchAction(t *testing.T) {
 
 func TestLargeCommunitiesMatchClearAction(t *testing.T) {
 	coms := []*bgp.LargeCommunity{
-		&bgp.LargeCommunity{ASN: 100, LocalData1: 100, LocalData2: 100},
-		&bgp.LargeCommunity{ASN: 100, LocalData1: 200, LocalData2: 200},
+		{ASN: 100, LocalData1: 100, LocalData2: 100},
+		{ASN: 100, LocalData1: 200, LocalData2: 200},
 	}
 	p := NewPath(nil, nil, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeLargeCommunities(coms)}, time.Time{}, false)
 
@@ -3193,17 +3193,17 @@ func TestAfiSafiInMatchPath(t *testing.T) {
 func TestMultipleStatementPolicy(t *testing.T) {
 	r := NewRoutingPolicy(logger)
 	rp := config.RoutingPolicy{
-		PolicyDefinitions: []config.PolicyDefinition{config.PolicyDefinition{
+		PolicyDefinitions: []config.PolicyDefinition{{
 			Name: "p1",
 			Statements: []config.Statement{
-				config.Statement{
+				{
 					Actions: config.Actions{
 						BgpActions: config.BgpActions{
 							SetMed: "+100",
 						},
 					},
 				},
-				config.Statement{
+				{
 					Actions: config.Actions{
 						BgpActions: config.BgpActions{
 							SetLocalPref: 100,

--- a/internal/pkg/zebra/zapi.go
+++ b/internal/pkg/zebra/zapi.go
@@ -1524,7 +1524,7 @@ func (c *Client) SupportMpls() bool {
 	// Note: frr3&4 have LABEL_MANAGER_CONNECT& GET_LABEL_CHUNK. However
 	// Routes will not be installed via zebra of frr3&4 after call these APIs.
 	if c.Version < 5 || c.SoftwareName == "frr4" {
-		return false // if frr4 or ealier are used
+		return false // if frr4 or earlier are used
 	}
 	return true // if frr5 or later are used
 }
@@ -2329,7 +2329,7 @@ func (b *IPRouteBody) RouteFamily(logger log.Logger, version uint8, softwareName
 	}
 	safi := b.safi(logger, version, softwareName)
 	if safi == safiEvpn {
-		return bgp.RF_EVPN // sucess
+		return bgp.RF_EVPN // success
 	}
 	family := b.Prefix.Family
 	if family == syscall.AF_UNSPEC {
@@ -2353,7 +2353,7 @@ func (b *IPRouteBody) RouteFamily(logger log.Logger, version uint8, softwareName
 			"Safi":  safi.String(),
 			"Rf":    rf.String()})
 
-	return rf // sucess
+	return rf // success
 }
 
 // IsWithdraw is referred in zclient

--- a/internal/pkg/zebra/zapi_test.go
+++ b/internal/pkg/zebra/zapi_test.go
@@ -17,11 +17,12 @@ package zebra
 
 import (
 	"encoding/binary"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net"
 	"syscall"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_Header(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -235,9 +235,7 @@ func InitialConfig(ctx context.Context, bgpServer *server.BgpServer, newConfig *
 	if newConfig.Zebra.Config.Enabled {
 		tps := newConfig.Zebra.Config.RedistributeRouteTypeList
 		l := make([]string, 0, len(tps))
-		for _, t := range tps {
-			l = append(l, string(t))
-		}
+		l = append(l, tps...)
 		if err := bgpServer.EnableZebra(ctx, &api.EnableZebraRequest{
 			Url:                  newConfig.Zebra.Config.Url,
 			RouteTypes:           l,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -29,7 +29,7 @@ func ExampleInitialConfig() {
 	}
 }
 
-// ExampleUpdateConfig shows how UpdateConfig is used in conjuction with
+// ExampleUpdateConfig shows how UpdateConfig is used in conjunction with
 // InitialConfig.
 func ExampleUpdateConfig() {
 	bgpServer := server.NewBgpServer()

--- a/tools/config/example_toml.go
+++ b/tools/config/example_toml.go
@@ -17,19 +17,19 @@ func main() {
 			},
 		},
 		Neighbors: []config.Neighbor{
-			config.Neighbor{
+			{
 				Config: config.NeighborConfig{
 					PeerAs:          12333,
 					AuthPassword:    "apple",
 					NeighborAddress: "192.168.177.33",
 				},
 				AfiSafis: []config.AfiSafi{
-					config.AfiSafi{
+					{
 						Config: config.AfiSafiConfig{
 							AfiSafiName: "ipv4-unicast",
 						},
 					},
-					config.AfiSafi{
+					{
 						Config: config.AfiSafiConfig{
 							AfiSafiName: "ipv6-unicast",
 						},
@@ -44,7 +44,7 @@ func main() {
 				},
 			},
 
-			config.Neighbor{
+			{
 				Config: config.NeighborConfig{
 					PeerAs:          12334,
 					AuthPassword:    "orange",
@@ -52,7 +52,7 @@ func main() {
 				},
 			},
 
-			config.Neighbor{
+			{
 				Config: config.NeighborConfig{
 					PeerAs:          12335,
 					AuthPassword:    "grape",
@@ -81,7 +81,7 @@ func policy() config.RoutingPolicy {
 	ps := config.PrefixSet{
 		PrefixSetName: "ps1",
 		PrefixList: []config.Prefix{
-			config.Prefix{
+			{
 				IpPrefix:        "10.3.192.0/21",
 				MasklengthRange: "21..24",
 			}},


### PR DESCRIPTION
golangci-lint includes staticcheck (https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/staticcheck.go) and provides more features that help to improve the code.

Current output:

```
internal/pkg/zebra/zapi.go:44:2: `maxPathNum` is unused (deadcode)
        maxPathNum              = 64
        ^
internal/pkg/zebra/zapi.go:980:2: `zapi4MessageTag` is unused (deadcode)
        zapi4MessageTag      MessageFlag = 0x10
        ^
internal/pkg/zebra/zapi.go:982:2: `zapi4MessageSRCPFX` is unused (deadcode)
        zapi4MessageSRCPFX   MessageFlag = 0x40
        ^
internal/pkg/zebra/zapi.go:1962:2: `zapiNexthopFlagOnlink` is unused (deadcode)
        zapiNexthopFlagOnlink    uint8 = 0x01 // frr7.1, 7.2, 7.3, 7.4, 7.5
        ^
internal/pkg/zebra/zapi.go:1305:13: Error return value of `c.SendHello` is not checked (errcheck)
        c.SendHello()
                   ^
internal/pkg/zebra/zapi.go:1306:19: Error return value of `c.SendRouterIDAdd` is not checked (errcheck)
        c.SendRouterIDAdd()
                         ^
internal/pkg/zebra/zapi.go:1309:28: Error return value of `c.sendLabelManagerConnect` is not checked (errcheck)
                c.sendLabelManagerConnect(true)
                                         ^
internal/pkg/zebra/zapi.go:1456:16: Error return value of `c.sendCommand` is not checked (errcheck)
                c.sendCommand(routerIDAdd, DefaultVrf, body)
                             ^
internal/pkg/zebra/zapi.go:1485:17: Error return value of `c.sendCommand` is not checked (errcheck)
                        c.sendCommand(redistributeAdd, vrfID, body)
                                     ^
internal/pkg/zebra/zapi.go:2796:2: ineffectual assignment to `pos` (ineffassign)
        pos += nexthopsByteLen
        ^
internal/pkg/zebra/zapi.go:3074:2: ineffectual assignment to `offset` (ineffassign)
        offset += nexthopsByteLen
        ^
internal/pkg/zebra/zapi_test.go:129:4: ineffectual assignment to `pos` (ineffassign)
                        pos++
                        ^
internal/pkg/zebra/zapi_test.go:441:3: ineffectual assignment to `pos` (ineffassign)
                pos += 4
                ^
internal/pkg/zebra/zapi.go:2298:2: `srteColor` is unused (structcheck)
        srteColor      uint32
        ^
pkg/packet/bgp/bgp.go:416:46: Error return value of `c.DefaultParameterCapability.DecodeFromBytes` is not checked (errcheck)
        c.DefaultParameterCapability.DecodeFromBytes(data)
                                                    ^
pkg/packet/bgp/bgp.go:508:46: Error return value of `c.DefaultParameterCapability.DecodeFromBytes` is not checked (errcheck)
        c.DefaultParameterCapability.DecodeFromBytes(data)
                                                    ^
pkg/packet/bgp/bgp.go:596:46: Error return value of `c.DefaultParameterCapability.DecodeFromBytes` is not checked (errcheck)
        c.DefaultParameterCapability.DecodeFromBytes(data)
                                                    ^
pkg/packet/bgp/bgp.go:1146:21: Error return value of `p.DecodeFromBytes` is not checked (errcheck)
                        p.DecodeFromBytes(data[2 : 2+paramlen])
                                         ^
pkg/packet/bgp/bgp.go:1388:36: Error return value of `p.IPAddrPrefixDefault.decodePrefix` is not checked (errcheck)
        p.IPAddrPrefixDefault.decodePrefix(net.ParseIP(prefix).To4(), length, 4)
                                          ^
pkg/packet/bgp/bgp.go:1421:36: Error return value of `p.IPAddrPrefixDefault.decodePrefix` is not checked (errcheck)
        p.IPAddrPrefixDefault.decodePrefix(net.ParseIP(prefix), length, 16)
                                          ^
pkg/packet/bgp/bgp.go:1846:26: Error return value of `l.Labels.DecodeFromBytes` is not checked (errcheck)
        l.Labels.DecodeFromBytes(data, options...)
                                ^
pkg/packet/bgp/bgp.go:2010:26: Error return value of `l.Labels.DecodeFromBytes` is not checked (errcheck)
        l.Labels.DecodeFromBytes(data)
                                ^
pkg/packet/bgp/bgp.go:2828:24: Error return value of `er.ESI.DecodeFromBytes` is not checked (errcheck)
        er.ESI.DecodeFromBytes(data)
                              ^
pkg/packet/bgp/bgp.go:11425:24: Error return value of `tuple.DecodeFromBytes` is not checked (errcheck)
                tuple.DecodeFromBytes(value)
                                     ^
pkg/packet/bgp/bgp.go:13464:13: Error return value of `FlatUpdate` is not checked (errcheck)
                FlatUpdate(flat, ec.Flat())
                          ^
pkg/packet/bgp/bgp_test.go:94:16: Error return value of `r.decodePrefix` is not checked (errcheck)
        r.decodePrefix(b, 33, 4)
                      ^
pkg/packet/bgp/bgp_test.go:1187:20: Error return value of `b.DecodeFromBytes` is not checked (errcheck)
                b.DecodeFromBytes([]byte{0})
                                 ^
pkg/packet/bgp/bgp_test.go:1197:18: Error return value of `ParseBGPMessage` is not checked (errcheck)
                ParseBGPMessage([]byte(f))
                               ^
pkg/packet/bgp/bgp_test.go:1294:20: Error return value of `p.DecodeFromBytes` is not checked (errcheck)
                p.DecodeFromBytes(b)
                                 ^
pkg/packet/bgp/validate_test.go:155:24: Error return value of `origin.DecodeFromBytes` is not checked (errcheck)
        origin.DecodeFromBytes(originBytes)
                              ^
pkg/packet/bgp/validate_test.go:200:24: Error return value of `origin.DecodeFromBytes` is not checked (errcheck)
        origin.DecodeFromBytes(originBytes)
                              ^
pkg/packet/bgp/validate_test.go:222:25: Error return value of `nexthop.DecodeFromBytes` is not checked (errcheck)
        nexthop.DecodeFromBytes(nexthopBytes)
                               ^
pkg/packet/bgp/validate_test.go:244:25: Error return value of `nexthop.DecodeFromBytes` is not checked (errcheck)
        nexthop.DecodeFromBytes(nexthopBytes)
                               ^
pkg/packet/bgp/validate_test.go:266:25: Error return value of `nexthop.DecodeFromBytes` is not checked (errcheck)
        nexthop.DecodeFromBytes(nexthopBytes)
                               ^
pkg/packet/bgp/validate_test.go:287:25: Error return value of `unknown.DecodeFromBytes` is not checked (errcheck)
        unknown.DecodeFromBytes(unknownBytes)
                               ^
pkg/packet/bgp/bgp.go:11313:3: ineffectual assignment to `transitive` (ineffassign)
                transitive = true
                ^
internal/pkg/table/destination.go:259:27: Error return value of `dest.computeKnownBestPath` is not checked (errcheck)
        dest.computeKnownBestPath()
                                 ^
internal/pkg/table/destination_test.go:271:24: Error return value of `UpdatePathAttrs4ByteAs` is not checked (errcheck)
        UpdatePathAttrs4ByteAs(updateMsg.Body.(*bgp.BGPUpdate))
                              ^
internal/pkg/table/destination_test.go:292:24: Error return value of `UpdatePathAttrs4ByteAs` is not checked (errcheck)
        UpdatePathAttrs4ByteAs(updateMsg.Body.(*bgp.BGPUpdate))
                              ^
internal/pkg/table/destination_test.go:313:24: Error return value of `UpdatePathAttrs4ByteAs` is not checked (errcheck)
        UpdatePathAttrs4ByteAs(updateMsg.Body.(*bgp.BGPUpdate))
                              ^
internal/pkg/table/message_test.go:38:24: Error return value of `UpdatePathAttrs2ByteAs` is not checked (errcheck)
        UpdatePathAttrs2ByteAs(msg)
                              ^
internal/pkg/table/message_test.go:65:24: Error return value of `UpdatePathAttrs2ByteAs` is not checked (errcheck)
        UpdatePathAttrs2ByteAs(msg)
                              ^
internal/pkg/table/policy.go:384:16: Error return value of `lhs.tree.Add` is not checked (errcheck)
                        lhs.tree.Add(r, append(lp, rp...))
                                    ^
internal/pkg/table/policy.go:386:16: Error return value of `lhs.tree.Add` is not checked (errcheck)
                        lhs.tree.Add(r, v)
                                    ^
internal/pkg/table/policy.go:420:19: Error return value of `lhs.tree.Delete` is not checked (errcheck)
                        lhs.tree.Delete(r)
                                       ^
internal/pkg/table/policy.go:422:16: Error return value of `lhs.tree.Add` is not checked (errcheck)
                        lhs.tree.Add(r, new)
                                    ^
internal/pkg/table/policy.go:489:12: Error return value of `tree.Add` is not checked (errcheck)
                        tree.Add(x.Prefix, append(ps, x))
                                ^
internal/pkg/table/policy.go:491:12: Error return value of `tree.Add` is not checked (errcheck)
                        tree.Add(x.Prefix, []*Prefix{x})
                                ^
internal/pkg/table/policy.go:524:12: Error return value of `tree.Add` is not checked (errcheck)
                        tree.Add(y.Prefix, append(ps, y))
                                ^
internal/pkg/table/policy.go:3435:20: Error return value of `r.setDefaultPolicy` is not checked (errcheck)
        r.setDefaultPolicy(GLOBAL_RIB_NAME, POLICY_DIRECTION_IMPORT, ROUTE_TYPE_ACCEPT)
                          ^
internal/pkg/table/policy.go:3436:20: Error return value of `r.setDefaultPolicy` is not checked (errcheck)
        r.setDefaultPolicy(GLOBAL_RIB_NAME, POLICY_DIRECTION_EXPORT, ROUTE_TYPE_ACCEPT)
                          ^
internal/pkg/table/policy.go:3855:21: Error return value of `r.setDefaultPolicy` is not checked (errcheck)
                r.setDefaultPolicy(id, dir, def)
                                  ^
internal/pkg/table/policy.go:3856:14: Error return value of `r.setPolicy` is not checked (errcheck)
                r.setPolicy(id, dir, ps)
                           ^
internal/pkg/table/policy_test.go:696:23: Error return value of `r.validateCondition` is not checked (errcheck)
                        r.validateCondition(c)
                                           ^
internal/pkg/table/policy_test.go:751:10: Error return value of `r.reload` is not checked (errcheck)
        r.reload(pl)
                ^
internal/pkg/table/policy_test.go:1384:10: Error return value of `r.reload` is not checked (errcheck)
        r.reload(pl)
                ^
internal/pkg/table/policy_test.go:2602:10: Error return value of `r.reload` is not checked (errcheck)
        r.reload(pl)
                ^
internal/pkg/table/roa.go:170:15: Error return value of `tree.Delete` is not checked (errcheck)
                        tree.Delete(key)
                                   ^
internal/pkg/table/table.go:218:9: Error return value of `r.Add` is not checked (errcheck)
                        r.Add(nlriToIPNet(dst.nlri), dst)
                             ^
pkg/config/config.go:57:31: Error return value of `bgpServer.SetPolicyAssignment` is not checked (errcheck)
        bgpServer.SetPolicyAssignment(ctx, &api.SetPolicyAssignmentRequest{
                                     ^
pkg/server/fsm.go:876:2: ineffectual assignment to `handling` (ineffassign)
        handling := bgp.ERROR_HANDLING_NONE
        ^
```