### PR TITLE
fix flops value was not copied to api struct

### DIFF
--- a/pkg/config/oc/util.go
+++ b/pkg/config/oc/util.go
@@ -515,6 +515,7 @@ func NewPeerFromConfigStruct(pconf *Neighbor) *api.Peer {
 			RemoteCap:       remoteCap,
 			LocalCap:        localCap,
 			RouterId:        s.RemoteRouterId,
+			Flops:           s.Flops,
 		},
 		EbgpMultihop: &api.EbgpMultihop{
 			Enabled:     pconf.EbgpMultihop.Config.Enabled,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -872,6 +872,7 @@ func (s *BgpServer) toConfig(peer *peer, getAdvertised bool) *oc.Neighbor {
 	peer.fsm.lock.RLock()
 	conf.State.SessionState = oc.IntToSessionStateMap[int(peer.fsm.state)]
 	conf.State.AdminState = oc.IntToAdminStateMap[int(peer.fsm.adminState)]
+	conf.State.Flops = peer.fsm.pConf.State.Flops
 	state := peer.fsm.state
 	peer.fsm.lock.RUnlock()
 


### PR DESCRIPTION
Flops count was only in the internal state, methods that allowed access to Peer values from the internal state omitted this value during creating the copy of the `state.Flops`.

One of the ways to observe this issue was by using command: `gobgp neighbor <IP address>`, and the Flops count was always zero.