### PR TITLE
bgp: turn RouteFamily into uint32

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -9947,7 +9947,7 @@ func RouteFamilyToAfiSafi(rf RouteFamily) (uint16, uint8) {
 	return uint16(int(rf) >> 16), uint8(int(rf) & 0xff)
 }
 
-type RouteFamily int
+type RouteFamily uint32
 
 func (f RouteFamily) String() string {
 	if n, y := AddressFamilyNameMap[f]; y {


### PR DESCRIPTION
1. On 64-bit platform, it takes less space to store an uint32 because an int is equivalent to int64. An uint32 is enough as AFI is 16-bit and SAFI is 8-bit.

2. On 32-bit platform, int is int32 and it is not big enough to encode all route families, notably the ones with AFI > 2**15. At runtime, this is not a problem, however, at compile time, we get an error.