### PR TITLE
Pass BGPUpdate message even on error

### DIFF
--- a/pkg/packet/bmp/bmp.go
+++ b/pkg/packet/bmp/bmp.go
@@ -164,12 +164,11 @@ func NewBMPRouteMonitoring(p BMPPeerHeader, update *bgp.BGPMessage) *BMPMessage 
 }
 
 func (body *BMPRouteMonitoring) ParseBody(msg *BMPMessage, data []byte) error {
-	update, err := bgp.ParseBGPMessage(data)
-	if err != nil {
-		return err
-	}
-	body.BGPUpdate = update
-	return nil
+	var err error
+
+	body.BGPUpdate, err = bgp.ParseBGPMessage(data)
+
+	return err
 }
 
 func (body *BMPRouteMonitoring) Serialize() ([]byte, error) {
@@ -1065,8 +1064,13 @@ func ParseBMPMessage(data []byte) (msg *BMPMessage, err error) {
 
 	err = msg.Body.ParseBody(msg, data)
 	if err != nil {
+		if msg.Header.Type == BMP_MSG_ROUTE_MONITORING {
+			return msg, err
+		}
+
 		return nil, err
 	}
+
 	return msg, nil
 }
 


### PR DESCRIPTION
Hello!

This PR is related to the issue https://github.com/osrg/gobgp/issues/2122 . But generally, if there is an error during parsing of a BMP message, I should follow the `ErrorHandling` "instructions" on how to handle the error. In this case, the policy is `ERROR_HANDLING_TREAT_AS_WITHDRAW`. So, if I understand the RFC correctly (see https://datatracker.ietf.org/doc/html/rfc7606#section-2 ), I should treat all `BGPUpdate.NLRI` same as if they were in `BGPUpdate.WithdrawnRoutes`. But the issue is that on any error I don't receive the update message when using the `ParseBMPMessage` function, as any error causes the function to return `nil` for the message.

Maybe instead of `if msg.Header.Type == BMP_MSG_ROUTE_MONITORING {` I should check the error type and if it's `*bgp.MessageError`, check the `ErrorHandling` attribute and return the message for `ERROR_HANDLING_TREAT_AS_WITHDRAW` (and maybe `ERROR_HANDLING_AFISAFI_DISABLE`?)?