### PR TITLE
grpc: fix goroutine leak in `WatchEvent`

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -235,7 +235,7 @@ func (s *server) ListPath(r *api.ListPathRequest, stream api.GobgpApi_ListPathSe
 }
 
 func (s *server) WatchEvent(r *api.WatchEventRequest, stream api.GobgpApi_WatchEventServer) error {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(stream.Context())
 	s.bgpServer.WatchEvent(ctx, r, func(rsp *api.WatchEventResponse) {
 		if err := stream.Send(rsp); err != nil {
 			cancel()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4349,6 +4349,9 @@ func (w *watcher) notify(v watchEvent) {
 
 func (w *watcher) loop() {
 	for ev := range w.ch.Out() {
+		if ev == nil {
+			break
+		}
 		w.realCh <- ev.(watchEvent)
 	}
 	close(w.realCh)


### PR DESCRIPTION
The context used there was a background context, which was not inherited from the stream. Thus when the client ends the stream (e.g. ^C `gobgp monitor global rib`), the context never completed, preventing the stop of most goroutines responsible for forwarding events. The only case where it completes is when an event gets generated, the transmit channel was closed, ending the chain of goroutines.

Fix by inheriting the context from the stream, which completes when the stream ends, properly cleaning up all resources.

### Steps to reproduce

1. Start gobgp
2. Observe the goroutine count using the pprof http server
3. Run and stop multiple `gobgp monitor global rib` and observe the goroutine count go up

Using the pprof interfaces also confirms that all the leaky goroutines are just parked and not doing anything.