### PR TITLE
support for injecting the prefixes in MRT file only from a specified AS number

### DIFF
--- a/cmd/gobgp/common.go
+++ b/cmd/gobgp/common.go
@@ -117,6 +117,7 @@ var mrtOpts struct {
 	SkipV4      bool   `long:"no-ipv4" description:"Skip importing IPv4 routes"`
 	SkipV6      bool   `long:"no-ipv4" description:"Skip importing IPv6 routes"`
 	NextHop     net.IP `long:"nexthop" description:"Rewrite nexthop"`
+	PeerASN     uint32 `long:"peer-asn" description:"Inject prefixes only from specified AS number"`
 }
 
 var bmpOpts struct {

--- a/cmd/gobgp/mrt.go
+++ b/cmd/gobgp/mrt.go
@@ -57,6 +57,10 @@ func injectMrt() error {
 		fmt.Println("You should probably specify either --no-ipv4 or --no-ipv6 when overwriting nexthop, unless your dump contains only one type of routes")
 	}
 
+	if mrtOpts.Best && mrtOpts.PeerASN != 0 {
+		fmt.Println("--only-best has no effect when --peer-asn is specified")
+	}
+
 	var idx int64
 	if mrtOpts.QueueSize < 1 {
 		return fmt.Errorf("specified queue size is smaller than 1, refusing to run with unbounded memory usage")
@@ -132,6 +136,10 @@ func injectMrt() error {
 					}
 					//t := time.Unix(int64(e.OriginatedTime), 0)
 
+					if mrtOpts.PeerASN != 0 && peers[e.PeerIndex].AS != mrtOpts.PeerASN {
+						continue
+					}
+
 					var attrs []bgp.PathAttributeInterface
 					switch subType {
 					case mrt.RIB_IPV4_UNICAST, mrt.RIB_IPV4_UNICAST_ADDPATH:
@@ -169,7 +177,7 @@ func injectMrt() error {
 				}
 
 				// TODO: calculate properly if necessary.
-				if mrtOpts.Best {
+				if mrtOpts.Best && len(paths) > 0 {
 					paths = []*api.Path{paths[0]}
 				}
 
@@ -250,5 +258,6 @@ func newMrtCmd() *cobra.Command {
 	mrtCmd.PersistentFlags().BoolVarP(&mrtOpts.SkipV6, "no-ipv6", "", false, "Do not import IPv6 routes")
 	mrtCmd.PersistentFlags().IntVarP(&mrtOpts.QueueSize, "queue-size", "", 1<<10, "Maximum number of updates to keep queued")
 	mrtCmd.PersistentFlags().IPVarP(&mrtOpts.NextHop, "nexthop", "", nil, "Overwrite nexthop")
+	mrtCmd.PersistentFlags().Uint32VarP(&mrtOpts.PeerASN, "peer-asn", "", 0, "Inject prefixes only from specified AS number")
 	return mrtCmd
 }


### PR DESCRIPTION
I created a small patch that adds support for injecting prefixes from a MRT file only for a specified AS number. For example, suppose one needs to inject only the prefixes received from `AS 6667` by the [RIPE RIS](https://www.ripe.net/analyse/internet-measurements/routing-information-service-ris/) [RRC07 (Route Collector 7)](https://www.ris.ripe.net/peerlist/all.shtml). With the proposed patch, this could be accomplished with `gobgp mrt inject global --peer-asn 6667 latest-bview-rrc07.gz` where `latest-bview-rrc07.gz` is the compressed MRT file.