### PR TITLE
Show the peer-group name in the output of the 'gobgp neighbor' cli command

### DIFF
--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -162,6 +162,7 @@ func showNeighbors(vrf string) error {
 		return nil
 	}
 	maxaddrlen := 0
+	maxgrouplen := len("Group")
 	maxaslen := 2
 	maxtimelen := len("Up/Down")
 	timedelta := []string{}
@@ -189,6 +190,9 @@ func showNeighbors(vrf string) error {
 		} else if j := len(n.State.NeighborAddress); j > maxaddrlen {
 			maxaddrlen = j
 		}
+		if l := len(n.Conf.PeerGroup); l > maxgrouplen {
+			maxgrouplen = l
+		}
 		if l := len(getRemoteASN(n)); l > maxaslen {
 			maxaslen = l
 		}
@@ -206,9 +210,9 @@ func showNeighbors(vrf string) error {
 		timedelta = append(timedelta, timeStr)
 	}
 
-	format := "%-" + fmt.Sprint(maxaddrlen) + "s" + " %" + fmt.Sprint(maxaslen) + "s" + " %" + fmt.Sprint(maxtimelen) + "s"
+	format := "%-" + fmt.Sprint(maxaddrlen) + "s" + " %" + fmt.Sprint(maxgrouplen) + "s" + " %" + fmt.Sprint(maxaslen) + "s" + " %" + fmt.Sprint(maxtimelen) + "s"
 	format += " %-11s |%9s %9s\n"
-	fmt.Printf(format, "Peer", "AS", "Up/Down", "State", "#Received", "Accepted")
+	fmt.Printf(format, "Peer", "Group", "AS", "Up/Down", "State", "#Received", "Accepted")
 	formatFsm := func(admin api.PeerState_AdminState, fsm api.PeerState_SessionState) string {
 		switch admin {
 		case api.PeerState_DOWN:
@@ -244,7 +248,7 @@ func showNeighbors(vrf string) error {
 			neigh = n.Conf.NeighborInterface
 		}
 		received, accepted, _, _ := counter(n)
-		fmt.Printf(format, neigh, getRemoteASN(n), timedelta[i], formatFsm(n.State.AdminState, n.State.SessionState), fmt.Sprint(received), fmt.Sprint(accepted))
+		fmt.Printf(format, neigh, n.Conf.PeerGroup, getRemoteASN(n), timedelta[i], formatFsm(n.State.AdminState, n.State.SessionState), fmt.Sprint(received), fmt.Sprint(accepted))
 	}
 
 	return nil


### PR DESCRIPTION
Example:
```
$ gobgp neighbor
Peer          Group     AS      Up/Down State       |#Received  Accepted
127.0.0.1 reflector 123456 16d 11:56:29 Establ      |   195075    195075
127.0.0.2 reflector 123456 16d 11:55:46 Establ      |   195075    195075
127.0.0.3 reflector 123456 16d 11:56:04 Establ      |   195075    195075
127.0.3.1    group2 123456 16d 11:53:09 Establ      |     5166      5166
```