### PR TITLE
rtc: implement default route target and cli support

### DIFF
--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -1282,7 +1282,12 @@ func MarshalNLRI(value bgp.AddrPrefixInterface) (*apb.Any, error) {
 			Prefix:    v.Prefix.String(),
 		}
 	case *bgp.RouteTargetMembershipNLRI:
-		rt, err := MarshalRT(v.RouteTarget)
+		rt, err := func() (*apb.Any, error) {
+			if v.RouteTarget == nil {
+				return nil, nil
+			}
+			return MarshalRT(v.RouteTarget)
+		}()
 		if err != nil {
 			return nil, err
 		}
@@ -1620,7 +1625,12 @@ func UnmarshalNLRI(rf bgp.RouteFamily, an *apb.Any) (bgp.AddrPrefixInterface, er
 			nlri = bgp.NewLabeledVPNIPv6AddrPrefix(uint8(v.PrefixLen), v.Prefix, *bgp.NewMPLSLabelStack(v.Labels...), rd)
 		}
 	case *api.RouteTargetMembershipNLRI:
-		rt, err := UnmarshalRT(v.Rt)
+		rt, err := func() (bgp.ExtendedCommunityInterface, error) {
+			if v.Rt == nil {
+				return nil, nil
+			}
+			return UnmarshalRT(v.Rt)
+		}()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -209,6 +209,39 @@ func Test_RouteTargetMembershipNLRIString(t *testing.T) {
 	assert.Equal(nil, err)
 	assert.Equal("65546:1000000", r.String())
 
+	// Default
+	buf = make([]byte, 1)
+	buf[0] = 0 // in bit length
+	r = &RouteTargetMembershipNLRI{}
+	err = r.DecodeFromBytes(buf)
+	assert.Equal(nil, err)
+	assert.Equal("default", r.String())
+	buf, err = r.Serialize()
+	assert.Equal(nil, err)
+	err = r.DecodeFromBytes(buf)
+	assert.Equal(nil, err)
+	assert.Equal("default", r.String())
+	r = NewRouteTargetMembershipNLRI(0, nil)
+	buf, err = r.Serialize()
+	assert.Equal(nil, err)
+	err = r.DecodeFromBytes(buf)
+	assert.Equal(nil, err)
+	assert.Equal("default", r.String())
+
+	// AS only
+	buf = make([]byte, 5)
+	buf[0] = 32 // in bit length
+	binary.BigEndian.PutUint32(buf[1:5], 65546)
+	r = &RouteTargetMembershipNLRI{}
+	err = r.DecodeFromBytes(buf)
+	assert.Equal(nil, err)
+	assert.Equal("65546:0:0", r.String())
+	r = NewRouteTargetMembershipNLRI(65546, nil)
+	buf, err = r.Serialize()
+	assert.Equal(nil, err)
+	err = r.DecodeFromBytes(buf)
+	assert.Equal(nil, err)
+	assert.Equal("65546:0:0", r.String())
 }
 
 func Test_MalformedUpdateMsg(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1322,8 +1322,15 @@ func (s *BgpServer) propagateUpdate(peer *peer, pathList []*table.Path) {
 					// Ignore duplicate Membership announcements
 					membershipsForSource := s.globalRib.GetPathListWithSource(table.GLOBAL_RIB_NAME, []bgp.RouteFamily{bgp.RF_RTC_UC}, path.GetSource())
 					found := false
+					equalRT := func(a, b bgp.ExtendedCommunityInterface) bool {
+						if a == nil && b == nil {
+							return true
+						}
+						return a != nil && b != nil && a.String() == b.String()
+					}
 					for _, membership := range membershipsForSource {
-						if membership.GetNlri().(*bgp.RouteTargetMembershipNLRI).RouteTarget.String() == rt.String() {
+						mrt := membership.GetNlri().(*bgp.RouteTargetMembershipNLRI).RouteTarget
+						if equalRT(mrt, rt) {
 							found = true
 							break
 						}


### PR DESCRIPTION
* add support for cli add/del operations
* add support for default route target via api/cli
* fix panic while deduplication of default route target
* fix rt membership validation, partial prefixes are still not supported, just 0/32/96-bit for consistency
* add tests