### PR TITLE
fix: prevent AS loop

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -691,7 +691,7 @@ func filterpath(peer *peer, path, old *table.Path) *table.Path {
 		return nil
 	}
 
-	if !peer.isRouteServerClient() && isASLoop(peer, path) && !path.IsLocal() {
+	if !peer.isRouteServerClient() && isASLoop(peer, path) {
 		return nil
 	}
 	return path


### PR DESCRIPTION
Revert https://github.com/osrg/gobgp/issues/2488
We should not allow a path with an AS loop to be advertised.
iBGP peers should not add locally originated routes with there own AS in their path.