### PR TITLE
API: Preserve UUID in path table

### DIFF
--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -24,6 +24,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/osrg/gobgp/v3/internal/pkg/config"
 	"github.com/osrg/gobgp/v3/pkg/log"
 	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
@@ -141,6 +143,9 @@ type Path struct {
 	// For BGP Nexthop Tracking, this field shows if nexthop is invalidated by IGP.
 	IsNexthopInvalid bool
 	IsWithdraw       bool
+
+	// Only exists for paths added via AddPath API
+	Uuid *uuid.UUID
 }
 
 var localSource = &PeerInfo{}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -174,7 +174,6 @@ type BgpServer struct {
 	bmpManager   *bmpClientManager
 	mrtManager   *mrtManager
 	roaTable     *table.ROATable
-	uuidMap      map[string]uuid.UUID
 	logger       log.Logger
 }
 
@@ -195,7 +194,6 @@ func NewBgpServer(opt ...ServerOption) *BgpServer {
 		policy:       table.NewRoutingPolicy(logger),
 		mgmtCh:       make(chan *mgmtOp, 1),
 		watcherMap:   make(map[watchEventType][]*watcher),
-		uuidMap:      make(map[string]uuid.UUID),
 		roaManager:   newROAManager(roaTable, logger),
 		roaTable:     roaTable,
 		logger:       logger,
@@ -2131,6 +2129,7 @@ func (s *BgpServer) AddPath(ctx context.Context, r *api.AddPathRequest) (*api.Ad
 	var uuidBytes []byte
 	err := s.mgmtOperation(func() error {
 		id, err := uuid.NewRandom()
+
 		if err != nil {
 			return err
 		}
@@ -2139,13 +2138,15 @@ func (s *BgpServer) AddPath(ctx context.Context, r *api.AddPathRequest) (*api.Ad
 		if err != nil {
 			return err
 		}
+
+		path.Uuid = &id
+
 		err = s.addPathList(r.VrfId, []*table.Path{path})
 		if err != nil {
 			return err
 		}
 
-		s.uuidMap[pathTokey(path)] = id
-		uuidBytes, _ = id.MarshalBinary()
+		uuidBytes, _ = path.Uuid.MarshalBinary()
 		return nil
 	}, true)
 	return &api.AddPathResponse{Uuid: uuidBytes}, err
@@ -2172,15 +2173,9 @@ func (s *BgpServer) DeletePath(ctx context.Context, r *api.DeletePathRequest) er
 		if len(r.Uuid) > 0 {
 			// Delete locally generated path which has the given UUID
 			path := func() *table.Path {
-				id, _ := uuid.FromBytes(r.Uuid)
-				for k, v := range s.uuidMap {
-					if v == id {
-						for _, path := range s.globalRib.GetPathList(table.GLOBAL_RIB_NAME, 0, s.globalRib.GetRFlist()) {
-							if path.IsLocal() && k == pathTokey(path) {
-								delete(s.uuidMap, k)
-								return path
-							}
-						}
+				for _, path := range s.globalRib.GetPathList(table.GLOBAL_RIB_NAME, 0, s.globalRib.GetRFlist()) {
+					if path.Uuid != nil && bytes.Equal(path.Uuid[:], r.Uuid) {
+						return path
 					}
 				}
 				return nil
@@ -2201,15 +2196,11 @@ func (s *BgpServer) DeletePath(ctx context.Context, r *api.DeletePathRequest) er
 					deletePathList = append(deletePathList, path.Clone(true))
 				}
 			}
-			s.uuidMap = make(map[string]uuid.UUID)
 		} else {
 			if err := s.fixupApiPath(r.VrfId, pathList); err != nil {
 				return err
 			}
 			deletePathList = pathList
-			for _, p := range deletePathList {
-				delete(s.uuidMap, pathTokey(p))
-			}
 		}
 		s.propagateUpdate(nil, deletePathList)
 		return nil


### PR DESCRIPTION
Changes the AddPath API to add the UUID generated to the path object. Previously this UUID was only usable for deleting routes, and would be dropped when inserted into the table. That meant then if the same route was passed to a table event watcher, the UUID was set to nil, despite being made by the API.

With this change, the UUID is preserved and will be passed to callers of ListPath, or when passed to an event watcher. To implement this an additional UUID field has been added onto the table path object, and the AddPath, api2Path functions modified to preserve them. The Marshaller was also updated to return this value to end users as well.

Additionally the DeletePath call has been simplified when deleting paths by UUID. Since each path now stores the UUID they are checked directly rather than using a lookup map. This also means that the `uuidMap` has been removed. 