### PR TITLE
flowspec: Add sub-command for FlowSpec with SR Policy

### DIFF
--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -389,23 +389,30 @@ func parseExtendedCommunities(args []string) ([]bgp.ExtendedCommunityInterface, 
 	return exts, nil
 }
 
-func parseFlowSpecArgs(rf bgp.RouteFamily, args []string) (bgp.AddrPrefixInterface, []string, error) {
+func parseFlowSpecArgs(rf bgp.RouteFamily, args []string) (bgp.AddrPrefixInterface, *bgp.PathAttributePrefixSID, []string, error) {
 	// Format:
 	// match <rule>... [then <action>...] [rd <rd>] [rt <rt>...]
+	// or
+	// match <rule>... then redirect <rt> [color <color>] [prefix <prefix>] [locator-node-length <length>] [function-length <length>] [behavior <behavior>]
 	req := 3 // match <key1> <arg1> [<key2> <arg2>...]
 	if len(args) < req {
-		return nil, nil, fmt.Errorf("%d args required at least, but got %d", req, len(args))
+		return nil, nil, nil, fmt.Errorf("%d args required at least, but got %d", req, len(args))
 	}
 	m, err := extractReserved(args, map[string]int{
-		"match": paramList,
-		"then":  paramList,
-		"rd":    paramSingle,
-		"rt":    paramList})
+		"match":               paramList,
+		"then":                paramList,
+		"rd":                  paramSingle,
+		"rt":                  paramList,
+		"color":               paramSingle,
+		"prefix":              paramSingle,
+		"locator-node-length": paramSingle,
+		"function-length":     paramSingle,
+		"behavior":            paramSingle})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if len(m["match"]) == 0 {
-		return nil, nil, fmt.Errorf("specify filtering rules with keyword 'match'")
+		return nil, nil, nil, fmt.Errorf("specify filtering rules with keyword 'match'")
 	}
 
 	var rd bgp.RouteDistinguisherInterface
