### PR TITLE
Move SelectionOptions and UseMultiplePath to server-local vars

### DIFF
--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -23,6 +23,7 @@ import (
 
 	farm "github.com/dgryski/go-farm"
 
+	"github.com/osrg/gobgp/v3/pkg/config/oc"
 	"github.com/osrg/gobgp/v3/pkg/log"
 	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
 )
@@ -114,14 +115,18 @@ func ProcessMessage(m *bgp.BGPMessage, peerInfo *PeerInfo, timestamp time.Time) 
 type TableManager struct {
 	Tables map[bgp.RouteFamily]*Table
 	Vrfs   map[string]*Vrf
+	SelectionOptions *oc.RouteSelectionOptionsConfig
+	UseMultiplePaths *oc.UseMultiplePathsConfig
 	rfList []bgp.RouteFamily
 	logger log.Logger
 }
 
-func NewTableManager(logger log.Logger, rfList []bgp.RouteFamily) *TableManager {
+func NewTableManager(logger log.Logger, rfList []bgp.RouteFamily, selectionOptions *oc.RouteSelectionOptionsConfig, useMultiplePaths *oc.UseMultiplePathsConfig) *TableManager {
 	t := &TableManager{
 		Tables: make(map[bgp.RouteFamily]*Table),
 		Vrfs:   make(map[string]*Vrf),
+		SelectionOptions: selectionOptions,
+		UseMultiplePaths: useMultiplePaths,
 		rfList: rfList,
 		logger: logger,
 	}
@@ -192,7 +197,7 @@ func (manager *TableManager) update(newPath *Path) *Update {
 	t := manager.Tables[newPath.GetRouteFamily()]
 	t.validatePath(newPath)
 	dst := t.getOrCreateDest(newPath.GetNlri(), 64)
-	u := dst.Calculate(manager.logger, newPath)
+	u := dst.Calculate(manager.logger, newPath, manager.SelectionOptions)
 	if len(dst.knownPathList) == 0 {
 		t.deleteDest(dst)
 	}
@@ -292,7 +297,7 @@ func (manager *TableManager) getDestinationCount(rfList []bgp.RouteFamily) int {
 }
 
 func (manager *TableManager) GetBestPathList(id string, as uint32, rfList []bgp.RouteFamily) []*Path {
-	if SelectionOptions.DisableBestPathSelection {
+	if manager.SelectionOptions.DisableBestPathSelection {
 		// Note: If best path selection disabled, there is no best path.
 		return nil
 	}
@@ -304,7 +309,7 @@ func (manager *TableManager) GetBestPathList(id string, as uint32, rfList []bgp.
 }
 
 func (manager *TableManager) GetBestMultiPathList(id string, rfList []bgp.RouteFamily) [][]*Path {
-	if !UseMultiplePaths.Enabled || SelectionOptions.DisableBestPathSelection {
+	if !manager.UseMultiplePaths.Enabled || manager.SelectionOptions.DisableBestPathSelection {
 		// Note: If multi path not enabled or best path selection disabled,
 		// there is no best multi path.
 		return nil

--- a/internal/pkg/table/table_manager_test.go
+++ b/internal/pkg/table/table_manager_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/osrg/gobgp/v3/pkg/config/oc"
 	"github.com/osrg/gobgp/v3/pkg/log"
 	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
 
@@ -38,7 +39,7 @@ func (manager *TableManager) ProcessUpdate(fromPeer *PeerInfo, message *bgp.BGPM
 		dsts = append(dsts, manager.Update(path)...)
 	}
 	for _, d := range dsts {
-		b, _, _ := d.GetChanges(GLOBAL_RIB_NAME, 0, false)
+		b, _, _ := d.GetChanges(GLOBAL_RIB_NAME, 0, false, manager.UseMultiplePaths)
 		pathList = append(pathList, b)
 	}
 	return pathList, nil
@@ -78,7 +79,7 @@ func peerR3() *PeerInfo {
 // test best path calculation and check the result path is from R1
 func TestProcessBGPUpdate_0_select_onlypath_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	bgpMessage := update_fromR1()
 	peer := peerR1()
@@ -128,7 +129,7 @@ func TestProcessBGPUpdate_0_select_onlypath_ipv4(t *testing.T) {
 // test best path calculation and check the result path is from R1
 func TestProcessBGPUpdate_0_select_onlypath_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	bgpMessage := update_fromR1_ipv6()
 	peer := peerR1()
@@ -179,7 +180,7 @@ func TestProcessBGPUpdate_0_select_onlypath_ipv6(t *testing.T) {
 // test: compare localpref
 func TestProcessBGPUpdate_1_select_high_localpref_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	// low localpref message
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -259,7 +260,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_1_select_high_localpref_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
@@ -341,7 +342,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv6(t *testing.T) {
 // test: compare localOrigin
 func TestProcessBGPUpdate_2_select_local_origin_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	// low localpref message
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -423,7 +424,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_2_select_local_origin_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
@@ -508,7 +509,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv6(t *testing.T) {
 // test: compare AS_PATH
 func TestProcessBGPUpdate_3_select_aspath_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	bgpMessage1 := update_fromR2viaR1()
 	peer1 := peerR1()
@@ -563,7 +564,7 @@ func TestProcessBGPUpdate_3_select_aspath_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_3_select_aspath_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	bgpMessage1 := update_fromR2viaR1_ipv6()
 	peer1 := peerR1()
@@ -620,7 +621,7 @@ func TestProcessBGPUpdate_3_select_aspath_ipv6(t *testing.T) {
 // test: compare Origin
 func TestProcessBGPUpdate_4_select_low_origin_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	// low origin message
 	origin1 := bgp.NewPathAttributeOrigin(1)
@@ -700,7 +701,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_4_select_low_origin_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	origin1 := bgp.NewPathAttributeOrigin(1)
 	aspath1 := createAsPathAttribute([]uint32{65200, 65000})
@@ -782,7 +783,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv6(t *testing.T) {
 // test: compare MED
 func TestProcessBGPUpdate_5_select_low_med_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	// low origin message
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -862,7 +863,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_5_select_low_med_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65200, 65000})
@@ -944,7 +945,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv6(t *testing.T) {
 // test: compare AS_NUMBER(prefer eBGP path)
 func TestProcessBGPUpdate_6_select_ebgp_path_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	// low origin message
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -1024,7 +1025,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000, 65200})
@@ -1107,9 +1108,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 
 // test: compare Router ID
 func TestProcessBGPUpdate_7_select_low_routerid_path_ipv4(t *testing.T) {
-
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
-	SelectionOptions.ExternalCompareRouterId = true
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC}, &oc.RouteSelectionOptionsConfig{ ExternalCompareRouterId:  true}, &oc.UseMultiplePathsConfig{})
 
 	// low origin message
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -1189,7 +1188,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_7_select_low_routerid_path_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000, 65200})
@@ -1271,7 +1270,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv6(t *testing.T) {
 // test: withdraw and mpunreach path
 func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	// path1
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -1374,7 +1373,7 @@ func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 // TODO MP_UNREACH
 func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
@@ -1502,7 +1501,7 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 // handle bestpath lost
 func TestProcessBGPUpdate_bestpath_lost_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	// path1
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -1572,7 +1571,7 @@ func TestProcessBGPUpdate_bestpath_lost_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_bestpath_lost_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
@@ -1643,7 +1642,7 @@ func TestProcessBGPUpdate_bestpath_lost_ipv6(t *testing.T) {
 // test: implicit withdrawal case
 func TestProcessBGPUpdate_implicit_withdrwal_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	// path1
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -1724,7 +1723,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_implicit_withdrwal_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000, 65100, 65200})
@@ -1831,7 +1830,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv6(t *testing.T) {
 // check multiple paths
 func TestProcessBGPUpdate_multiple_nlri_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	createPathAttr := func(aspaths []uint32, nh string) []bgp.PathAttributeInterface {
 		origin := bgp.NewPathAttributeOrigin(0)
@@ -1964,7 +1963,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv4(t *testing.T) {
 // check multiple paths
 func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC}, &oc.RouteSelectionOptionsConfig{}, &oc.UseMultiplePathsConfig{})
 
 	createPathAttr := func(aspaths []uint32) []bgp.PathAttributeInterface {
 		origin := bgp.NewPathAttributeOrigin(0)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -778,7 +778,7 @@ func (s *BgpServer) setPathVrfIdMap(paths []*table.Path, m map[uint32]bool) {
 // Note: the destination would be the same for all the paths passed here
 // The wather (only zapi) needs a unique list of vrf IDs
 func (s *BgpServer) notifyBestWatcher(best []*table.Path, multipath [][]*table.Path) {
-	if table.SelectionOptions.DisableBestPathSelection {
+	if s.bgpConfig.Global.RouteSelectionOptions.Config.DisableBestPathSelection {
 		// Note: If best path selection disabled, no best path to notify.
 		return
 	}
@@ -786,12 +786,12 @@ func (s *BgpServer) notifyBestWatcher(best []*table.Path, multipath [][]*table.P
 	clonedM := make([][]*table.Path, len(multipath))
 	for i, pathList := range multipath {
 		clonedM[i] = clonePathList(pathList)
-		if table.UseMultiplePaths.Enabled {
+		if s.bgpConfig.Global.UseMultiplePaths.Config.Enabled {
 			s.setPathVrfIdMap(clonedM[i], m)
 		}
 	}
 	clonedB := clonePathList(best)
-	if !table.UseMultiplePaths.Enabled {
+	if !s.bgpConfig.Global.UseMultiplePaths.Config.Enabled {
 		s.setPathVrfIdMap(clonedB, m)
 	}
 	w := &watchEventBestPath{PathList: clonedB, MultiPathList: clonedM}
@@ -1257,13 +1257,13 @@ func (s *BgpServer) propagateUpdate(peer *peer, pathList []*table.Path) {
 	}
 }
 
-func dstsToPaths(id string, as uint32, dsts []*table.Update) ([]*table.Path, []*table.Path, [][]*table.Path) {
+func dstsToPaths(id string, as uint32, dsts []*table.Update, useMultiplePaths *oc.UseMultiplePathsConfig) ([]*table.Path, []*table.Path, [][]*table.Path) {
 	bestList := make([]*table.Path, 0, len(dsts))
 	oldList := make([]*table.Path, 0, len(dsts))
 	mpathList := make([][]*table.Path, 0, len(dsts))
 
 	for _, dst := range dsts {
-		best, old, mpath := dst.GetChanges(id, as, false)
+		best, old, mpath := dst.GetChanges(id, as, false, useMultiplePaths)
 		bestList = append(bestList, best)
 		oldList = append(oldList, old)
 		if mpath != nil {
@@ -1274,13 +1274,13 @@ func dstsToPaths(id string, as uint32, dsts []*table.Update) ([]*table.Path, []*
 }
 
 func (s *BgpServer) propagateUpdateToNeighbors(source *peer, newPath *table.Path, dsts []*table.Update, needOld bool) {
-	if table.SelectionOptions.DisableBestPathSelection {
+	if s.bgpConfig.Global.RouteSelectionOptions.Config.DisableBestPathSelection {
 		return
 	}
 	var gBestList, gOldList, bestList, oldList []*table.Path
 	var mpathList [][]*table.Path
 	if source == nil || !source.isRouteServerClient() {
-		gBestList, gOldList, mpathList = dstsToPaths(table.GLOBAL_RIB_NAME, 0, dsts)
+		gBestList, gOldList, mpathList = dstsToPaths(table.GLOBAL_RIB_NAME, 0, dsts, &s.bgpConfig.Global.UseMultiplePaths.Config)
 		s.notifyBestWatcher(gBestList, mpathList)
 	}
 	family := newPath.GetRouteFamily()
@@ -1336,7 +1336,7 @@ func (s *BgpServer) propagateUpdateToNeighbors(source *peer, newPath *table.Path
 				}
 				continue
 			}
-			bestList, oldList, _ = dstsToPaths(targetPeer.TableID(), targetPeer.AS(), dsts)
+			bestList, oldList, _ = dstsToPaths(targetPeer.TableID(), targetPeer.AS(), dsts, &s.bgpConfig.Global.UseMultiplePaths.Config)
 		} else {
 			bestList = gBestList
 			oldList = gOldList
@@ -2255,16 +2255,14 @@ func (s *BgpServer) StartBgp(ctx context.Context, r *api.StartBgpRequest) error 
 		}
 
 		rfs, _ := oc.AfiSafis(c.AfiSafis).ToRfList()
-		s.globalRib = table.NewTableManager(s.logger, rfs)
-		s.rsRib = table.NewTableManager(s.logger, rfs)
+		s.globalRib = table.NewTableManager(s.logger, rfs, &c.RouteSelectionOptions.Config, &c.UseMultiplePaths.Config)
+		s.rsRib = table.NewTableManager(s.logger, rfs, &c.RouteSelectionOptions.Config, &c.UseMultiplePaths.Config)
 
 		if err := s.policy.Initialize(); err != nil {
 			return err
 		}
 		s.bgpConfig.Global = *c
-		// update route selection options
-		table.SelectionOptions = c.RouteSelectionOptions.Config
-		table.UseMultiplePaths = c.UseMultiplePaths.Config
+
 		return nil
 	}, false)
 }
@@ -2679,7 +2677,7 @@ func (s *BgpServer) ListPath(ctx context.Context, r *api.ListPathRequest, fn fun
 			knownPathList := dst.GetAllKnownPathList()
 			for i, path := range knownPathList {
 				p := toPathApi(path, getValidation(v, path), r.EnableOnlyBinary, r.EnableNlriBinary, r.EnableAttributeBinary)
-				if !table.SelectionOptions.DisableBestPathSelection {
+				if !s.bgpConfig.Global.RouteSelectionOptions.Config.DisableBestPathSelection {
 					if i == 0 {
 						switch r.TableType {
 						case api.TableType_LOCAL, api.TableType_GLOBAL:

--- a/pkg/server/zclient.go
+++ b/pkg/server/zclient.go
@@ -420,7 +420,7 @@ func (z *zebraClient) loop() {
 		case ev := <-w.Event():
 			switch msg := ev.(type) {
 			case *watchEventBestPath:
-				if table.UseMultiplePaths.Enabled {
+				if z.server.bgpConfig.Global.UseMultiplePaths.Config.Enabled {
 					for _, paths := range msg.MultiPathList {
 						z.updatePathByNexthopCache(paths)
 						for i := range msg.Vrf {


### PR DESCRIPTION
In destination.go there were two global variables used for controlling path and multi-path support for BGP servers, which were populated and modified by gRPC/public API calls. In scenarios where multiple BGP servers are running using the public API it would mean that the last server created would override the options for all running servers. It also lead to data races (Confirmed by using Go's data race detector) that could crash Go's runtime as the value would be overridden unexpectedly.

To resolve this, both options have been moved into the TableManager itself which takes a pointer option to both structs populated via the StartBgp API call. These are then passed to the internal methods as new function parameters, ensuring that every server has a unique copy of these structs.

All tests were updated to conform to the new API.