### PR TITLE
pkg/packet/bgp: add mutex to PrefixDefault to avoid data race

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 type MarshallingOption struct {
@@ -1229,23 +1230,36 @@ func LabelString(nlri AddrPrefixInterface) string {
 }
 
 type PrefixDefault struct {
+	mu      sync.Mutex
 	id      uint32
 	localId uint32
 }
 
 func (p *PrefixDefault) PathIdentifier() uint32 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	return p.id
 }
 
 func (p *PrefixDefault) SetPathIdentifier(id uint32) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	p.id = id
 }
 
 func (p *PrefixDefault) PathLocalIdentifier() uint32 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	return p.localId
 }
 
 func (p *PrefixDefault) SetPathLocalIdentifier(id uint32) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	p.localId = id
 }
 

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -771,20 +771,20 @@ func Test_CompareFlowSpecNLRI(t *testing.T) {
 	cmp, err := ParseFlowSpecComponents(RF_FS_IPv4_UC, "destination 10.0.0.2/32 source 10.0.0.1/32 destination-port ==3128 protocol tcp")
 	assert.Nil(err)
 	// Note: Use NewFlowSpecIPv4Unicast() for the consistent ordered rules.
-	n1 := NewFlowSpecIPv4Unicast(cmp).FlowSpecNLRI
+	n1 := &NewFlowSpecIPv4Unicast(cmp).FlowSpecNLRI
 	cmp, err = ParseFlowSpecComponents(RF_FS_IPv4_UC, "source 10.0.0.0/24 destination-port ==3128 protocol tcp")
 	assert.Nil(err)
-	n2 := NewFlowSpecIPv4Unicast(cmp).FlowSpecNLRI
-	r, err := CompareFlowSpecNLRI(&n1, &n2)
+	n2 := &NewFlowSpecIPv4Unicast(cmp).FlowSpecNLRI
+	r, err := CompareFlowSpecNLRI(n1, n2)
 	assert.Nil(err)
 	assert.True(r > 0)
 	cmp, err = ParseFlowSpecComponents(RF_FS_IPv4_UC, "source 10.0.0.9/32 port ==80 ==8080 destination-port >8080&<8080 ==3128 source-port >1024 protocol ==udp ==tcp")
-	n3 := NewFlowSpecIPv4Unicast(cmp).FlowSpecNLRI
+	n3 := &NewFlowSpecIPv4Unicast(cmp).FlowSpecNLRI
 	assert.Nil(err)
 	cmp, err = ParseFlowSpecComponents(RF_FS_IPv4_UC, "destination 192.168.0.2/32")
-	n4 := NewFlowSpecIPv4Unicast(cmp).FlowSpecNLRI
+	n4 := &NewFlowSpecIPv4Unicast(cmp).FlowSpecNLRI
 	assert.Nil(err)
-	r, err = CompareFlowSpecNLRI(&n3, &n4)
+	r, err = CompareFlowSpecNLRI(n3, n4)
 	assert.Nil(err)
 	assert.True(r < 0)
 }


### PR DESCRIPTION
Signed-off-by: Matt Layher <mlayher@fastly.com>

Resolves a data race regarding the use of path identifiers:

```
==================
WARNING: DATA RACE
Write at 0x00c0004ddc84 by goroutine 41:
  github.com/osrg/gobgp/pkg/packet/bgp.(*PrefixDefault).SetPathLocalIdentifier()
      /project/vendor/github.com/osrg/gobgp/pkg/packet/bgp/bgp.go:1243 +0x36
  github.com/osrg/gobgp/pkg/packet/bgp.(*IPv6AddrPrefix).SetPathLocalIdentifier()
      <autogenerated>:1 +0x44
  github.com/osrg/gobgp/internal/pkg/table.(*Destination).explicitWithdraw()
      /project/vendor/github.com/osrg/gobgp/internal/pkg/table/destination.go:299 +0x688
  github.com/osrg/gobgp/internal/pkg/table.(*Destination).Calculate()
      /project/vendor/github.com/osrg/gobgp/internal/pkg/table/destination.go:237 +0xf2
  github.com/osrg/gobgp/internal/pkg/table.(*TableManager).update()
      /project/vendor/github.com/osrg/gobgp/internal/pkg/table/table_manager.go:193 +0x106
  github.com/osrg/gobgp/internal/pkg/table.(*TableManager).Update()
      /project/vendor/github.com/osrg/gobgp/internal/pkg/table/table_manager.go:209 +0x13c
  github.com/osrg/gobgp/pkg/server.(*BgpServer).propagateUpdate()
      /project/vendor/github.com/osrg/gobgp/pkg/server/server.go:1219 +0x9db
  github.com/osrg/gobgp/pkg/server.(*BgpServer).deleteNeighbor()
      /project/vendor/github.com/osrg/gobgp/pkg/server/server.go:3011 +0xa18
  github.com/osrg/gobgp/pkg/server.(*BgpServer).DeletePeer.func1()
      /project/vendor/github.com/osrg/gobgp/pkg/server/server.go:3036 +0xc4
  github.com/osrg/gobgp/pkg/server.(*BgpServer).handleMGMTOp()
      /project/vendor/github.com/osrg/gobgp/pkg/server/server.go:240 +0xa1
  github.com/osrg/gobgp/pkg/server.(*BgpServer).Serve()
      /project/vendor/github.com/osrg/gobgp/pkg/server/server.go:422 +0x915
  github.com/fastly/project/internal/projectd.(*Server).ServeBGP·dwrap·1()
      /project/internal/routed/bgp.go:53 +0x39

Previous read at 0x00c0004ddc84 by goroutine 103:
  [failed to restore the stack]

Goroutine 41 (running) created at:
  github.com/fastly/project/internal/projectd.(*Server).ServeBGP()
      /project/internal/routed/bgp.go:53 +0x12a
  main.main.func4()
      /project/cmd/project/main.go:157 +0xfb
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /project/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x96

Goroutine 103 (running) created at:
  github.com/osrg/gobgp/pkg/server.(*BgpServer).MonitorTable()
      /project/vendor/github.com/osrg/gobgp/pkg/server/server.go:3793 +0x1b0
  github.com/fastly/project/internal/projectd.(*Server).ServeBGP()
      /project/internal/routed/bgp.go:148 +0xe2d
  main.main.func4()
      /project/cmd/project/main.go:157 +0xfb
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /project/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x96
==================
```