### PR TITLE
Fix `ListPath` for `ADJ_IN` and `EnableFiltered=true` and add tests.

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2627,8 +2627,10 @@ func (s *BgpServer) getAdjRib(addr string, family bgp.RouteFamily, in bool, enab
 					options := &table.PolicyOptions{
 						Validate: s.roaTable.Validate,
 					}
-					if s.policy.ApplyPolicy(peer.TableID(), table.POLICY_DIRECTION_IMPORT, path, options) == nil {
+					if p := s.policy.ApplyPolicy(peer.TableID(), table.POLICY_DIRECTION_IMPORT, path, options); p == nil {
 						filtered[path.GetNlri().String()] = path
+					} else {
+						adjRib.Update([]*table.Path{p})
 					}
 				}
 			}


### PR DESCRIPTION
Currently, even though `ApplyPolicy` is called for determining the accepted routes after apply policy, the new route with attribute modifications is not returned. This is problematic for gRPC API users.

Validation is added within `TestListPathEnableFiltered` for all four cases that were described in https://github.com/osrg/gobgp/issues/2765. This PR makes the behaviour conform to "Case/Attempt 2" described in the issue.