### PR TITLE
Update configuration documentation for overriding peer-as checking during FSM

### DIFF
--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -58,6 +58,7 @@
 [[neighbors]]
     [neighbors.config]
         peer-as = 2
+        # To disable AS checking set to 0
         auth-password = "password"
         neighbor-address = "192.168.10.2"
         # override global.config.as value


### PR DESCRIPTION
Proposing update to the configuration documentation on bypassing autonomous system checking during FSM.