### PR TITLE
server: use SetsockoptTCPMD5Sig from golang.org/x/sys/unix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	golang.org/x/net v0.7.0
+	golang.org/x/sys v0.6.0
 	golang.org/x/text v0.7.0
 	google.golang.org/grpc v1.51.0
 	google.golang.org/protobuf v1.28.1
@@ -42,7 +43,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae // indirect
-	golang.org/x/sys v0.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20221024183307-1bc688fe9f3e // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,8 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
-golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/server/sockopt_linux_test.go
+++ b/pkg/server/sockopt_linux_test.go
@@ -26,9 +26,9 @@ import (
 )
 
 func Test_buildTcpMD5Sig(t *testing.T) {
-	s, _ := buildTcpMD5Sig("1.2.3.4", "hello")
+	s := buildTcpMD5Sig("1.2.3.4", "hello")
 
-	if unsafe.Sizeof(s) != 216 {
+	if unsafe.Sizeof(*s) != 216 {
 		t.Error("TCPM5Sig struct size is wrong", unsafe.Sizeof(s))
 	}
 
@@ -47,7 +47,7 @@ func Test_buildTcpMD5Sig(t *testing.T) {
 }
 
 func Test_buildTcpMD5Sigv6(t *testing.T) {
-	s, _ := buildTcpMD5Sig("fe80::4850:31ff:fe01:fc55", "helloworld")
+	s := buildTcpMD5Sig("fe80::4850:31ff:fe01:fc55", "helloworld")
 
 	buf1 := new(bytes.Buffer)
 	if err := binary.Write(buf1, binary.LittleEndian, s); err != nil {


### PR DESCRIPTION
Use the TCPMD5Sig type and the corresponding SetsockoptTCPMD5Sig func added upstream in golang.org/x/sys v0.6.0