### PR TITLE
fix: call validatePathAttributeFlags after parsing and setting path attribute length

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -10029,9 +10029,6 @@ func (p *PathAttribute) DecodeFromBytes(data []byte, options ...*MarshallingOpti
 	}
 	p.Flags = BGPAttrFlag(data[0])
 	p.Type = BGPAttrType(data[1])
-	if eMsg := validatePathAttributeFlags(p.Type, p.Flags); eMsg != "" {
-		return nil, NewMessageError(eCode, BGP_ERROR_SUB_ATTRIBUTE_FLAGS_ERROR, data, eMsg)
-	}
 
 	if p.Flags&BGP_ATTR_FLAG_EXTENDED_LENGTH != 0 {
 		if len(data) < 4 {
@@ -10048,6 +10045,10 @@ func (p *PathAttribute) DecodeFromBytes(data []byte, options ...*MarshallingOpti
 	}
 	if len(data) < int(p.Length) {
 		return nil, NewMessageError(eCode, eSubCode, data, "attribute value length is short")
+	}
+
+	if eMsg := validatePathAttributeFlags(p.Type, p.Flags); eMsg != "" {
+		return nil, NewMessageError(eCode, BGP_ERROR_SUB_ATTRIBUTE_FLAGS_ERROR, data, eMsg)
 	}
 
 	return data[:p.Length], nil


### PR DESCRIPTION
I recently started using gobgp package libraries to parse BMP messages from a third party source (BIRD). BIRD has a bug whereby the BMP messages it emits do not have the transitive flag set on well known path attributes on route monitoring messages. GoBGP correctly checks for this condition [here](https://github.com/osrg/gobgp/blob/1b975be057fc02848d205361bdc5426110b99930/pkg/packet/bgp/validate.go#L230-L236). There is a subtle bug that shows up when parsing a BGP update message that fails this check which is that `PathAttribute.DecodeFromBytes()` exits early before it sets the `PathAttribute.Length`. 

Highlighting this with an example this is a byte slice from an update pack after gobgp has stripped out everything from the packet byte slice leaving Path Attributes and NLRI:

![image](https://github.com/osrg/gobgp/assets/5504449/f11c1760-c59d-4329-9f0e-303922f8a6e4)


Byte slice for the packet in the picture above looks like this (path attributes and NLRI is all that remains):
```
[0 1 1 0 64 2 6 2 1 0 0 253 232 0 3 4 10 0 2 100 0 4 4 0 0 0 98 0 5 4 0 0 0 50 24 198 51 100]
```

`0 1 1 0` at the beginning of the slice is the origin attribute. `0` are the flags which is invalid given the transitive flag should be set but it is not. As a result of this in the current gobgp master branch we return an error but this does not exit the loop processing all path attributes (the function waits for the end and returns the [strongest error](https://github.com/osrg/gobgp/blob/1b975be057fc02848d205361bdc5426110b99930/pkg/packet/bgp/bgp.go#L14336-L14348). Instead we continue and slice the byte slice by the `Len()` function here: https://github.com/osrg/gobgp/blob/1b975be057fc02848d205361bdc5426110b99930/pkg/packet/bgp/bgp.go#L14358

But if the `Length` attribute is not set we end up slicing by `3 + int(p.Length)`  (3 + 0) in my case instead of 4 which is incorrect:
https://github.com/osrg/gobgp/blob/1b975be057fc02848d205361bdc5426110b99930/pkg/packet/bgp/bgp.go#L10009-L10014

This means we cannot decode the next attribute because we have sliced incorrectly. The next attribute is unknown `BGPAttrType(64)` as the slice now looks like this:

```
[0 64 2 6 2 1 0 0 253 232 0 3 4 10 0 2 100 0 4 4 0 0 0 98 0 5 4 0 0 0 50 24 198 51 100]
```

In the above it thinks the flags for the next attribute is actually the type field


But should instead be:

```
[64 2 6 2 1 0 0 253 232 0 3 4 10 0 2 100 0 4 4 0 0 0 98 0 5 4 0 0 0 50 24 198 51 100]
```

This is easy to resolve by moving the path attribute flag validations a few lines down after we have recorded the length of a path attribute.
