### PR TITLE
ci: build with latest stable Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
       - run: |
           go env
           go build ./cmd/gobgp
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
       - run: |
           go test -race -timeout 240s ./...
           if [ "$(go env GOARCH)" = "amd64" ]; then go test -race github.com/osrg/gobgp/v3/pkg/packet/bgp -run ^Test_RaceCondition$; else echo 'skip'; fi
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
       - run: |
           go env GOARCH
           go test -timeout 240s ./...
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
 
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
       - run: |
           python test/scenario_test/ci-scripts/build_embeded_go.py docs/sources/lib.md
           python test/scenario_test/ci-scripts/build_embeded_go.py docs/sources/lib-ls.md
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
       - name: container image
         run: |
           sudo apt-get install python3-setuptools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
Previously, we were using `go-version-file: 'go.mod'`, which refers to the `go: 1.20` directive in `go.mod`. That means that `go1.20.14` was being used as the toolchain version. That's very out-of-date and no longer maintained. We have run into sporadic runtime fatal errors, and I believe that using a newer Go version will help with this.

I could specify `'1.22'` instead, if that's preferred. I chose `stable` just because when future major Go versions are released, they will be picked up automatically on the next build-and-release GitHub Actions run.

The version used to build a specific `gobgpd` binary can be found with `go version -m ./gobgpd`.