### PR TITLE
#2591 Correct value of bsid in grpc list path

### DIFF
--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -1652,7 +1652,8 @@ func NewTunnelEncapAttributeFromNative(a *bgp.PathAttributeTunnelEncap) (*api.Tu
 				if err != nil {
 					return nil, err
 				}
-				subTlv = t
+				subTlv = &api.TunnelEncapSubTLVSRBindingSID{
+                                        Bsid:t}
 				// TODO (sbezverk) Add processing of SRv6 Binding SID when it gets assigned ID
 			case *bgp.TunnelEncapSubTLVSRCandidatePathName:
 				subTlv = &api.TunnelEncapSubTLVSRCandidatePathName{

--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -1653,7 +1653,7 @@ func NewTunnelEncapAttributeFromNative(a *bgp.PathAttributeTunnelEncap) (*api.Tu
 					return nil, err
 				}
 				subTlv = &api.TunnelEncapSubTLVSRBindingSID{
-                                        Bsid:t}
+					Bsid: t}
 				// TODO (sbezverk) Add processing of SRv6 Binding SID when it gets assigned ID
 			case *bgp.TunnelEncapSubTLVSRCandidatePathName:
 				subTlv = &api.TunnelEncapSubTLVSRCandidatePathName{


### PR DESCRIPTION
This allows ListhPath request for a SR Policy to correctly display the type and decode the value inside the TLVs 