### PR TITLE
graceful-restart: expose peer graceful restart state information via API

### DIFF
--- a/internal/pkg/config/util.go
+++ b/internal/pkg/config/util.go
@@ -555,6 +555,8 @@ func NewPeerFromConfigStruct(pconf *Neighbor) *api.Peer {
 			NotificationEnabled: pconf.GracefulRestart.Config.NotificationEnabled,
 			LonglivedEnabled:    pconf.GracefulRestart.Config.LongLivedEnabled,
 			LocalRestarting:     pconf.GracefulRestart.State.LocalRestarting,
+			PeerRestartTime:     uint32(pconf.GracefulRestart.State.PeerRestartTime),
+			PeerRestarting:      pconf.GracefulRestart.State.PeerRestarting,
 		},
 		Transport: &api.Transport{
 			RemotePort:    uint32(pconf.Transport.Config.RemotePort),


### PR DESCRIPTION
Exposing PeerRestartTime and PeerRestarting info in config.NewPeerFromConfigStruct.