### PR TITLE
Clone OriginInfo in Path Clone

### DIFF
--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -328,11 +328,14 @@ func (path *Path) IsIBGP() bool {
 
 // create new PathAttributes
 func (path *Path) Clone(isWithdraw bool) *Path {
+	newOriginInfo := *path.info
+
 	return &Path{
 		parent:           path,
 		IsWithdraw:       isWithdraw,
 		IsNexthopInvalid: path.IsNexthopInvalid,
 		attrsHash:        path.attrsHash,
+		info:             &newOriginInfo,
 	}
 }
 


### PR DESCRIPTION
OriginInfo assigned to Path objects is a pointer to the originating peer's info, which is populated by the FSM goroutine handling the peer's connection. This value is typically protected by the FSM lock, but in the event a path watch is running, it gets converted to a protobuf object in toPathAPI in a separate goroutine. This method reads from this same structure without any data synchronisation, leading to a data race.

To ensure this cannot happen, this commit adds a line to clone the field before it is passed to the event watcher, ensuring the data race cannot occur.

This issue was found when the project was built using Golang's data race detector.