### PR TITLE
fix 'LsTLVIPReachability Prefix Set Value' bug

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -5694,7 +5694,7 @@ func NewLsPrefixTLVs(pd *LsPrefixDescriptor) []LsTLVInterface {
 					Length: lenIpReach,
 				},
 				PrefixLength: uint8(prefixSize),
-				Prefix:       []byte(ip)[:((lenIpPrefix-1)/8 + 1)],
+				Prefix: []byte(ip),
 			}
 		} else if ipReach.IP.To16() != nil {
 			ip := ipReach.IP.To16()
@@ -5704,7 +5704,7 @@ func NewLsPrefixTLVs(pd *LsPrefixDescriptor) []LsTLVInterface {
 					Length: lenIpReach,
 				},
 				PrefixLength: uint8(prefixSize),
-				Prefix:       []byte(ip)[:((lenIpPrefix-1)/8 + 1)],
+				Prefix: []byte(ip),
 			}
 		}
 		lsTLVs = append(lsTLVs, tlv)


### PR DESCRIPTION
Running the following command causes a panic:

# ./gobgp g r -a ls -j -u localhost -p 50051

panic: runtime error: index out of range [1] with length 1 [recovered]
        panic: runtime error: index out of range [1] with length 1 [recovered]
        panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
encoding/json.(*encodeState).marshal.func1()
        /usr/lib/go/src/encoding/json/encode.go:293 +0x6d
panic({0xc39d60?, 0xc00020da28?})
        /usr/lib/go/src/runtime/panic.go:770 +0x132
encoding/json.(*encodeState).marshal.func1()
        /usr/lib/go/src/encoding/json/encode.go:293 +0x6d
panic({0xc39d60?, 0xc00020da28?})
        /usr/lib/go/src/runtime/panic.go:770 +0x132
github.com/osrg/gobgp/v3/pkg/packet/bgp.(*LsTLVIPReachability).ToIPNet(0xc0004cbda0, 0x0)
        ../github.com/osrg/gobgp/pkg/packet/bgp/bgp.go:7135 +0x225
github.com/osrg/gobgp/v3/pkg/packet/bgp.(*LsPrefixDescriptor).ParseTLVs(0xc00044edb8, {0xc0004cbdc0?, 0x10?, 0xc0003192b0?}, 0x0)
        ../github.com/osrg/gobgp/pkg/packet/bgp/bgp.go:5545 +0x93
