### PR TITLE
Fix UpdatePathAggregator4ByteAs() ignores 32bit value

### DIFF
--- a/internal/pkg/table/message.go
+++ b/internal/pkg/table/message.go
@@ -240,6 +240,8 @@ func UpdatePathAggregator4ByteAs(msg *bgp.BGPUpdate) error {
 			if attr.Value.Askind == reflect.Uint16 {
 				aggAttr = attr
 				aggAttr.Value.Askind = reflect.Uint32
+			} else if attr.Value.Askind == reflect.Uint32 {
+				aggAttr = attr
 			}
 		case *bgp.PathAttributeAs4Aggregator:
 			agg4Attr = agg

--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -1083,7 +1083,11 @@ func (h *fsmHandler) recvMessageWithError() (*fsmMsg, error) {
 					}
 				}
 
-				table.UpdatePathAttrs4ByteAs(h.fsm.logger, body)
+				if err = table.UpdatePathAttrs4ByteAs(h.fsm.logger, body); err != nil {
+					fmsg.MsgData = err
+					return fmsg, err
+				}
+
 				if err = table.UpdatePathAggregator4ByteAs(body); err != nil {
 					fmsg.MsgData = err
 					return fmsg, err


### PR DESCRIPTION
I noticed that the `UpdatePathAggregator4ByteAs()` function is returning an error related to malformed attribute list error:

```
Reason="notification-sent code 3(update) subcode 1(malformed attribute list)" State=BGP_FSM_ESTABLISHED Topic=Peer
```

A path that triggered this looked something like:

```
&{0 [] 138 [{MpReach(ipv6-unicast): {Nexthop: 2001:de8:1:2::33, NLRIs: [2404:b5c0::/32]}} {Origin: i} 134911 {Med: 98} {LocalPref: 55} {Aggregate: {AS: 134911, Address: 10.0.0.1}} {Extcomms: [2:2]} {As4Aggregator: {AS: 134911, Address: 10.0.0.1}} {LargeCommunity: [ 65102:1:1]}] []
```

We can see in the above the `Aggregate.AS` was `134911` which falls into 32-bit space, but we were only setting the aggregator in cases where the kind was a uint16 here: https://github.com/osrg/gobgp/blob/0cc8a9880b218ad95c9f922ea5a688f814862fdc/internal/pkg/table/message.go#L240-L243

And as a result we end up matching this condition and sending a notification:

https://github.com/osrg/gobgp/blob/0cc8a9880b218ad95c9f922ea5a688f814862fdc/internal/pkg/table/message.go#L253-L255

This change corrects this to validate the aggregator in cases where aggregator is a 32bit value.

Additionally as I was stepping through the FSM logic I noticed that `table.UpdatePathAttrs4ByteAs()` returns an error but we do not check the value of the error. So additionally I am adding a small fix to correct that.

