### PR TITLE
Fix data race in newWatchEventPeer

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -915,12 +915,13 @@ func (s *BgpServer) notifyPostPolicyUpdateWatcher(peer *peer, pathList []*table.
 func newWatchEventPeer(peer *peer, m *fsmMsg, oldState bgp.FSMState, t PeerEventType) *watchEventPeer {
 	var laddr string
 	var rport, lport uint16
+
+	peer.fsm.lock.RLock()
 	if peer.fsm.conn != nil {
 		_, rport = peer.fsm.RemoteHostPort()
 		laddr, lport = peer.fsm.LocalHostPort()
 	}
 	sentOpen := buildopen(peer.fsm.gConf, peer.fsm.pConf)
-	peer.fsm.lock.RLock()
 	recvOpen := peer.fsm.recvOpen
 	e := &watchEventPeer{
 		Type:          t,


### PR DESCRIPTION
This method was attempting to read from peer.fsm before acquiring a read lock, leading to a data race as this struct is written by a different goroutine in parallel. Commit moves the call to RLock before the first read from the struct. 

Issue was flagged when the project was built with Golang's data race detector. 