### PR TITLE
Added local ASN and local BGP peering address for gobgp neighbor command

### DIFF
--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -96,10 +96,18 @@ func getNeighbors(address string, enableAdv bool) ([]*api.Peer, error) {
 	return l, err
 }
 
-func getASN(p *api.Peer) string {
+func getRemoteASN(p *api.Peer) string {
 	asn := "*"
 	if p.State.PeerAsn > 0 {
 		asn = fmt.Sprint(p.State.PeerAsn)
+	}
+	return asn
+}
+
+func getLocalASN(p *api.Peer) string {
+	asn := "*"
+	if p.State.LocalAsn > 0 {
+		asn = fmt.Sprint(p.State.LocalAsn)
 	}
 	return asn
 }
@@ -181,7 +189,7 @@ func showNeighbors(vrf string) error {
 		} else if j := len(n.State.NeighborAddress); j > maxaddrlen {
 			maxaddrlen = j
 		}
-		if l := len(getASN(n)); l > maxaslen {
+		if l := len(getRemoteASN(n)); l > maxaslen {
 			maxaslen = l
 		}
 		timeStr := "never"
@@ -236,7 +244,7 @@ func showNeighbors(vrf string) error {
 			neigh = n.Conf.NeighborInterface
 		}
 		received, accepted, _, _ := counter(n)
-		fmt.Printf(format, neigh, getASN(n), timedelta[i], formatFsm(n.State.AdminState, n.State.SessionState), fmt.Sprint(received), fmt.Sprint(accepted))
+		fmt.Printf(format, neigh, getRemoteASN(n), timedelta[i], formatFsm(n.State.AdminState, n.State.SessionState), fmt.Sprint(received), fmt.Sprint(accepted))
 	}
 
 	return nil
@@ -255,7 +263,7 @@ func showNeighbor(args []string) error {
 		return nil
 	}
 
-	fmt.Printf("BGP neighbor is %s, remote AS %s", p.State.NeighborAddress, getASN(p))
+	fmt.Printf("BGP neighbor is %s, remote AS %s", p.State.NeighborAddress, getRemoteASN(p))
 
 	if p.RouteReflector.RouteReflectorClient {
 		fmt.Printf(", route-reflector-client\n")
@@ -277,6 +285,7 @@ func showNeighbor(args []string) error {
 		fmt.Print("\n")
 	}
 	fmt.Printf("  BGP OutQ = %d, Flops = %d\n", p.State.Queues.Output, p.State.Flops)
+	fmt.Printf("  Local address is %s, local ASN: %s\n", p.Transport.LocalAddress, getLocalASN(p))
 	fmt.Printf("  Hold time is %d, keepalive interval is %d seconds\n", int(p.Timers.State.NegotiatedHoldTime), int(p.Timers.State.KeepaliveInterval))
 	fmt.Printf("  Configured hold time is %d, keepalive interval is %d seconds\n", int(p.Timers.Config.HoldTime), int(p.Timers.Config.KeepaliveInterval))
 

--- a/internal/pkg/config/util.go
+++ b/internal/pkg/config/util.go
@@ -508,6 +508,7 @@ func NewPeerFromConfigStruct(pconf *Neighbor) *api.Peer {
 				},
 			},
 			PeerAsn:         s.PeerAs,
+			LocalAsn:        s.LocalAs,
 			Type:            api.PeerType(s.PeerType.ToInt()),
 			NeighborAddress: pconf.State.NeighborAddress,
 			Queues:          &api.Queues{},


### PR DESCRIPTION
  Hello!
  
  I hope you're doing well.
  
  Thank you so much for your hard work in maintaining GoBGP.
  
  Some of our customers have quite complicated setups with different local ASNs numbers, for example:
  ```
  [global.config]
    as = 65001
    router-id = "11.22.33.44"
    port = 179
  
  [[neighbors]]
    [neighbors.config]
      neighbor-address = "22.33.44.55"
      local-as = 65444
      peer-as = 65001
      [[neighbors.afi-safis]]
      [neighbors.afi-safis.config]
        afi-safi-name = "ipv4-unicast"
  
      [neighbors.transport.config]
        local-address = "11.22.33.44"
  [[neighbors]]
    [neighbors.config]
      neighbor-address = "77.77.77.77"
      local-as = 65333
      peer-as = 56000
      [[neighbors.afi-safis]]
      [neighbors.afi-safis.config]
        afi-safi-name = "ipv4-unicast"
  
      [neighbors.transport.config]
        local-address = "33.33.44.55"
  ``` 
  
  Unfortunately, gobgp neighbor command does not show local ASN but only shows remote ASNs both in summary command:
  ```
  gobgp nei
  Peer           AS Up/Down State       |#Received  Accepted
  22.33.44.55 65001   never Active      |        0         0
  77.77.77.77 56000   never Active      |        0         0
  ```
  
Detailed show neighbour does not show local ASN either:
```
BGP neighbor is 77.77.77.77, remote AS 56000
  BGP version 4, remote router ID unknown
  BGP state = ACTIVE
  BGP OutQ = 0, Flops = 0
  Hold time is 0, keepalive interval is 0 seconds
  Configured hold time is 90, keepalive interval is 30 seconds
  
  Neighbor capabilities:
    multiprotocol:
        ipv4-unicast:	advertised
    route-refresh:	advertised
    extended-nexthop:	advertised
        Local:  nlri: ipv4-unicast, nexthop: ipv6
    4-octet-as:	advertised
  Message statistics:
                         Sent       Rcvd
    Opens:                  0          0
    Notifications:          0          0
    Updates:                0          0
    Keepalives:             0          0
    Route Refresh:          0          0
    Discarded:              0          0
    Total:                  0          0
  Route statistics:
    Advertised:             0
    Received:               0
    Accepted:               0
```

So I decided to implement this logic and after this patch we will be able to see local ASN and local peer address in detailed show neighbour output this way:
```Local address is 11.22.33.44, local ASN: 65444```

You may find detailed output below:
```
gobgp nei 22.33.44.55
BGP neighbor is 22.33.44.55, remote AS 65001
  BGP version 4, remote router ID unknown
  BGP state = ACTIVE
  BGP OutQ = 0, Flops = 0
  Local address is 11.22.33.44, local ASN: 65444
  Hold time is 0, keepalive interval is 0 seconds
  Configured hold time is 90, keepalive interval is 30 seconds
  
  Neighbor capabilities:
    multiprotocol:
        ipv4-unicast:	advertised
    route-refresh:	advertised
    extended-nexthop:	advertised
        Local:  nlri: ipv4-unicast, nexthop: ipv6
    4-octet-as:	advertised
    fqdn:	advertised
      Local:
         name: station1, domain: 
  Message statistics:
                         Sent       Rcvd
    Opens:                  0          0
    Notifications:          0          0
    Updates:                0          0
    Keepalives:             0          0
    Route Refresh:          0          0
    Discarded:              0          0
    Total:                  0          0
  Route statistics:
    Advertised:             0
    Received:               0
    Accepted:               0
```

Thank you for review. I'll be happy to make any adjustments for it.