### PR TITLE
Stop gRPC server when stopping GoBGP server

### DIFF
--- a/cmd/gobgpd/main.go
+++ b/cmd/gobgpd/main.go
@@ -34,7 +34,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	api "github.com/osrg/gobgp/api"
 	"github.com/osrg/gobgp/internal/pkg/version"
 	"github.com/osrg/gobgp/pkg/config"
 	"github.com/osrg/gobgp/pkg/server"
@@ -219,7 +218,9 @@ func main() {
 }
 
 func stopServer(bgpServer *server.BgpServer, useSdNotify bool) {
-	bgpServer.StopBgp(context.Background(), &api.StopBgpRequest{})
+	log.Info("stopping gobgpd server")
+
+	bgpServer.Stop()
 	if useSdNotify {
 		daemon.SdNotify(false, daemon.SdNotifyStopping)
 	}


### PR DESCRIPTION
This doesn't matter when you use TCP for API server, but when you use UNIX socket then the "forced" shutdown of the gRPC server causes the socket to be left behind, preventing the GoBGP server to start again.

```
$ ls -l api.sock
ls: cannot access 'api.sock': No such file or directory

$ go run ./cmd/gobgpd --api-hosts=unix://api.sock >/dev/null &
[1] 144472

$ ls -l api.sock
srwxrwxr-x 1 grongor grongor 0 lis 16 14:36 api.sock

$ killall -e gobgpd
[1]  + 144472 done       go run ./cmd/gobgpd --api-hosts=unix://api.sock > /dev/null                                                                         

$ ls -l api.sock   
srwxrwxr-x 1 grongor grongor 0 lis 16 14:36 api.sock

$ go run ./cmd/gobgpd --api-hosts=unix://api.sock             
{"level":"info","msg":"gobgpd started","time":"2021-11-16T14:36:42+01:00"}
{"Error":"listen unix api.sock: bind: address already in use","Key":"unix://api.sock","Topic":"grpc","level":"warning","msg":"listen failed","time":"2021-11-16T14:36:42+01:00"}
{"level":"fatal","msg":"failed to listen grpc port: listen unix api.sock: bind: address already in use","time":"2021-11-16T14:36:42+01:00"}
exit status 1

$ rm api.sock

$ git checkout fix-server-shutdown 
Switched to branch 'fix-server-shutdown'

$ go run ./cmd/gobgpd --api-hosts=unix://api.sock >/dev/null &
[1] 144901

$ killall -e gobgpd                                           
[1]  + 144901 done       go run ./cmd/gobgpd --api-hosts=unix://api.sock > /dev/null                                                                         

$ ls -l api.sock   
ls: cannot access 'api.sock': No such file or directory

$ go run ./cmd/gobgpd --api-hosts=unix://api.sock
{"level":"info","msg":"gobgpd started","time":"2021-11-16T14:37:12+01:00"}
```