### PR TITLE
Fix dynamic neighbor connect failed with auth-password(TCP-MD5) and wildcard mask

### DIFF
--- a/pkg/server/sockopt_linux.go
+++ b/pkg/server/sockopt_linux.go
@@ -79,7 +79,7 @@ func setTCPMD5SigSockopt(l *net.TCPListener, address string, key string) error {
 	if err := sc.Control(func(s uintptr) {
 		opt := unix.TCP_MD5SIG
 
-		if t.Prefixlen != 0 {
+		if strings.Contains(address, "/") {
 			opt = unix.TCP_MD5SIG_EXT
 		}
 


### PR DESCRIPTION
I want to use dynamic neighbor to accept all bgp clients, so I using the following config. BUT, all the bgp clients can not connect to gobgp.

I used `tcpdump -M` to capture the traffic, and I found the MD5 authentication was correct. At the end, I found the problem turned out to be the use of `::/0`.  In the current code, when the IPv4 or IPv6 mask is 0 (such as wildcard mask), `TCP_MD5SIG` will be used rather than `TCP_MD5SIG_EXT`, it cause the issue.

I've fixed it.

```yaml
global:
  config:
    as: 65504
    router-id: 1.1.1.1
    port: 20179
peer-groups:
  - config:
      peer-group-name: dmwgd
      peer-as: 65504
      auth-password: "password"
    timers:
      config:
        connect-retry: 5
        hold-time: 15
        keepalive-interval: 3
    afi-safis:
      - config:
          afi-safi-name: ipv4-unicast
    transport:
      config:
        passive-mode: true
        ttl: 64
    route-reflector:
      config:
        route-reflector-client: true
        route-reflector-cluster-id: 1.1.1.0

dynamic-neighbors:
  - config:
      prefix: "::/0"
      peer-group: dmwgd
```
