### PR TITLE
pkg/packet/bgp: fix PathAttributeUnknown output format

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -12788,7 +12788,7 @@ func (p *PathAttributeUnknown) Serialize(options ...*MarshallingOption) ([]byte,
 }
 
 func (p *PathAttributeUnknown) String() string {
-	return fmt.Sprintf("{Flags: %s, Type: %s, Value: %s}", p.Flags, p.Type, p.Value)
+	return fmt.Sprintf("{Flags: %s, Type: %s, Value: %v}", p.Flags, p.Type, p.Value)
 }
 
 func (p *PathAttributeUnknown) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Formatting PathAttributeUnknown binary value as a string breaks text
output and may cause data truncation while line-by-line parsing.

Signed-off-by: Vladislav Grishenko <themiron@yandex-team.ru>