### PR TITLE
Update gobgp.yang for AllowAsPathLoopLocal config option

### DIFF
--- a/pkg/config/oc/bgp_configs.go
+++ b/pkg/config/oc/bgp_configs.go
@@ -2216,11 +2216,13 @@ type AsPathOptionsState struct {
 	// Replace occurrences of the peer's AS in the AS_PATH
 	// with the local autonomous system number.
 	ReplacePeerAs bool `mapstructure:"replace-peer-as" json:"replace-peer-as,omitempty"`
+	// original -> gobgp:allow-as-path-loop-local
+	// gobgp:allow-as-path-loop-local's original type is boolean.
 	// Bypasses as-path loop detection on locally sourced (static) routes
 	// when exporting towards iBGP neighbors. This is needed in some environments
 	// where gobgp is functioning as a route injector. Non-local routes
 	// are still checked for as-path loops.
-	AllowAsPathLoopLocal bool `mapstructure:"allow-aspath-loop-local" json:"allow-aspath-loop-local,omitempty"`
+	AllowAsPathLoopLocal bool `mapstructure:"allow-as-path-loop-local" json:"allow-as-path-loop-local,omitempty"`
 }
 
 // struct for container bgp:config.
@@ -2236,11 +2238,13 @@ type AsPathOptionsConfig struct {
 	// Replace occurrences of the peer's AS in the AS_PATH
 	// with the local autonomous system number.
 	ReplacePeerAs bool `mapstructure:"replace-peer-as" json:"replace-peer-as,omitempty"`
+	// original -> gobgp:allow-as-path-loop-local
+	// gobgp:allow-as-path-loop-local's original type is boolean.
 	// Bypasses as-path loop detection on locally sourced (static) routes
-	// when exporting towards neighbors. This is needed in some environments
+	// when exporting towards iBGP neighbors. This is needed in some environments
 	// where gobgp is functioning as a route injector. Non-local routes
 	// are still checked for as-path loops.
-	AllowAsPathLoopLocal bool `mapstructure:"allow-aspath-loop-local" json:"allow-aspath-loop-local,omitempty"`
+	AllowAsPathLoopLocal bool `mapstructure:"allow-as-path-loop-local" json:"allow-as-path-loop-local,omitempty"`
 }
 
 func (lhs *AsPathOptionsConfig) Equal(rhs *AsPathOptionsConfig) bool {
@@ -2251,6 +2255,9 @@ func (lhs *AsPathOptionsConfig) Equal(rhs *AsPathOptionsConfig) bool {
 		return false
 	}
 	if lhs.ReplacePeerAs != rhs.ReplacePeerAs {
+		return false
+	}
+	if lhs.AllowAsPathLoopLocal != rhs.AllowAsPathLoopLocal {
 		return false
 	}
 	return true

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -1458,4 +1458,26 @@ module gobgp {
       }
     }
   }
+
+  augment "/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:as-path-options/bgp:config" {
+    leaf allow-as-path-loop-local {
+      type boolean;
+      description
+        "Bypasses as-path loop detection on locally sourced (static) routes
+        when exporting towards iBGP neighbors. This is needed in some environments
+        where gobgp is functioning as a route injector. Non-local routes
+        are still checked for as-path loops.";
+    }
+  }
+
+  augment "/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:as-path-options/bgp:state" {
+    leaf allow-as-path-loop-local {
+      type boolean;
+      description
+        "Bypasses as-path loop detection on locally sourced (static) routes
+        when exporting towards iBGP neighbors. This is needed in some environments
+        where gobgp is functioning as a route injector. Non-local routes
+        are still checked for as-path loops.";
+    }
+  }
 }


### PR DESCRIPTION
Update gobgp.yang for AllowAsPathLoopLocal config option and generate bgp_configs.go.

Seems that the commit 16ea4f9c592a ("Add neighbor config option to bypass as-path loop detection on local (static) routes") updates bgp_configs.go by hand.