### PR TITLE
server: fix WatchEvent API delay

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3978,9 +3978,9 @@ func (s *BgpServer) WatchEvent(ctx context.Context, r *api.WatchEventRequest, fn
 	if len(opts) == 0 {
 		return fmt.Errorf("no events to watch")
 	}
+	w := s.watch(opts...)
 
 	go func() {
-		w := s.watch(opts...)
 		defer func() {
 			w.Stop()
 		}()


### PR DESCRIPTION
needs to call the internal watch() API before creating goroutine
rather than calling it inside goroutine. We don't miss events.

Signed-off-by: FUJITA Tomonori <fujita.tomonori@gmail.com>