### PR TITLE
Return MpGracefulRestart.State in ListPeer() api call

### DIFF
--- a/internal/pkg/config/util.go
+++ b/internal/pkg/config/util.go
@@ -384,6 +384,13 @@ func newMpGracefulRestartFromConfigStruct(c *MpGracefulRestart) *api.MpGracefulR
 		Config: &api.MpGracefulRestartConfig{
 			Enabled: c.Config.Enabled,
 		},
+		State: &api.MpGracefulRestartState{
+			Enabled:          c.State.Enabled,
+			Received:         c.State.Received,
+			Advertised:       c.State.Advertised,
+			EndOfRibReceived: c.State.EndOfRibReceived,
+			EndOfRibSent:     c.State.EndOfRibSent,
+		},
 	}
 }
 


### PR DESCRIPTION
I have a use-case to check the value of `EndOfRibReceived` in `ListPeer()` api calls. It looks like the code was only returning `MpGracefulRestart.Config`. This adds `MpGracefulRestart.State` (which includes `EndOfRibRceived`).