### PR TITLE
Optimize RTC exchange performance in global RIB

### DIFF
--- a/internal/pkg/table/adj.go
+++ b/internal/pkg/table/adj.go
@@ -38,7 +38,7 @@ func (rtc *rtCounter) add(path *Path) {
 	if !ok {
 		return
 	}
-	rtHash, err := nlriRouteTargetKey(nlri)
+	rtHash, err := NlriRouteTargetKey(nlri)
 	if err != nil {
 		return
 	}
@@ -60,7 +60,7 @@ func (rtc *rtCounter) sub(path *Path) {
 	if !ok {
 		return
 	}
-	rtHash, err := nlriRouteTargetKey(nlri)
+	rtHash, err := NlriRouteTargetKey(nlri)
 	if err != nil {
 		return
 	}

--- a/internal/pkg/table/destination_test.go
+++ b/internal/pkg/table/destination_test.go
@@ -334,14 +334,17 @@ func TestMultipath(t *testing.T) {
 	d := newDestination(nlri, 0)
 	d.Calculate(logger, path2)
 
-	best, old, multi := d.Calculate(logger, path1).GetChanges(GLOBAL_RIB_NAME, 0, false)
+	dd, oldC := d.Calculate(logger, path1)
+	assert.Nil(t, oldC)
+	best, old, multi := dd.GetChanges(GLOBAL_RIB_NAME, 0, false)
 	assert.NotNil(t, best)
 	assert.Equal(t, old, path2)
 	assert.Equal(t, len(multi), 2)
 	assert.Equal(t, len(d.GetKnownPathList(GLOBAL_RIB_NAME, 0)), 2)
 
 	path3 := path2.Clone(true)
-	dd := d.Calculate(logger, path3)
+	dd, oldC = d.Calculate(logger, path3)
+	assert.Equal(t, path2, oldC)
 	best, old, multi = dd.GetChanges(GLOBAL_RIB_NAME, 0, false)
 	assert.Nil(t, best)
 	assert.Equal(t, old, path1)
@@ -359,7 +362,8 @@ func TestMultipath(t *testing.T) {
 	}
 	updateMsg = bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path4 := ProcessMessage(updateMsg, peer3, time.Now(), false)[0]
-	dd = d.Calculate(logger, path4)
+	dd, oldDD := d.Calculate(logger, path4)
+	assert.Nil(t, oldDD)
 	best, _, multi = dd.GetChanges(GLOBAL_RIB_NAME, 0, false)
 	assert.NotNil(t, best)
 	assert.Equal(t, len(multi), 1)
@@ -374,7 +378,8 @@ func TestMultipath(t *testing.T) {
 	}
 	updateMsg = bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path5 := ProcessMessage(updateMsg, peer2, time.Now(), false)[0]
-	best, _, multi = d.Calculate(logger, path5).GetChanges(GLOBAL_RIB_NAME, 0, false)
+	dd, _ = d.Calculate(logger, path5)
+	best, _, multi = dd.GetChanges(GLOBAL_RIB_NAME, 0, false)
 	assert.NotNil(t, best)
 	assert.Equal(t, len(multi), 2)
 	assert.Equal(t, len(d.GetKnownPathList(GLOBAL_RIB_NAME, 0)), 3)
@@ -441,7 +446,7 @@ func TestDestination_Calculate_ExplicitWithdraw(t *testing.T) {
 
 	// Test explicit withdraw
 	withdrawPath := NewPath(bgp.RF_IPv4_UC, peer1, bgp.PathNLRI{NLRI: nlri}, true, attrs, time.Now(), false)
-	update := d.Calculate(logger, withdrawPath)
+	update, _ := d.Calculate(logger, withdrawPath)
 
 	assert.Len(t, update.KnownPathList, 1)
 	assert.Equal(t, peer2.Address.String(), update.KnownPathList[0].GetSource().Address.String())
@@ -465,7 +470,7 @@ func TestDestination_Calculate_ImplicitWithdraw(t *testing.T) {
 		bgp.NewPathAttributeMultiExitDisc(100),
 	}
 	p2 := NewPath(bgp.RF_IPv4_UC, peer1, bgp.PathNLRI{NLRI: nlri}, false, newAttrs, time.Now(), false)
-	update := d.Calculate(logger, p2)
+	update, _ := d.Calculate(logger, p2)
 
 	assert.Len(t, update.KnownPathList, 1)
 	assert.Equal(t, uint32(100), update.KnownPathList[0].getPathAttr(bgp.BGP_ATTR_TYPE_MULTI_EXIT_DISC).(*bgp.PathAttributeMultiExitDisc).Value)
@@ -686,7 +691,7 @@ func TestDestination_Calculate_AddAndWithdrawPath(t *testing.T) {
 
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("13.2.6.0/24"))
 	p4 := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
-	update := d.Calculate(logger, p4)
+	update, _ := d.Calculate(logger, p4)
 	assert.Len(t, update.KnownPathList, 3)
 	assert.Len(t, update.KnownPathList, 3)
 	assert.NotEqualValues(t, update.OldKnownPathList, update.KnownPathList)
@@ -697,7 +702,7 @@ func TestDestination_Calculate_AddAndWithdrawPath(t *testing.T) {
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("13.2.3.0/24"))
 	p1 = NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), true)
 	d = newDestination(nlri, 0, p1, p2, p3)
-	update = d.Calculate(logger, p4)
+	update, _ = d.Calculate(logger, p4)
 	assert.Len(t, update.KnownPathList, 3)
 	assert.Len(t, update.KnownPathList, 3)
 	assert.NotEqualValues(t, update.OldKnownPathList, update.KnownPathList)
@@ -709,7 +714,7 @@ func TestDestination_Calculate_AddAndWithdrawPath(t *testing.T) {
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("13.2.8.0/24"))
 	p5 := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
 	d = newDestination(nlri, 0, p1, p2, p3, p5)
-	update = d.Calculate(logger, p4)
+	update, _ = d.Calculate(logger, p4)
 
 	assert.Len(t, update.KnownPathList, 4)
 	assert.Len(t, update.KnownPathList, 4)

--- a/internal/pkg/table/table_manager_test.go
+++ b/internal/pkg/table/table_manager_test.go
@@ -2411,3 +2411,155 @@ func TestVRF(t *testing.T) {
 		assert.Contains(t, deletedRTsStr, importRTStr)
 	}
 }
+
+func TestTableManagerRTC(t *testing.T) {
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv6_VPN, bgp.RF_IPv4_VPN, bgp.RF_IPv4_UC})
+
+	rtStrings := []string{"100:100", "100:200", "100:300", "100:400"}
+	rts := make([]bgp.ExtendedCommunityInterface, 0)
+	for _, strRT := range rtStrings {
+		rt, err := bgp.ParseRouteTarget(strRT)
+		assert.NoError(t, err)
+		rts = append(rts, rt)
+	}
+	assert.Equal(t, 4, len(rts))
+
+	declarations6 := []testPathWithRTs{
+		{
+			rd:     "100:100",
+			prefix: "100:1::/64",
+			rts:    []bgp.ExtendedCommunityInterface{rts[3]},
+		},
+		{
+			rd:     "101:100",
+			prefix: "100:3:1::/48",
+			rts:    []bgp.ExtendedCommunityInterface{rts[3], rts[1]},
+		},
+		{
+			rd:     "100:300",
+			prefix: "10.10.10.13/32",
+			rts:    []bgp.ExtendedCommunityInterface{rts[2]},
+		},
+	}
+	var paths6 []*Path
+	tm.Tables[bgp.RF_IPv6_VPN], paths6 = makeTableWithRT(t, tm.Tables[bgp.RF_IPv6_VPN], declarations6, bgp.RF_IPv6_VPN)
+
+	declarations4 := []testPathWithRTs{
+		{
+			rd:     "100:100",
+			prefix: "10.10.10.10/32",
+			rts:    []bgp.ExtendedCommunityInterface{rts[0]},
+		},
+		{
+			rd:     "101:100",
+			prefix: "10.10.10.11/32",
+			rts:    []bgp.ExtendedCommunityInterface{rts[0], rts[1]},
+		},
+		{
+			rd:     "100:200",
+			prefix: "10.10.10.12/32",
+			rts:    []bgp.ExtendedCommunityInterface{rts[1]},
+		},
+		{
+			rd:     "100:300",
+			prefix: "10.10.10.13/32",
+			rts:    []bgp.ExtendedCommunityInterface{rts[2]},
+		},
+	}
+	var paths4 []*Path
+	tm.Tables[bgp.RF_IPv4_VPN], paths4 = makeTableWithRT(t, tm.Tables[bgp.RF_IPv4_VPN], declarations4, bgp.RF_IPv4_VPN)
+
+	hash0, err := extCommRouteTargetKey(rts[0])
+	assert.NoError(t, err)
+	pathsRT := tm.GetBestPathListForAddedRT(hash0, "127.0.0.1:1", "global", 0,
+		[]bgp.Family{bgp.RF_IPv6_VPN, bgp.RF_IPv4_VPN, bgp.RF_IPv4_UC})
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths4[0], paths4[1]}))
+
+	hash1, err := extCommRouteTargetKey(rts[1])
+	assert.NoError(t, err)
+
+	pathsRT = tm.GetBestPathListForAddedRT(hash1, "127.0.0.1:1", "global", 0,
+		[]bgp.Family{bgp.RF_IPv6_VPN, bgp.RF_IPv4_VPN, bgp.RF_IPv4_UC})
+	assert.Equal(t, 3, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths4[1], paths4[2], paths6[1]}))
+
+	hash2, err := extCommRouteTargetKey(rts[2])
+	assert.NoError(t, err)
+
+	pathsRT = tm.GetBestPathListForAddedRT(hash2, "127.0.0.1:1", "global", 0,
+		[]bgp.Family{bgp.RF_IPv6_VPN, bgp.RF_IPv4_VPN, bgp.RF_IPv4_UC})
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths4[3], paths6[2]}))
+
+	pathsRT = tm.GetBestPathListForAddedRT(hash1, "127.0.0.1:1", "global", 0,
+		[]bgp.Family{bgp.RF_IPv6_VPN, bgp.RF_IPv4_VPN, bgp.RF_IPv4_UC})
+	assert.Equal(t, 0, len(pathsRT))
+
+	pathsRT = tm.GetBestPathListForAddedRT(hash0, "127.0.0.1:2", "global", 0,
+		[]bgp.Family{bgp.RF_IPv6_VPN, bgp.RF_IPv4_VPN, bgp.RF_IPv4_UC})
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths4[0], paths4[1]}))
+
+	pathsRT = tm.GetBestPathListForAddedRT(hash1, "127.0.0.1:2", "global", 0,
+		[]bgp.Family{bgp.RF_IPv6_VPN, bgp.RF_IPv4_VPN, bgp.RF_IPv4_UC})
+	assert.Equal(t, 3, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths4[1], paths4[2], paths6[1]}))
+
+	hash3, err := extCommRouteTargetKey(rts[3])
+	assert.NoError(t, err)
+	pathsRT = tm.GetBestPathListForAddedRT(hash3, "127.0.0.1:2", "global", 0,
+		[]bgp.Family{bgp.RF_IPv6_VPN, bgp.RF_IPv4_VPN, bgp.RF_IPv4_UC})
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths6[0], paths6[1]}))
+
+	update := tm.Tables[bgp.RF_IPv4_VPN].update(paths4[2].Clone(true))
+	assert.Equal(t, 0, len(update.KnownPathList))
+	assert.Equal(t, 1, len(update.OldKnownPathList))
+	assert.True(t, update.OldKnownPathList[0].Equal(paths4[2]))
+
+	update = tm.Tables[bgp.RF_IPv4_VPN].update(paths4[1].Clone(false))
+	assert.Equal(t, 1, len(update.KnownPathList))
+	assert.Equal(t, 1, len(update.OldKnownPathList))
+	assert.True(t, update.KnownPathList[0].Equal(paths4[1]))
+	assert.True(t, update.OldKnownPathList[0].Equal(paths4[1]))
+
+	update = tm.Tables[bgp.RF_IPv6_VPN].update(paths6[1].Clone(true))
+	assert.Equal(t, 0, len(update.KnownPathList))
+	assert.Equal(t, 1, len(update.OldKnownPathList))
+	assert.True(t, update.OldKnownPathList[0].Equal(paths6[1]))
+
+	rf := []bgp.Family{bgp.RF_IPv6_VPN, bgp.RF_IPv4_VPN, bgp.RF_IPv4_UC}
+
+	pathsRT = tm.GetBestPathListForAddedRT(hash0, "127.0.0.1:1", "global", 0, rf)
+	assert.Equal(t, 0, len(pathsRT))
+
+	pathsRT = tm.GetBestPathListForAddedRT(hash1, "127.0.0.1:1", "global", 0, rf)
+	assert.Equal(t, 0, len(pathsRT))
+
+	pathsRT = tm.GetBestPathListForAddedRT(hash2, "127.0.0.1:1", "global", 0, rf)
+	assert.Equal(t, 0, len(pathsRT))
+
+	pathsRT = tm.GetBestPathListForWithdrawnRT(tm.BestPathListForRTMaxLen(hash0, rf), hash0, "127.0.0.1:1", "global", 0, rf)
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths4[0], paths4[1]}))
+
+	pathsRT = tm.GetBestPathListForWithdrawnRT(0, hash1, "127.0.0.1:1", "global", 0, rf)
+	assert.Equal(t, 1, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths4[1]}))
+
+	pathsRT = tm.GetBestPathListForAddedRT(hash1, "127.0.0.1:1", "global", 0, rf)
+	assert.Equal(t, 1, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths4[1]}))
+
+	pathsRT = tm.GetBestPathListForAddedRT(hash2, "127.0.0.1:3", "global", 0, rf)
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths4[3], paths6[2]}))
+
+	pathsRT = tm.GetBestPathListForAddedRT(hash2, "127.0.0.1:3", "global", 0, rf)
+	assert.Equal(t, 0, len(pathsRT))
+
+	pathsRT = tm.GetBestPathListForWithdrawnRT(30, hash2, "127.0.0.1:3", "global", 0, rf)
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths4[3], paths6[2]}))
+}

