### PR TITLE
Use standard library context package

### DIFF
--- a/cmd/gobgpd/main.go
+++ b/cmd/gobgpd/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -35,7 +36,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.1
 	github.com/vishvananda/netlink v1.2.1-beta.2
-	golang.org/x/net v0.8.0
 	golang.org/x/sys v0.6.0
 	golang.org/x/text v0.8.0
 	google.golang.org/grpc v1.53.0
@@ -50,6 +49,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
+	golang.org/x/net v0.8.0 // indirect
 	google.golang.org/genproto v0.0.0-20230320184635-7606e756e683 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,7 +1,8 @@
 package config
 
 import (
-	"golang.org/x/net/context"
+	"context"
+
 	apb "google.golang.org/protobuf/types/known/anypb"
 
 	api "github.com/osrg/gobgp/v3/api"

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -17,6 +17,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -28,7 +29,6 @@ import (
 	"time"
 
 	"github.com/dgryski/go-farm"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	apb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/emptypb"

--- a/pkg/server/rpki.go
+++ b/pkg/server/rpki.go
@@ -16,14 +16,13 @@
 package server
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
 	"strconv"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/osrg/gobgp/v3/internal/pkg/config"
 	"github.com/osrg/gobgp/v3/internal/pkg/table"


### PR DESCRIPTION
Use Go's standard library `context` package instead of the `golang.org/x/net/context` package. Package `context has been available in the standard library since Go 1.7 and `x/net/context.Context` is merely an alias for the standard library type.