### PR TITLE
Only wait for GR End of RIB for the received address family

### DIFF
--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -206,7 +206,7 @@ func (peer *peer) recvedAllEOR() bool {
 	peer.fsm.lock.RLock()
 	defer peer.fsm.lock.RUnlock()
 	for _, a := range peer.fsm.pConf.AfiSafis {
-		if s := a.MpGracefulRestart.State; s.Enabled && !s.EndOfRibReceived {
+		if s := a.MpGracefulRestart.State; s.Enabled && s.Received && !s.EndOfRibReceived {
 			return false
 		}
 	}


### PR DESCRIPTION
Currently, graceful restart waits for the EoR message for all address families "enabled" for the peer, but it should only wait for "received" address families (the address families the peer is capable of handling).

Fixes: #2524