### PR TITLE
grpc: fix ListPath batch_size parameter

### DIFF
--- a/cmd/gobgp/common.go
+++ b/cmd/gobgp/common.go
@@ -100,6 +100,7 @@ const (
 
 var subOpts struct {
 	AddressFamily string `short:"a" long:"address-family" description:"specifying an address family"`
+	BatchSize     uint64 `short:"b" long:"batch-size" description:"Size of the temporary buffer in the server memory. Zero is unlimited (default)"`
 }
 
 var neighborsOpts struct {

--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -2326,6 +2326,7 @@ func newGlobalCmd() *cobra.Command {
 	}
 
 	ribCmd.PersistentFlags().StringVarP(&subOpts.AddressFamily, "address-family", "a", "", "address family")
+	ribCmd.PersistentFlags().Uint64VarP(&subOpts.BatchSize, "batch-size", "b", 0, "Size of the temporary buffer in the server memory. Zero is unlimited (default)")
 
 	for _, v := range []string{cmdAdd, cmdDel} {
 		cmd := &cobra.Command{

--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -974,6 +974,7 @@ func showNeighborRib(r string, name string, args []string) error {
 		Prefixes:       filter,
 		SortType:       api.ListPathRequest_PREFIX,
 		EnableFiltered: enableFiltered,
+		BatchSize:      subOpts.BatchSize,
 	})
 	if err != nil {
 		return err

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -261,8 +261,8 @@ func (s *server) ListPath(r *api.ListPathRequest, stream api.GobgpApi_ListPathSe
 	}
 	var sendErr error
 	err := s.bgpServer.ListPath(ctx, r, func(d *api.Destination) {
-		if uint64(len(l)) < batchSize {
-			l = append(l, d)
+		l = append(l, d)
+		if uint64(len(l)) <= batchSize {
 			return
 		}
 		if sendErr = send(); sendErr != nil {


### PR DESCRIPTION
With the append being gated by the length check, for each batch sent, we were dropped the current path. Change to always append first, then check the length.

The effect on small batch sizes was dramatic, and best shown with a size of 1: exactly half of the routes were missing.

GoBGP with 500 routes:

    $ ./gobgp global rib -a evpn | wc -l
    501
    $ ./gobgp global rib -a evpn -b 1 | wc -l
    251
    $ ./gobgp global rib -a evpn -b 2 | wc -l
    335
    $ ./gobgp global rib -a evpn -b 500 | wc -l
    501

Note: the above example uses 500 routes, but the issue is present even with two routes.

This commit also adds a --batch-size to gobgp rib commands, to be able to use the tweak from the cli. It is very useful with a large number of routes to avoid GoBGP gobbling up gigabytes of memory.