### PR TITLE
cli,mup: fix prefix and route type handling

### DIFF
--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -854,8 +854,6 @@ func showNeighborRib(r string, name string, args []string) error {
 	switch rf {
 	case bgp.RF_IPv4_MPLS, bgp.RF_IPv6_MPLS, bgp.RF_IPv4_VPN, bgp.RF_IPv6_VPN, bgp.RF_EVPN:
 		showLabel = true
-	case bgp.RF_MUP_IPv4, bgp.RF_MUP_IPv6:
-		showMUP = true
 	}
 
 	var filter []*api.TableLookupPrefix
@@ -865,7 +863,11 @@ func showNeighborRib(r string, name string, args []string) error {
 		case bgp.RF_EVPN:
 			// Uses target as EVPN Route Type string
 		case bgp.RF_MUP_IPv4, bgp.RF_MUP_IPv6:
-			// Uses target as MUP Route Type string
+			// Uses target as MUP Route Type string or route key
+			// Only t1st has MUP specific columns
+			if target == "t1st" {
+				showMUP = true
+			}
 		default:
 			if _, _, err = parseCIDRorIP(target); err != nil {
 				return err

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -288,9 +288,9 @@ func (t *Table) GetEvpnDestinationsWithRouteType(typ string) ([]*Destination, er
 	return results, nil
 }
 
-func (t *Table) GetMUPDestinationsWithRouteType(typ string) ([]*Destination, error) {
+func (t *Table) GetMUPDestinationsWithRouteType(p string) ([]*Destination, error) {
 	var routeType uint16
-	switch strings.ToLower(typ) {
+	switch strings.ToLower(p) {
 	case "isd":
 		routeType = bgp.MUP_ROUTE_TYPE_INTERWORK_SEGMENT_DISCOVERY
 	case "dsd":
@@ -300,7 +300,7 @@ func (t *Table) GetMUPDestinationsWithRouteType(typ string) ([]*Destination, err
 	case "t2st":
 		routeType = bgp.MUP_ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED
 	default:
-		return nil, fmt.Errorf("unsupported mup route type: %s", typ)
+		// use prefix as route key
 	}
 	destinations := t.GetDestinations()
 	results := make([]*Destination, 0, len(destinations))
@@ -310,6 +310,8 @@ func (t *Table) GetMUPDestinationsWithRouteType(typ string) ([]*Destination, err
 			if nlri, ok := dst.nlri.(*bgp.MUPNLRI); !ok {
 				return nil, fmt.Errorf("invalid mup nlri type detected: %T", dst.nlri)
 			} else if nlri.RouteType == routeType {
+				results = append(results, dst)
+			} else if nlri.String() == p {
 				results = append(results, dst)
 			}
 		}


### PR DESCRIPTION
This PR enables to use `<prefix>` as not only route type but also route key.