### PR TITLE
Fix AddPath IPv6 injected routes not honoring PathIdentifier

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -332,7 +332,6 @@ func api2Path(resource api.TableType, path *api.Path, isWithdraw bool) (*table.P
 			if len(a.Value) == 0 {
 				return nil, fmt.Errorf("invalid mp reach attribute")
 			}
-			nlri = a.Value[0]
 			nexthop = a.Nexthop.String()
 		default:
 			pattrs = append(pattrs, attr)


### PR DESCRIPTION
Fixes the problem described in https://github.com/osrg/gobgp/issues/2541

I also added some simple test cases to make ensure the scenario described in this issue are covered in `AddPath` and `DeletePath` tests.