### PR TITLE
Add FSM loop timings

### DIFF
--- a/cmd/gobgpd/main.go
+++ b/cmd/gobgpd/main.go
@@ -230,8 +230,14 @@ func main() {
 
 	logger.Info("gobgpd started")
 	bgpLogger := &builtinLogger{logger: logger, cfgStrict: opts.ConfigStrict}
-	bgpServer := server.NewBgpServer(server.GrpcListenAddress(opts.GrpcHosts), server.GrpcOption(grpcOpts), server.LoggerOption(bgpLogger))
+	fsmTimingCollector := metrics.NewFSMTimingsCollector()
+	bgpServer := server.NewBgpServer(
+		server.GrpcListenAddress(opts.GrpcHosts),
+		server.GrpcOption(grpcOpts),
+		server.LoggerOption(bgpLogger),
+		server.TimingHookOption(fsmTimingCollector))
 	prometheus.MustRegister(metrics.NewBgpCollector(bgpServer))
+	prometheus.MustRegister(fsmTimingCollector)
 	go bgpServer.Serve()
 
 	if opts.UseSdNotify {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/k-sone/critbitgo v1.4.0
 	github.com/kr/pretty v0.3.1
 	github.com/prometheus/client_golang v1.16.0
+	github.com/prometheus/client_model v0.3.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.16.0
@@ -41,7 +42,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect

--- a/pkg/server/rpki.go
+++ b/pkg/server/rpki.go
@@ -53,6 +53,7 @@ type roaEvent struct {
 	Src       string
 	Data      []byte
 	conn      *net.TCPConn
+	timestamp time.Time
 }
 
 type roaManager struct {
@@ -149,6 +150,7 @@ func (c *roaClient) lifetimeout() {
 	c.eventCh <- &roaEvent{
 		EventType: roaLifetimeout,
 		Src:       c.host,
+		timestamp: time.Now(),
 	}
 }
 
@@ -407,6 +409,7 @@ func (c *roaClient) tryConnect() {
 				EventType: roaConnected,
 				Src:       c.host,
 				conn:      conn.(*net.TCPConn),
+				timestamp: time.Now(),
 			}
 			return
 		}
@@ -419,6 +422,7 @@ func (c *roaClient) established() (err error) {
 		c.eventCh <- &roaEvent{
 			EventType: roaDisconnected,
 			Src:       c.host,
+			timestamp: time.Now(),
 		}
 	}()
 
@@ -445,6 +449,7 @@ func (c *roaClient) established() (err error) {
 			EventType: roaRTR,
 			Src:       c.host,
 			Data:      append(header, body...),
+			timestamp: time.Now(),
 		}
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -44,6 +44,25 @@ import (
 	"github.com/osrg/gobgp/v3/pkg/zebra"
 )
 
+type FSMOperation uint
+
+const (
+	FSMMgmtOp FSMOperation = iota
+	FSMAccept
+	FSMROAEvent
+	FSMMessage
+
+	FSMOperationTypeCount
+)
+
+type FSMTimingHook interface {
+	Observe(op FSMOperation, tOp, tWait time.Duration)
+}
+
+type nopTimingHook struct{}
+
+func (n nopTimingHook) Observe(op FSMOperation, tOp, tWait time.Duration) {}
+
 type tcpListener struct {
 	l      *net.TCPListener
 	ch     chan struct{}
@@ -141,6 +160,7 @@ type options struct {
 	grpcAddress string
 	grpcOption  []grpc.ServerOption
 	logger      log.Logger
+	timingHook  FSMTimingHook
 }
 
 type ServerOption func(*options)
@@ -160,6 +180,12 @@ func GrpcOption(opt []grpc.ServerOption) ServerOption {
 func LoggerOption(logger log.Logger) ServerOption {
 	return func(o *options) {
 		o.logger = logger
+	}
+}
+
+func TimingHookOption(hook FSMTimingHook) ServerOption {
+	return func(o *options) {
+		o.timingHook = hook
 	}
 }
 
@@ -184,10 +210,13 @@ type BgpServer struct {
 	roaTable     *table.ROATable
 	uuidMap      map[string]uuid.UUID
 	logger       log.Logger
+	timingHook   FSMTimingHook
 }
 
 func NewBgpServer(opt ...ServerOption) *BgpServer {
-	opts := options{}
+	opts := options{
+		timingHook: nopTimingHook{},
+	}
 	for _, o := range opt {
 		o(&opts)
 	}
@@ -207,6 +236,7 @@ func NewBgpServer(opt ...ServerOption) *BgpServer {
 		roaManager:   newROAManager(roaTable, logger),
 		roaTable:     roaTable,
 		logger:       logger,
+		timingHook:   opts.timingHook,
 	}
 	s.bmpManager = newBmpClientManager(s)
 	s.mrtManager = newMrtManager(s)
@@ -269,6 +299,7 @@ type mgmtOp struct {
 	f           func() error
 	errCh       chan error
 	checkActive bool // check BGP global setting is configured before calling f()
+	timestamp   time.Time
 }
 
 func (s *BgpServer) handleMGMTOp(op *mgmtOp) {
@@ -288,6 +319,7 @@ func (s *BgpServer) mgmtOperation(f func() error, checkActive bool) (err error) 
 		f:           f,
 		errCh:       ch,
 		checkActive: checkActive,
+		timestamp:   time.Now(),
 	}
 	return
 }
@@ -485,22 +517,33 @@ func (s *BgpServer) Serve() {
 		}
 
 		chosen, value, ok := reflect.Select(cases)
+		tStart := time.Now()
 		switch chosen {
 		case 0:
 			op := value.Interface().(*mgmtOp)
+			tWait := tStart.Sub(op.timestamp)
 			s.handleMGMTOp(op)
+			s.timingHook.Observe(FSMMgmtOp, time.Since(tStart), tWait)
 		case 1:
+			// NOTE: it would be useful to use kernel metrics such as SO_TIMESTAMPING to record time we got
+			// first SYN packet in TCP connection. For now we skip tWait for accept events, message/mgmt op
+			// delays should be enough to analyze FSM loop.
 			conn := value.Interface().(*net.TCPConn)
 			s.passConnToPeer(conn)
+			s.timingHook.Observe(FSMAccept, time.Since(tStart), 0)
 		case 2:
 			ev := value.Interface().(*roaEvent)
+			tWait := tStart.Sub(ev.timestamp)
 			s.roaManager.HandleROAEvent(ev)
+			s.timingHook.Observe(FSMROAEvent, time.Since(tStart), tWait)
 		default:
 			// in the case of dynamic peer, handleFSMMessage closed incoming channel so
 			// nil fsmMsg can happen here.
 			if ok {
 				e := value.Interface().(*fsmMsg)
+				tWait := tStart.Sub(e.timestamp)
 				handlefsmMsg(e)
+				s.timingHook.Observe(FSMMessage, time.Since(tStart), tWait)
 			}
 		}
 	}


### PR DESCRIPTION
As the issue #2854 demonstrates, Main FSM loop performance is crucial for overall GoBGP performance. While we're far from hitting those limits yet, we want to be sure that we have enough capacity in FSM loop.

To achieve that, we add FSM loop timing histograms, which are showing:
    - timing_sec - amount of time handling each message took
    - wait_sec - amount of time each message spent in a channel before it was received by the main FSM loop. The latter (wait times) allows to detect situation when FSM loop performance is inadequate, while the former (timings) allows to understand which component causes such delays.

For the sake of simplicity, further classification of message types, such as RouterID of the peer or name of gRPC operation is not made.