### PR TITLE
Add ability to inject gzip/bzip2 compressed MRT files

### DIFF
--- a/cmd/gobgp/mrt.go
+++ b/cmd/gobgp/mrt.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"compress/bzip2"
 	"compress/gzip"
 	"fmt"
 	"io"
@@ -33,20 +34,21 @@ import (
 )
 
 func injectMrt() error {
-	var reader io.ReadCloser
+	var reader io.Reader
 	fileReader, err := os.Open(mrtOpts.Filename)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %s", err)
 	}
-	defer fileReader.Close()
 
 	if strings.HasSuffix(mrtOpts.Filename, ".gz") {
 		gzReader, err := gzip.NewReader(fileReader)
 		if err != nil {
 			return fmt.Errorf("failed to open gzip file: %s", err)
 		}
-		defer gzReader.Close()
 		reader = gzReader
+	} else if strings.HasSuffix(mrtOpts.Filename, ".bz2") {
+		bz2Reader := bzip2.NewReader(fileReader)
+		reader = bz2Reader
 	} else {
 		reader = fileReader
 	}

--- a/tools/spell-check/dictionary.txt
+++ b/tools/spell-check/dictionary.txt
@@ -16,6 +16,7 @@ flowspec
 gobgp
 gobgpd
 grpc
+gzip
 ibgp
 ipproto
 isis


### PR DESCRIPTION
This small addition to the MRT command makes it easier to directly inject gzip and bzip2 compressed MRT files. RIPE RIS provides them in the former, RouteViews provides them in the latter format.

A quick benchmark shows that injecting a gzipped and bzip2ed MRT file (from RIPE route collector rrc18) takes almost the same time as injecting the uncompressed file:

```
$ time ./gobgp mrt inject global ~/latest-bview.gz

real	0m52.668s
user	0m51.392s
sys	0m5.315s

# Restart gobgpd

$ time ./gobgp mrt inject global ~/latest-bview.bz2

real	0m53.537s
user	0m48.198s
sys	0m3.960s

# Restart gobgpd

$ time ./gobgp mrt inject global ~/latest-bview

real	0m52.175s
user	0m52.177s
sys	0m8.418s
```
