### PR TITLE
packet/bmp: enable parsing/serializing add-path-enabled BGP updates

### DIFF
--- a/pkg/packet/bmp/bmp_test.go
+++ b/pkg/packet/bmp/bmp_test.go
@@ -78,6 +78,36 @@ func Test_RouteMonitoringAdjRIBOut(t *testing.T) {
 	verify(t, NewBMPRouteMonitoring(*p0, m))
 }
 
+func Test_RouteMonitoringAddPath(t *testing.T) {
+	opt := &bgp.MarshallingOption{
+		AddPath: map[bgp.RouteFamily]bgp.BGPAddPathMode{bgp.RF_IPv4_UC: bgp.BGP_ADD_PATH_BOTH},
+	}
+	p1 := bgp.NewIPAddrPrefix(24, "10.10.10.0")
+	p1.SetPathLocalIdentifier(10)
+	p := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(3),
+		bgp.NewPathAttributeNextHop("129.1.1.2"),
+	}
+	m := bgp.NewBGPUpdateMessage([]*bgp.IPAddrPrefix{}, p, []*bgp.IPAddrPrefix{p1})
+	p0 := NewBMPPeerHeader(0, 0, 1000, "fe80::6e40:8ff:feab:2c2a", 70000, "10.0.0.2", 1)
+
+	m1 := NewBMPRouteMonitoring(*p0, m)
+	buf1, _ := m1.Serialize(opt)
+	m2, err := ParseBMPMessageWithOptions(buf1, func(BMPPeerHeader) []*bgp.MarshallingOption {
+		return []*bgp.MarshallingOption{opt}
+	})
+	require.NoError(t, err)
+
+	// We need to fix tha path identifier (local/remote)
+	u2 := m2.Body.(*BMPRouteMonitoring).BGPUpdate.Body.(*bgp.BGPUpdate).NLRI[0]
+	assert.Equal(t, u2.PathIdentifier(), uint32(10))
+	assert.Equal(t, u2.PathLocalIdentifier(), uint32(0))
+	u2.SetPathIdentifier(0)
+	u2.SetPathLocalIdentifier(10)
+
+	assert.Equal(t, m1, m2)
+}
+
 func Test_StatisticsReport(t *testing.T) {
 	p0 := NewBMPPeerHeader(0, 0, 1000, "10.0.0.1", 70000, "10.0.0.2", 1)
 	s0 := NewBMPStatisticsReport(


### PR DESCRIPTION
`ParseBody()` and `Serialize()` need to be aware if we Add-Path is
enabled to be able to parse/serialize BGP updates correctly.

This solves only half of the problem: server/bmp also needs to be
updated.