### PR TITLE
Fix: Opaque NLRI

### DIFF
--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -1345,6 +1345,11 @@ func MarshalNLRI(value bgp.AddrPrefixInterface) (*apb.Any, error) {
 			Rd:    rd,
 			Rules: rules,
 		}
+	case *bgp.OpaqueNLRI:
+		nlri = &api.OpaqueNLRI{
+			Key:   v.Key,
+			Value: v.Value,
+		}
 	case *bgp.LsAddrPrefix:
 		switch n := v.NLRI.(type) {
 		case *bgp.LsNodeNLRI:
@@ -1648,6 +1653,8 @@ func UnmarshalNLRI(rf bgp.RouteFamily, an *apb.Any) (bgp.AddrPrefixInterface, er
 		case bgp.RF_FS_L2_VPN:
 			nlri = bgp.NewFlowSpecL2VPN(rd, rules)
 		}
+	case *api.OpaqueNLRI:
+		nlri = bgp.NewOpaqueNLRI(v.Key, v.Value)
 	case *api.MUPInterworkSegmentDiscoveryRoute:
 		rd, err := UnmarshalRD(v.Rd)
 		if err != nil {

--- a/pkg/apiutil/attribute_test.go
+++ b/pkg/apiutil/attribute_test.go
@@ -1208,6 +1208,41 @@ func Test_MpReachNLRIAttribute_FS_L2_VPN(t *testing.T) {
 	}
 }
 
+func Test_MpReachNLRIAttribute_IPv4_Opaque(t *testing.T) {
+	assert := assert.New(t)
+
+	nlris := make([]*apb.Any, 0, 1)
+	a, err := apb.New(&api.OpaqueNLRI{
+		Key:   []byte{0x48, 0x65, 0x6c, 0x6c, 0x6f}, //hello
+		Value: []byte{0x77, 0x6f, 0x72, 0x6c, 0x64}, //world
+	})
+	assert.Nil(err)
+	nlris = append(nlris, a)
+
+	input := &api.MpReachNLRIAttribute{
+		Family: &api.Family{
+			Afi:  api.Family_AFI_OPAQUE,
+			Safi: api.Family_SAFI_KEY_VALUE,
+		},
+		NextHops: []string{"192.168.1.1"},
+		Nlris:    nlris,
+	}
+	a, err = apb.New(input)
+	assert.Nil(err)
+	n, err := UnmarshalAttribute(a)
+	assert.Nil(err)
+
+	output, _ := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
+	assert.Equal(input.Family.Afi, output.Family.Afi)
+	assert.Equal(input.Family.Safi, output.Family.Safi)
+	assert.Equal(1, len(output.Nlris))
+	for idx, inputNLRI := range input.Nlris {
+		outputNLRI := output.Nlris[idx]
+		assert.Equal(inputNLRI.TypeUrl, outputNLRI.TypeUrl)
+		assert.Equal(inputNLRI.Value, outputNLRI.Value)
+	}
+}
+
 func Test_MpReachNLRIAttribute_MUPInterworkSegmentDiscoveryRoute(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
Fix: Opaque NLRI
I cannot execute the below example command.
`gobgp global rib add -a opaque key hello value world`
`rpc error: code = Unknown desc = failed to unmarshal nlri: proto: invalid empty type URL`

Then, I fixed this. 
As a result, the result of the rib after executing the command is as follows.

#### local bgp daemon
```
root@n1:/gobgp/cmd/gobgp# ./gobgp global rib add -a opaque key hello value world
root@n1:/gobgp/cmd/gobgp# ./gobgp global rib -a opaque
   Network              Next Hop             AS_PATH              Age        Attrs
*> hello                0.0.0.0                                   00:00:19   [{Origin: ?}]

```
#### peer bgp daemon
```
root@n2:/gobgp/cmd/gobgp# ./gobgp global rib -a opaque
   Network              Next Hop             AS_PATH              Age        Attrs
*> hello                172.20.20.2          65000                00:01:10   [{Origin: ?}]
```
closes: #2897 