### PR TITLE
Implementation of Dynamic Neighbor MD5 (Issue #2589)

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3103,6 +3103,28 @@ func (s *BgpServer) AddDynamicNeighbor(ctx context.Context, r *api.AddDynamicNei
 			PeerGroup: r.DynamicNeighbor.PeerGroup},
 		}
 		s.peerGroupMap[c.Config.PeerGroup].AddDynamicNeighbor(c)
+
+		pConf := s.peerGroupMap[c.Config.PeerGroup].Conf
+		if pConf.Config.AuthPassword != "" {
+			prefix := r.DynamicNeighbor.Prefix
+			addr, _, _ := net.ParseCIDR(prefix)
+			for _, l := range s.listListeners(addr.String()) {
+				if err := setTCPMD5SigSockopt(l, prefix, pConf.Config.AuthPassword); err != nil {
+					s.logger.Warn("failed to set md5",
+						log.Fields{
+							"Topic": "Peer",
+							"Key":   prefix,
+							"Err":   err})
+				} else {
+					s.logger.Info("successfully set md5 for dynamic peer",
+						log.Fields{
+							"Topic": "Peer",
+							"Key":   prefix,
+						},
+					)
+				}
+			}
+		}
 		return nil
 	}, true)
 }
@@ -3207,6 +3229,32 @@ func (s *BgpServer) DeleteDynamicNeighbor(ctx context.Context, r *api.DeleteDyna
 	}
 	return s.mgmtOperation(func() error {
 		s.peerGroupMap[r.PeerGroup].DeleteDynamicNeighbor(r.Prefix)
+
+		if pg, ok := s.peerGroupMap[r.PeerGroup]; ok {
+			pConf := pg.Conf
+			if pConf.Config.AuthPassword != "" {
+				prefix := r.Prefix
+				addr, _, perr := net.ParseCIDR(prefix)
+				if perr == nil {
+					for _, l := range s.listListeners(addr.String()) {
+						if err := setTCPMD5SigSockopt(l, prefix, ""); err != nil {
+							s.logger.Warn("failed to clear md5",
+								log.Fields{
+									"Topic": "Peer",
+									"Key":   prefix,
+									"Err":   err})
+						}
+					}
+				} else {
+					s.logger.Warn("Cannot clear up dynamic MD5, invalid prefix",
+						log.Fields{
+							"Topic": "Peer",
+							"Key":   prefix,
+							"Err":   perr,
+						})
+				}
+			}
+		}
 		return nil
 	}, true)
 }


### PR DESCRIPTION
Adds usage of the "prefix-based" TCP MD5 for dynamic neighbors. Non-dynamic neighbors will continue to use non-prefix based, which makes it more compatible with running on older kernels, as only 4.14+ includes the necessary support.

This change also includes tests of dynamic peers in general.

In the tests I tried to follow some of the naming/addressing that was in place already but might not have stuck with that as well as I could have.

Intended as fix for Issue #2589 
