### PR TITLE
server: only log warning if grpcServer.Serve() returned an error.

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -93,11 +93,13 @@ func (s *server) serve() error {
 	serve := func(lis net.Listener) {
 		defer wg.Done()
 		err := s.grpcServer.Serve(lis)
-		s.bgpServer.logger.Warn("accept failed",
-			log.Fields{
-				"Topic": "grpc",
-				"Key":   lis,
-				"Error": err})
+		if err != nil {
+			s.bgpServer.logger.Warn("accept failed",
+				log.Fields{
+					"Topic": "grpc",
+					"Key":   lis.Addr().String(),
+					"Error": err})
+		}
 	}
 
 	for _, lis := range l {


### PR DESCRIPTION
Additionally change the `Key` to be the listener address, which is hopefully more useful than a difficult-to-decipher dump of the listener struct.

The previous behavior would result in log lines like the following, even if nothing went wrong:
```
time="2024-01-31T17:30:25Z" level=warning msg="accept failed" Error="<nil>" Key="&{0x140002e4000 {<nil> 0 0}}" Topic=grpc
```
With this change, the message is only logged if there was an error, and it will look like this:
```
time="2024-01-31T17:40:25Z" level=warning msg="accept failed" Error="lolol just testing" Key="127.0.0.1:59289" Topic=grpc
```