@@ -413,11 +420,11 @@ func parseFlowSpecArgs(rf bgp.RouteFamily, args []string) (bgp.AddrPrefixInterfa
 	switch rf {
 	case bgp.RF_FS_IPv4_VPN, bgp.RF_FS_IPv6_VPN, bgp.RF_FS_L2_VPN:
 		if len(m["rd"]) == 0 {
-			return nil, nil, fmt.Errorf("specify rd")
+			return nil, nil, nil, fmt.Errorf("specify rd")
 		}
 		var err error
 		if rd, err = bgp.ParseRouteDistinguisher(m["rd"][0]); err != nil {
-			return nil, nil, fmt.Errorf("invalid rd: %s", m["rd"][0])
+			return nil, nil, nil, fmt.Errorf("invalid rd: %s", m["rd"][0])
 		}
 		if len(m["rt"]) > 0 {
 			extcomms = append(extcomms, "rt")
@@ -425,16 +432,16 @@ func parseFlowSpecArgs(rf bgp.RouteFamily, args []string) (bgp.AddrPrefixInterfa
 		}
 	default:
 		if len(m["rd"]) > 0 {
-			return nil, nil, fmt.Errorf("cannot specify rd for %s", rf.String())
+			return nil, nil, nil, fmt.Errorf("cannot specify rd for %s", rf.String())
 		}
 		if len(m["rt"]) > 0 {
-			return nil, nil, fmt.Errorf("cannot specify rt for %s", rf.String())
+			return nil, nil, nil, fmt.Errorf("cannot specify rt for %s", rf.String())
 		}
 	}
 
 	rules, err := bgp.ParseFlowSpecComponents(rf, strings.Join(m["match"], " "))
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	var nlri bgp.AddrPrefixInterface
@@ -450,10 +457,61 @@ func parseFlowSpecArgs(rf bgp.RouteFamily, args []string) (bgp.AddrPrefixInterfa
 	case bgp.RF_FS_L2_VPN:
 		nlri = bgp.NewFlowSpecL2VPN(rd, rules)
 	default:
-		return nil, nil, fmt.Errorf("invalid route family")
+		return nil, nil, nil, fmt.Errorf("invalid route family")
 	}
 
-	return nlri, extcomms, nil
+	var psid *bgp.PathAttributePrefixSID
+	hasAnySRv6PolicyParam := len(m["prefix"]) > 0 || len(m["locator-node-length"]) > 0 || len(m["function-length"]) > 0 || len(m["behavior"]) > 0
+
+	if len(m["then"]) != 0 && m["then"][0] == "redirect" {
+		if len(m["color"]) == 0 && hasAnySRv6PolicyParam {
+			return nil, nil, nil, fmt.Errorf("specify color")
+		}
+		if len(m["color"]) > 0 {
+			extcomms = append(extcomms, "color", m["color"][0])
+			if hasAnySRv6PolicyParam {
+				// Check if all optional SRv6 Policy parameters are specified.
+				required := []string{"prefix", "locator-node-length", "function-length", "behavior"}
+				for _, param := range required {
+					if len(m[param]) == 0 {
+						return nil, nil, nil, fmt.Errorf("specify %s", param)
+					}
+				}
+
+				sid, err := netip.ParsePrefix(m["prefix"][0])
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				nl, err := strconv.ParseUint(m["locator-node-length"][0], 10, 8)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				fl, err := strconv.ParseUint(m["function-length"][0], 10, 8)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				behavior, ok := api.SRv6Behavior_value[m["behavior"][0]]
+				if !ok {
+					return nil, nil, nil, fmt.Errorf("unknown behavior: %s", m["behavior"][0])
+				}
+
+				psid = bgp.NewPathAttributePrefixSID(
+					bgp.NewSRv6ServiceTLV(
+						bgp.TLVTypeSRv6L3Service,
+						bgp.NewSRv6InformationSubTLV(
+							sid.Addr(),
+							bgp.SRBehavior(behavior),
+							bgp.NewSRv6SIDStructureSubSubTLV(uint8(sid.Bits()), uint8(nl), uint8(fl), 0, 0, 0),
+						),
+					),
+				)
+			}
+		}
+	} else if hasAnySRv6PolicyParam {
+		return nil, nil, nil, fmt.Errorf("cannot specify %s for %s", strings.Join([]string{"prefix", "locator-node-length", "function-length", "behavior"}, ", "), m["then"][0])
+	}
+
+	return nlri, psid, extcomms, nil
 }
 
 func parseEvpnEthernetAutoDiscoveryArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {
@@ -2034,7 +2092,7 @@ func parsePath(rf bgp.RouteFamily, args []string) (*api.Path, error) {
 	case bgp.RF_EVPN:
 		nlri, extcomms, err = parseEvpnArgs(args)
 	case bgp.RF_FS_IPv4_UC, bgp.RF_FS_IPv4_VPN, bgp.RF_FS_IPv6_UC, bgp.RF_FS_IPv6_VPN, bgp.RF_FS_L2_VPN:
-		nlri, extcomms, err = parseFlowSpecArgs(rf, args)
+		nlri, psid, extcomms, err = parseFlowSpecArgs(rf, args)
 	case bgp.RF_OPAQUE:
 		m, err := extractReserved(args, map[string]int{
 			"key":   paramSingle,
@@ -2168,7 +2226,7 @@ usage: %s rib -a %%s %s%%s match <MATCH> then <THEN>%%s%%s%%s
     <THEN> : { %s |
                %s |
                %s <RATE> [as <AS>] |
-               %s <RT> |
+               %s <RT> [color <color>] [prefix <prefix>] [locator-node-length <length>] [function-length <length>] [behavior <behavior>] |
                %s <DEC_NUM> |
                %s { sample | terminal | sample-terminal } }...
     <RT> : xxx:yyy, xxx.xxx.xxx.xxx:yyy, xxxx::xxxx:yyy, xxx.xxx:yyy`,


### PR DESCRIPTION
This PR adds sub-command for FlowSpec with SR Policy as defined in [draft-ietf-idr-ts-flowspec-srv6-policy-05](https://www.ietf.org/archive/id/draft-ietf-idr-ts-flowspec-srv6-policy-05.html).

- Usage Examples:
  - Option 1: [section-5 Fig2](https://www.ietf.org/archive/id/draft-ietf-idr-ts-flowspec-srv6-policy-05.html#section-5)
  ```
  $ gobgp global rib -a ipv6-flowspec add match destination 2001:db8::/64 then redirect fd00:1::1:0 color 100 prefix 2001:db8:2:2::/64 locator-node-length 24 function-length 16 behavior END_DT6
  $ gobgp global rib -a ipv6-flowspec
     Network                        Next Hop             AS_PATH              Age        Attrs
  *> [destination: 2001:db8::/64/0] fictitious                                00:00:21   [{Origin: ?} {Extcomms: [100]} {Extcomms: [redirect: fd00:1::1:0]} {Prefix SID attributes: {SRv6 L3 Service Attribute: {SRv6 Information Sub TLV: SID: 2001:db8:2:2:: Flag: 0 Endpoint Behavior: 18 {SRv6 Structure Sub Sub TLV: [ Locator Block Length: 64, Locator Node Length: 24, Function Length: 16, Argument Length: 0, Transposition Length: 0, Transposition Offset: 0] } } } }]
  ```

  - Option 2: [section-5 Fig3](https://www.ietf.org/archive/id/draft-ietf-idr-ts-flowspec-srv6-policy-05.html#section-5)
  ```
  $ gobgp global rib -a ipv6-flowspec add match destination 2001:db8::/64 then redirect fd00:1::1:0 color 100
  $ gobgp global rib -a ipv6-flowspec
     Network                        Next Hop             AS_PATH              Age        Attrs
  *> [destination: 2001:db8::/64/0] fictitious                                00:00:02   [{Origin: ?} {Extcomms: [100]} {Extcomms: [redirect: fd00:1::1:0]}]
  ```