### PR TITLE
Fix overwriteConfig if field order mismatches

### DIFF
--- a/pkg/config/oc/bgp_configs.go
+++ b/pkg/config/oc/bgp_configs.go
@@ -3175,9 +3175,6 @@ type NeighborConfig struct {
 	// original -> bgp:peer-group
 	// The peer-group with which this neighbor is associated.
 	PeerGroup string `mapstructure:"peer-group" json:"peer-group,omitempty"`
-	// original -> gobgp:send-software-version
-	// gobgp:send-software-version's original type is boolean.
-	SendSoftwareVersion bool `mapstructure:"send-software-version" json:"send-software-version,omitempty"`
 	// original -> bgp:neighbor-address
 	// bgp:neighbor-address's original type is inet:ip-address.
 	// Address of the BGP peer, either in IPv4 or IPv6.
@@ -3190,6 +3187,9 @@ type NeighborConfig struct {
 	NeighborInterface string `mapstructure:"neighbor-interface" json:"neighbor-interface,omitempty"`
 	// original -> gobgp:vrf
 	Vrf string `mapstructure:"vrf" json:"vrf,omitempty"`
+	// original -> gobgp:send-software-version
+	// gobgp:send-software-version's original type is boolean.
+	SendSoftwareVersion bool `mapstructure:"send-software-version" json:"send-software-version,omitempty"`
 }
 
 func (lhs *NeighborConfig) Equal(rhs *NeighborConfig) bool {

--- a/pkg/config/oc/default.go
+++ b/pkg/config/oc/default.go
@@ -516,13 +516,12 @@ func OverwriteNeighborConfigWithPeerGroup(c *Neighbor, pg *PeerGroup) error {
 
 func overwriteConfig(c, pg interface{}, tagPrefix string, v *viper.Viper) {
 	nValue := reflect.Indirect(reflect.ValueOf(c))
-	nType := reflect.Indirect(nValue).Type()
 	pgValue := reflect.Indirect(reflect.ValueOf(pg))
 	pgType := reflect.Indirect(pgValue).Type()
 
 	for i := 0; i < pgType.NumField(); i++ {
 		field := pgType.Field(i).Name
-		tag := tagPrefix + "." + nType.Field(i).Tag.Get("mapstructure")
+		tag := tagPrefix + "." + pgType.Field(i).Tag.Get("mapstructure")
 		if func() bool {
 			for _, t := range forcedOverwrittenConfig {
 				if t == tag {
@@ -531,7 +530,9 @@ func overwriteConfig(c, pg interface{}, tagPrefix string, v *viper.Viper) {
 			}
 			return false
 		}() || !v.IsSet(tag) {
-			nValue.FieldByName(field).Set(pgValue.FieldByName(field))
+			if nField := nValue.FieldByName(field); nField.IsValid() {
+				nField.Set(pgValue.FieldByName(field))
+			}
 		}
 	}
 }


### PR DESCRIPTION
As mentioned in https://github.com/osrg/gobgp/pull/2863#discussion_r1897329474 - automatically generating bgp_configs.go moves SendSoftwareVersion to the bottom (expected), but that requires fix to `overwriteConfig` so peerGroup fields would be applied correctly if their order doesn't patch order in neighbor config.