### PR TITLE
cmd/gobgp: Fix evpn parsing

### DIFF
--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -470,7 +470,7 @@ func parseEvpnEthernetAutoDiscoveryArgs(args []string) (bgp.AddrPrefixInterface,
 		"rd":        paramSingle,
 		"rt":        paramList,
 		"encap":     paramSingle,
-		"esi-label": paramSingle})
+		"esi-label": paramList})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -536,13 +536,14 @@ func parseEvpnMacAdvArgs(args []string) (bgp.AddrPrefixInterface, []string, erro
 		return nil, nil, fmt.Errorf("%d args required at least, but got %d", req, len(args))
 	}
 	m, err := extractReserved(args, map[string]int{
-		"esi":        paramList,
-		"etag":       paramSingle,
-		"label":      paramSingle,
-		"rd":         paramSingle,
-		"rt":         paramList,
-		"encap":      paramSingle,
-		"router-mac": paramSingle})
+		"esi":             paramList,
+		"etag":            paramSingle,
+		"label":           paramSingle,
+		"rd":              paramSingle,
+		"rt":              paramList,
+		"encap":           paramSingle,
+		"router-mac":      paramSingle,
+		"default-gateway": paramFlag})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -631,11 +632,8 @@ func parseEvpnMacAdvArgs(args []string) (bgp.AddrPrefixInterface, []string, erro
 		extcomms = append(extcomms, "router-mac", m["router-mac"][0])
 	}
 
-	for _, a := range args {
-		if a == "default-gateway" {
-			extcomms = append(extcomms, "default-gateway")
-			break
-		}
+	if _, ok := m["default-gateway"]; ok {
+		extcomms = append(extcomms, "default-gateway")
 	}
 
 	r := &bgp.EVPNMacIPAdvertisementRoute{

--- a/cmd/gobgp/global_test.go
+++ b/cmd/gobgp/global_test.go
@@ -37,3 +37,31 @@ func Test_ParsePath(t *testing.T) {
 		i = int(a.GetType())
 	}
 }
+
+func Test_ParseEvpnPath(t *testing.T) {
+	var tests = []struct {
+		name string
+		path string
+	}{
+		{"Ethernet Auto-Discovery", "a-d esi LACP aa:bb:cc:dd:ee:ff 100 etag 200 label 300 rd 1.1.1.1:65000 rt 65000:200 encap vxlan esi-label 400 single-active"},
+		{"MAC/IP Advertisement", "macadv aa:bb:cc:dd:ee:ff 10.0.0.1 esi AS 65000 100 etag 200 label 300 rd 1.1.1.1:65000 rt 65000:400 encap vxlan default-gateway"},
+		{"I-PMSI", "i-pmsi etag 100 rd 1.1.1.1:65000 rt 65000:200 encap vxlan pmsi ingress-repl 100 1.1.1.1"},
+		{"IP Prefix", "prefix 10.0.0.0/24 172.16.0.1 esi MSTP aa:aa:aa:aa:aa:aa 100 etag 200 label 300 rd 1.1.1.1:65000 rt 65000:200 encap vxlan router-mac bb:bb:bb:bb:bb:bb"},
+		{"Multicast", "multicast 10.0.0.1 etag 100 rd 1.1.1.1:65000 rt 65000:200 encap vxlan pmsi ingress-repl 100 1.1.1.1"},
+		{"Ethernet Segment Identifier", "esi 10.0.0.1 esi MAC aa:bb:cc:dd:ee:ff 100 rd 1.1.1.1:65000 rt 65000:200 encap vxlan"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			path, err := parsePath(bgp.RF_EVPN, strings.Split(tt.path, " "))
+			assert.Nil(err)
+			i := 0
+			attrs, _ := apiutil.GetNativePathAttributes(path)
+			for _, a := range attrs {
+				assert.True(i < int(a.GetType()))
+				i = int(a.GetType())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR:
1. Adds tests for all EVPN cli parsers using the full examples under `docs/source/evpn.md` for each.
2. Fixes a parsing issue for evpn a-d, not parsing `esi-label` with optional arguments correctly.
3. Fixes a parsing issue for evpn macadv parsing breaking when `default-gateway` is set
