### PR TITLE
Allow non-disruptive changes of TTL in UpdatePeer

### DIFF
--- a/internal/pkg/config/util.go
+++ b/internal/pkg/config/util.go
@@ -227,7 +227,6 @@ func (n *Neighbor) NeedsResendOpenMessage(new *Neighbor) bool {
 		!n.AddPaths.Config.Equal(&new.AddPaths.Config) ||
 		!n.AsPathOptions.Config.Equal(&new.AsPathOptions.Config) ||
 		!n.GracefulRestart.Config.Equal(&new.GracefulRestart.Config) ||
-		!n.EbgpMultihop.Config.Equal(&new.EbgpMultihop.Config) ||
 		isAfiSafiChanged(n.AfiSafis, new.AfiSafis)
 }
 


### PR DESCRIPTION
This PR allows non-disruptive (not causing connection reset) changes of TTL on BGP peer connections via neighbor's `EbgpMultihop` or `TtlSecurity` config in the `UpdatePeer` RPC.

It enhances my previous PR https://github.com/osrg/gobgp/pull/2658 where `EbgpMultihop` change in `UpdatePeer` was enabled, but required connection reset. This one also allows `TtlSecurity` change in the `UpdatePeer` RPC.