### PR TITLE
Fix panic on malformed MRT injection

### DIFF
--- a/cmd/gobgp/mrt.go
+++ b/cmd/gobgp/mrt.go
@@ -111,7 +111,7 @@ func injectMrt() error {
 				paths := make([]*api.Path, 0, len(rib.Entries))
 
 				for _, e := range rib.Entries {
-					if len(peers) < int(e.PeerIndex) {
+					if len(peers) <= int(e.PeerIndex) {
 						exitWithError(fmt.Errorf("invalid peer index: %d (PEER_INDEX_TABLE has only %d peers)", e.PeerIndex, len(peers)))
 					}
 					//t := time.Unix(int64(e.OriginatedTime), 0)


### PR DESCRIPTION
This PR fixes a comparison that was not being triggered when a RIB had a not valid peerIndex, causing the client to panic:

`panic: runtime error: index out of range [1] with length 1`

The same malformed MRT file would throw the following error with BGPDump as a comparison:
`Assertion failed: (e->peer_index < entry->dump->table_dump_v2_peer_index_table->peer_count), function process_mrtd_table_dump_v2_ipv6_unicast, file bgpdump_lib.c, line 687`

With this patch gobgp now shows the following error before exiting (as expected):
`invalid peer index: 1 (PEER_INDEX_TABLE has only 1 peers)`

Another test, when the peer index table is present, but contains 0 peers, still works as intended:
`invalid peer index: 0 (PEER_INDEX_TABLE has only 0 peers)`

