### PR TITLE
Proposal to bind gRPC API to localhost by default

### DIFF
--- a/cmd/gobgp/root.go
+++ b/cmd/gobgp/root.go
@@ -86,7 +86,7 @@ func newRootCmd() *cobra.Command {
 		},
 	}
 
-	rootCmd.PersistentFlags().StringVarP(&globalOpts.Host, "host", "u", "127.0.0.1", "host")
+	rootCmd.PersistentFlags().StringVarP(&globalOpts.Host, "host", "u", "::1", "host")
 	rootCmd.PersistentFlags().IntVarP(&globalOpts.Port, "port", "p", 50051, "port")
 	rootCmd.PersistentFlags().StringVarP(&globalOpts.Target, "target", "", "", "alternative to host/port when using UDS. Ex: unix:///var/run/go-bgp.sock if running gobgpd with a UDS socket.")
 	rootCmd.PersistentFlags().BoolVarP(&globalOpts.Json, "json", "j", false, "use json format to output format")

--- a/cmd/gobgpd/main.go
+++ b/cmd/gobgpd/main.go
@@ -60,7 +60,7 @@ func main() {
 		Facility        string `long:"syslog-facility" description:"specify syslog facility"`
 		DisableStdlog   bool   `long:"disable-stdlog" description:"disable standard logging"`
 		CPUs            int    `long:"cpus" description:"specify the number of CPUs to be used"`
-		GrpcHosts       string `long:"api-hosts" description:"specify the hosts that gobgpd listens on" default:":50051"`
+		GrpcHosts       string `long:"api-hosts" description:"specify the hosts that gobgpd listens on" default:"[::1]:50051"`
 		GracefulRestart bool   `short:"r" long:"graceful-restart" description:"flag restart-state in graceful-restart capability"`
 		Dry             bool   `short:"d" long:"dry-run" description:"check configuration"`
 		PProfHost       string `long:"pprof-host" description:"specify the host that gobgpd listens on for pprof and metrics" default:"localhost:6060"`

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -153,6 +153,8 @@ class GoBGPContainer(BGPContainer):
         return daemons
 
     def _is_running(self):
+        print ("Running command gobgp global 2>&1")
+        print (self.local('gobgp global', capture=True))
         return self.local('gobgp global'
                           ' > /dev/null 2>&1; echo $?', capture=True) == '0'
 

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -111,7 +111,7 @@ class GoBGPContainer(BGPContainer):
     def _start_gobgp(self, graceful_restart=False):
         c = CmdBuffer()
         c << '#!/bin/sh'
-        c << '/go/bin/gobgpd -f {0}/gobgpd.conf --api-hosts="0.0.0.0:50051" -l {1} -p {2} -t {3} > ' \
+        c << '/go/bin/gobgpd -f {0}/gobgpd.conf --api-hosts="[::]:50051" -l {1} -p {2} -t {3} > ' \
              '{0}/gobgpd.log 2>&1'.format(self.SHARED_VOLUME, self.log_level, '-r' if graceful_restart else '', self.config_format)
         cmd = 'echo "{0:s}" > {1}/start.sh'.format(str(c), self.config_dir)
         local(cmd, capture=True)

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -111,7 +111,7 @@ class GoBGPContainer(BGPContainer):
     def _start_gobgp(self, graceful_restart=False):
         c = CmdBuffer()
         c << '#!/bin/sh'
-        c << '/go/bin/gobgpd -f {0}/gobgpd.conf -l {1} -p {2} -t {3} > ' \
+        c << '/go/bin/gobgpd -f {0}/gobgpd.conf --api-hosts="0.0.0.0:50051" -l {1} -p {2} -t {3} > ' \
              '{0}/gobgpd.log 2>&1'.format(self.SHARED_VOLUME, self.log_level, '-r' if graceful_restart else '', self.config_format)
         cmd = 'echo "{0:s}" > {1}/start.sh'.format(str(c), self.config_dir)
         local(cmd, capture=True)


### PR DESCRIPTION
Hello!

I just pulled latest gRPC 3.15.0 and noticed that it binds gRPC to 0.0.0.0 / :: by default and exposes API to wild world of the Internet:
```
tcp6       0      0 :::50051                :::*                    LISTEN      3234326/./gobgpd    
```

As you can see I did not use any arguments or options for it. I'm pretty sure that majority of new deployments starts similar way and they will be vulnerable to attacks and will be insecure by default.

We discussed this issue while ago and it was partially addressed here by providing command line argument to specify API bind host (--api-hosts="::1"): https://github.com/osrg/gobgp/issues/796

In this PR I changed default wildcard bind to :: which listens on all available interfaces to more specific IPv6 localhost ::1 which makes GoBGP secure by default. 

Some may argue that not all servers have IPv6 connectivity but IPv6 localhost is available on all modern distributions. 

Thank you!