### PR TITLE
Re-allow unspecified IPv6 local transport address

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -880,7 +880,7 @@ func (s *BgpServer) toConfig(peer *peer, getAdvertised bool) *oc.Neighbor {
 	if state == bgp.BGP_FSM_ESTABLISHED {
 		peer.fsm.lock.RLock()
 		conf.Transport.State.LocalAddress, conf.Transport.State.LocalPort = peer.fsm.LocalHostPort()
-		if conf.Transport.Config.LocalAddress != netip.IPv4Unspecified().String() {
+		if conf.Transport.Config.LocalAddress != netip.IPv4Unspecified().String() && conf.Transport.Config.LocalAddress != netip.IPv6Unspecified().String() {
 			conf.Transport.State.LocalAddress = conf.Transport.Config.LocalAddress
 		}
 		_, conf.Transport.State.RemotePort = peer.fsm.RemoteHostPort()
@@ -1620,7 +1620,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 			// exclude zone info
 			ipaddr, _ := net.ResolveIPAddr("ip", laddr)
 			peer.fsm.peerInfo.LocalAddress = ipaddr.IP
-			if peer.fsm.pConf.Transport.Config.LocalAddress != netip.IPv4Unspecified().String() {
+			if peer.fsm.pConf.Transport.Config.LocalAddress != netip.IPv4Unspecified().String() && peer.fsm.pConf.Transport.Config.LocalAddress != netip.IPv6Unspecified().String() {
 				peer.fsm.peerInfo.LocalAddress = net.ParseIP(peer.fsm.pConf.Transport.Config.LocalAddress)
 				peer.fsm.pConf.Transport.State.LocalAddress = peer.fsm.pConf.Transport.Config.LocalAddress
 			}


### PR DESCRIPTION
Fixes regression introduced by 832b2d99c7de2a5461e3028ed56aec1c8b59ad14 which breaks peerings with unspecified IPv6 local transport address.

Fixes: https://github.com/osrg/gobgp/issues/2844