--- a/internal/pkg/table/table_test.go
+++ b/internal/pkg/table/table_test.go
@@ -33,6 +33,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCreateTable(t *testing.T) {
+	table := NewTable(logger, bgp.RF_FS_IPv4_VPN)
+	assert.NotNil(t, table.grtRts)
+
+	table = NewTable(logger, bgp.RF_RTC_UC)
+	assert.Nil(t, table.grtRts)
+
+	table = NewTable(logger, bgp.RF_IPv4_MPLS)
+	assert.NotNil(t, table.grtRts)
+}
+
 func TestLookupLonger(t *testing.T) {
 	tbl := NewTable(logger, bgp.RF_IPv4_UC)
 
@@ -734,7 +745,7 @@ func Test_RouteTargetKey(t *testing.T) {
 	binary.BigEndian.PutUint32(buf[9:], 0x15161718)
 	r, err := bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	key, err := nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
+	key, err := NlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NoError(err)
 	assert.Equal(uint64(0x0002131415161718), key)
 
@@ -749,7 +760,7 @@ func Test_RouteTargetKey(t *testing.T) {
 	binary.BigEndian.PutUint16(buf[11:], 0x1314)
 	r, err = bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	key, err = nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
+	key, err = NlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NoError(err)
 	assert.Equal(uint64(0x01020a0102031314), key)
 
@@ -763,7 +774,7 @@ func Test_RouteTargetKey(t *testing.T) {
 	binary.BigEndian.PutUint16(buf[11:], 0x1314)
 	r, err = bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	key, err = nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
+	key, err = NlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NoError(err)
 	assert.Equal(uint64(0x0202151617181314), key)
 
@@ -775,16 +786,175 @@ func Test_RouteTargetKey(t *testing.T) {
 	binary.BigEndian.PutUint32(buf[9:], 1000000)
 	r, err = bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	_, err = nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
+	_, err = NlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NotNil(err)
 
 	r = &bgp.RouteTargetMembershipNLRI{}
-	key, err = nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
+	key, err = NlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NoError(err)
 	assert.Equal(DefaultRT, key)
 
 	_, err = extCommRouteTargetKey(nil)
 	assert.Equal(ErrNilCommunity, err)
+}
+
+type testPathWithRTs struct {
+	rd     string
+	prefix string
+	rts    []bgp.ExtendedCommunityInterface
+}
+
+func TestTableRTC(t *testing.T) {
+	rtStrings := []string{"100:100", "100:200", "100:300"}
+	rts := make([]bgp.ExtendedCommunityInterface, 0)
+	for _, strRT := range rtStrings {
+		rt, err := bgp.ParseRouteTarget(strRT)
+		assert.NoError(t, err)
+		rts = append(rts, rt)
+	}
+	assert.Equal(t, 3, len(rts))
+
+	declarations := []testPathWithRTs{
+		{
+			rd:     "100:100",
+			prefix: "10.10.10.10/32",
+			rts:    []bgp.ExtendedCommunityInterface{rts[0]},
+		},
+		{
+			rd:     "101:100",
+			prefix: "10.10.10.11/32",
+			rts:    []bgp.ExtendedCommunityInterface{rts[0], rts[1]},
+		},
+		{
+			rd:     "100:200",
+			prefix: "10.10.10.12/32",
+			rts:    []bgp.ExtendedCommunityInterface{rts[1]},
+		},
+		{
+			rd:     "100:300",
+			prefix: "10.10.10.13/32",
+			rts:    []bgp.ExtendedCommunityInterface{rts[2]},
+		},
+	}
+	table, paths := makeTableWithRT(t, nil, declarations, bgp.RF_IPv4_VPN)
+	assert.Equal(t, 4, len(table.GetDestinations()))
+
+	hash0, err := extCommRouteTargetKey(rts[0])
+	assert.NoError(t, err)
+	pathsRT := table.getBestsForNewlyAttachedRTtoPeer(hash0, "127.0.0.1:1", "global", 0, nil)
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[0], paths[1]}))
+
+	hash1, err := extCommRouteTargetKey(rts[1])
+	assert.NoError(t, err)
+
+	pathsRT = table.getBestsForNewlyAttachedRTtoPeer(hash1, "127.0.0.1:1", "global", 0, nil)
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[1], paths[2]}))
+
+	hash2, err := extCommRouteTargetKey(rts[2])
+	assert.NoError(t, err)
+
+	pathsRT = table.getBestsForNewlyAttachedRTtoPeer(hash2, "127.0.0.1:1", "global", 0, pathsRT)
+	assert.Equal(t, 3, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[1], paths[2], paths[3]}))
+
+	pathsRT = table.getBestsForNewlyAttachedRTtoPeer(hash1, "127.0.0.1:1", "global", 0, nil)
+	assert.Equal(t, 0, len(pathsRT))
+
+	pathsRT = table.getBestsForNewlyAttachedRTtoPeer(hash2, "127.0.0.1:1", "global", 0, nil)
+	assert.Equal(t, 0, len(pathsRT))
+
+	pathsRT = table.getBestsForNewlyAttachedRTtoPeer(hash0, "127.0.0.1:2", "global", 0, nil)
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[0], paths[1]}))
+
+	pathsRT = table.getBestsForNewlyAttachedRTtoPeer(hash1, "127.0.0.1:2", "global", 0, nil)
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[1], paths[2]}))
+
+	update := table.update(paths[2].Clone(true))
+	assert.Equal(t, 0, len(update.KnownPathList))
+	assert.Equal(t, 1, len(update.OldKnownPathList))
+	assert.True(t, update.OldKnownPathList[0].Equal(paths[2]))
+
+	update = table.update(paths[1].Clone(false))
+	assert.Equal(t, 1, len(update.KnownPathList))
+	assert.Equal(t, 1, len(update.OldKnownPathList))
+	assert.True(t, update.KnownPathList[0].Equal(paths[1]))
+	assert.True(t, update.OldKnownPathList[0].Equal(paths[1]))
+
+	pathsRT = table.getBestsForNewlyAttachedRTtoPeer(hash0, "127.0.0.1:1", "global", 0, nil)
+	assert.Equal(t, 0, len(pathsRT))
+
+	pathsRT = table.getBestsForNewlyAttachedRTtoPeer(hash1, "127.0.0.1:1", "global", 0, nil)
+	assert.Equal(t, 0, len(pathsRT))
+
+	pathsRT = table.getBestsForNewlyAttachedRTtoPeer(hash2, "127.0.0.1:1", "global", 0, nil)
+	assert.Equal(t, 0, len(pathsRT))
+
+	pathsRT = table.getBestsForDetachedRTFromPeer(hash0, "127.0.0.1:1", "global", 0, nil)
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[0], paths[1]}))
+
+	pathsRT = table.getBestsForDetachedRTFromPeer(hash2, "127.0.0.1:1", "global", 0, pathsRT)
+	assert.Equal(t, 3, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[0], paths[1], paths[3]}))
+
+	pathsRT = table.getBestsForDetachedRTFromPeer(hash1, "127.0.0.1:1", "global", 0, nil)
+	assert.Equal(t, 1, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[1]}))
+
+	pathsRT = table.getBestsForDetachedRTFromPeer(hash1, "127.0.0.1:1", "global", 0, nil)
+	assert.Equal(t, 0, len(pathsRT))
+
+	pathsRT = table.getBestsForNewlyAttachedRTtoPeer(hash1, "127.0.0.1:1", "global", 0, nil)
+	assert.Equal(t, 1, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[1]}))
+}
+
+func equalPaths(paths1, paths2 []*Path) bool {
+	if len(paths1) != len(paths2) {
+		return false
+	}
+	cp2 := paths2[:]
+	for _, p1 := range paths1 {
+		found := false
+		for i2, p2 := range cp2 {
+			if p1.Equal(p2) {
+				found = true
+				cp2 = append(cp2[:i2], cp2[i2+1:]...)
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return len(cp2) == 0
+}
+
+func makeTableWithRT(t *testing.T, table *Table, declarations []testPathWithRTs, rf bgp.Family) (*Table, []*Path) {
+	if table == nil {
+		table = NewTable(logger, rf)
+	}
+	paths := make([]*Path, 0)
+	for _, item := range declarations {
+		rd, _ := bgp.ParseRouteDistinguisher(item.rd)
+		nlri, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix(item.prefix), *bgp.NewMPLSLabelStack(), rd)
+		var pattr *bgp.PathAttributeExtendedCommunities
+		if len(item.rts) > 0 {
+			pattr = bgp.NewPathAttributeExtendedCommunities(item.rts)
+		}
+		path := NewPath(rf, nil, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{pattr}, time.Now(), false)
+
+		update := table.update(path)
+		assert.Equal(t, 1, len(update.KnownPathList))
+		assert.Equal(t, 0, len(update.OldKnownPathList))
+		assert.True(t, update.KnownPathList[0].Equal(path))
+		paths = append(paths, path)
+	}
+	return table, paths
 }
 
 func TestContainsCIDR(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -973,6 +973,18 @@ func (s *BgpServer) getBestFromLocal(peer *peer, rfList []bgp.Family, addEOR boo
 	return pathList, filtered
 }
 
+func (s *BgpServer) filterPathListForWithdrawnRT(rt uint64, peer *peer, rfList []bgp.Family) []*table.Path {
+	maxLen := s.globalRib.BestPathListForRTMaxLen(rt, rfList)
+
+	filtered := make([]*table.Path, 0, maxLen)
+	for _, path := range s.globalRib.GetBestPathListForWithdrawnRT(maxLen, rt, peer.ID(), peer.TableID(), 0, rfList) {
+		if p := s.filterpath(peer, path, nil); p == nil {
+			filtered = append(filtered, path)
+		}
+	}
+	return filtered
+}
+
 func needToAdvertise(peer *peer) bool {
 	state := peer.State()
 	peer.fsm.lock.Lock()
@@ -1133,61 +1145,60 @@ func (s *BgpServer) propagateUpdate(peer *peer, pathList []*table.Path) {
 			// between the previous and current state of the route distribution
 			// graph that is derived from Route Target membership information.
 			if peer != nil && path != nil && path.GetFamily() == bgp.RF_RTC_UC {
-				rt := path.GetNlri().(*bgp.RouteTargetMembershipNLRI).RouteTarget
+				nlri, ok := path.GetNlri().(*bgp.RouteTargetMembershipNLRI)
+				if !ok {
+					s.logger.Debug("NLRI is not a Route Target, ignore",
+						slog.String("Topic", "Peer"),
+						slog.String("Key", peer.ID()),
+						slog.Any("Data", path))
+					continue
+				}
+				rtHash, err := table.NlriRouteTargetKey(nlri)
+				if err != nil {
+					s.logger.Warn("Route Target wrong format, ignore",
+						slog.String("Topic", "Peer"),
+						slog.String("Key", peer.ID()),
+						slog.Any("Data", path))
+					continue
+				}
 				fs := make([]bgp.Family, 0, len(peer.negotiatedRFList()))
 				for _, f := range peer.negotiatedRFList() {
 					if f != bgp.RF_RTC_UC {
 						fs = append(fs, f)
 					}
 				}
-				var candidates []*table.Path
+				var paths []*table.Path
 				if path.IsWithdraw {
-					// Note: The paths to be withdrawn are filtered because the
-					// given RT on RTM NLRI is already removed from adj-RIB-in.
-					_, candidates = s.getBestFromLocal(peer, fs, true)
-				} else {
-					// https://github.com/osrg/gobgp/issues/1777
-					// Ignore duplicate Membership announcements
-					membershipsForSource := s.globalRib.GetPathListWithSource(table.GLOBAL_RIB_NAME, []bgp.Family{bgp.RF_RTC_UC}, path.GetSource())
-					found := false
-					equalRT := func(a, b bgp.ExtendedCommunityInterface) bool {
-						if a == nil && b == nil {
-							return true
+					if rtHash == table.DefaultRT {
+						// Note: The paths to be withdrawn are filtered because the
+						// given RT on RTM NLRI is already removed from adj-RIB-in.
+						_, paths = s.getBestFromLocal(peer, fs, true)
+						withdrawnPaths := make([]*table.Path, 0, len(paths))
+						for _, p := range paths {
+							withdrawnPaths = append(withdrawnPaths, p.Clone(true))
 						}
-						return a != nil && b != nil && a.String() == b.String()
+						paths = withdrawnPaths
+					} else {
+						paths = s.filterPathListForWithdrawnRT(rtHash, peer, fs)
 					}
-					for _, membership := range membershipsForSource {
-						mrt := membership.GetNlri().(*bgp.RouteTargetMembershipNLRI).RouteTarget
-						if equalRT(mrt, rt) {
-							found = true
-							break
-						}
-					}
-					if !found {
-						candidates = s.globalRib.GetBestPathList(peer.TableID(), 0, fs)
-					}
-				}
-				paths := make([]*table.Path, 0, len(candidates))
-				for _, p := range candidates {
-					for _, ext := range p.GetExtCommunities() {
-						if rt == nil || ext.String() == rt.String() {
-							if path.IsWithdraw {
-								p = p.Clone(true)
-							}
-							paths = append(paths, p)
-							break
-						}
-					}
-				}
-				if path.IsWithdraw {
 					// Skips filtering because the paths are already filtered
 					// and the withdrawal does not need the path attributes.
 					sendfsmOutgoingMsg(peer, paths)
-				} else if !peer.getRtcEORWait() {
-					paths = s.processOutgoingPaths(peer, paths, nil)
-					sendfsmOutgoingMsg(peer, paths)
 				} else {
-					peer.fsm.logger.Debug("Nothing sent in response to RT received. Waiting for RTC EOR.", slog.Any("Path", path))
+					if rtHash == table.DefaultRT {
+						paths = s.globalRib.GetBestPathList(peer.TableID(), 0, fs)
+					} else {
+						paths = s.globalRib.GetBestPathListForAddedRT(rtHash, peer.ID(), peer.TableID(), 0, fs)
+					}
+					if !peer.getRtcEORWait() {
+						paths = s.processOutgoingPaths(peer, paths, nil)
+						sendfsmOutgoingMsg(peer, paths)
+					} else {
+						s.logger.Debug("Nothing sent in response to RT received. Waiting for RTC EOR.",
+							slog.String("Topic", "Peer"),
+							slog.String("Key", peer.ID()),
+							slog.Any("Data", path))
+					}
 				}
 			}
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1987,6 +1987,145 @@ func TestDoNotReactToDuplicateRTCMemberships(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestRouteWithDoubleRTinRTC(t *testing.T) {
+	ctx := context.Background()
+
+	s1 := runNewServer(t, 1, "1.1.1.1", 10179)
+	defer s1.StopBgp(context.Background(), &api.StopBgpRequest{})
+	err := s1.SetLogLevel(context.Background(), &api.SetLogLevelRequest{Level: api.SetLogLevelRequest_LEVEL_DEBUG})
+	assert.NoError(t, err)
+	s2 := runNewServer(t, 1, "2.2.2.2", 20179)
+	defer s2.StopBgp(context.Background(), &api.StopBgpRequest{})
+	err = s2.SetLogLevel(context.Background(), &api.SetLogLevelRequest{Level: api.SetLogLevelRequest_LEVEL_DEBUG})
+	assert.NoError(t, err)
+
+	if err := peerServers(t, ctx, []*BgpServer{s1, s2}, []oc.AfiSafiType{oc.AFI_SAFI_TYPE_L3VPN_IPV4_UNICAST, oc.AFI_SAFI_TYPE_RTC}); err != nil {
+		t.Fatal(err)
+	}
+	watcher := s1.watch(WatchUpdate(true, "", ""))
+
+	rt100 := bgp.NewTwoOctetAsSpecificExtended(bgp.EC_SUBTYPE_ROUTE_TARGET, 100, 100, true)
+	rt200 := bgp.NewTwoOctetAsSpecificExtended(bgp.EC_SUBTYPE_ROUTE_TARGET, 200, 200, true)
+
+	panh, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("3.3.3.3"))
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		panh,
+		bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rt100, rt200}),
+	}
+	rd, _ := bgp.ParseRouteDistinguisher("100:100")
+	labels := bgp.NewMPLSLabelStack(100, 200)
+	prefix, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("10.30.2.0/24"), *labels, rd)
+	path, _ := apiutil.NewPath(bgp.RF_IPv4_VPN, prefix, false, attrs, time.Now())
+	if _, err := s2.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(path)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	panh, _ = bgp.NewPathAttributeNextHop(netip.MustParseAddr("1.1.1.1"))
+	attrsRtc := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		panh,
+	}
+	pathRtc1, _ := apiutil.NewPath(bgp.RF_RTC_UC, bgp.NewRouteTargetMembershipNLRI(1, rt100), false, attrsRtc, time.Now())
+	if _, err := s1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc1)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	pathRtc2, _ := apiutil.NewPath(bgp.RF_RTC_UC, bgp.NewRouteTargetMembershipNLRI(1, rt200), false, attrsRtc, time.Now())
+	if _, err := s1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc2)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// s1 should receive this route from s2
+	t1 := time.NewTimer(30 * time.Second)
+	for found := false; !found; {
+		select {
+		case ev := <-watcher.Event():
+			switch msg := ev.(type) {
+			case *watchEventUpdate:
+				for _, path := range msg.PathList {
+					t.Logf("tester received path: %s", path.String())
+					if vpnPath, ok := path.GetNlri().(*bgp.LabeledVPNIPAddrPrefix); ok {
+						if vpnPath.Prefix == prefix.Prefix {
+							t.Logf("tester found expected prefix: %s", vpnPath.Prefix)
+							found = true
+						} else {
+							t.Logf("unknown prefix %s != %s", vpnPath.Prefix, prefix.Prefix)
+						}
+					}
+				}
+			}
+		case <-t1.C:
+			t.Fatalf("timeout while waiting for update path event")
+		}
+	}
+	t1.Stop()
+
+	err = s1.DeletePath(apiutil.DeletePathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc2)}})
+	assert.NoError(t, err)
+
+	// s1 should not receive withdrawn route from s2
+	t1 = time.NewTimer(30 * time.Second)
+	for found := false; !found; {
+		select {
+		case ev := <-watcher.Event():
+			switch msg := ev.(type) {
+			case *watchEventUpdate:
+				for _, path := range msg.PathList {
+					t.Logf("tester received path: %s", path.String())
+					if vpnPath, ok := path.GetNlri().(*bgp.LabeledVPNIPAddrPrefix); ok {
+						if vpnPath.Prefix == prefix.Prefix {
+							if path.IsWithdraw {
+								t.Fatalf("active path is withdrawn")
+							} else {
+								t.Logf("tester found expected prefix: %s", vpnPath.Prefix)
+								found = true
+							}
+						} else {
+							t.Logf("unknown prefix %s != %s", vpnPath.Prefix, prefix.Prefix)
+						}
+					}
+				}
+			}
+		case <-t1.C:
+			t.Fatalf("timeout while waiting for withdrawn paths")
+		}
+	}
+	t1.Stop()
+
+	err = s1.DeletePath(apiutil.DeletePathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc1)}})
+	assert.NoError(t, err)
+
+	// s1 should receive withdrawn route from s2
+	t1 = time.NewTimer(30 * time.Second)
+	for found := false; !found; {
+		select {
+		case ev := <-watcher.Event():
+			switch msg := ev.(type) {
+			case *watchEventUpdate:
+				for _, path := range msg.PathList {
+					t.Logf("tester received path: %s", path.String())
+					if vpnPath, ok := path.GetNlri().(*bgp.LabeledVPNIPAddrPrefix); ok {
+						if vpnPath.Prefix == prefix.Prefix {
+							if path.IsWithdraw {
+								t.Logf("tester found expected prefix: %s", vpnPath.Prefix)
+								found = true
+							} else {
+								t.Fatalf("this path should be withdrawn: %s", vpnPath.Prefix)
+							}
+						} else {
+							t.Logf("unknown prefix %s != %s", vpnPath.Prefix, prefix.Prefix)
+						}
+					}
+				}
+			}
+		case <-t1.C:
+			t.Fatalf("timeout while waiting for update path event")
+		}
+	}
+	t1.Stop()
+}
+
 func TestDelVrfWithRTC(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
1. Add Key(RouteTarget)->uint64.
2. Add map[Key(rt)]map[*Path]{} to globalRib VPN tables for fast making path list by RT.
3. Add map[Key(rt)]int to Adj RTC tables for fast filtering paths by RTs.
4. Add tests on pp.1-3.
5. Non-VPN paths must not depend on RTC.

This is about complexity of RTC.
1. Currently, filtering a single VPN path before sending requires O(n) operations, where n is the number of RTs in the RF_RTC_UC table. Constructing a list of VPNs takes O(nm) operations, where m is the number of VPN paths (filterpath).
2. When a new RT is received, filtering VPNs to respond (propagateUpdate) requires O(m) operations.

This PR proposes a new approach that potentially reduces the complexity to O(1) for filtering and retrieving VPN paths, assuming the map container is used effectively. However, this approach requires additional memory. Specifically, for each VPN GRT, it necessitates:
  n\*L\*m\*sizeof(\*Path) , where L is the average number of extRTs in the Path, m - number of paths, n - number of known RTs + 
  n\*sizeof(RouterID) - to store interested on RT peers + 
  n\*sizeof(uint64) - for indexing RTs
Additionally, for each Adj RF_RTC_UC table, the memory requirement is approximately:
  n\*(sizeof(uint64)+sizeof(int))