### PR TITLE
server: fix output of gobgp rpki server

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3815,7 +3815,7 @@ func (s *BgpServer) DisableMrt(ctx context.Context, r *api.DisableMrtRequest) er
 }
 
 func (s *BgpServer) ListRpki(ctx context.Context, r *api.ListRpkiRequest, fn func(*api.Rpki)) error {
-	if r == nil || r.Family == nil {
+	if r == nil {
 		return fmt.Errorf("nil request")
 	}
 	var l []*api.Rpki


### PR DESCRIPTION
gobgp rpki server command hasn't been working correctly since #a40bc53.
This code will fix it.