### PR TITLE
evpn: fix quadratic mac-mobility handling for gRPC routes

### DIFF
--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -480,7 +480,7 @@ func (t *Table) GetKnownPathList(id string, as uint32) []*Path {
 	return paths
 }
 
-func (t *Table) GetKnownPathListWithMac(id string, as uint32, mac net.HardwareAddr) []*Path {
+func (t *Table) GetKnownPathListWithMac(id string, as uint32, mac net.HardwareAddr, onlyBest bool) []*Path {
 	var paths []*Path
 	if rds, ok := t.macIndex[*(*string)(unsafe.Pointer(&mac))]; ok {
 		for rd := range rds {
@@ -490,7 +490,11 @@ func (t *Table) GetKnownPathListWithMac(id string, as uint32, mac net.HardwareAd
 			copy(b[9:15], mac)
 			key := *(*string)(unsafe.Pointer(&b))
 			if dst, ok := t.destinations[key]; ok {
-				paths = append(paths, dst.GetKnownPathList(id, as)...)
+				if onlyBest {
+					paths = append(paths, dst.GetBestPath(id, as))
+				} else {
+					paths = append(paths, dst.GetKnownPathList(id, as)...)
+				}
 			}
 		}
 	}

--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -329,7 +329,7 @@ func (manager *TableManager) GetPathList(id string, as uint32, rfList []bgp.Rout
 func (manager *TableManager) GetPathListWithMac(id string, as uint32, rfList []bgp.RouteFamily, mac net.HardwareAddr) []*Path {
 	var paths []*Path
 	for _, t := range manager.tables(rfList...) {
-		paths = append(paths, t.GetKnownPathListWithMac(id, as, mac)...)
+		paths = append(paths, t.GetKnownPathListWithMac(id, as, mac, false)...)
 	}
 	return paths
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2115,7 +2115,8 @@ func (s *BgpServer) fixupApiPath(vrfId string, pathList []*table.Path) error {
 			switch r := nlri.RouteTypeData.(type) {
 			case *bgp.EVPNMacIPAdvertisementRoute:
 				// MAC Mobility Extended Community
-				paths := s.globalRib.GetBestPathList(table.GLOBAL_RIB_NAME, 0, []bgp.RouteFamily{bgp.RF_EVPN})
+				mac := path.GetNlri().(*bgp.EVPNNLRI).RouteTypeData.(*bgp.EVPNMacIPAdvertisementRoute).MacAddress
+				paths := s.globalRib.GetPathListWithMac(table.GLOBAL_RIB_NAME, 0, []bgp.RouteFamily{bgp.RF_EVPN}, mac)
 				if m := getMacMobilityExtendedCommunity(r.ETag, r.MacAddress, paths); m != nil {
 					pm := getMacMobilityExtendedCommunity(r.ETag, r.MacAddress, []*table.Path{path})
 					if pm == nil {


### PR DESCRIPTION
The gRPC code paths uses different functions than the BGP code path. Thus is did not receive the fix for the mac mobility handling.

Fixes: c393f43 ("evpn: fix quadratic evpn mac-mobility handling")