### PR TITLE
Fix setting of TTL on a nil connection in updateNeighbor

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3354,7 +3354,7 @@ func (s *BgpServer) updateNeighbor(c *config.Neighbor) (needsSoftResetIn bool, e
 		peer.fsm.pConf.TtlSecurity.Config = c.TtlSecurity.Config
 		setTTL = true
 	}
-	if setTTL {
+	if setTTL && peer.fsm.conn != nil {
 		if err := setPeerConnTTL(peer.fsm); err != nil {
 			s.logger.Error("failed to set peer connection TTL",
 				log.Fields{


### PR DESCRIPTION
This fixes a bug introduced by my previous PR: https://github.com/osrg/gobgp/pull/2661

Avoids attempt to set TTL on a nil connection in `updateNeighbor`.

This can happen e.g. if `UpdatePeer` comes very quickly after `AddPeer` and the connection is not yet created.