### PR TITLE
server: disable tcpkeepalive

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -555,6 +555,7 @@ func (h *fsmHandler) connectLoop(ctx context.Context, wg *sync.WaitGroup) {
 			d := net.Dialer{
 				LocalAddr: laddr,
 				Timeout:   time.Duration(tick-1) * time.Second,
+				KeepAlive: -1,
 				Control: func(network, address string, c syscall.RawConn) error {
 					return dialerControl(fsm.logger, network, address, c, ttl, ttlMin, password, bindInterface)
 				},


### PR DESCRIPTION
The default value for tcpkeepalive in the standard net package is 15 seconds, while the default value for BGP keepalive is 30 seconds. If the network is not good, the TCP connection is disconnected before BGP can send keepalive messages.

Therefore, BGP keepalive is effectively invalid.

The solution is that since we have BGP keepalive, we don't need to open tcp keepalive.