### PR TITLE
Allow EbgpMultihop change in UpdatePeer

### DIFF
--- a/internal/pkg/config/util.go
+++ b/internal/pkg/config/util.go
@@ -227,6 +227,7 @@ func (n *Neighbor) NeedsResendOpenMessage(new *Neighbor) bool {
 		!n.AddPaths.Config.Equal(&new.AddPaths.Config) ||
 		!n.AsPathOptions.Config.Equal(&new.AsPathOptions.Config) ||
 		!n.GracefulRestart.Config.Equal(&new.GracefulRestart.Config) ||
+		!n.EbgpMultihop.Config.Equal(&new.EbgpMultihop.Config) ||
 		isAfiSafiChanged(n.AfiSafis, new.AfiSafis)
 }
 


### PR DESCRIPTION
This PR allows changing `EbgpMultihop` configuration via `UpdatePeer` RPC.

Before this change the `EbgpMultihop` changes are ignored in `UpdatePeer` and old configuration remains in place.

As TTL is configured via socket options at connect, we need to reconnect if it is updated.