### PR TITLE
evpn type2 use in graceful restart crash

### DIFF
--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -254,7 +254,7 @@ func (manager *TableManager) handleMacMobility(path *Path) []*Path {
 					break
 				}
 			}
-			return d.ESI, d.ETag, d.MacAddress, seq, p.info.source.Address
+			return d.ESI, d.ETag, d.MacAddress, seq, p.GetSource().Address
 		}
 		e1, et1, m1, s1, i1 := f(path)
 		e2, et2, m2, s2, i2 := f(path2)


### PR DESCRIPTION
Gobgp will crash when use evpn type2 sync in graceful restart and peer(crash or out by kill -9/reboot)