### PR TITLE
Enable match-prefix-set policy for vpnv4/vpnv6 prefixes

### DIFF
--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -1241,6 +1241,16 @@ func nlriToIPNet(nlri bgp.AddrPrefixInterface) *net.IPNet {
 			IP:   net.IP(T.Prefix.To16()),
 			Mask: net.CIDRMask(int(T.Length)-T.Labels.Len()*8, 128),
 		}
+	case *bgp.LabeledVPNIPAddrPrefix:
+		return &net.IPNet{
+			IP:   net.IP(T.Prefix.To4()),
+			Mask: net.CIDRMask(int(T.Length)-T.Labels.Len()*8-T.RD.Len()*8, 32),
+		}
+	case *bgp.LabeledVPNIPv6AddrPrefix:
+		return &net.IPNet{
+			IP:   net.IP(T.Prefix.To16()),
+			Mask: net.CIDRMask(int(T.Length)-T.Labels.Len()*8-T.RD.Len()*8, 128),
+		}
 	}
 	return nil
 }

--- a/internal/pkg/table/path_test.go
+++ b/internal/pkg/table/path_test.go
@@ -382,4 +382,13 @@ func TestNLRIToIPNet(t *testing.T) {
 	_, n4, _ := net.ParseCIDR("2806:106e:19::/48")
 	ipNet = nlriToIPNet(bgp.NewLabeledIPv6AddrPrefix(48, "2806:106e:19::", *labels))
 	assert.Equal(t, n4, ipNet)
+
+	rd, _ := bgp.ParseRouteDistinguisher("100:100")
+	_, n5, _ := net.ParseCIDR("40.40.40.0/24")
+	ipNet = nlriToIPNet(bgp.NewLabeledVPNIPAddrPrefix(24, "40.40.40.0", *labels, rd))
+	assert.Equal(t, n5, ipNet)
+
+	_, n6, _ := net.ParseCIDR("2001:db8:53::/64")
+	ipNet = nlriToIPNet(bgp.NewLabeledVPNIPv6AddrPrefix(64, "2001:db8:53::", *labels, rd))
+	assert.Equal(t, n6, ipNet)
 }


### PR DESCRIPTION
Fixes #2527, vpn routes can be filetred with match-sets.