### PR TITLE
Fix accepted/rejected adj-in commands

### DIFF
--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -944,13 +944,19 @@ func showNeighborRib(r string, name string, args []string) error {
 		}
 	}
 
-	var t api.TableType
+	var (
+		t              api.TableType
+		enableFiltered bool
+	)
 	switch r {
 	case cmdGlobal:
 		t = api.TableType_GLOBAL
 	case cmdLocal:
 		t = api.TableType_LOCAL
-	case cmdAdjIn, cmdAccepted, cmdRejected:
+	case cmdAccepted, cmdRejected:
+		enableFiltered = true
+		fallthrough
+	case cmdAdjIn:
 		t = api.TableType_ADJ_IN
 		showIdentifier = bgp.BGP_ADD_PATH_RECEIVE
 	case cmdAdjOut:
@@ -961,11 +967,12 @@ func showNeighborRib(r string, name string, args []string) error {
 	}
 
 	stream, err := client.ListPath(ctx, &api.ListPathRequest{
-		TableType: t,
-		Family:    family,
-		Name:      name,
-		Prefixes:  filter,
-		SortType:  api.ListPathRequest_PREFIX,
+		TableType:      t,
+		Family:         family,
+		Name:           name,
+		Prefixes:       filter,
+		SortType:       api.ListPathRequest_PREFIX,
+		EnableFiltered: enableFiltered,
 	})
 	if err != nil {
 		return err
@@ -1059,19 +1066,15 @@ func showNeighborRib(r string, name string, args []string) error {
 		}
 
 		for _, d := range dsts {
-			switch r {
-			case cmdAccepted:
+			if enableFiltered {
+				showFiltered := r == cmdRejected
 				l := make([]*api.Path, 0, len(d.Paths))
 				for _, p := range d.GetPaths() {
-					if !p.Filtered {
+					if p.Filtered == showFiltered {
 						l = append(l, p)
 					}
 				}
 				d.Paths = l
-			case cmdRejected:
-				// always nothing
-				d.Paths = []*api.Path{}
-			default:
 			}
 		}
 		if len(dsts) > 0 {

--- a/docs/sources/policy.md
+++ b/docs/sources/policy.md
@@ -985,6 +985,8 @@ $ gobgp neighbor 10.0.255.3 local
 *> 10.33.0.0/16       10.0.255.1      [65001]    00:49:38   [{Origin: 0} {Med: 0}]
 ```
 
+Routes accepted or rejected by import policy can be checked using `gobgp neighbor 10.0.255.2 accepted|rejected` command.
+
 ## Policy and Soft Reset
 
 When you change an import policy and reset the inbound routing table (aka soft reset in), a withdraw for a route rejected by the latest import policies will be sent to peers. However, when you change an export policy and reset the outbound routing table (aka soft reset out), even if a route is rejected by the latest export policies, a withdraw for the route will not be sent.


### PR DESCRIPTION
Original logic for accepted/rejected commands was removed in 2dbca9e29a6813f2df53261ffaa59b9439c13fdd when IN policies were deprecated.

Then 7e5eb10a8470826a14ec225cf6a7264785ea3603 added support for server-side filtering based on IMPORT polcies, but CLI support wasn't added. Repurposing accepted/rejected commands for this.