### PR TITLE
Enhance AsPath attribute String() format

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -10380,7 +10380,7 @@ func (p *PathAttributeAsPath) String() string {
 	for _, param := range p.Value {
 		params = append(params, param.String())
 	}
-	return strings.Join(params, " ")
+	return "{AsPath: " + strings.Join(params, " ") + "}"
 }
 
 func (p *PathAttributeAsPath) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Enhances AsPath attribute `String()` format to be consistent with others, e.g.

`String()` of a Path attributes before the fix:
```
[{Origin: i} 65000 65001 {Nexthop: 172.0.0.1}]
```

after the fix:
```
[{Origin: i} {AsPath: 65000 65001} {Nexthop: 172.0.0.1}]
```