### PR TITLE
Fix panic in table.GetLongerPrefixDestinations() with invalid cidr

### DIFF
--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -70,9 +70,7 @@ func (b *Bitmap) FindandSetZeroBit() (uint, error) {
 func (b *Bitmap) Expand() {
 	old := b.bitmap
 	new := make([]uint64, len(old)+1)
-	for i := 0; i < len(old); i++ {
-		new[i] = old[i]
-	}
+	copy(new, old)
 	b.bitmap = new
 }
 

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -212,10 +212,11 @@ func (t *Table) GetLongerPrefixDestinations(key string) ([]*Destination, error) 
 	switch t.routeFamily {
 	case bgp.RF_IPv4_UC, bgp.RF_IPv6_UC, bgp.RF_IPv4_MPLS, bgp.RF_IPv6_MPLS:
 		_, prefix, err := net.ParseCIDR(key)
-		ones, bits := prefix.Mask.Size()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error parsing cidr %s: %v", key, err)
 		}
+		ones, bits := prefix.Mask.Size()
+
 		r := critbitgo.NewNet()
 		for _, dst := range t.GetDestinations() {
 			r.Add(nlriToIPNet(dst.nlri), dst)


### PR DESCRIPTION
Fixes issue outlined in https://github.com/osrg/gobgp/issues/2555