### PR TITLE
table: keep receiver name the same

### DIFF
--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -186,8 +186,8 @@ func (manager *TableManager) DeleteVrf(name string) ([]*Path, error) {
 	return msgs, nil
 }
 
-func (tm *TableManager) update(newPath *Path) *Update {
-	t := tm.Tables[newPath.GetRouteFamily()]
+func (manager *TableManager) update(newPath *Path) *Update {
+	t := manager.Tables[newPath.GetRouteFamily()]
 	t.validatePath(newPath)
 	dst := t.getOrCreateDest(newPath.GetNlri(), 64)
 	u := dst.Calculate(newPath)


### PR DESCRIPTION
keep receiver name the same, it's more readable for IDE.