### PR TITLE
make fsm ingoing channel finite

### DIFF
--- a/pkg/server/fsm_test.go
+++ b/pkg/server/fsm_test.go
@@ -376,7 +376,7 @@ func makePeerAndHandler() (*peer, *fsmHandler) {
 	h := &fsmHandler{
 		fsm:           p.fsm,
 		stateReasonCh: make(chan fsmStateReason, 2),
-		incoming:      channels.NewInfiniteChannel(),
+		incoming:      make(chan interface{}, bufferSize),
 		outgoing:      channels.NewInfiniteChannel(),
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1435,7 +1435,7 @@ func TestTcpConnectionClosedAfterPeerDel(t *testing.T) {
 	assert.Nil(err)
 
 	// Wait for the s1 to receive the tcp connection from s2.
-	ev := <-incoming.Out()
+	ev := <-incoming
 	msg := ev.(*fsmMsg)
 	nextState := msg.MsgData.(bgp.FSMState)
 	assert.Equal(nextState, bgp.BGP_FSM_OPENSENT)
@@ -1453,7 +1453,7 @@ func TestTcpConnectionClosedAfterPeerDel(t *testing.T) {
 	assert.Nil(err)
 
 	// Send the message OPENSENT transition message again to the server.
-	incoming.In() <- msg
+	incoming <- msg
 
 	// Wait for peer connection channel to be closed and check that the open
 	// tcp connection has also been closed.

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -27,6 +27,12 @@ import (
 	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
 )
 
+func cleanFiniteChannel(ch chan interface{}) {
+	close(ch)
+	for range ch {
+	}
+}
+
 func cleanInfiniteChannel(ch *channels.InfiniteChannel) {
 	ch.Close()
 	// drain all remaining items


### PR DESCRIPTION
Currently we use an infinite channel (using a queue) for incoming messages, this results in explosion in memory consumption in the case of a route update storm. This change prevents this behavior by using a fixed size buffered channel.