### PR TITLE
Bypass as-path loop filtering on locally injected routes

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -577,7 +577,7 @@ func filterpath(peer *peer, path, old *table.Path) *table.Path {
 		return nil
 	}
 
-	if !peer.isRouteServerClient() && isASLoop(peer, path) {
+	if !peer.isRouteServerClient() && isASLoop(peer, path) && !path.IsLocal() {
 		return nil
 	}
 	return path


### PR DESCRIPTION
Addresses issue raised in: https://github.com/osrg/gobgp/issues/2488