### PR TITLE
mup: fix route key for Type 1 ST Route

### DIFF
--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -288,6 +288,39 @@ func (t *Table) GetEvpnDestinationsWithRouteType(typ string) ([]*Destination, er
 	return results, nil
 }
 
+func (t *Table) GetMUPDestinationsWithRouteType(typ string) ([]*Destination, error) {
+	var routeType uint16
+	switch strings.ToLower(typ) {
+	case "isd":
+		routeType = bgp.MUP_ROUTE_TYPE_INTERWORK_SEGMENT_DISCOVERY
+	case "dsd":
+		routeType = bgp.MUP_ROUTE_TYPE_DIRECT_SEGMENT_DISCOVERY
+	case "t1st":
+		routeType = bgp.MUP_ROUTE_TYPE_TYPE_1_SESSION_TRANSFORMED
+	case "t2st":
+		routeType = bgp.MUP_ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED
+	default:
+		return nil, fmt.Errorf("unsupported mup route type: %s", typ)
+	}
+	destinations := t.GetDestinations()
+	results := make([]*Destination, 0, len(destinations))
+	switch t.routeFamily {
+	case bgp.RF_MUP_IPv4, bgp.RF_MUP_IPv6:
+		for _, dst := range destinations {
+			if nlri, ok := dst.nlri.(*bgp.MUPNLRI); !ok {
+				return nil, fmt.Errorf("invalid mup nlri type detected: %T", dst.nlri)
+			} else if nlri.RouteType == routeType {
+				results = append(results, dst)
+			}
+		}
+	default:
+		for _, dst := range destinations {
+			results = append(results, dst)
+		}
+	}
+	return results, nil
+}
+
 func (t *Table) setDestination(dst *Destination) {
 	t.destinations[t.tableKey(dst.nlri)] = dst
 }
@@ -431,6 +464,18 @@ func (t *Table) Select(option ...TableSelectOption) (*Table, error) {
 			for _, p := range prefixes {
 				// Uses LookupPrefix.Prefix as EVPN Route Type string
 				ds, err := t.GetEvpnDestinationsWithRouteType(p.Prefix)
+				if err != nil {
+					return nil, err
+				}
+				for _, dst := range ds {
+					if d := dst.Select(dOption); d != nil {
+						r.setDestination(d)
+					}
+				}
+			}
+		case bgp.RF_MUP_IPv4, bgp.RF_MUP_IPv6:
+			for _, p := range prefixes {
+				ds, err := t.GetMUPDestinationsWithRouteType(p.Prefix)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/packet/bgp/mup.go
+++ b/pkg/packet/bgp/mup.go
@@ -213,6 +213,48 @@ func NewMUPNLRI(afi uint16, at uint8, rt uint16, data MUPRouteTypeInterface) *MU
 	}
 }
 
