### PR TITLE
packet/bgp,mup: fix prefix format in Type 1 ST route

### DIFF
--- a/pkg/packet/bgp/mup_test.go
+++ b/pkg/packet/bgp/mup_test.go
@@ -115,7 +115,7 @@ func Test_MUPType1SessionTransformedRouteIPv4(t *testing.T) {
 	rd, _ := ParseRouteDistinguisher("100:100")
 	r := &MUPType1SessionTransformedRoute{
 		RD:                    rd,
-		Prefix:                netip.MustParsePrefix("192.100.0.1/32"),
+		Prefix:                netip.MustParsePrefix("192.100.0.0/24"),
 		TEID:                  100,
 		QFI:                   9,
 		EndpointAddressLength: 32,
@@ -140,7 +140,7 @@ func Test_MUPType1SessionTransformedRouteIPv6(t *testing.T) {
 	rd, _ := ParseRouteDistinguisher("100:100")
 	r := &MUPType1SessionTransformedRoute{
 		RD:                    rd,
-		Prefix:                netip.MustParsePrefix("2001:db8:1:1::1/128"),
+		Prefix:                netip.MustParsePrefix("2001:db8:1::/48"),
 		TEID:                  100,
 		QFI:                   9,
 		EndpointAddressLength: 128,


### PR DESCRIPTION
https://www.ietf.org/archive/id/draft-mpmz-bess-mup-safi-01.html#section-3.1.3
The Prefix field must be encoded as described in RFC4271 4.3. UPDATE Message Format.
https://www.rfc-editor.org/rfc/rfc4271.html#section-4.3

The attached image is fixed UPDATE message.
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/733288/218257553-178b6acb-88de-4e37-8a05-3caac35542d3.png">
