### PR TITLE
Add SIGINT as shutdown signal

### DIFF
--- a/cmd/gobgpd/main.go
+++ b/cmd/gobgpd/main.go
@@ -42,7 +42,7 @@ import (
 
 func main() {
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTERM)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 
 	var opts struct {
 		ConfigFile      string `short:"f" long:"config-file" description:"specifying a config file"`

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -126,7 +126,7 @@ class GoBGPContainer(BGPContainer):
         self._wait_for_boot()
 
     def stop_gobgp(self):
-        self.local("pkill -INT gobgpd")
+        self.local("pkill -KILL gobgpd")
 
     def _start_zebra(self):
         if self.zapi_version == 2:


### PR DESCRIPTION
...so that you can stop the GoBGP server gracefully via `CTRL+C` when started directly from CLI