+func TEIDString(nlri AddrPrefixInterface) string {
+	s := ""
+	switch n := nlri.(type) {
+	case *MUPNLRI:
+		switch route := n.RouteTypeData.(type) {
+		case *MUPType1SessionTransformedRoute:
+			s = fmt.Sprintf("%d", route.TEID)
+		default:
+			s = ""
+		}
+	}
+	return s
+}
+
+func QFIString(nlri AddrPrefixInterface) string {
+	s := ""
+	switch n := nlri.(type) {
+	case *MUPNLRI:
+		switch route := n.RouteTypeData.(type) {
+		case *MUPType1SessionTransformedRoute:
+			s = fmt.Sprintf("%d", route.QFI)
+		default:
+			s = ""
+		}
+	}
+	return s
+}
+
+func EndpointString(nlri AddrPrefixInterface) string {
+	s := ""
+	switch n := nlri.(type) {
+	case *MUPNLRI:
+		switch route := n.RouteTypeData.(type) {
+		case *MUPType1SessionTransformedRoute:
+			s = route.EndpointAddress.String()
+		default:
+			s = ""
+		}
+	}
+	return s
+}
+
 // MUPInterworkSegmentDiscoveryRoute represents BGP Interwork Segment Discovery route as described in
 // https://datatracker.ietf.org/doc/html/draft-mpmz-bess-mup-safi-00#section-3.1.1
 type MUPInterworkSegmentDiscoveryRoute struct {

--- a/pkg/packet/bgp/mup.go
+++ b/pkg/packet/bgp/mup.go
@@ -295,6 +295,9 @@ func (r *MUPInterworkSegmentDiscoveryRoute) Len() int {
 }
 
 func (r *MUPInterworkSegmentDiscoveryRoute) String() string {
+	// I-D.draft-mpmz-bess-mup-safi-01
+	// 3.1.1.  BGP Interwork Segment Discovery route
+	// For the purpose of BGP route key processing, only the RD, Prefix Length and Prefix are considered to be part of the prefix in the NLRI.
 	return fmt.Sprintf("[type:isd][rd:%s][prefix:%s]", r.RD, r.Prefix)
 }
 
@@ -380,6 +383,9 @@ func (r *MUPDirectSegmentDiscoveryRoute) Len() int {
 }
 
 func (r *MUPDirectSegmentDiscoveryRoute) String() string {
+	// I-D.draft-mpmz-bess-mup-safi-01
+	// 3.1.2.  BGP Direct Segment Discovery route
+	// For the purpose of BGP route key processing, only the RD and Address are considered to be part of the prefix in the NLRI.
 	return fmt.Sprintf("[type:dsd][rd:%s][prefix:%s]", r.RD, r.Address)
 }
 
@@ -512,7 +518,10 @@ func (r *MUPType1SessionTransformedRoute) Len() int {
 }
 
 func (r *MUPType1SessionTransformedRoute) String() string {
-	return fmt.Sprintf("[type:t1st][rd:%s][prefix:%s][teid:%d][qfi:%d][endpoint:%s]", r.RD, r.Prefix, r.TEID, r.QFI, r.EndpointAddress)
+	// I-D.draft-mpmz-bess-mup-safi-01
+	// 3.1.3.  BGP Type 1 Session Transformed (ST) Route
+	// For the purpose of BGP route key processing, only the RD, Prefix Length and Prefix are considered to be part of the prefix in the NLRI.
+	return fmt.Sprintf("[type:t1st][rd:%s][prefix:%s]", r.RD, r.Prefix)
 }
 
 func (r *MUPType1SessionTransformedRoute) MarshalJSON() ([]byte, error) {
@@ -631,6 +640,9 @@ func (r *MUPType2SessionTransformedRoute) Len() int {
 }
 
 func (r *MUPType2SessionTransformedRoute) String() string {
+	// I-D.draft-mpmz-bess-mup-safi-01
+	// 3.1.4.  BGP Type 2 Session Transformed (ST) Route
+	// For the purpose of BGP route key processing, only the RD, Endpoint Address and Architecture specific Endpoint Identifier are considered to be part of the prefix in the NLRI.
 	return fmt.Sprintf("[type:t2st][rd:%s][endpoint:%s][teid:%d]", r.RD, r.EndpointAddress, r.TEID)
 }
 


### PR DESCRIPTION
- [mup: fix route key for Type 1 ST Route](https://github.com/osrg/gobgp/commit/411667d052c0ea2a8ba095da7cc764371fde86dd)
    - Removed TEID, QFI and Endpoint from route key to I-D compliant.
- [cli,mup: show TEID,QFI,Endpoint for Type 1 ST Route](https://github.com/osrg/gobgp/commit/82b708a95440ccf8052316b2ea08a7e5ffe5cdbf)
- [cli,mup: add support for filtering MUP routes with route type](https://github.com/osrg/gobgp/commit/dc328dccf667d2a5331ef764dfed02ca845fc784)