### PR TITLE
graceful restart: send initial paths list to all neighbors

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1650,9 +1650,10 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 				if allEnd {
 					for _, p := range s.neighborMap {
 						p.fsm.lock.Lock()
+						peerLocalRestarting := p.fsm.pConf.GracefulRestart.State.LocalRestarting
 						p.fsm.pConf.GracefulRestart.State.LocalRestarting = false
 						p.fsm.lock.Unlock()
-						if !p.isGracefulRestartEnabled() {
+						if !p.isGracefulRestartEnabled() && !peerLocalRestarting {
 							continue
 						}
 						paths, _ := s.getBestFromLocal(p, p.configuredRFlist())
@@ -1791,9 +1792,10 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 					if allEnd {
 						for _, p := range s.neighborMap {
 							p.fsm.lock.Lock()
+							peerLocalRestarting := p.fsm.pConf.GracefulRestart.State.LocalRestarting
 							p.fsm.pConf.GracefulRestart.State.LocalRestarting = false
 							p.fsm.lock.Unlock()
-							if !p.isGracefulRestartEnabled() {
+							if !p.isGracefulRestartEnabled() && !peerLocalRestarting {
 								continue
 							}
 							paths, _ := s.getBestFromLocal(p, p.negotiatedRFList())


### PR DESCRIPTION
Before this PR, when graceful restart was configured for a neighbor and when the restart flag was set by the restarting speaker, if the neighbor was not advertising the GR capability, the initial paths list was never sent by the restarting speaker to its neighbor

This is a problem when the server is configured with graceful restart for all its peers without knowing if the peer supports it. If some of the peers don't support it, they may never receive the routes from the restarting speaker, leading to an inconsistent routing state.

@fujita, I closed previous PR #2794 and re-created this new one with some modification based on the discussion there