### PR TITLE
Add option to register BGP-LS NLRI in gobgp command

### DIFF
--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -1295,9 +1295,9 @@ func parseMUPArgs(args []string, afi uint16, nexthop string) (bgp.AddrPrefixInte
 	return nil, nil, nil, fmt.Errorf("invalid subtype. expect [isd|dsd|t1st|t2st] but %s", subtype)
 }
 
-func parseLsLinkProtocol(args []string, afi uint16) (bgp.AddrPrefixInterface, error) {
+func parseLsLinkProtocol(args []string, afi uint16) (bgp.AddrPrefixInterface, *bgp.PathAttributeLs, error) {
 	if len(args) < 2 {
-		return nil, fmt.Errorf("lack of protocolType")
+		return nil, nil, fmt.Errorf("lack of protocolType")
 	}
 	protocolType := args[1]
 	switch protocolType {
@@ -1305,15 +1305,15 @@ func parseLsLinkProtocol(args []string, afi uint16) (bgp.AddrPrefixInterface, er
 	case "bgp":
 		return parseLsLinkNLRIType(args, afi)
 	}
-	return nil, fmt.Errorf("invalid protocolType. expect [bgp] but %s", protocolType)
+	return nil, nil, fmt.Errorf("invalid protocolType. expect [bgp] but %s", protocolType)
 }
 
-func parseLsLinkNLRIType(args []string, afi uint16) (bgp.AddrPrefixInterface, error) {
+func parseLsLinkNLRIType(args []string, afi uint16) (bgp.AddrPrefixInterface, *bgp.PathAttributeLs, error) {
 	// Format:
 	// <ip prefix> identifier <identifier> asn <asn> bgp-ls-id <bgp-ls-id> ospf
 	req := 26
 	if len(args) < req {
-		return nil, fmt.Errorf("%d args required at least, but got %d", req, len(args))
+		return nil, nil, fmt.Errorf("%d args required at least, but got %d", req, len(args))
 	}
 
 	m, err := extractReserved(args, map[string]int{
@@ -1332,29 +1332,34 @@ func parseLsLinkNLRIType(args []string, afi uint16) (bgp.AddrPrefixInterface, er
 		"ipv6-neighbor-address":           paramSingle,
 		"sid":                             paramSingle,
 		"sid-type":                        paramSingle,
+		"v-flag":                          paramFlag,
+		"l-flag":                          paramFlag,
+		"b-flag":                          paramFlag,
+		"p-flag":                          paramFlag,
+		"weight":                          paramSingle,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	identifier, err := strconv.ParseUint(m["identifier"][0], 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	localAsn, err := strconv.ParseUint(m["local-asn"][0], 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 	localBgpLsId, err := strconv.ParseUint(m["local-bgp-ls-id"][0], 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 	localBgpConfederationMember, err := strconv.ParseUint(m["local-bgp-confederation-member"][0], 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 	lnd := &bgp.LsNodeDescriptor{
@@ -1368,17 +1373,17 @@ func parseLsLinkNLRIType(args []string, afi uint16) (bgp.AddrPrefixInterface, er
 	}
 	RemoteAsn, err := strconv.ParseUint(m["remote-asn"][0], 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 	RemoteBgpLsId, err := strconv.ParseUint(m["remote-bgp-ls-id"][0], 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 	RemoteBgpConfederationMember, err := strconv.ParseUint(m["remote-bgp-confederation-member"][0], 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 
 	}
 	rnd := &bgp.LsNodeDescriptor{
@@ -1414,9 +1419,94 @@ func parseLsLinkNLRIType(args []string, afi uint16) (bgp.AddrPrefixInterface, er
 	rndTLV := bgp.NewLsTLVNodeDescriptor(rnd, bgp.LS_TLV_REMOTE_NODE_DESC)
 	ldTLV := bgp.NewLsLinkTLVs(ld)
 
+	sidTypeString := m["sid-type"][0]
+
+	sidtype := lsTLVTypeSelect(sidTypeString)
+
+	var peerNodeFlag uint8
+
+	if _, ok := m["v-flag"]; ok {
+		peerNodeFlag = peerNodeFlag | 0x80
+	}
+	if _, ok := m["l-flag"]; ok {
+		peerNodeFlag = peerNodeFlag | 0x40
+	}
+	if _, ok := m["b-flag"]; ok {
+		peerNodeFlag = peerNodeFlag | 0x20
+	}
+	if _, ok := m["p-flag"]; ok {
+		peerNodeFlag = peerNodeFlag | 0x10
+	}
+
+	lsTLVWeight, err := strconv.ParseUint(m["weight"][0], 10, 64)
+	if err != nil {
+		return nil, nil, err
+	}
+	lsTLVSid, err := strconv.ParseUint(m["sid"][0], 10, 64)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	const lsTlvLen = 7
+	const t = bgp.BGP_ATTR_TYPE_LS
+	const pathAttrHdrLen = 4
+	var tlvs []bgp.LsTLVInterface
+	length := uint16(pathAttrHdrLen + lsTlvLen)
+
+	switch sidtype {
+	case bgp.LS_TLV_PEER_NODE_SID:
+
+		lsTLV := &bgp.LsTLVPeerNodeSID{
+			LsTLV: bgp.LsTLV{
+				Type:   sidtype,
+				Length: uint16(lsTlvLen),
+			},
+			Flags:  peerNodeFlag,
+			Weight: uint8(lsTLVWeight),
+			SID:    uint32(lsTLVSid),
+		}
+		tlvs = append(tlvs, lsTLV)
+	case bgp.LS_TLV_ADJACENCY_SID:
+		lsTLV := &bgp.LsTLVAdjacencySID{
+			LsTLV: bgp.LsTLV{
+				Type:   sidtype,
+				Length: uint16(lsTlvLen),
+			},
+			Flags:  peerNodeFlag,
+			Weight: uint8(lsTLVWeight),
+			SID:    uint32(lsTLVSid),
+		}
+		tlvs = append(tlvs, lsTLV)
+	case bgp.LS_TLV_PEER_SET_SID:
+		lsTLV := &bgp.LsTLVPeerSetSID{
+			LsTLV: bgp.LsTLV{
+				Type:   sidtype,
+				Length: uint16(lsTlvLen),
+			},
+			Flags:  peerNodeFlag,
+			Weight: uint8(lsTLVWeight),
+			SID:    uint32(lsTLVSid),
+		}
+		tlvs = append(tlvs, lsTLV)
+	}
+
+	pathAttributeLs := &bgp.PathAttributeLs{
+		PathAttribute: bgp.PathAttribute{
+			Flags:  bgp.PathAttrFlags[t],
+			Type:   t,
+			Length: length,
+		},
+		TLVs: tlvs,
+	}
+	len := len(ldTLV)
+	var sum int
+	for i := 0; i < len; i++ {
+		sum += ldTLV[i].Len()
+	}
+
 	const CodeLen = 1
 	const topologyLen = 8
-	LsNLRIhdrlen := lndTLV.Len() + rndTLV.Len() + topologyLen + CodeLen
+	LsNLRIhdrlen := sum + lndTLV.Len() + rndTLV.Len() + topologyLen + CodeLen
 	lsNlri := bgp.LsNLRI{
 		NLRIType:   bgp.LS_NLRI_TYPE_NODE,
 		Length:     uint16(LsNLRIhdrlen),
@@ -1433,12 +1523,26 @@ func parseLsLinkNLRIType(args []string, afi uint16) (bgp.AddrPrefixInterface, er
 			LinkDesc:       ldTLV,
 		},
 	}
-	return nlri, nil
+	return nlri, pathAttributeLs, nil
 }
 
-func parseLsArgs(args []string, afi uint16) (bgp.AddrPrefixInterface, error) {
+func lsTLVTypeSelect(s string) bgp.LsTLVType {
+	switch s {
+	case "node":
+		return bgp.LS_TLV_PEER_NODE_SID
+	case "adj":
+		return bgp.LS_TLV_ADJACENCY_SID
+	case "set":
+		return bgp.LS_TLV_PEER_SET_SID
+	}
+
+	return bgp.LS_TLV_UNKNOWN
+
+}
+
+func parseLsArgs(args []string, afi uint16) (bgp.AddrPrefixInterface, *bgp.PathAttributeLs, error) {
 	if len(args) < 1 {
-		return nil, fmt.Errorf("lack of nlriType")
+		return nil, nil, fmt.Errorf("lack of nlriType")
 	}
 	nlriType := args[0]
 	switch nlriType {
@@ -1447,7 +1551,7 @@ func parseLsArgs(args []string, afi uint16) (bgp.AddrPrefixInterface, error) {
 		// TODO: case node / IPv4 Topology Prefix / IPv6 Topology Prefix / TE Policy / SRv6 SID
 	}
 
-	return nil, fmt.Errorf("invalid nlriType. expect [link] but %s", nlriType)
+	return nil, nil, fmt.Errorf("invalid nlriType. expect [link] but %s", nlriType)
 }
 
 func extractOrigin(args []string) ([]string, bgp.PathAttributeInterface, error) {
@@ -1691,6 +1795,7 @@ func parsePath(rf bgp.RouteFamily, args []string) (*api.Path, error) {
 	var nlri bgp.AddrPrefixInterface
 	var extcomms []string
 	var psid *bgp.PathAttributePrefixSID
+	var ls *bgp.PathAttributeLs
 	var err error
 	attrs := make([]bgp.PathAttributeInterface, 0, 1)
 
@@ -1842,12 +1947,15 @@ func parsePath(rf bgp.RouteFamily, args []string) (*api.Path, error) {
 	case bgp.RF_MUP_IPv6:
 		nlri, psid, extcomms, err = parseMUPArgs(args, bgp.AFI_IP6, nexthop)
 	case bgp.RF_LS:
-		nlri, err = parseLsArgs(args, bgp.AFI_LS)
+		nlri, ls, err = parseLsArgs(args, bgp.AFI_LS)
 	default:
 		return nil, fmt.Errorf("unsupported route family: %s", rf)
 	}
 	if err != nil {
 		return nil, err
+	}
+	if ls != nil {
+		attrs = append(attrs, ls)
 	}
 
 	if rf == bgp.RF_IPv4_UC && net.ParseIP(nexthop).To4() != nil {
@@ -1930,10 +2038,10 @@ func modPath(resource string, name, modtype string, args []string) error {
 		helpErrMap := map[bgp.RouteFamily]error{}
 		baseHelpMsgFmt := fmt.Sprintf(`error: %s
 usage: %s rib -a %%s %s <PREFIX> %%s [origin { igp | egp | incomplete }] [aspath <ASPATH>] [nexthop <ADDRESS>] [med <NUM>] [local-pref <NUM>] [community <COMMUNITY>] [aigp metric <NUM>] [large-community <LARGE_COMMUNITY>] [aggregator <AGGREGATOR>]
-	<ASPATH>: <AS>[,<AS>],
-	<COMMUNITY>: xxx:xxx|internet|planned-shut|accept-own|route-filter-translated-v4|route-filter-v4|route-filter-translated-v6|route-filter-v6|llgr-stale|no-llgr|blackhole|no-export|no-advertise|no-export-subconfed|no-peer,
-	<LARGE_COMMUNITY>: xxx:xxx:xxx[,<LARGE_COMMUNITY>],
-	<AGGREGATOR>: <AS>:<ADDRESS>`,
+    <ASPATH>: <AS>[,<AS>],
+    <COMMUNITY>: xxx:xxx|internet|planned-shut|accept-own|route-filter-translated-v4|route-filter-v4|route-filter-translated-v6|route-filter-v6|llgr-stale|no-llgr|blackhole|no-export|no-advertise|no-export-subconfed|no-peer,
+    <LARGE_COMMUNITY>: xxx:xxx:xxx[,<LARGE_COMMUNITY>],
+    <AGGREGATOR>: <AS>:<ADDRESS>`,
 			err,
 			cmdstr,
 			// <address family>

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -6917,8 +6917,14 @@ func (l *LsTLVBgpRouterID) DecodeFromBytes(data []byte) error {
 }
 
 func (l *LsTLVBgpRouterID) Serialize() ([]byte, error) {
-	var buf [4]byte
-	copy(buf[:], l.RouterID)
+	tmpaddr := l.RouterID
+	if tmpaddr.To4() != nil {
+		var buf [4]byte
+		copy(buf[:], l.RouterID.To4())
+		return l.LsTLV.Serialize(buf[:])
+	}
+	var buf [16]byte
+	copy(buf[:], l.RouterID.To16())
 	return l.LsTLV.Serialize(buf[:])
 }
 

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -7943,7 +7943,7 @@ func NewLsTLVAdjacencySID(l *uint32) *LsTLVAdjacencySID {
 	var flags uint8
 	return &LsTLVAdjacencySID{
 		LsTLV: LsTLV{
-			Type:   BGP_ASPATH_ATTR_TYPE_SET,
+			Type:   LS_TLV_ADJACENCY_SID,
 			Length: 7, // TODO: Implementation to judge 7 octets or 8 octets
 		},
 		Flags:  flags,
@@ -8075,7 +8075,7 @@ type LsTLVPeerNodeSID struct {
 func NewLsTLVPeerNodeSID(l *LsBgpPeerSegmentSID) *LsTLVPeerNodeSID {
 	return &LsTLVPeerNodeSID{
 		LsTLV: LsTLV{
-			Type:   BGP_ASPATH_ATTR_TYPE_SET,
+			Type:   LS_TLV_PEER_NODE_SID,
 			Length: l.Flags.SidLen(),
 		},
 		Flags:  l.Flags.FlagBits(),
@@ -8166,7 +8166,7 @@ type LsTLVPeerAdjacencySID struct {
 func NewLsTLVPeerAdjacencySID(l *LsBgpPeerSegmentSID) *LsTLVPeerAdjacencySID {
 	return &LsTLVPeerAdjacencySID{
 		LsTLV: LsTLV{
-			Type:   BGP_ASPATH_ATTR_TYPE_SET,
+			Type:   LS_TLV_ADJACENCY_SID,
 			Length: l.Flags.SidLen(),
 		},
 		Flags:  l.Flags.FlagBits(),
@@ -8257,7 +8257,7 @@ type LsTLVPeerSetSID struct {
 func NewLsTLVPeerSetSID(l *LsBgpPeerSegmentSID) *LsTLVPeerSetSID {
 	return &LsTLVPeerSetSID{
 		LsTLV: LsTLV{
-			Type:   BGP_ASPATH_ATTR_TYPE_SET,
+			Type:   LS_TLV_PEER_SET_SID,
 			Length: l.Flags.SidLen(),
 		},
 		Flags:  l.Flags.FlagBits(),


### PR DESCRIPTION
We implemented an option adding the BGP-LS NLRI to the gobgp command.   

This implementation is interoperable with Cisco XRd and Juniper cRPD.    

## Example of registering a route

gobgp command:
``` bash
gobgp global rib add -a ls link bgp identifier 0 local-asn 65002 local-bgp-ls-id 0 local-bgp-router-id 2.2.2.2 local-bgp-confederation-member 1 remote-asn 65001 remote-bgp-ls-id 0 remote-bgp-router-id 1.1.1.1 remote
-bgp-confederation-member 0 ipv4-interface-address 10.0.0.2 ipv4-neighbor-address 10.0.0.1 sid 1000002 sid-type node v-flag l-flag b-flag p-flag weight 1 ipv6-interface-address fd00::1 ipv6-neighbor-address fd00::2
```

BGP-LS options can specified with `-a ls`.

- NLRI type: `node`/`link`
- Protocol ID: Only bgp is implemented
- paramSingle options: `identifier`/`local-asn`/`local-bgp-ls-id`/`local-bgp-router-id`/`local-bgp-confederation-member`/`remote-asn`/`remote-bgp-ls-id`/`remote-bgp-router-id`/`remote-bgp-confederation-member`/`ipv4-interface-address`/`ipv4-neighbor-address`/`ipv6-interface-address`/`ipv6-neighbor-address`/`sid`/`sid-type`/`weight`
- paramFlag: `v-flag`/`l-flag`/`b-flag`/`p-flag`

## Example of checking routes

gobgp:
`#gobgp global rib -a ls`

```
   Network                                                                               Next Hop             AS_PATH              Age        Attrs
*> NLRI { LINK { LOCAL_NODE: 2.2.2.2 REMOTE_NODE: 1.1.1.1 LINK: 10.0.0.2->10.0.0.1} }    0.0.0.0                                   00:57:59   [{Origin: ?} {LsAttributes: {Peer Node SID: 1000002} }]
(snip.)
```


Cisco XRd:
`#show bgp link-state link-state [E][B][I0x0][N[c65002][b0.0.0.0][q2.2.2.2][u0205000400000001]][R[c65001][b0.0.0.0][q1.1.1.1]][L[l0.0][i10.0.0.2][n10.0.0.1][ifd00::1][nfd00::2]]/1144 detail`

```
BGP routing table entry for [E][B][I0x0][N[c65002][b0.0.0.0][q2.2.2.2][u0205000400000001]][R[c65001][b0.0.0.0][q1.1.1.1]][L[l0.0][i10.0.0.2][n10.0.0.1][ifd00::1][nfd00::2]]/1144
NLRI Type: Link
Protocol: BGP
Identifier: 0x0
Local Node Descriptor:
        AS Number: 65002
        BGP Identifier: 0.0.0.0
        BGP Router Identifier: 2.2.2.2
[u0205000400000001
Remote Node Descriptor:
        AS Number: 65001
        BGP Identifier: 0.0.0.0
        BGP Router Identifier: 1.1.1.1
Link Descriptor:
        Link ID: 0.0
        Local Interface Address IPv4: 10.0.0.2
        Neighbor Interface Address IPv4: 10.0.0.1
        Local Interface Address IPv6: fd00::1
        Neighbor Interface Address IPv6: fd00::2

Versions:
  Process           bRIB/RIB  SendTblVer
  Speaker                   8            8
    Flags: 0x00000001+0x00000000; 
Last Modified: May 21 01:48:42.576 for 00:02:54
Paths: (1 available, best #1)
  Advertised to update-groups (with more than one peer):
    0.2 
  Path #1: Received by speaker 0
  Flags: 0x2000000001060001+0x00, import: 0x020
  Advertised to update-groups (with more than one peer):
    0.2 
  65001 65000
    10.0.0.1 from 10.0.0.1 (1.1.1.1), if-handle 0x00000000
      Origin incomplete, localpref 100, valid, external, best, group-best
      Received Path ID 0, Local Path ID 1, version 8
      Link-state: Peer-SID: 1000002
```

Juniper cRPD:
`> show route table lsdist.0 detail | no-more`
```
*BGP    Preference: 170/-101                                                                                                                                                                                                  
                Next hop type: Router, Next hop index: 0                                                                                                                                                                              
                Address: 0x563b2956785c                  
                Next-hop reference count: 3, key opaque handle: (nil), non-key opaque handle: (nil)
                Source: 10.0.1.2                                                                                   
                Next hop: 10.0.1.2 via eth2, selected
                Session Id: 0                                                                                      
                State: <Active Ext>                   
                Local AS: 65001 Peer AS: 65000                              
                Age: 43                                                     
                Validation State: unverified                                
                Task: BGP_65000.10.0.1.2                                    
                Announcement bits (1): 0-BGP_RT_Background                   
                AS path: 65000 ?                                            
                Accepted                                                                                           
                Label: 1000002, Flags: 0xf0, Weight: 1                      
                Localpref: 100                                              
                Router ID: 10.255.0.3                                       
                Thread: junos-main                                          
         BGP    Preference: 170/-101                                        
                Next hop type: Router, Next hop index: 0                    
                Address: 0x563b295673dc                                     
                Next-hop reference count: 5, key opaque handle: (nil), non-key opaque handle: (nil)
                Source: 10.0.0.2                                            
                Next hop: 10.0.0.2 via eth1, selected                       
                Session Id: 0                                               
                State: <Ext Changed>                                        
                Inactive reason: AS path                                    
                Local AS: 65001 Peer AS: 65002                              
                Age: 34                                                     
                Validation State: unverified                                
                Task: BGP_65002.10.0.0.2                                                                           
                AS path: 65002 65000 ?                                      
                Accepted                                                    
                Label: 1000002, Flags: 0xf0, Weight: 1                      
                Localpref: 100                                              
                Router ID: 2.2.2.2                                          
                Thread: junos-main

```
