### PR TITLE
chore: fix linting ineffassign and redundant type from array, slice, …

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -873,7 +873,8 @@ func (h *fsmHandler) afiSafiDisable(rf bgp.RouteFamily) string {
 }
 
 func (h *fsmHandler) handlingError(m *bgp.BGPMessage, e error, useRevisedError bool) bgp.ErrorHandling {
-	handling := bgp.ERROR_HANDLING_NONE
+	// ineffectual assignment to handling (ineffassign)
+	var handling bgp.ErrorHandling
 	if m.Header.Type == bgp.BGP_MSG_UPDATE && useRevisedError {
 		factor := e.(*bgp.MessageError)
 		handling = factor.ErrorHandling

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -112,7 +112,7 @@ func TestModPolicyAssign(t *testing.T) {
 		}
 	}
 
-	r := f([]*config.PolicyDefinition{&config.PolicyDefinition{Name: "p1"}, &config.PolicyDefinition{Name: "p2"}, &config.PolicyDefinition{Name: "p3"}})
+	r := f([]*config.PolicyDefinition{{Name: "p1"}, {Name: "p2"}, {Name: "p3"}})
 	r.Direction = api.PolicyDirection_IMPORT
 	r.DefaultAction = api.RouteAction_ACCEPT
 	r.Name = table.GLOBAL_RIB_NAME
@@ -130,7 +130,7 @@ func TestModPolicyAssign(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(len(ps[0].Policies), 3)
 
-	r = f([]*config.PolicyDefinition{&config.PolicyDefinition{Name: "p1"}})
+	r = f([]*config.PolicyDefinition{{Name: "p1"}})
 	r.Direction = api.PolicyDirection_IMPORT
 	r.DefaultAction = api.RouteAction_ACCEPT
 	r.Name = table.GLOBAL_RIB_NAME
@@ -187,7 +187,7 @@ func TestListPolicyAssignment(t *testing.T) {
 			Direction:     api.PolicyDirection_IMPORT,
 			DefaultAction: api.RouteAction_ACCEPT,
 			Name:          addr,
-			Policies:      []*api.Policy{&api.Policy{Name: fmt.Sprintf("p%d", i)}},
+			Policies:      []*api.Policy{{Name: fmt.Sprintf("p%d", i)}},
 		}
 		err = s.AddPolicyAssignment(context.Background(), &api.AddPolicyAssignmentRequest{Assignment: pa})
 		assert.Nil(err)
@@ -243,7 +243,7 @@ func TestListPathEnableFiltered(test *testing.T) {
 		DefinedType: api.DefinedType_PREFIX,
 		Name:        "d1",
 		Prefixes: []*api.Prefix{
-			&api.Prefix{
+			{
 				IpPrefix:      "10.1.0.0/24",
 				MaskLengthMax: 24,
 				MaskLengthMin: 24,
@@ -384,7 +384,7 @@ func TestListPathEnableFiltered(test *testing.T) {
 		DefinedType: api.DefinedType_PREFIX,
 		Name:        "d2",
 		Prefixes: []*api.Prefix{
-			&api.Prefix{
+			{
 				IpPrefix:      "10.3.0.0/24",
 				MaskLengthMax: 24,
 				MaskLengthMin: 24,
@@ -835,7 +835,7 @@ func TestFilterpathWithRejectPolicy(t *testing.T) {
 	p, _ := table.NewPolicy(policy)
 	p2.policy.AddPolicy(p, false)
 	policies := []*config.PolicyDefinition{
-		&config.PolicyDefinition{
+		{
 			Name: "policy1",
 		},
 	}


### PR DESCRIPTION
fix linting warnings
chore: fix linting ineffassign and redundant type from array, slice, or map composite literal
