### PR TITLE
Bmp AdjRIBOut

### DIFF
--- a/pkg/packet/bmp/bmp_test.go
+++ b/pkg/packet/bmp/bmp_test.go
@@ -71,6 +71,13 @@ func Test_RouteMonitoring(t *testing.T) {
 	verify(t, NewBMPRouteMonitoring(*p0, m))
 }
 
+func Test_RouteMonitoringAdjRIBOut(t *testing.T) {
+	m := bgp.NewTestBGPUpdateMessage()
+	p0 := NewBMPPeerHeader(0, 16, 1000, "10.0.0.1", 12345, "10.0.0.2", 1)
+	assert.True(t, p0.IsAdjRIBOut())
+	verify(t, NewBMPRouteMonitoring(*p0, m))
+}
+
 func Test_StatisticsReport(t *testing.T) {
 	p0 := NewBMPPeerHeader(0, 0, 1000, "10.0.0.1", 70000, "10.0.0.2", 1)
 	s0 := NewBMPStatisticsReport(
@@ -79,6 +86,18 @@ func Test_StatisticsReport(t *testing.T) {
 			NewBMPStatsTLV32(BMP_STAT_TYPE_REJECTED, 100),
 			NewBMPStatsTLV64(BMP_STAT_TYPE_ADJ_RIB_IN, 200),
 			NewBMPStatsTLVPerAfiSafi64(BMP_STAT_TYPE_PER_AFI_SAFI_LOC_RIB, bgp.AFI_IP, bgp.SAFI_UNICAST, 300),
+		},
+	)
+	verify(t, s0)
+}
+
+func Test_StatisticsReportAdjRIBOut(t *testing.T) {
+	p0 := NewBMPPeerHeader(0, 8, 1000, "10.0.0.1", 12345, "10.0.0.2", 1)
+	s0 := NewBMPStatisticsReport(
+		*p0,
+		[]BMPStatsTLVInterface{
+			NewBMPStatsTLV64(BMP_STAT_TYPE_ADJ_RIB_OUT_POST_POLICY, 200),
+			NewBMPStatsTLVPerAfiSafi64(BMP_STAT_TYPE_PER_AFI_SAFI_ADJ_RIB_OUT_POST_POLICY, bgp.AFI_IP, bgp.SAFI_UNICAST, 300),
 		},
 	)
 	verify(t, s0)


### PR DESCRIPTION
This PR adds support for parsing BMP AdjRIBOut route monitoring messages per https://datatracker.ietf.org/doc/html/draft-ietf-grow-bmp-adj-rib-out-03
It also fixup a couple of things:
- create an IP from data slice by using copy(). Using net.IP() directly can have unexpected results . ( this probably also needs to change in the bgp packet parsing also ).
- for the scanner split func, only parse the header instead of full message since we only need header info to decide message boundaries. 