### PR TITLE
Fix SRv6 prefix SID unmarshalling

### DIFF
--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -2768,8 +2768,8 @@ func UnmarshalPrefixSID(psid *api.PrefixSID) (*bgp.PathAttributePrefixSID, error
 			return nil, fmt.Errorf("unknown or not implemented Prefix SID type: %+v", v)
 		}
 	}
-	// Final Path Attribute Length is 3 bytes of the header and 1 byte Reserved1
-	s.PathAttribute.Length += (3 + 1)
+	// Final Path Attribute Length is 3 bytes of the Path Attribute header longer
+	s.PathAttribute.Length += 3
 	return s, nil
 }
 
@@ -2813,7 +2813,7 @@ func UnmarshalSubTLVs(stlvs map[uint32]*api.SRv6TLV) (uint16, []bgp.PrefixSIDTLV
 				// SRv6 Information Sub TLV length consists 1 byte Resrved2, 16 bytes SID, 1 byte flags, 2 bytes Endpoint Behavior
 				// 1 byte Reserved3 and length of Sub Sub TLVs
 				info.SubTLV.Length = 1 + 16 + 1 + 2 + 1 + sstlvslength
-				// For total Srv6 Information Sub TLV length, adding 3 bytes of the Sub TLV header
+				// For total Prefix SID TLV length, adding 3 bytes of the TLV header + 1 byte of Reserved1
 				l += info.SubTLV.Length + 4
 				p = append(p, info)
 			}

--- a/pkg/apiutil/attribute_test.go
+++ b/pkg/apiutil/attribute_test.go
@@ -1849,6 +1849,9 @@ func TestFullCyclePrefixSID(t *testing.T) {
 			if err != nil {
 				t.Fatalf("test failed with error: %+v", err)
 			}
+			if recoveredPrefixSID.Len() != attribute.Len() {
+				t.Fatalf("recovered attribute length (%d) is not matching original attribute length (%d)", recoveredPrefixSID.Len(), attribute.Len())
+			}
 			recovered, err := recoveredPrefixSID.Serialize()
 			if err != nil {
 				t.Fatalf("test failed with error: %+v", err)


### PR DESCRIPTION
During SRv6 prefix SID unmarshalling, wrong Path Attribute length was applied (`4`B instead of `3`B). This was causing a 1 byte difference in PathAttribute length after marshalling & unmarshalling.

Screenshot from the `TestFullCyclePrefixSID` unit test shows the difference in PathAttribute Length (`38` vs `37`) before the fix (now asserted in the unit test): 

![Screenshot from 2023-07-31 10-26-14](https://github.com/osrg/gobgp/assets/15926980/88b63d92-c60a-4c0c-b6e8-f96d06f2ffee)
