### PR TITLE
server: fix nil pointer exception in evpn mac mobility

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2041,6 +2041,9 @@ func getMacMobilityExtendedCommunity(etag uint32, mac net.HardwareAddr, evpnPath
 	}, 0)
 
 	for _, path := range evpnPaths {
+		if path == nil {
+			continue
+		}
 		nlri := path.GetNlri().(*bgp.EVPNNLRI)
 		target, ok := nlri.RouteTypeData.(*bgp.EVPNMacIPAdvertisementRoute)
 		if !ok {


### PR DESCRIPTION
With large EVPN fabrics, it can happen that some paths are nil in the mac mobility codepath, causing crashes of the process.

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xb8e03a]
    goroutine 25 [running]:
    github.com/osrg/gobgp/v3/internal/pkg/table.(*Path).root(...)
        /home/tuetuopay/dev/gobgp/internal/pkg/table/path.go:341
    github.com/osrg/gobgp/v3/internal/pkg/table.(*Path).OriginInfo(...)
        /home/tuetuopay/dev/gobgp/internal/pkg/table/path.go:348
    github.com/osrg/gobgp/v3/internal/pkg/table.(*Path).GetNlri(...)
        /home/tuetuopay/dev/gobgp/internal/pkg/table/path.go:460
    github.com/osrg/gobgp/v3/pkg/server.getMacMobilityExtendedCommunity(0x0, {0xc002833520, 0x6, 0xc00033ec00?}, {0xc001a52008, 0xa72, 0xc000000000?})
        /home/tuetuopay/dev/gobgp/pkg/server/server.go:2044 +0x1da
    github.com/osrg/gobgp/v3/pkg/server.(*BgpServer).fixupApiPath(0xc000372008, {0x0, 0x0}, {0xc0008fbe48, 0x1, 0x0?})
        /home/tuetuopay/dev/gobgp/pkg/server/server.go:2120 +0x4bc
    github.com/osrg/gobgp/v3/pkg/server.(*BgpServer).addPathList(0xc000372008, {0x0?, 0x0?}, {0xc0008fbe48, 0x1, 0x1})
        /home/tuetuopay/dev/gobgp/pkg/server/server.go:2162 +0x2c
    github.com/osrg/gobgp/v3/pkg/server.(*BgpServer).AddPath.func1()
        /home/tuetuopay/dev/gobgp/pkg/server/server.go:2191 +0xa5
    github.com/osrg/gobgp/v3/pkg/server.(*BgpServer).handleMGMTOp(0xc0b4e0?, 0xc001243140)
        /home/tuetuopay/dev/gobgp/pkg/server/server.go:280 +0x82
    github.com/osrg/gobgp/v3/pkg/server.(*BgpServer).Serve(0xc000372008)
        /home/tuetuopay/dev/gobgp/pkg/server/server.go:490 +0x53a
    created by main.main in goroutine 1
        /home/tuetuopay/dev/gobgp/cmd/gobgpd/main.go:202 +0x13ea