### PR TITLE
Use configured local address over the one that is taken from the BGP session

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -879,6 +879,9 @@ func (s *BgpServer) toConfig(peer *peer, getAdvertised bool) *oc.Neighbor {
 	if state == bgp.BGP_FSM_ESTABLISHED {
 		peer.fsm.lock.RLock()
 		conf.Transport.State.LocalAddress, conf.Transport.State.LocalPort = peer.fsm.LocalHostPort()
+		if conf.Transport.Config.LocalAddress != "0.0.0.0" {
+			conf.Transport.State.LocalAddress = conf.Transport.Config.LocalAddress
+		}
 		_, conf.Transport.State.RemotePort = peer.fsm.RemoteHostPort()
 		buf, _ := peer.fsm.recvOpen.Serialize()
 		// need to copy all values here
@@ -1616,6 +1619,10 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 			// exclude zone info
 			ipaddr, _ := net.ResolveIPAddr("ip", laddr)
 			peer.fsm.peerInfo.LocalAddress = ipaddr.IP
+			if peer.fsm.pConf.Transport.Config.LocalAddress != "0.0.0.0" {
+				peer.fsm.peerInfo.LocalAddress = net.ParseIP(peer.fsm.pConf.Transport.Config.LocalAddress)
+				peer.fsm.pConf.Transport.State.LocalAddress = peer.fsm.pConf.Transport.Config.LocalAddress
+			}
 			neighborAddress := peer.fsm.pConf.State.NeighborAddress
 			peer.fsm.lock.Unlock()
 			deferralExpiredFunc := func(family bgp.RouteFamily) func() {


### PR DESCRIPTION
Use configured local address over the one that is taken from the BGP TCP connection.

This is needed in cases when using VRFs over GENEVE Tunnels where we bind the listening address to one internal IP for security reasons. Without this fix the local address was overridden with the listening address resulting in wrong nexthop advertisement.