### PR TITLE
Add the possibility to choose the local port in the TCP connection to a peer.

### DIFF
--- a/internal/pkg/config/bgp_configs.go
+++ b/internal/pkg/config/bgp_configs.go
@@ -1141,7 +1141,7 @@ type ZebraState struct {
 	MplsLabelRangeSize uint32 `mapstructure:"mpls-label-range-size" json:"mpls-label-range-size,omitempty"`
 	// original -> gobgp:software-name
 	// Configure zebra software name.
-	// frr4, cumulus, frr6, frr7, frr7.2, and frr7.3 can be used.
+	// frr4, cumulus, frr6, frr7, frr7.2 and frr7.3 can be used.
 	SoftwareName string `mapstructure:"software-name" json:"software-name,omitempty"`
 }
 
@@ -1171,7 +1171,7 @@ type ZebraConfig struct {
 	MplsLabelRangeSize uint32 `mapstructure:"mpls-label-range-size" json:"mpls-label-range-size,omitempty"`
 	// original -> gobgp:software-name
 	// Configure zebra software name.
-	// frr4, cumulus, frr6, frr7, frr7.2, and frr7.3 can be used.
+	// frr4, cumulus, frr6, frr7, frr7.2 and frr7.3 can be used.
 	SoftwareName string `mapstructure:"software-name" json:"software-name,omitempty"`
 }
 
@@ -2580,6 +2580,10 @@ type TransportConfig struct {
 	// may be expressed as either an IP address or reference
 	// to the name of an interface.
 	LocalAddress string `mapstructure:"local-address" json:"local-address,omitempty"`
+	// original -> gobgp:local-port
+	// gobgp:local-port's original type is inet:port-number.
+	// Set the local port (if available) to use for the session.
+	LocalPort uint16 `mapstructure:"local-port" json:"local-port,omitempty"`
 	// original -> gobgp:remote-port
 	// gobgp:remote-port's original type is inet:port-number.
 	RemotePort uint16 `mapstructure:"remote-port" json:"remote-port,omitempty"`
@@ -2605,6 +2609,9 @@ func (lhs *TransportConfig) Equal(rhs *TransportConfig) bool {
 		return false
 	}
 	if lhs.LocalAddress != rhs.LocalAddress {
+		return false
+	}
+	if lhs.LocalPort != rhs.LocalPort {
 		return false
 	}
 	if lhs.RemotePort != rhs.RemotePort {

--- a/internal/pkg/config/util.go
+++ b/internal/pkg/config/util.go
@@ -555,6 +555,7 @@ func NewPeerFromConfigStruct(pconf *Neighbor) *api.Peer {
 		},
 		Transport: &api.Transport{
 			RemotePort:    uint32(pconf.Transport.Config.RemotePort),
+			LocalPort:     uint32(pconf.Transport.Config.LocalPort),
 			LocalAddress:  localAddress,
 			PassiveMode:   pconf.Transport.Config.PassiveMode,
 			BindInterface: pconf.Transport.Config.BindInterface,

--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -493,7 +493,7 @@ func (h *fsmHandler) connectLoop(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
 	fsm := h.fsm
 
-	retry, addr, port, password, ttl, ttlMin, localAddress, bindInterface := func() (int, string, int, string, uint8, uint8, string, string) {
+	retry, addr, port, password, ttl, ttlMin, localAddress, localPort, bindInterface := func() (int, string, int, string, uint8, uint8, string, int, string) {
 		fsm.lock.RLock()
 		defer fsm.lock.RUnlock()
 
@@ -520,7 +520,7 @@ func (h *fsmHandler) connectLoop(ctx context.Context, wg *sync.WaitGroup) {
 				ttl = fsm.pConf.EbgpMultihop.Config.MultihopTtl
 			}
 		}
-		return tick, addr, port, password, ttl, ttlMin, fsm.pConf.Transport.Config.LocalAddress, fsm.pConf.Transport.Config.BindInterface
+		return tick, addr, port, password, ttl, ttlMin, fsm.pConf.Transport.Config.LocalAddress, int(fsm.pConf.Transport.Config.LocalPort), fsm.pConf.Transport.Config.BindInterface
 	}()
 
 	tick := minConnectRetryInterval
@@ -542,7 +542,7 @@ func (h *fsmHandler) connectLoop(ctx context.Context, wg *sync.WaitGroup) {
 					"Key":   addr})
 		}
 
-		laddr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(localAddress, "0"))
+		laddr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(localAddress, strconv.Itoa(localPort)))
 		if err != nil {
 			fsm.logger.Warn("failed to resolve local address",
 				log.Fields{

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -718,6 +718,7 @@ func newNeighborFromAPIStruct(a *api.Peer) (*config.Neighbor, error) {
 		pconf.Transport.Config.LocalAddress = a.Transport.LocalAddress
 		pconf.Transport.Config.PassiveMode = a.Transport.PassiveMode
 		pconf.Transport.Config.RemotePort = uint16(a.Transport.RemotePort)
+		pconf.Transport.Config.LocalPort = uint16(a.Transport.LocalPort)
 		pconf.Transport.Config.BindInterface = a.Transport.BindInterface
 	}
 	if a.EbgpMultihop != nil {

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -926,6 +926,11 @@ module gobgp {
   }
 
   augment "/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:transport/bgp:config" {
+    leaf local-port {
+      description "Set the local port (if available) to use for the session.";
+      type inet:port-number;
+    }
+
     leaf remote-port {
       type inet:port-number;
     }


### PR DESCRIPTION
It allows to have more control on the connection established to peers by GoBGP. 

In my use case, I have an access list mechanism for incoming packets. Knowing the port in advance allows to accept the packets corresponding to a given BGP peering session. If I cannot set the port before initiating the connection, I would have to learn it dynamically, but that means dropping the first return packets from the remote peer (SYN+ACK), which is pretty ugly and unpredictable.