### PR TITLE
server: fix bmp crash

### DIFF
--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -222,7 +222,7 @@ func (b *bmpClient) loop() {
 								if err := write(bmpPeerUp(msg, bmp.BMP_PEER_TYPE_GLOBAL, false, 0)); err != nil {
 									return false
 								}
-							} else if msg.Type != PEER_EVENT_INIT {
+							} else if msg.Type != PEER_EVENT_INIT && msg.OldState == bgp.BGP_FSM_ESTABLISHED {
 								if err := write(bmpPeerDown(msg, bmp.BMP_PEER_TYPE_GLOBAL, false, 0)); err != nil {
 									return false
 								}


### PR DESCRIPTION
fixed the following bug. With bmp established, adding a peer config
leads to this. Adding a peer config should not send bmp peer message.

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa41c0a]

goroutine 36 [running]:
github.com/osrg/gobgp/v3/pkg/server.bmpPeerDown(0xc00032c370, 0x18, 0x0, 0xc00040cc78)
	/home/ubuntu/git/gobgp/pkg/server/bmp.go:296 +0x10a
github.com/osrg/gobgp/v3/pkg/server.(*bmpClient).loop.func1(0xc00037f0e0, 0xc000416000)
	/home/ubuntu/git/gobgp/pkg/server/bmp.go:228 +0xe65
github.com/osrg/gobgp/v3/pkg/server.(*bmpClient).loop(0x0)
	/home/ubuntu/git/gobgp/pkg/server/bmp.go:265 +0x85
created by github.com/osrg/gobgp/v3/pkg/server.(*bmpClientManager).addServer
	/home/ubuntu/git/gobgp/pkg/server/bmp.go:370 +0x2b3

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>