### PR TITLE
rename RouteFamily to Family

### DIFF
--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -389,7 +389,7 @@ func parseExtendedCommunities(args []string) ([]bgp.ExtendedCommunityInterface, 
 	return exts, nil
 }
 
-func parseFlowSpecArgs(rf bgp.RouteFamily, args []string) (bgp.AddrPrefixInterface, *bgp.PathAttributePrefixSID, []string, error) {
+func parseFlowSpecArgs(rf bgp.Family, args []string) (bgp.AddrPrefixInterface, *bgp.PathAttributePrefixSID, []string, error) {
 	// Format:
 	// match <rule>... [then <action>...] [rd <rd>] [rt <rt>...]
 	// or
@@ -1836,8 +1836,8 @@ func extractAsPath(args []string) ([]string, bgp.PathAttributeInterface, error) 
 	return args, nil, nil
 }
 
-func extractNexthop(rf bgp.RouteFamily, args []string) ([]string, string, error) {
-	afi, _ := bgp.RouteFamilyToAfiSafi(rf)
+func extractNexthop(rf bgp.Family, args []string) ([]string, string, error) {
+	afi, _ := bgp.FamilyToAfiSafi(rf)
 	nexthop := "0.0.0.0"
 	if afi == bgp.AFI_IP6 {
 		nexthop = "::"
@@ -1981,7 +1981,7 @@ func extractAggregator(args []string) ([]string, bgp.PathAttributeInterface, err
 	return args, nil, nil
 }
 
-func parsePath(rf bgp.RouteFamily, args []string) (*api.Path, error) {
+func parsePath(rf bgp.Family, args []string) (*api.Path, error) {
 	var nlri bgp.AddrPrefixInterface
 	var extcomms []string
 	var psid *bgp.PathAttributePrefixSID
@@ -2210,7 +2210,7 @@ func modPath(resource string, name, modtype string, args []string) error {
 	if err != nil {
 		return err
 	}
-	rf := apiutil.ToRouteFamily(f)
+	rf := apiutil.ToFamily(f)
 	path, err := parsePath(rf, args)
 	if err != nil {
 		cmdstr := "global"
@@ -2238,7 +2238,7 @@ func modPath(resource string, name, modtype string, args []string) error {
 		sort.SliceStable(ss, func(i, j int) bool { return ss[i] < ss[j] })
 		ss = append(ss, "<DEC_NUM>")
 		etherTypes := strings.Join(ss, ", ")
-		helpErrMap := map[bgp.RouteFamily]error{}
+		helpErrMap := map[bgp.Family]error{}
 		baseHelpMsgFmt := fmt.Sprintf(`error: %s
 usage: %s rib -a %%s %s <PREFIX> %%s [origin { igp | egp | incomplete }] [aspath <ASPATH>] [nexthop <ADDRESS>] [med <NUM>] [local-pref <NUM>] [community <COMMUNITY>] [aigp metric <NUM>] [large-community <LARGE_COMMUNITY>] [aggregator <AGGREGATOR>]
     <ASPATH>: <AS>[,<AS>],

--- a/cmd/gobgp/global_test.go
+++ b/cmd/gobgp/global_test.go
@@ -69,7 +69,7 @@ func Test_ParseEvpnPath(t *testing.T) {
 func Test_ParseFlowSpecPath(t *testing.T) {
 	var tests = []struct {
 		name        string
-		rf          bgp.RouteFamily
+		rf          bgp.Family
 		path        string
 		expectedErr bool
 	}{

--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -383,7 +383,7 @@ func showNeighbor(args []string) error {
 					str += "\n"
 				}
 				for _, t := range g.Tuples {
-					str += fmt.Sprintf("	    %s", bgp.AfiSafiToRouteFamily(t.AFI, t.SAFI))
+					str += fmt.Sprintf("	    %s", bgp.AfiSafiToFamily(t.AFI, t.SAFI))
 					if t.Flags == 0x80 {
 						str += ", forward flag set"
 					}
@@ -408,7 +408,7 @@ func showNeighbor(args []string) error {
 			grStr := func(g *bgp.CapLongLivedGracefulRestart) string {
 				var str string
 				for _, t := range g.Tuples {
-					str += fmt.Sprintf("	    %s, restart time %d sec", bgp.AfiSafiToRouteFamily(t.AFI, t.SAFI), t.RestartTime)
+					str += fmt.Sprintf("	    %s, restart time %d sec", bgp.AfiSafiToFamily(t.AFI, t.SAFI), t.RestartTime)
 					if t.Flags == 0x80 {
 						str += ", forward flag set"
 					}
@@ -442,7 +442,7 @@ func showNeighbor(args []string) error {
 					default:
 						nhafi = fmt.Sprintf("%d", t.NexthopAFI)
 					}
-					line := fmt.Sprintf("nlri: %s, nexthop: %s", bgp.AfiSafiToRouteFamily(t.NLRIAFI, uint8(t.NLRISAFI)), nhafi)
+					line := fmt.Sprintf("nlri: %s, nexthop: %s", bgp.AfiSafiToFamily(t.NLRIAFI, uint8(t.NLRISAFI)), nhafi)
 					lines = append(lines, line)
 				}
 				return strings.Join(lines, "\n")
@@ -464,13 +464,13 @@ func showNeighbor(args []string) error {
 			if m := lookup(c, lcaps); m != nil {
 				fmt.Println("      Local:")
 				for _, item := range m.(*bgp.CapAddPath).Tuples {
-					fmt.Printf("         %s:\t%s\n", item.RouteFamily, item.Mode)
+					fmt.Printf("         %s:\t%s\n", item.Family, item.Mode)
 				}
 			}
 			if m := lookup(c, rcaps); m != nil {
 				fmt.Println("      Remote:")
 				for _, item := range m.(*bgp.CapAddPath).Tuples {
-					fmt.Printf("         %s:\t%s\n", item.RouteFamily, item.Mode)
+					fmt.Printf("         %s:\t%s\n", item.Family, item.Mode)
 				}
 			}
 		case bgp.BGP_CAP_FQDN:
@@ -522,7 +522,7 @@ func showNeighbor(args []string) error {
 				fmt.Println("  Prefix Limits:")
 				first = false
 			}
-			rf := apiutil.ToRouteFamily(limit.Family)
+			rf := apiutil.ToFamily(limit.Family)
 			fmt.Printf("    %s:\tMaximum prefixes allowed %d", bgp.AddressFamilyNameMap[rf], limit.MaxPrefixes)
 			if limit.ShutdownThresholdPct > 0 {
 				fmt.Printf(", Threshold for warning message %d%%\n", limit.ShutdownThresholdPct)
@@ -878,7 +878,7 @@ func showNeighborRib(r string, name string, args []string) error {
 	if err != nil {
 		return err
 	}
-	rf := apiutil.ToRouteFamily(family)
+	rf := apiutil.ToFamily(family)
 	switch rf {
 	case bgp.RF_IPv4_MPLS, bgp.RF_IPv6_MPLS, bgp.RF_IPv4_VPN, bgp.RF_IPv6_VPN, bgp.RF_EVPN:
 		showLabel = true
@@ -1360,11 +1360,11 @@ func modNeighbor(cmdType string, args []string) error {
 		if len(m["family"]) == 1 {
 			peer.AfiSafis = make([]*api.AfiSafi, 0) // for the case of cmdUpdate
 			for _, f := range strings.Split(m["family"][0], ",") {
-				rf, err := bgp.GetRouteFamily(f)
+				rf, err := bgp.GetFamily(f)
 				if err != nil {
 					return err
 				}
-				afi, safi := bgp.RouteFamilyToAfiSafi(rf)
+				afi, safi := bgp.FamilyToAfiSafi(rf)
 				peer.AfiSafis = append(peer.AfiSafis, &api.AfiSafi{Config: &api.AfiSafiConfig{Family: apiutil.ToApiFamily(afi, safi)}})
 			}
 		}

--- a/cmd/gobgp/policy.go
+++ b/cmd/gobgp/policy.go
@@ -811,7 +811,7 @@ func modCondition(name, op string, args []string) error {
 	case "afi-safi-in":
 		afiSafisInList := make([]*api.Family, 0, len(args))
 		for _, arg := range args {
-			afi, safi := bgp.RouteFamilyToAfiSafi(bgp.AddressFamilyValueMap[arg])
+			afi, safi := bgp.FamilyToAfiSafi(bgp.AddressFamilyValueMap[arg])
 			afiSafisInList = append(afiSafisInList, apiutil.ToApiFamily(afi, safi))
 		}
 		stmt.Conditions.AfiSafiIn = afiSafisInList

--- a/internal/pkg/table/adj_test.go
+++ b/internal/pkg/table/adj_test.go
@@ -34,13 +34,13 @@ func TestAddPath(t *testing.T) {
 	nlri2 := bgp.NewIPAddrPrefix(24, "20.20.20.0")
 	nlri2.SetPathIdentifier(2)
 	p2 := NewPath(pi, nlri2, false, attrs, time.Now(), false)
-	family := p1.GetRouteFamily()
-	families := []bgp.RouteFamily{family}
+	family := p1.GetFamily()
+	families := []bgp.Family{family}
 
 	adj := NewAdjRib(logger, families)
 	adj.Update([]*Path{p1, p2})
 	assert.Equal(t, len(adj.table[family].destinations), 1)
-	assert.Equal(t, adj.Count([]bgp.RouteFamily{family}), 2)
+	assert.Equal(t, adj.Count([]bgp.Family{family}), 2)
 
 	p3 := NewPath(pi, nlri2, false, attrs, time.Now(), false)
 	adj.Update([]*Path{p3})
@@ -56,7 +56,7 @@ func TestAddPath(t *testing.T) {
 	}
 	assert.Equal(t, found, p3)
 	adj.Update([]*Path{p3.Clone(true)})
-	assert.Equal(t, adj.Count([]bgp.RouteFamily{family}), 1)
+	assert.Equal(t, adj.Count([]bgp.Family{family}), 1)
 	adj.Update([]*Path{p1.Clone(true)})
 	assert.Equal(t, 0, len(adj.table[family].destinations))
 }
@@ -81,13 +81,13 @@ func TestAddPathAdjOut(t *testing.T) {
 	nlri4.SetPathIdentifier(3)
 	nlri4.SetPathLocalIdentifier(4)
 	p4 := NewPath(pi, nlri4, false, attrs, time.Now(), false)
-	family := p1.GetRouteFamily()
-	families := []bgp.RouteFamily{family}
+	family := p1.GetFamily()
+	families := []bgp.Family{family}
 
 	adj := NewAdjRib(logger, families)
 	adj.UpdateAdjRibOut([]*Path{p1, p2, p3, p4})
 	assert.Equal(t, len(adj.table[family].destinations), 1)
-	assert.Equal(t, adj.Count([]bgp.RouteFamily{family}), 4)
+	assert.Equal(t, adj.Count([]bgp.Family{family}), 4)
 }
 
 func TestStale(t *testing.T) {
@@ -100,19 +100,19 @@ func TestStale(t *testing.T) {
 	p2 := NewPath(pi, nlri2, false, attrs, time.Now(), false)
 	p2.SetRejected(true)
 
-	family := p1.GetRouteFamily()
-	families := []bgp.RouteFamily{family}
+	family := p1.GetFamily()
+	families := []bgp.Family{family}
 
 	adj := NewAdjRib(logger, families)
 	adj.Update([]*Path{p1, p2})
-	assert.Equal(t, adj.Count([]bgp.RouteFamily{family}), 2)
-	assert.Equal(t, adj.Accepted([]bgp.RouteFamily{family}), 1)
+	assert.Equal(t, adj.Count([]bgp.Family{family}), 2)
+	assert.Equal(t, adj.Accepted([]bgp.Family{family}), 1)
 
 	stalePathList := adj.StaleAll(families)
 	// As looped path should not be returned
 	assert.Equal(t, 1, len(stalePathList))
 
-	for _, p := range adj.PathList([]bgp.RouteFamily{family}, false) {
+	for _, p := range adj.PathList([]bgp.Family{family}, false) {
 		assert.True(t, p.IsStale())
 	}
 
@@ -122,7 +122,7 @@ func TestStale(t *testing.T) {
 
 	droppedPathList := adj.DropStale(families)
 	assert.Equal(t, 2, len(droppedPathList))
-	assert.Equal(t, adj.Count([]bgp.RouteFamily{family}), 1)
+	assert.Equal(t, adj.Count([]bgp.Family{family}), 1)
 	assert.Equal(t, 1, len(adj.table[family].destinations))
 }
 
@@ -148,17 +148,17 @@ func TestLLGRStale(t *testing.T) {
 	// dropped on MarkLLGRStaleOrDrop
 	p4.SetCommunities([]uint32{uint32(bgp.COMMUNITY_NO_LLGR)}, false)
 
-	family := p1.GetRouteFamily()
-	families := []bgp.RouteFamily{family}
+	family := p1.GetFamily()
+	families := []bgp.Family{family}
 
 	adj := NewAdjRib(logger, families)
 	adj.Update([]*Path{p1, p2, p3, p4})
-	assert.Equal(t, adj.Count([]bgp.RouteFamily{family}), 4)
-	assert.Equal(t, adj.Accepted([]bgp.RouteFamily{family}), 2)
+	assert.Equal(t, adj.Count([]bgp.Family{family}), 4)
+	assert.Equal(t, adj.Accepted([]bgp.Family{family}), 2)
 
 	pathList := adj.MarkLLGRStaleOrDrop(families)
 	assert.Equal(t, 3, len(pathList)) // Does not return aslooped path that is retained in adjrib
-	assert.Equal(t, adj.Count([]bgp.RouteFamily{family}), 2)
-	assert.Equal(t, adj.Accepted([]bgp.RouteFamily{family}), 1)
+	assert.Equal(t, adj.Count([]bgp.Family{family}), 2)
+	assert.Equal(t, adj.Accepted([]bgp.Family{family}), 1)
 	assert.Equal(t, 2, len(adj.table[family].destinations))
 }

--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -135,7 +135,7 @@ func NewPeerInfo(g *oc.Global, p *oc.Neighbor) *PeerInfo {
 }
 
 type Destination struct {
-	routeFamily   bgp.RouteFamily
+	family        bgp.Family
 	nlri          bgp.AddrPrefixInterface
 	knownPathList []*Path
 	localIdMap    *Bitmap
@@ -143,7 +143,7 @@ type Destination struct {
 
 func NewDestination(nlri bgp.AddrPrefixInterface, mapSize int, known ...*Path) *Destination {
 	d := &Destination{
-		routeFamily:   bgp.AfiSafiToRouteFamily(nlri.AFI(), nlri.SAFI()),
+		family:        bgp.AfiSafiToFamily(nlri.AFI(), nlri.SAFI()),
 		nlri:          nlri,
 		knownPathList: known,
 		localIdMap:    NewBitmap(mapSize),
@@ -155,12 +155,12 @@ func NewDestination(nlri bgp.AddrPrefixInterface, mapSize int, known ...*Path) *
 	return d
 }
 
-func (dd *Destination) Family() bgp.RouteFamily {
-	return dd.routeFamily
+func (dd *Destination) Family() bgp.Family {
+	return dd.family
 }
 
-func (dd *Destination) setRouteFamily(routeFamily bgp.RouteFamily) {
-	dd.routeFamily = routeFamily
+func (dd *Destination) setFamily(Family bgp.Family) {
+	dd.family = Family
 }
 
 func (dd *Destination) GetNlri() bgp.AddrPrefixInterface {
@@ -532,7 +532,7 @@ func (u *Update) GetChanges(id string, as uint32, peerDown bool) (*Path, *Path, 
 			// peers, it is necessary to consider all available iBGP paths for a
 			// given RT prefix, for building the outbound route filter, and not just
 			// the best path.
-			if best.GetRouteFamily() == bgp.RF_RTC_UC {
+			if best.GetFamily() == bgp.RF_RTC_UC {
 				return best, old
 			}
 			// For BGP Nexthop Tracking, checks if the nexthop reachability

--- a/internal/pkg/table/destination_test.go
+++ b/internal/pkg/table/destination_test.go
@@ -40,15 +40,15 @@ func TestDestinationNewIPv6(t *testing.T) {
 	assert.NotNil(t, ipv6d)
 }
 
-func TestDestinationSetRouteFamily(t *testing.T) {
+func TestDestinationSetFamily(t *testing.T) {
 	dd := &Destination{}
-	dd.setRouteFamily(bgp.RF_IPv4_UC)
+	dd.setFamily(bgp.RF_IPv4_UC)
 	rf := dd.Family()
 	assert.Equal(t, rf, bgp.RF_IPv4_UC)
 }
-func TestDestinationGetRouteFamily(t *testing.T) {
+func TestDestinationGetFamily(t *testing.T) {
 	dd := &Destination{}
-	dd.setRouteFamily(bgp.RF_IPv6_UC)
+	dd.setFamily(bgp.RF_IPv6_UC)
 	rf := dd.Family()
 	assert.Equal(t, rf, bgp.RF_IPv6_UC)
 }

--- a/internal/pkg/table/message.go
+++ b/internal/pkg/table/message.go
@@ -282,7 +282,7 @@ type packerInterface interface {
 
 type packer struct {
 	eof    bool
-	family bgp.RouteFamily
+	family bgp.Family
 	total  uint32
 }
 
@@ -339,7 +339,7 @@ func (p *packerMP) pack(options ...*bgp.MarshallingOption) []*bgp.BGPMessage {
 	return msgs
 }
 
-func newPackerMP(f bgp.RouteFamily) *packerMP {
+func newPackerMP(f bgp.Family) *packerMP {
 	return &packerMP{
 		packer: packer{
 			family: f,
@@ -482,7 +482,7 @@ func (p *packerV4) pack(options ...*bgp.MarshallingOption) []*bgp.BGPMessage {
 	return msgs
 }
 
-func newPackerV4(f bgp.RouteFamily) *packerV4 {
+func newPackerV4(f bgp.Family) *packerV4 {
 	return &packerV4{
 		packer: packer{
 			family: f,
@@ -493,7 +493,7 @@ func newPackerV4(f bgp.RouteFamily) *packerV4 {
 	}
 }
 
-func newPacker(f bgp.RouteFamily) packerInterface {
+func newPacker(f bgp.Family) packerInterface {
 	switch f {
 	case bgp.RF_IPv4_UC:
 		return newPackerV4(bgp.RF_IPv4_UC)
@@ -505,9 +505,9 @@ func newPacker(f bgp.RouteFamily) packerInterface {
 func CreateUpdateMsgFromPaths(pathList []*Path, options ...*bgp.MarshallingOption) []*bgp.BGPMessage {
 	msgs := make([]*bgp.BGPMessage, 0, len(pathList))
 
-	m := make(map[bgp.RouteFamily]packerInterface)
+	m := make(map[bgp.Family]packerInterface)
 	for _, path := range pathList {
-		f := path.GetRouteFamily()
+		f := path.GetFamily()
 		if _, y := m[f]; !y {
 			m[f] = newPacker(f)
 		}

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -152,7 +152,7 @@ const (
 )
 
 type PathDestLocalKey struct {
-	Family bgp.RouteFamily
+	Family bgp.Family
 	Prefix string
 }
 type PathLocalKey struct {
@@ -160,7 +160,7 @@ type PathLocalKey struct {
 	Id uint32
 }
 
-func NewPathDestLocalKey(f bgp.RouteFamily, destPrefix string) *PathDestLocalKey {
+func NewPathDestLocalKey(f bgp.Family, destPrefix string) *PathDestLocalKey {
 	return &PathDestLocalKey{
 		Family: f,
 		Prefix: destPrefix,
@@ -189,9 +189,9 @@ func NewPath(source *PeerInfo, nlri bgp.AddrPrefixInterface, isWithdraw bool, pa
 	}
 }
 
-func NewEOR(family bgp.RouteFamily) *Path {
-	afi, safi := bgp.RouteFamilyToAfiSafi(family)
-	nlri, _ := bgp.NewPrefixFromRouteFamily(afi, safi)
+func NewEOR(family bgp.Family) *Path {
+	afi, safi := bgp.FamilyToAfiSafi(family)
+	nlri, _ := bgp.NewPrefixFromFamily(afi, safi)
 	return &Path{
 		info: &originInfo{
 			nlri: nlri,
@@ -298,7 +298,7 @@ func UpdatePathAttrs(logger log.Logger, global *oc.Global, peer *oc.Neighbor, in
 			// the Originator attribute shall be set to the router-id of the
 			// advertiser, and the Next-hop attribute shall be set of the local
 			// address for that session.
-			if path.GetRouteFamily() == bgp.RF_RTC_UC {
+			if path.GetFamily() == bgp.RF_RTC_UC {
 				path.SetNexthop(localAddress)
 				path.setPathAttr(bgp.NewPathAttributeOriginatorId(info.LocalID.String()))
 			} else if path.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGINATOR_ID) == nil {
@@ -384,8 +384,8 @@ func (path *Path) SetIsFromExternal(y bool) {
 	path.OriginInfo().isFromExternal = y
 }
 
-func (path *Path) GetRouteFamily() bgp.RouteFamily {
-	return bgp.AfiSafiToRouteFamily(path.OriginInfo().nlri.AFI(), path.OriginInfo().nlri.SAFI())
+func (path *Path) GetFamily() bgp.Family {
+	return bgp.AfiSafiToFamily(path.OriginInfo().nlri.AFI(), path.OriginInfo().nlri.SAFI())
 }
 
 func (path *Path) GetSource() *PeerInfo {
@@ -463,7 +463,7 @@ func (path *Path) GetNexthop() net.IP {
 }
 
 func (path *Path) SetNexthop(nexthop net.IP) {
-	if path.GetRouteFamily() == bgp.RF_IPv4_UC && nexthop.To4() == nil {
+	if path.GetFamily() == bgp.RF_IPv4_UC && nexthop.To4() == nil {
 		path.delPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
 		mpreach := bgp.NewPathAttributeMpReachNLRI(nexthop.String(), []bgp.AddrPrefixInterface{path.GetNlri()})
 		path.setPathAttr(mpreach)
@@ -587,7 +587,7 @@ func (path *Path) delPathAttr(typ bgp.BGPAttrType) {
 func (path *Path) String() string {
 	s := bytes.NewBuffer(make([]byte, 0, 64))
 	if path.IsEOR() {
-		s.WriteString(fmt.Sprintf("{ %s EOR | src: %s }", path.GetRouteFamily(), path.GetSource()))
+		s.WriteString(fmt.Sprintf("{ %s EOR | src: %s }", path.GetFamily(), path.GetSource()))
 		return s.String()
 	}
 	s.WriteString(fmt.Sprintf("{ %s | ", path.GetPrefix()))
@@ -614,7 +614,7 @@ func (path *Path) GetLocalKey() PathLocalKey {
 // GetDestLocalKey identifies the path destination in the local BGP server.
 func (path *Path) GetDestLocalKey() PathDestLocalKey {
 	return PathDestLocalKey{
-		Family: path.GetRouteFamily(),
+		Family: path.GetFamily(),
 		Prefix: path.GetNlri().String(),
 	}
 }
@@ -1115,7 +1115,7 @@ func (lhs *Path) Compare(rhs *Path) int {
 
 func (v *Vrf) ToGlobalPath(path *Path) error {
 	nlri := path.GetNlri()
-	switch rf := path.GetRouteFamily(); rf {
+	switch rf := path.GetFamily(); rf {
 	case bgp.RF_IPv4_UC:
 		n := nlri.(*bgp.IPAddrPrefix)
 		pathIdentifier := path.GetNlri().PathIdentifier()
@@ -1167,7 +1167,7 @@ func (p *Path) ToGlobal(vrf *Vrf) *Path {
 	nlri := p.GetNlri()
 	nh := p.GetNexthop()
 	pathId := nlri.PathIdentifier()
-	switch rf := p.GetRouteFamily(); rf {
+	switch rf := p.GetFamily(); rf {
 	case bgp.RF_IPv4_UC:
 		n := nlri.(*bgp.IPAddrPrefix)
 		nlri = bgp.NewLabeledVPNIPAddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(vrf.MplsLabel), vrf.Rd)
@@ -1230,7 +1230,7 @@ func (p *Path) ToGlobal(vrf *Vrf) *Path {
 
 func (p *Path) ToLocal() *Path {
 	nlri := p.GetNlri()
-	f := p.GetRouteFamily()
+	f := p.GetFamily()
 	localPathId := nlri.PathLocalIdentifier()
 	pathId := nlri.PathIdentifier()
 	switch f {

--- a/internal/pkg/table/roa.go
+++ b/internal/pkg/table/roa.go
@@ -69,12 +69,12 @@ func (r *roaBucket) GetEntries() []*ROA {
 }
 
 type ROATable struct {
-	trees  map[bgp.RouteFamily]*critbitgo.Net
+	trees  map[bgp.Family]*critbitgo.Net
 	logger log.Logger
 }
 
 func NewROATable(logger log.Logger) *ROATable {
-	m := make(map[bgp.RouteFamily]*critbitgo.Net)
+	m := make(map[bgp.Family]*critbitgo.Net)
 	m[bgp.RF_IPv4_UC] = critbitgo.NewNet()
 	m[bgp.RF_IPv6_UC] = critbitgo.NewNet()
 	return &ROATable{
@@ -179,7 +179,7 @@ func (rt *ROATable) Validate(path *Path) *Validation {
 		// RPKI isn't enabled or invalid path
 		return nil
 	}
-	tree, ok := rt.trees[path.GetRouteFamily()]
+	tree, ok := rt.trees[path.GetFamily()]
 	if !ok {
 		return nil
 	}
@@ -251,7 +251,7 @@ func (rt *ROATable) Validate(path *Path) *Validation {
 	return validation
 }
 
-func (rt *ROATable) Info(family bgp.RouteFamily) (map[string]uint32, map[string]uint32) {
+func (rt *ROATable) Info(family bgp.Family) (map[string]uint32, map[string]uint32) {
 	records := make(map[string]uint32)
 	prefixes := make(map[string]uint32)
 
@@ -275,15 +275,15 @@ func (rt *ROATable) Info(family bgp.RouteFamily) (map[string]uint32, map[string]
 	return records, prefixes
 }
 
-func (rt *ROATable) List(family bgp.RouteFamily) ([]*ROA, error) {
-	var rfList []bgp.RouteFamily
+func (rt *ROATable) List(family bgp.Family) ([]*ROA, error) {
+	var rfList []bgp.Family
 	switch family {
 	case bgp.RF_IPv4_UC:
-		rfList = []bgp.RouteFamily{bgp.RF_IPv4_UC}
+		rfList = []bgp.Family{bgp.RF_IPv4_UC}
 	case bgp.RF_IPv6_UC:
-		rfList = []bgp.RouteFamily{bgp.RF_IPv6_UC}
+		rfList = []bgp.Family{bgp.RF_IPv6_UC}
 	default:
-		rfList = []bgp.RouteFamily{bgp.RF_IPv4_UC, bgp.RF_IPv6_UC}
+		rfList = []bgp.Family{bgp.RF_IPv4_UC, bgp.RF_IPv6_UC}
 	}
 	l := make([]*ROA, 0)
 	for _, rf := range rfList {

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -54,7 +54,7 @@ type TableSelectOption struct {
 }
 
 type Table struct {
-	routeFamily  bgp.RouteFamily
+	Family       bgp.Family
 	destinations map[string]*Destination
 	logger       log.Logger
 	// index of evpn prefixes with paths to a specific MAC in a MAC-VRF
@@ -63,9 +63,9 @@ type Table struct {
 	macIndex map[string]map[string]struct{}
 }
 
-func NewTable(logger log.Logger, rf bgp.RouteFamily, dsts ...*Destination) *Table {
+func NewTable(logger log.Logger, rf bgp.Family, dsts ...*Destination) *Table {
 	t := &Table{
-		routeFamily:  rf,
+		Family:       rf,
 		destinations: make(map[string]*Destination),
 		logger:       logger,
 		macIndex:     make(map[string]map[string]struct{}),
@@ -76,8 +76,8 @@ func NewTable(logger log.Logger, rf bgp.RouteFamily, dsts ...*Destination) *Tabl
 	return t
 }
 
-func (t *Table) GetRoutefamily() bgp.RouteFamily {
-	return t.routeFamily
+func (t *Table) GetFamily() bgp.Family {
+	return t.Family
 }
 
 func (t *Table) deletePathsByVrf(vrf *Vrf) []*Path {
@@ -109,7 +109,7 @@ func (t *Table) deletePathsByVrf(vrf *Vrf) []*Path {
 
 func (t *Table) deleteRTCPathsByVrf(vrf *Vrf, vrfs map[string]*Vrf) []*Path {
 	pathList := make([]*Path, 0)
-	if t.routeFamily != bgp.RF_RTC_UC {
+	if t.Family != bgp.RF_RTC_UC {
 		return pathList
 	}
 	for _, target := range vrf.ImportRt {
@@ -166,15 +166,15 @@ func (t *Table) validatePath(path *Path) {
 		t.logger.Error("path is nil",
 			log.Fields{
 				"Topic": "Table",
-				"Key":   t.routeFamily})
+				"Key":   t.Family})
 	}
-	if path.GetRouteFamily() != t.routeFamily {
-		t.logger.Error("Invalid path. RouteFamily mismatch",
+	if path.GetFamily() != t.Family {
+		t.logger.Error("Invalid path. Family mismatch",
 			log.Fields{
 				"Topic":      "Table",
-				"Key":        t.routeFamily,
+				"Key":        t.Family,
 				"Prefix":     path.GetPrefix(),
-				"ReceivedRf": path.GetRouteFamily().String()})
+				"ReceivedRf": path.GetFamily().String()})
 	}
 	if attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_AS_PATH); attr != nil {
 		pathParam := attr.(*bgp.PathAttributeAsPath).Value
@@ -184,7 +184,7 @@ func (t *Table) validatePath(path *Path) {
 				t.logger.Fatal("AsPathParam must be converted to As4PathParam",
 					log.Fields{
 						"Topic": "Table",
-						"Key":   t.routeFamily,
+						"Key":   t.Family,
 						"As":    as})
 			}
 		}
@@ -193,13 +193,13 @@ func (t *Table) validatePath(path *Path) {
 		t.logger.Fatal("AS4_PATH must be converted to AS_PATH",
 			log.Fields{
 				"Topic": "Table",
-				"Key":   t.routeFamily})
+				"Key":   t.Family})
 	}
 	if path.GetNlri() == nil {
 		t.logger.Fatal("path's nlri is nil",
 			log.Fields{
 				"Topic": "Table",
-				"Key":   t.routeFamily})
+				"Key":   t.Family})
 	}
 }
 
@@ -260,7 +260,7 @@ func (t *Table) GetDestination(nlri bgp.AddrPrefixInterface) *Destination {
 
 func (t *Table) GetLongerPrefixDestinations(key string) ([]*Destination, error) {
 	results := make([]*Destination, 0, len(t.GetDestinations()))
-	switch t.routeFamily {
+	switch t.Family {
 	case bgp.RF_IPv4_UC, bgp.RF_IPv6_UC, bgp.RF_IPv4_MPLS, bgp.RF_IPv6_MPLS:
 		_, prefix, err := net.ParseCIDR(key)
 		if err != nil {
@@ -304,7 +304,7 @@ func (t *Table) GetLongerPrefixDestinations(key string) ([]*Destination, error) 
 		r := critbitgo.NewNet()
 		for _, dst := range t.GetDestinations() {
 			var dstRD bgp.RouteDistinguisherInterface
-			switch t.routeFamily {
+			switch t.Family {
 			case bgp.RF_IPv4_VPN:
 				dstRD = dst.nlri.(*bgp.LabeledVPNIPAddrPrefix).RD
 			case bgp.RF_IPv6_VPN:
@@ -368,7 +368,7 @@ func (t *Table) GetEvpnDestinationsWithRouteType(typ string) ([]*Destination, er
 	}
 	destinations := t.GetDestinations()
 	results := make([]*Destination, 0, len(destinations))
-	switch t.routeFamily {
+	switch t.Family {
 	case bgp.RF_EVPN:
 		for _, dst := range destinations {
 			if nlri, ok := dst.nlri.(*bgp.EVPNNLRI); !ok {
@@ -401,7 +401,7 @@ func (t *Table) GetMUPDestinationsWithRouteType(p string) ([]*Destination, error
 	}
 	destinations := t.GetDestinations()
 	results := make([]*Destination, 0, len(destinations))
-	switch t.routeFamily {
+	switch t.Family {
 	case bgp.RF_MUP_IPv4, bgp.RF_MUP_IPv6:
 		for _, dst := range destinations {
 			if nlri, ok := dst.nlri.(*bgp.MUPNLRI); !ok {
@@ -544,21 +544,21 @@ func (t *Table) Select(option ...TableSelectOption) (*Table, error) {
 	}
 	dOption := DestinationSelectOption{ID: id, AS: as, VRF: vrf, adj: adj, Best: best, MultiPath: mp}
 	r := &Table{
-		routeFamily:  t.routeFamily,
+		Family:       t.Family,
 		destinations: make(map[string]*Destination),
 		macIndex:     make(map[string]map[string]struct{}),
 	}
 
 	if len(prefixes) != 0 {
-		switch t.routeFamily {
+		switch t.Family {
 		case bgp.RF_IPv4_UC, bgp.RF_IPv6_UC:
 			f := func(prefixStr string) (bool, error) {
 				var nlri bgp.AddrPrefixInterface
 				var err error
-				if t.routeFamily == bgp.RF_IPv4_UC {
-					nlri, err = bgp.NewPrefixFromRouteFamily(bgp.AFI_IP, bgp.SAFI_UNICAST, prefixStr)
+				if t.Family == bgp.RF_IPv4_UC {
+					nlri, err = bgp.NewPrefixFromFamily(bgp.AFI_IP, bgp.SAFI_UNICAST, prefixStr)
 				} else {
-					nlri, err = bgp.NewPrefixFromRouteFamily(bgp.AFI_IP6, bgp.SAFI_UNICAST, prefixStr)
+					nlri, err = bgp.NewPrefixFromFamily(bgp.AFI_IP6, bgp.SAFI_UNICAST, prefixStr)
 				}
 				if err != nil {
 					return false, err
@@ -598,7 +598,7 @@ func (t *Table) Select(option ...TableSelectOption) (*Table, error) {
 				default:
 					if host := net.ParseIP(key); host != nil {
 						masklen := 32
-						if t.routeFamily == bgp.RF_IPv6_UC {
+						if t.Family == bgp.RF_IPv6_UC {
 							masklen = 128
 						}
 						for i := masklen; i >= 0; i-- {
@@ -624,10 +624,10 @@ func (t *Table) Select(option ...TableSelectOption) (*Table, error) {
 				var nlri bgp.AddrPrefixInterface
 				var err error
 
-				if t.routeFamily == bgp.RF_IPv4_VPN {
-					nlri, err = bgp.NewPrefixFromRouteFamily(bgp.AFI_IP, bgp.SAFI_MPLS_VPN, prefixStr)
+				if t.Family == bgp.RF_IPv4_VPN {
+					nlri, err = bgp.NewPrefixFromFamily(bgp.AFI_IP, bgp.SAFI_MPLS_VPN, prefixStr)
 				} else {
-					nlri, err = bgp.NewPrefixFromRouteFamily(bgp.AFI_IP6, bgp.SAFI_MPLS_VPN, prefixStr)
+					nlri, err = bgp.NewPrefixFromFamily(bgp.AFI_IP6, bgp.SAFI_MPLS_VPN, prefixStr)
 				}
 				if err != nil {
 					return fmt.Errorf("failed to create prefix: %w", err)

--- a/internal/pkg/table/table_manager_test.go
+++ b/internal/pkg/table/table_manager_test.go
@@ -78,7 +78,7 @@ func peerR3() *PeerInfo {
 // test best path calculation and check the result path is from R1
 func TestProcessBGPUpdate_0_select_onlypath_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 
 	bgpMessage := update_fromR1()
 	peer := peerR1()
@@ -89,7 +89,7 @@ func TestProcessBGPUpdate_0_select_onlypath_ipv4(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv4_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv4_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage.Body.(*bgp.BGPUpdate).PathAttributes
@@ -128,7 +128,7 @@ func TestProcessBGPUpdate_0_select_onlypath_ipv4(t *testing.T) {
 // test best path calculation and check the result path is from R1
 func TestProcessBGPUpdate_0_select_onlypath_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv6_UC})
 
 	bgpMessage := update_fromR1_ipv6()
 	peer := peerR1()
@@ -139,7 +139,7 @@ func TestProcessBGPUpdate_0_select_onlypath_ipv6(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv6_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv6_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage.Body.(*bgp.BGPUpdate).PathAttributes
@@ -179,7 +179,7 @@ func TestProcessBGPUpdate_0_select_onlypath_ipv6(t *testing.T) {
 // test: compare localpref
 func TestProcessBGPUpdate_1_select_high_localpref_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 
 	// low localpref message
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -221,7 +221,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv4(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv4_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv4_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -259,7 +259,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_1_select_high_localpref_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv6_UC})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
@@ -301,7 +301,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv6(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv6_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv6_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -341,7 +341,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv6(t *testing.T) {
 // test: compare localOrigin
 func TestProcessBGPUpdate_2_select_local_origin_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 
 	// low localpref message
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -385,7 +385,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv4(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv4_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv4_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -423,7 +423,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_2_select_local_origin_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv6_UC})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
@@ -468,7 +468,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv6(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv6_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv6_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -508,7 +508,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv6(t *testing.T) {
 // test: compare AS_PATH
 func TestProcessBGPUpdate_3_select_aspath_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 
 	bgpMessage1 := update_fromR2viaR1()
 	peer1 := peerR1()
@@ -525,7 +525,7 @@ func TestProcessBGPUpdate_3_select_aspath_ipv4(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv4_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv4_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -563,7 +563,7 @@ func TestProcessBGPUpdate_3_select_aspath_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_3_select_aspath_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv6_UC})
 
 	bgpMessage1 := update_fromR2viaR1_ipv6()
 	peer1 := peerR1()
@@ -580,7 +580,7 @@ func TestProcessBGPUpdate_3_select_aspath_ipv6(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv6_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv6_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -620,7 +620,7 @@ func TestProcessBGPUpdate_3_select_aspath_ipv6(t *testing.T) {
 // test: compare Origin
 func TestProcessBGPUpdate_4_select_low_origin_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 
 	// low origin message
 	origin1 := bgp.NewPathAttributeOrigin(1)
@@ -662,7 +662,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv4(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv4_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv4_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -700,7 +700,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_4_select_low_origin_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv6_UC})
 
 	origin1 := bgp.NewPathAttributeOrigin(1)
 	aspath1 := createAsPathAttribute([]uint32{65200, 65000})
@@ -742,7 +742,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv6(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv6_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv6_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -782,7 +782,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv6(t *testing.T) {
 // test: compare MED
 func TestProcessBGPUpdate_5_select_low_med_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 
 	// low origin message
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -824,7 +824,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv4(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv4_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv4_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -862,7 +862,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_5_select_low_med_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv6_UC})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65200, 65000})
@@ -904,7 +904,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv6(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv6_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv6_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -944,7 +944,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv6(t *testing.T) {
 // test: compare AS_NUMBER(prefer eBGP path)
 func TestProcessBGPUpdate_6_select_ebgp_path_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 
 	// low origin message
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -986,7 +986,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv4(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv4_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv4_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -1024,7 +1024,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv6_UC})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000, 65200})
@@ -1066,7 +1066,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv6_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv6_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -1108,7 +1108,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 // test: compare Router ID
 func TestProcessBGPUpdate_7_select_low_routerid_path_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 	SelectionOptions.ExternalCompareRouterId = true
 
 	// low origin message
@@ -1151,7 +1151,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv4(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv4_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv4_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -1189,7 +1189,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_7_select_low_routerid_path_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv6_UC})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000, 65200})
@@ -1231,7 +1231,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv6(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv6_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv6_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -1271,7 +1271,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv6(t *testing.T) {
 // test: withdraw and mpunreach path
 func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 
 	// path1
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -1313,7 +1313,7 @@ func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv4_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv4_UC)
 
 	// check PathAttribute
 	checkPattr := func(expected *bgp.BGPMessage, actual *Path) {
@@ -1360,7 +1360,7 @@ func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 	assert.NoError(t, err)
 
 	path = pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv4_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv4_UC)
 
 	checkPattr(bgpMessage1, path)
 	// check destination
@@ -1374,7 +1374,7 @@ func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 // TODO MP_UNREACH
 func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv6_UC})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
@@ -1416,7 +1416,7 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv6_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv6_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -1487,7 +1487,7 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 	assert.NoError(t, err)
 
 	path = pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv6_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv6_UC)
 
 	checkPattr(bgpMessage1, path)
 	// check destination
@@ -1502,7 +1502,7 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 // handle bestpath lost
 func TestProcessBGPUpdate_bestpath_lost_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 
 	// path1
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -1535,7 +1535,7 @@ func TestProcessBGPUpdate_bestpath_lost_ipv4(t *testing.T) {
 
 	// check old best path
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv4_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv4_UC)
 
 	// check PathAttribute
 	checkPattr := func(expected *bgp.BGPMessage, actual *Path) {
@@ -1572,7 +1572,7 @@ func TestProcessBGPUpdate_bestpath_lost_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_bestpath_lost_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv6_UC})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
@@ -1604,7 +1604,7 @@ func TestProcessBGPUpdate_bestpath_lost_ipv6(t *testing.T) {
 
 	// check old best path
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv6_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv6_UC)
 
 	// check PathAttribute
 	checkPattr := func(expected *bgp.BGPMessage, actual *Path) {
@@ -1643,7 +1643,7 @@ func TestProcessBGPUpdate_bestpath_lost_ipv6(t *testing.T) {
 // test: implicit withdrawal case
 func TestProcessBGPUpdate_implicit_withdrwal_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 
 	// path1
 	origin1 := bgp.NewPathAttributeOrigin(0)
@@ -1684,7 +1684,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv4(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv4_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv4_UC)
 
 	// check PathAttribute
 	checkPattr := func(expected *bgp.BGPMessage, actual *Path) {
@@ -1724,7 +1724,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv4(t *testing.T) {
 
 func TestProcessBGPUpdate_implicit_withdrwal_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv6_UC})
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000, 65100, 65200})
@@ -1765,7 +1765,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv6(t *testing.T) {
 
 	// check type
 	path := pList[0]
-	assert.Equal(t, path.GetRouteFamily(), bgp.RF_IPv6_UC)
+	assert.Equal(t, path.GetFamily(), bgp.RF_IPv6_UC)
 
 	// check PathAttribute
 	pathAttributes := bgpMessage2.Body.(*bgp.BGPUpdate).PathAttributes
@@ -1831,7 +1831,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv6(t *testing.T) {
 // check multiple paths
 func TestProcessBGPUpdate_multiple_nlri_ipv4(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 
 	createPathAttr := func(aspaths []uint32, nh string) []bgp.PathAttributeInterface {
 		origin := bgp.NewPathAttributeOrigin(0)
@@ -1872,8 +1872,8 @@ func TestProcessBGPUpdate_multiple_nlri_ipv4(t *testing.T) {
 		assert.Equal(t, len(pathAttributes), len(actual.GetPathAttrs()))
 	}
 
-	checkBestPathResult := func(rf bgp.RouteFamily, prefix, nexthop string, p *Path, m *bgp.BGPMessage) {
-		assert.Equal(t, p.GetRouteFamily(), rf)
+	checkBestPathResult := func(rf bgp.Family, prefix, nexthop string, p *Path, m *bgp.BGPMessage) {
+		assert.Equal(t, p.GetFamily(), rf)
 		checkPattr(m, p)
 		// check destination
 		assert.Equal(t, prefix, p.GetPrefix())
@@ -1964,7 +1964,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv4(t *testing.T) {
 // check multiple paths
 func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv6_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv6_UC})
 
 	createPathAttr := func(aspaths []uint32) []bgp.PathAttributeInterface {
 		origin := bgp.NewPathAttributeOrigin(0)
@@ -2012,8 +2012,8 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 		assert.Equal(t, len(bgpPathAttributes), len(actual.GetPathAttrs()))
 	}
 
-	checkBestPathResult := func(rf bgp.RouteFamily, prefix, nexthop string, p *Path, m *bgp.BGPMessage) {
-		assert.Equal(t, p.GetRouteFamily(), rf)
+	checkBestPathResult := func(rf bgp.Family, prefix, nexthop string, p *Path, m *bgp.BGPMessage) {
+		assert.Equal(t, p.GetFamily(), rf)
 		checkPattr(m, p)
 		// check destination
 		assert.Equal(t, prefix, p.GetPrefix())
@@ -2108,7 +2108,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 }
 
 func TestProcessBGPUpdate_multiple_nlri_ipv4_split(t *testing.T) {
-	tm := NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 
 	origin := bgp.NewPathAttributeOrigin(0)
 	aspath := createAsPathAttribute([]uint32{65000, 65100, 65200})
@@ -2152,7 +2152,7 @@ func TestProcessBGPUpdate_Timestamp(t *testing.T) {
 
 	nlri := []*bgp.IPAddrPrefix{bgp.NewIPAddrPrefix(24, "10.10.10.0")}
 
-	adjRib := NewAdjRib(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC, bgp.RF_IPv6_UC})
+	adjRib := NewAdjRib(logger, []bgp.Family{bgp.RF_IPv4_UC, bgp.RF_IPv6_UC})
 	m1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, nlri)
 	peer := peerR1()
 	pList1 := ProcessMessage(m1, peer, time.Now())
@@ -2166,7 +2166,7 @@ func TestProcessBGPUpdate_Timestamp(t *testing.T) {
 	//t2 = path2.timestamp
 	adjRib.Update(pList2)
 
-	inList := adjRib.PathList([]bgp.RouteFamily{bgp.RF_IPv4_UC}, false)
+	inList := adjRib.PathList([]bgp.Family{bgp.RF_IPv4_UC}, false)
 	assert.Equal(t, len(inList), 1)
 	assert.Equal(t, inList[0].GetTimestamp(), t1)
 
@@ -2183,7 +2183,7 @@ func TestProcessBGPUpdate_Timestamp(t *testing.T) {
 	t3 := pList3[0].GetTimestamp()
 	adjRib.Update(pList3)
 
-	inList = adjRib.PathList([]bgp.RouteFamily{bgp.RF_IPv4_UC}, false)
+	inList = adjRib.PathList([]bgp.Family{bgp.RF_IPv4_UC}, false)
 	assert.Equal(t, len(inList), 1)
 	assert.Equal(t, inList[0].GetTimestamp(), t3)
 }

--- a/internal/pkg/table/table_test.go
+++ b/internal/pkg/table/table_test.go
@@ -56,9 +56,9 @@ func TestTableDeleteDest(t *testing.T) {
 	assert.Nil(t, gdest)
 }
 
-func TestTableGetRouteFamily(t *testing.T) {
+func TestTableGetFamily(t *testing.T) {
 	ipv4t := NewTable(logger, bgp.RF_IPv4_UC)
-	rf := ipv4t.GetRoutefamily()
+	rf := ipv4t.GetFamily()
 	assert.Equal(t, rf, bgp.RF_IPv4_UC)
 }
 
@@ -93,9 +93,9 @@ func TestTableGetDestinations(t *testing.T) {
 
 func TestTableKey(t *testing.T) {
 	tb := NewTable(logger, bgp.RF_IPv4_UC)
-	n1, _ := bgp.NewPrefixFromRouteFamily(bgp.AFI_IP, bgp.SAFI_UNICAST, "0.0.0.0/0")
+	n1, _ := bgp.NewPrefixFromFamily(bgp.AFI_IP, bgp.SAFI_UNICAST, "0.0.0.0/0")
 	d1 := NewDestination(n1, 0)
-	n2, _ := bgp.NewPrefixFromRouteFamily(bgp.AFI_IP, bgp.SAFI_UNICAST, "0.0.0.0/1")
+	n2, _ := bgp.NewPrefixFromFamily(bgp.AFI_IP, bgp.SAFI_UNICAST, "0.0.0.0/1")
 	d2 := NewDestination(n2, 0)
 	assert.Equal(t, len(tb.tableKey(d1.GetNlri())), 5)
 	tb.setDestination(d1)
@@ -196,7 +196,7 @@ func TestTableSelectVPNv4(t *testing.T) {
 
 	table := NewTable(logger, bgp.RF_IPv4_VPN)
 	for _, prefix := range prefixes {
-		nlri, _ := bgp.NewPrefixFromRouteFamily(bgp.AFI_IP, bgp.SAFI_MPLS_VPN, prefix)
+		nlri, _ := bgp.NewPrefixFromFamily(bgp.AFI_IP, bgp.SAFI_MPLS_VPN, prefix)
 
 		destination := NewDestination(nlri, 0, NewPath(nil, nlri, false, nil, time.Now(), false))
 		table.setDestination(destination)
@@ -302,7 +302,7 @@ func TestTableSelectVPNv6(t *testing.T) {
 
 	table := NewTable(logger, bgp.RF_IPv6_VPN)
 	for _, prefix := range prefixes {
-		nlri, _ := bgp.NewPrefixFromRouteFamily(bgp.AFI_IP6, bgp.SAFI_MPLS_VPN, prefix)
+		nlri, _ := bgp.NewPrefixFromFamily(bgp.AFI_IP6, bgp.SAFI_MPLS_VPN, prefix)
 
 		destination := NewDestination(nlri, 0, NewPath(nil, nlri, false, nil, time.Now(), false))
 		table.setDestination(destination)

--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -75,12 +75,12 @@ func UnmarshalAttribute(attr *api.Attribute) (bgp.PathAttributeInterface, error)
 		if a.MpReach.Family == nil {
 			return nil, fmt.Errorf("empty family")
 		}
-		rf := ToRouteFamily(a.MpReach.Family)
+		rf := ToFamily(a.MpReach.Family)
 		nlris, err := UnmarshalNLRIs(rf, a.MpReach.Nlris)
 		if err != nil {
 			return nil, err
 		}
-		afi, safi := bgp.RouteFamilyToAfiSafi(rf)
+		afi, safi := bgp.FamilyToAfiSafi(rf)
 		nexthop := "0.0.0.0"
 		var linkLocalNexthop net.IP
 		if afi == bgp.AFI_IP6 {
@@ -104,7 +104,7 @@ func UnmarshalAttribute(attr *api.Attribute) (bgp.PathAttributeInterface, error)
 		attr.LinkLocalNexthop = linkLocalNexthop
 		return attr, nil
 	case *api.Attribute_MpUnreach:
-		rf := ToRouteFamily(a.MpUnreach.Family)
+		rf := ToFamily(a.MpUnreach.Family)
 		nlris, err := UnmarshalNLRIs(rf, a.MpUnreach.Nlris)
 		if err != nil {
 			return nil, err
@@ -1496,7 +1496,7 @@ func MarshalNLRIs(values []bgp.AddrPrefixInterface) ([]*api.NLRI, error) {
 	return nlris, nil
 }
 
-func UnmarshalNLRI(rf bgp.RouteFamily, an *api.NLRI) (bgp.AddrPrefixInterface, error) {
+func UnmarshalNLRI(rf bgp.Family, an *api.NLRI) (bgp.AddrPrefixInterface, error) {
 	var nlri bgp.AddrPrefixInterface
 
 	switch n := an.GetNlri().(type) {
@@ -1891,7 +1891,7 @@ func UnmarshalNLRI(rf bgp.RouteFamily, an *api.NLRI) (bgp.AddrPrefixInterface, e
 	return nlri, nil
 }
 
-func UnmarshalNLRIs(rf bgp.RouteFamily, values []*api.NLRI) ([]bgp.AddrPrefixInterface, error) {
+func UnmarshalNLRIs(rf bgp.Family, values []*api.NLRI) ([]bgp.AddrPrefixInterface, error) {
 	nlris := make([]bgp.AddrPrefixInterface, 0, len(values))
 	for _, an := range values {
 		nlri, err := UnmarshalNLRI(rf, an)

--- a/pkg/apiutil/capability.go
+++ b/pkg/apiutil/capability.go
@@ -23,7 +23,7 @@ import (
 )
 
 func NewMultiProtocolCapability(a *bgp.CapMultiProtocol) *api.MultiProtocolCapability {
-	afi, safi := bgp.RouteFamilyToAfiSafi(a.CapValue)
+	afi, safi := bgp.FamilyToAfiSafi(a.CapValue)
 	return &api.MultiProtocolCapability{
 		Family: ToApiFamily(afi, safi),
 	}
@@ -74,7 +74,7 @@ func NewFourOctetASNumberCapability(a *bgp.CapFourOctetASNumber) *api.FourOctetA
 func NewAddPathCapability(a *bgp.CapAddPath) *api.AddPathCapability {
 	tuples := make([]*api.AddPathCapabilityTuple, 0, len(a.Tuples))
 	for _, t := range a.Tuples {
-		afi, safi := bgp.RouteFamilyToAfiSafi(t.RouteFamily)
+		afi, safi := bgp.FamilyToAfiSafi(t.Family)
 		tuples = append(tuples, &api.AddPathCapabilityTuple{
 			Family: ToApiFamily(afi, safi),
 			Mode:   api.AddPathCapabilityTuple_Mode(t.Mode),
@@ -178,7 +178,7 @@ func unmarshalCapability(a *api.Capability) (bgp.ParameterCapabilityInterface, e
 	switch cap := a.GetCap().(type) {
 	case *api.Capability_MultiProtocol:
 		a := cap.MultiProtocol
-		return bgp.NewCapMultiProtocol(ToRouteFamily(a.Family)), nil
+		return bgp.NewCapMultiProtocol(ToFamily(a.Family)), nil
 	case *api.Capability_RouteRefresh:
 		return bgp.NewCapRouteRefresh(), nil
 	case *api.Capability_CarryingLabelInfo:
@@ -196,7 +196,7 @@ func unmarshalCapability(a *api.Capability) (bgp.ParameterCapabilityInterface, e
 			default:
 				return nil, fmt.Errorf("invalid address family for nexthop afi in extended nexthop capability: %s", t.NexthopFamily)
 			}
-			tuples = append(tuples, bgp.NewCapExtendedNexthopTuple(ToRouteFamily(t.NlriFamily), nhAfi))
+			tuples = append(tuples, bgp.NewCapExtendedNexthopTuple(ToFamily(t.NlriFamily), nhAfi))
 		}
 		return bgp.NewCapExtendedNexthop(tuples), nil
 	case *api.Capability_GracefulRestart:
@@ -207,7 +207,7 @@ func unmarshalCapability(a *api.Capability) (bgp.ParameterCapabilityInterface, e
 			if t.Flags&0x80 > 0 {
 				forward = true
 			}
-			tuples = append(tuples, bgp.NewCapGracefulRestartTuple(ToRouteFamily(t.Family), forward))
+			tuples = append(tuples, bgp.NewCapGracefulRestartTuple(ToFamily(t.Family), forward))
 		}
 		var restarting bool
 		if a.Flags&0x08 > 0 {
@@ -225,7 +225,7 @@ func unmarshalCapability(a *api.Capability) (bgp.ParameterCapabilityInterface, e
 		a := cap.AddPath
 		tuples := make([]*bgp.CapAddPathTuple, 0, len(a.Tuples))
 		for _, t := range a.Tuples {
-			tuples = append(tuples, bgp.NewCapAddPathTuple(ToRouteFamily(t.Family), bgp.BGPAddPathMode(t.Mode)))
+			tuples = append(tuples, bgp.NewCapAddPathTuple(ToFamily(t.Family), bgp.BGPAddPathMode(t.Mode)))
 		}
 		return bgp.NewCapAddPath(tuples), nil
 	case *api.Capability_EnhancedRouteRefresh:
@@ -238,7 +238,7 @@ func unmarshalCapability(a *api.Capability) (bgp.ParameterCapabilityInterface, e
 			if t.Flags&0x80 > 0 {
 				forward = true
 			}
-			tuples = append(tuples, bgp.NewCapLongLivedGracefulRestartTuple(ToRouteFamily(t.Family), forward, t.Time))
+			tuples = append(tuples, bgp.NewCapLongLivedGracefulRestartTuple(ToFamily(t.Family), forward, t.Time))
 		}
 		return bgp.NewCapLongLivedGracefulRestart(tuples), nil
 	case *api.Capability_RouteRefreshCisco:

--- a/pkg/apiutil/capability_test.go
+++ b/pkg/apiutil/capability_test.go
@@ -174,7 +174,7 @@ func Test_AddPathCapability(t *testing.T) {
 
 	c := n.(*bgp.CapAddPath)
 	assert.Equal(1, len(c.Tuples))
-	assert.Equal(bgp.RF_IPv4_UC, c.Tuples[0].RouteFamily)
+	assert.Equal(bgp.RF_IPv4_UC, c.Tuples[0].Family)
 	assert.Equal(bgp.BGP_ADD_PATH_BOTH, c.Tuples[0].Mode)
 
 	output := NewAddPathCapability(c)

--- a/pkg/apiutil/util.go
+++ b/pkg/apiutil/util.go
@@ -87,9 +87,9 @@ func NewPath(nlri bgp.AddrPrefixInterface, isWithdraw bool, attrs []bgp.PathAttr
 	}, nil
 }
 
-func getNLRI(family bgp.RouteFamily, buf []byte) (bgp.AddrPrefixInterface, error) {
-	afi, safi := bgp.RouteFamilyToAfiSafi(family)
-	nlri, err := bgp.NewPrefixFromRouteFamily(afi, safi)
+func getNLRI(family bgp.Family, buf []byte) (bgp.AddrPrefixInterface, error) {
+	afi, safi := bgp.FamilyToAfiSafi(family)
+	nlri, err := bgp.NewPrefixFromFamily(afi, safi)
 	if err != nil {
 		return nil, err
 	}
@@ -104,9 +104,9 @@ func GetNativeNlri(p *api.Path) (bgp.AddrPrefixInterface, error) {
 		return nil, fmt.Errorf("family cannot be nil")
 	}
 	if len(p.NlriBinary) > 0 {
-		return getNLRI(ToRouteFamily(p.Family), p.NlriBinary)
+		return getNLRI(ToFamily(p.Family), p.NlriBinary)
 	}
-	return UnmarshalNLRI(ToRouteFamily(p.Family), p.Nlri)
+	return UnmarshalNLRI(ToFamily(p.Family), p.Nlri)
 }
 
 func GetNativePathAttributes(p *api.Path) ([]bgp.PathAttributeInterface, error) {
@@ -129,8 +129,8 @@ func GetNativePathAttributes(p *api.Path) ([]bgp.PathAttributeInterface, error) 
 	return UnmarshalPathAttributes(p.Pattrs)
 }
 
-func ToRouteFamily(f *api.Family) bgp.RouteFamily {
-	return bgp.AfiSafiToRouteFamily(uint16(f.Afi), uint8(f.Safi))
+func ToFamily(f *api.Family) bgp.Family {
+	return bgp.AfiSafiToFamily(uint16(f.Afi), uint8(f.Safi))
 }
 
 func ToApiFamily(afi uint16, safi uint8) *api.Family {

--- a/pkg/config/oc/bgp_configs.go
+++ b/pkg/config/oc/bgp_configs.go
@@ -3994,7 +3994,7 @@ type AfiSafiState struct {
 	// original -> gobgp:family
 	// gobgp:family's original type is route-family.
 	// Address family value of AFI-SAFI pair translated from afi-safi-name.
-	Family bgp.RouteFamily `mapstructure:"family" json:"family,omitempty"`
+	Family bgp.Family `mapstructure:"family" json:"family,omitempty"`
 }
 
 // struct for container bgp-mp:config.

--- a/pkg/config/oc/default.go
+++ b/pkg/config/oc/default.go
@@ -189,7 +189,7 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, g *Glo
 			if len(afs) > i {
 				vv.Set("afi-safi", afs[i])
 			}
-			rf, err := bgp.GetRouteFamily(string(n.AfiSafis[i].Config.AfiSafiName))
+			rf, err := bgp.GetFamily(string(n.AfiSafis[i].Config.AfiSafiName))
 			if err != nil {
 				return err
 			}

--- a/pkg/config/oc/util.go
+++ b/pkg/config/oc/util.go
@@ -133,8 +133,8 @@ func (n *Neighbor) IsEBGPPeer(g *Global) bool {
 	return n.Config.PeerAs != n.Config.LocalAs
 }
 
-func (n *Neighbor) CreateRfMap() map[bgp.RouteFamily]bgp.BGPAddPathMode {
-	rfMap := make(map[bgp.RouteFamily]bgp.BGPAddPathMode)
+func (n *Neighbor) CreateRfMap() map[bgp.Family]bgp.BGPAddPathMode {
+	rfMap := make(map[bgp.Family]bgp.BGPAddPathMode)
 	for _, af := range n.AfiSafis {
 		mode := bgp.BGP_ADD_PATH_NONE
 		if af.AddPaths.State.Receive {
@@ -148,7 +148,7 @@ func (n *Neighbor) CreateRfMap() map[bgp.RouteFamily]bgp.BGPAddPathMode {
 	return rfMap
 }
 
-func (n *Neighbor) GetAfiSafi(family bgp.RouteFamily) *AfiSafi {
+func (n *Neighbor) GetAfiSafi(family bgp.Family) *AfiSafi {
 	for _, a := range n.AfiSafis {
 		if string(a.Config.AfiSafiName) == family.String() {
 			return &a
@@ -168,7 +168,7 @@ func (n *Neighbor) ExtractNeighborAddress() (string, error) {
 	return addr, nil
 }
 
-func (n *Neighbor) IsAddPathReceiveEnabled(family bgp.RouteFamily) bool {
+func (n *Neighbor) IsAddPathReceiveEnabled(family bgp.Family) bool {
 	for _, af := range n.AfiSafis {
 		if af.State.Family == family {
 			return af.AddPaths.State.Receive
@@ -179,8 +179,8 @@ func (n *Neighbor) IsAddPathReceiveEnabled(family bgp.RouteFamily) bool {
 
 type AfiSafis []AfiSafi
 
-func (c AfiSafis) ToRfList() ([]bgp.RouteFamily, error) {
-	rfs := make([]bgp.RouteFamily, 0, len(c))
+func (c AfiSafis) ToRfList() ([]bgp.Family, error) {
+	rfs := make([]bgp.Family, 0, len(c))
 	for _, af := range c {
 		rfs = append(rfs, af.State.Family)
 	}
@@ -282,7 +282,7 @@ func extractFamilyFromConfigAfiSafi(c *AfiSafi) uint32 {
 	// In case that Neighbor structure came from CLI or gRPC, address family
 	// value in AfiSafiState structure can be omitted.
 	// Here extracts value from AfiSafiName field in AfiSafiConfig structure.
-	if rf, err := bgp.GetRouteFamily(string(c.Config.AfiSafiName)); err == nil {
+	if rf, err := bgp.GetFamily(string(c.Config.AfiSafiName)); err == nil {
 		return uint32(rf)
 	}
 	// Ignores invalid address family name
@@ -291,7 +291,7 @@ func extractFamilyFromConfigAfiSafi(c *AfiSafi) uint32 {
 
 func newAfiSafiConfigFromConfigStruct(c *AfiSafi) *api.AfiSafiConfig {
 	rf := extractFamilyFromConfigAfiSafi(c)
-	afi, safi := bgp.RouteFamilyToAfiSafi(bgp.RouteFamily(rf))
+	afi, safi := bgp.FamilyToAfiSafi(bgp.Family(rf))
 	return &api.AfiSafiConfig{
 		Family:  &api.Family{Afi: api.Family_Afi(afi), Safi: api.Family_Safi(safi)},
 		Enabled: c.Config.Enabled,
@@ -332,7 +332,7 @@ func newPrefixLimitFromConfigStruct(c *AfiSafi) *api.PrefixLimit {
 	if c.PrefixLimit.Config.MaxPrefixes == 0 {
 		return nil
 	}
-	afi, safi := bgp.RouteFamilyToAfiSafi(bgp.RouteFamily(c.State.Family))
+	afi, safi := bgp.FamilyToAfiSafi(bgp.Family(c.State.Family))
 	return &api.PrefixLimit{
 		Family:               &api.Family{Afi: api.Family_Afi(afi), Safi: api.Family_Safi(safi)},
 		MaxPrefixes:          c.PrefixLimit.Config.MaxPrefixes,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -393,7 +393,7 @@ func (c *bgpCollector) Collect(out chan<- prometheus.Metric) {
 				continue
 			}
 			afiState := afiSafi.GetState()
-			family := bgp.AfiSafiToRouteFamily(
+			family := bgp.AfiSafiToFamily(
 				uint16(afiState.GetFamily().GetAfi()),
 				uint8(afiState.GetFamily().GetSafi()),
 			).String()

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -92,10 +92,10 @@ func Test_MalformedPrefixLookup(t *testing.T) {
 	assert := assert.New(t)
 
 	var tests = []struct {
-		inPrefix    string
-		routeFamily RouteFamily
-		want        AddrPrefixInterface
-		err         bool
+		inPrefix string
+		Family   Family
+		want     AddrPrefixInterface
+		err      bool
 	}{
 		{"129.6.128/22", RF_IPv4_UC, nil, true},
 		{"foo", RF_IPv4_UC, nil, true},
@@ -104,8 +104,8 @@ func Test_MalformedPrefixLookup(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		afi, safi := RouteFamilyToAfiSafi(RF_IPv4_UC)
-		p, err := NewPrefixFromRouteFamily(afi, safi, test.inPrefix)
+		afi, safi := FamilyToAfiSafi(RF_IPv4_UC)
+		p, err := NewPrefixFromFamily(afi, safi, test.inPrefix)
 		if test.err {
 			assert.Error(err)
 		} else {
@@ -495,7 +495,7 @@ func Test_FlowSpecNlri(t *testing.T) {
 	buf1, err := n1.Serialize()
 	assert.Nil(err)
 
-	n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_FS_IPv4_UC))
+	n2, err := NewPrefixFromFamily(FamilyToAfiSafi(RF_FS_IPv4_UC))
 	assert.Nil(err)
 
 	err = n2.DecodeFromBytes(buf1)
@@ -611,7 +611,7 @@ func Test_FlowSpecNlriv6(t *testing.T) {
 	buf1, err := n1.Serialize()
 	require.NoError(t, err)
 
-	n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_FS_IPv6_UC))
+	n2, err := NewPrefixFromFamily(FamilyToAfiSafi(RF_FS_IPv6_UC))
 	require.NoError(t, err)
 
 	err = n2.DecodeFromBytes(buf1)
@@ -649,7 +649,7 @@ func Test_FlowSpecNlriL2(t *testing.T) {
 	n1 := NewFlowSpecL2VPN(rd, cmp)
 	buf1, err := n1.Serialize()
 	assert.Nil(err)
-	n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_FS_L2_VPN))
+	n2, err := NewPrefixFromFamily(FamilyToAfiSafi(RF_FS_L2_VPN))
 	assert.Nil(err)
 	err = n2.DecodeFromBytes(buf1)
 	assert.Nil(err)
@@ -675,7 +675,7 @@ func Test_FlowSpecNlriVPN(t *testing.T) {
 	n1 := NewFlowSpecIPv4VPN(rd, cmp)
 	buf1, err := n1.Serialize()
 	assert.Nil(err)
-	n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_FS_IPv4_VPN))
+	n2, err := NewPrefixFromFamily(FamilyToAfiSafi(RF_FS_IPv4_VPN))
 	assert.Nil(err)
 	err = n2.DecodeFromBytes(buf1)
 	require.NoError(t, err)
@@ -701,7 +701,7 @@ func Test_EVPNIPPrefixRoute(t *testing.T) {
 	n1 := NewEVPNNLRI(EVPN_IP_PREFIX, r)
 	buf1, err := n1.Serialize()
 	assert.Nil(err)
-	n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_EVPN))
+	n2, err := NewPrefixFromFamily(FamilyToAfiSafi(RF_EVPN))
 	assert.Nil(err)
 	err = n2.DecodeFromBytes(buf1)
 	assert.Nil(err)
@@ -723,7 +723,7 @@ func Test_CapExtendedNexthop(t *testing.T) {
 
 func Test_AddPath(t *testing.T) {
 	assert := assert.New(t)
-	opt := &MarshallingOption{AddPath: map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}}
+	opt := &MarshallingOption{AddPath: map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}}
 	{
 		n1 := NewIPAddrPrefix(24, "10.10.10.0")
 		assert.Equal(n1.PathIdentifier(), uint32(0))
@@ -746,7 +746,7 @@ func Test_AddPath(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(n2.PathIdentifier(), uint32(0))
 	}
-	opt = &MarshallingOption{AddPath: map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH, RF_IPv6_UC: BGP_ADD_PATH_BOTH}}
+	opt = &MarshallingOption{AddPath: map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH, RF_IPv6_UC: BGP_ADD_PATH_BOTH}}
 	{
 		n1 := NewIPv6AddrPrefix(64, "2001::")
 		n1.SetPathLocalIdentifier(10)
@@ -757,7 +757,7 @@ func Test_AddPath(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(n2.PathIdentifier(), uint32(10))
 	}
-	opt = &MarshallingOption{AddPath: map[RouteFamily]BGPAddPathMode{RF_IPv4_VPN: BGP_ADD_PATH_BOTH, RF_IPv6_VPN: BGP_ADD_PATH_BOTH}}
+	opt = &MarshallingOption{AddPath: map[Family]BGPAddPathMode{RF_IPv4_VPN: BGP_ADD_PATH_BOTH, RF_IPv6_VPN: BGP_ADD_PATH_BOTH}}
 	{
 		rd, _ := ParseRouteDistinguisher("100:100")
 		labels := NewMPLSLabelStack(100, 200)
@@ -782,7 +782,7 @@ func Test_AddPath(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(n2.PathIdentifier(), uint32(20))
 	}
-	opt = &MarshallingOption{AddPath: map[RouteFamily]BGPAddPathMode{RF_IPv4_MPLS: BGP_ADD_PATH_BOTH, RF_IPv6_MPLS: BGP_ADD_PATH_BOTH}}
+	opt = &MarshallingOption{AddPath: map[Family]BGPAddPathMode{RF_IPv4_MPLS: BGP_ADD_PATH_BOTH, RF_IPv6_MPLS: BGP_ADD_PATH_BOTH}}
 	{
 		labels := NewMPLSLabelStack(100, 200)
 		n1 := NewLabeledIPAddrPrefix(24, "10.10.10.0", *labels)
@@ -805,7 +805,7 @@ func Test_AddPath(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(n2.PathIdentifier(), uint32(20))
 	}
-	opt = &MarshallingOption{AddPath: map[RouteFamily]BGPAddPathMode{RF_RTC_UC: BGP_ADD_PATH_BOTH}}
+	opt = &MarshallingOption{AddPath: map[Family]BGPAddPathMode{RF_RTC_UC: BGP_ADD_PATH_BOTH}}
 	{
 		rt, _ := ParseRouteTarget("100:100")
 		n1 := NewRouteTargetMembershipNLRI(65000, rt)
@@ -817,7 +817,7 @@ func Test_AddPath(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(n2.PathIdentifier(), uint32(30))
 	}
-	opt = &MarshallingOption{AddPath: map[RouteFamily]BGPAddPathMode{RF_EVPN: BGP_ADD_PATH_BOTH}}
+	opt = &MarshallingOption{AddPath: map[Family]BGPAddPathMode{RF_EVPN: BGP_ADD_PATH_BOTH}}
 	{
 		n1 := NewEVPNNLRI(EVPN_ROUTE_TYPE_ETHERNET_AUTO_DISCOVERY,
 			&EVPNEthernetAutoDiscoveryRoute{NewRouteDistinguisherFourOctetAS(5, 6),
@@ -830,7 +830,7 @@ func Test_AddPath(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(n2.PathIdentifier(), uint32(40))
 	}
-	opt = &MarshallingOption{AddPath: map[RouteFamily]BGPAddPathMode{RF_IPv4_ENCAP: BGP_ADD_PATH_BOTH}}
+	opt = &MarshallingOption{AddPath: map[Family]BGPAddPathMode{RF_IPv4_ENCAP: BGP_ADD_PATH_BOTH}}
 	{
 		n1 := NewEncapNLRI("10.10.10.0")
 		n1.SetPathLocalIdentifier(50)
@@ -841,7 +841,7 @@ func Test_AddPath(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(n2.PathIdentifier(), uint32(50))
 	}
-	opt = &MarshallingOption{AddPath: map[RouteFamily]BGPAddPathMode{RF_FS_IPv4_UC: BGP_ADD_PATH_BOTH}}
+	opt = &MarshallingOption{AddPath: map[Family]BGPAddPathMode{RF_FS_IPv4_UC: BGP_ADD_PATH_BOTH}}
 	{
 		n1 := NewFlowSpecIPv4Unicast([]FlowSpecComponentInterface{NewFlowSpecDestinationPrefix(NewIPAddrPrefix(24, "10.0.0.0"))})
 		n1.SetPathLocalIdentifier(60)
@@ -852,7 +852,7 @@ func Test_AddPath(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(n2.PathIdentifier(), uint32(60))
 	}
-	opt = &MarshallingOption{AddPath: map[RouteFamily]BGPAddPathMode{RF_OPAQUE: BGP_ADD_PATH_BOTH}}
+	opt = &MarshallingOption{AddPath: map[Family]BGPAddPathMode{RF_OPAQUE: BGP_ADD_PATH_BOTH}}
 	{
 		n1 := NewOpaqueNLRI([]byte("key"), []byte("value"))
 		n1.SetPathLocalIdentifier(70)
@@ -894,7 +894,7 @@ func Test_MpReachNLRIWithIPv4MappedIPv6Prefix(t *testing.T) {
 	n1 := NewIPv6AddrPrefix(120, "::ffff:10.0.0.0")
 	buf1, err := n1.Serialize()
 	assert.Nil(err)
-	n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_IPv6_UC))
+	n2, err := NewPrefixFromFamily(FamilyToAfiSafi(RF_IPv6_UC))
 	assert.Nil(err)
 	err = n2.DecodeFromBytes(buf1)
 	assert.Nil(err)
@@ -906,7 +906,7 @@ func Test_MpReachNLRIWithIPv4MappedIPv6Prefix(t *testing.T) {
 	n3 := NewLabeledIPv6AddrPrefix(120, "::ffff:10.0.0.0", *label)
 	buf1, err = n3.Serialize()
 	assert.Nil(err)
-	n4, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_IPv6_MPLS))
+	n4, err := NewPrefixFromFamily(FamilyToAfiSafi(RF_IPv6_MPLS))
 	assert.Nil(err)
 	err = n4.DecodeFromBytes(buf1)
 	assert.Nil(err)
@@ -3805,7 +3805,7 @@ func Test_BGPOpenDecodeCapabilities(t *testing.T) {
 	assert.Len(t, capMap[BGP_CAP_ADD_PATH], 1)
 	tuples := capMap[BGP_CAP_ADD_PATH][0].(*CapAddPath).Tuples
 	assert.Len(t, tuples, 1)
-	assert.Equal(t, tuples[0].RouteFamily, RF_IPv4_UC)
+	assert.Equal(t, tuples[0].Family, RF_IPv4_UC)
 	assert.Equal(t, tuples[0].Mode, BGP_ADD_PATH_SEND)
 }
 

--- a/pkg/packet/bgp/mup_test.go
+++ b/pkg/packet/bgp/mup_test.go
@@ -36,7 +36,7 @@ func Test_MUPInterworkSegmentDiscoveryRouteIPv4(t *testing.T) {
 	n1 := NewMUPNLRI(AFI_IP, MUP_ARCH_TYPE_3GPP_5G, MUP_ROUTE_TYPE_INTERWORK_SEGMENT_DISCOVERY, r)
 	buf1, err := n1.Serialize()
 	assert.Nil(err)
-	n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_MUP_IPv4))
+	n2, err := NewPrefixFromFamily(FamilyToAfiSafi(RF_MUP_IPv4))
 	assert.Nil(err)
 	err = n2.DecodeFromBytes(buf1)
 	assert.Nil(err)
@@ -57,7 +57,7 @@ func Test_MUPInterworkSegmentDiscoveryRouteIPv6(t *testing.T) {
 	n1 := NewMUPNLRI(AFI_IP6, MUP_ARCH_TYPE_3GPP_5G, MUP_ROUTE_TYPE_INTERWORK_SEGMENT_DISCOVERY, r)
 	buf1, err := n1.Serialize()
 	assert.Nil(err)
-	n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_MUP_IPv6))
+	n2, err := NewPrefixFromFamily(FamilyToAfiSafi(RF_MUP_IPv6))
 	assert.Nil(err)
 	err = n2.DecodeFromBytes(buf1)
 	assert.Nil(err)
@@ -78,7 +78,7 @@ func Test_MUPDirectSegmentDiscoveryRouteIPv4(t *testing.T) {
 	n1 := NewMUPNLRI(AFI_IP, MUP_ARCH_TYPE_3GPP_5G, MUP_ROUTE_TYPE_DIRECT_SEGMENT_DISCOVERY, r)
 	buf1, err := n1.Serialize()
 	assert.Nil(err)
-	n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_MUP_IPv4))
+	n2, err := NewPrefixFromFamily(FamilyToAfiSafi(RF_MUP_IPv4))
 	assert.Nil(err)
 	err = n2.DecodeFromBytes(buf1)
 	assert.Nil(err)
@@ -99,7 +99,7 @@ func Test_MUPDirectSegmentDiscoveryRouteIPv6(t *testing.T) {
 	n1 := NewMUPNLRI(AFI_IP6, MUP_ARCH_TYPE_3GPP_5G, MUP_ROUTE_TYPE_DIRECT_SEGMENT_DISCOVERY, r)
 	buf1, err := n1.Serialize()
 	assert.Nil(err)
-	n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_MUP_IPv6))
+	n2, err := NewPrefixFromFamily(FamilyToAfiSafi(RF_MUP_IPv6))
 	assert.Nil(err)
 	err = n2.DecodeFromBytes(buf1)
 	assert.Nil(err)
@@ -119,7 +119,7 @@ func Test_MUPType1SessionTransformedRoute(t *testing.T) {
 		name string
 		in   *MUPType1SessionTransformedRoute
 		afi  uint16
-		rf   RouteFamily
+		rf   Family
 	}{
 		{
 			name: "IPv4",
@@ -184,7 +184,7 @@ func Test_MUPType1SessionTransformedRoute(t *testing.T) {
 			n1 := NewMUPNLRI(tt.afi, MUP_ARCH_TYPE_3GPP_5G, MUP_ROUTE_TYPE_TYPE_1_SESSION_TRANSFORMED, tt.in)
 			buf1, err := n1.Serialize()
 			assert.Nil(err)
-			n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(tt.rf))
+			n2, err := NewPrefixFromFamily(FamilyToAfiSafi(tt.rf))
 			assert.Nil(err)
 			err = n2.DecodeFromBytes(buf1)
 			assert.Nil(err)
@@ -238,7 +238,7 @@ func Test_MUPType2SessionTransformedRouteIPv4(t *testing.T) {
 			n1 := NewMUPNLRI(AFI_IP, MUP_ARCH_TYPE_3GPP_5G, MUP_ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED, tt.in)
 			buf1, err := n1.Serialize()
 			assert.Nil(err)
-			n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_MUP_IPv4))
+			n2, err := NewPrefixFromFamily(FamilyToAfiSafi(RF_MUP_IPv4))
 			assert.Nil(err)
 			err = n2.DecodeFromBytes(buf1)
 			assert.Nil(err)
@@ -291,7 +291,7 @@ func Test_MUPType2SessionTransformedRouteIPv6(t *testing.T) {
 			n1 := NewMUPNLRI(AFI_IP6, MUP_ARCH_TYPE_3GPP_5G, MUP_ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED, tt.in)
 			buf1, err := n1.Serialize()
 			assert.Nil(err)
-			n2, err := NewPrefixFromRouteFamily(RouteFamilyToAfiSafi(RF_MUP_IPv6))
+			n2, err := NewPrefixFromFamily(FamilyToAfiSafi(RF_MUP_IPv6))
 			assert.Nil(err)
 			err = n2.DecodeFromBytes(buf1)
 			assert.Nil(err)

--- a/pkg/packet/bgp/sr_policy.go
+++ b/pkg/packet/bgp/sr_policy.go
@@ -10,7 +10,7 @@ import (
 
 type SRPolicyNLRI struct {
 	PrefixDefault
-	rf            RouteFamily
+	rf            Family
 	Length        uint8
 	Distinguisher uint32
 	Color         uint32
@@ -28,7 +28,7 @@ func (s *SRPolicyNLRI) Flat() map[string]string {
 	return map[string]string{}
 }
 
-func (s *SRPolicyNLRI) decodeFromBytes(rf RouteFamily, data []byte, options ...*MarshallingOption) error {
+func (s *SRPolicyNLRI) decodeFromBytes(rf Family, data []byte, options ...*MarshallingOption) error {
 	if IsAddPathEnabled(true, rf, options) {
 		var err error
 		data, err = s.decodePathIdentifier(data)
@@ -78,12 +78,12 @@ func (s *SRPolicyNLRI) Serialize(options ...*MarshallingOption) ([]byte, error) 
 }
 
 func (s *SRPolicyNLRI) AFI() uint16 {
-	afi, _ := RouteFamilyToAfiSafi(s.rf)
+	afi, _ := FamilyToAfiSafi(s.rf)
 	return afi
 }
 
 func (s *SRPolicyNLRI) SAFI() uint8 {
-	_, safi := RouteFamilyToAfiSafi(s.rf)
+	_, safi := FamilyToAfiSafi(s.rf)
 	return safi
 }
 
@@ -93,7 +93,7 @@ func (s *SRPolicyNLRI) Len(options ...*MarshallingOption) int {
 }
 
 func (s *SRPolicyNLRI) String() string {
-	afi, _ := RouteFamilyToAfiSafi(s.rf)
+	afi, _ := FamilyToAfiSafi(s.rf)
 	var endp string
 	switch afi {
 	case AFI_IP:

--- a/pkg/packet/bgp/validate.go
+++ b/pkg/packet/bgp/validate.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Validator for BGPUpdate
-func ValidateUpdateMsg(m *BGPUpdate, rfs map[RouteFamily]BGPAddPathMode, isEBGP bool, isConfed bool, loopbackNextHopAllowed bool) (bool, error) {
+func ValidateUpdateMsg(m *BGPUpdate, rfs map[Family]BGPAddPathMode, isEBGP bool, isConfed bool, loopbackNextHopAllowed bool) (bool, error) {
 	var strongestError error
 
 	eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
@@ -81,7 +81,7 @@ func ValidateUpdateMsg(m *BGPUpdate, rfs map[RouteFamily]BGPAddPathMode, isEBGP 
 	return strongestError == nil, strongestError
 }
 
-func ValidateAttribute(a PathAttributeInterface, rfs map[RouteFamily]BGPAddPathMode, isEBGP bool, isConfed bool, loopbackNextHopAllowed bool) (bool, error) {
+func ValidateAttribute(a PathAttributeInterface, rfs map[Family]BGPAddPathMode, isEBGP bool, isConfed bool, loopbackNextHopAllowed bool) (bool, error) {
 	var strongestError error
 
 	eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
@@ -92,7 +92,7 @@ func ValidateAttribute(a PathAttributeInterface, rfs map[RouteFamily]BGPAddPathM
 
 	checkPrefix := func(l []AddrPrefixInterface) error {
 		for _, prefix := range l {
-			rf := AfiSafiToRouteFamily(prefix.AFI(), prefix.SAFI())
+			rf := AfiSafiToFamily(prefix.AFI(), prefix.SAFI())
 			if _, ok := rfs[rf]; !ok {
 				return NewMessageError(0, 0, nil, fmt.Sprintf("Address-family %s not available for this session", rf))
 			}
@@ -125,7 +125,7 @@ func ValidateAttribute(a PathAttributeInterface, rfs map[RouteFamily]BGPAddPathM
 
 	switch p := a.(type) {
 	case *PathAttributeMpUnreachNLRI:
-		rf := AfiSafiToRouteFamily(p.AFI, p.SAFI)
+		rf := AfiSafiToFamily(p.AFI, p.SAFI)
 		if _, ok := rfs[rf]; !ok {
 			return false, NewMessageError(0, 0, nil, fmt.Sprintf("Address-family rf %d not available for session", rf))
 		}
@@ -133,7 +133,7 @@ func ValidateAttribute(a PathAttributeInterface, rfs map[RouteFamily]BGPAddPathM
 			return false, err
 		}
 	case *PathAttributeMpReachNLRI:
-		rf := AfiSafiToRouteFamily(p.AFI, p.SAFI)
+		rf := AfiSafiToFamily(p.AFI, p.SAFI)
 		if _, ok := rfs[rf]; !ok {
 			return false, NewMessageError(0, 0, nil, fmt.Sprintf("Address-family rf %d not available for session", rf))
 		}

--- a/pkg/packet/bgp/validate_test.go
+++ b/pkg/packet/bgp/validate_test.go
@@ -43,11 +43,11 @@ func bgpupdateV6() *BGPMessage {
 func Test_Validate_CapV4(t *testing.T) {
 	assert := assert.New(t)
 	message := bgpupdate().Body.(*BGPUpdate)
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv6_UC: BGP_ADD_PATH_BOTH}, false, false, false)
+	res, err := ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv6_UC: BGP_ADD_PATH_BOTH}, false, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 
-	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
+	res, err = ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
 	require.NoError(t, err)
 	assert.Equal(true, res)
 }
@@ -55,11 +55,11 @@ func Test_Validate_CapV4(t *testing.T) {
 func Test_Validate_CapV6(t *testing.T) {
 	assert := assert.New(t)
 	message := bgpupdateV6().Body.(*BGPUpdate)
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv6_UC: BGP_ADD_PATH_BOTH}, false, false, false)
+	res, err := ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv6_UC: BGP_ADD_PATH_BOTH}, false, false, false)
 	assert.NoError(err)
 	assert.True(res)
 
-	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
+	res, err = ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
 	assert.Error(err)
 	assert.False(res)
 }
@@ -67,7 +67,7 @@ func Test_Validate_CapV6(t *testing.T) {
 func Test_Validate_OK(t *testing.T) {
 	assert := assert.New(t)
 	message := bgpupdate().Body.(*BGPUpdate)
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
+	res, err := ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
 	assert.Equal(true, res)
 	assert.NoError(err)
 
@@ -82,7 +82,7 @@ func Test_Validate_OK(t *testing.T) {
 // 	origin.DecodeFromBytes(originBytes)
 // 	message.PathAttributes[0] = origin
 
-// 	res, err := ValidateUpdateMsg(message, []RouteFamily{RF_IPv4_UC,})
+// 	res, err := ValidateUpdateMsg(message, []Family{RF_IPv4_UC,})
 // 	assert.Equal(false, res)
 // 	assert.Error(err)
 // 	e := err.(*MessageError)
@@ -100,7 +100,7 @@ func Test_Validate_OK(t *testing.T) {
 // 	origin.DecodeFromBytes(originBytes)
 // 	message.PathAttributes[0] = origin
 
-// 	res, err := ValidateUpdateMsg(message, []RouteFamily{RF_IPv4_UC,})
+// 	res, err := ValidateUpdateMsg(message, []Family{RF_IPv4_UC,})
 // 	assert.Equal(false, res)
 // 	assert.Error(err)
 // 	e := err.(*MessageError)
@@ -118,7 +118,7 @@ func Test_Validate_OK(t *testing.T) {
 // 	origin.DecodeFromBytes(originBytes)
 // 	message.PathAttributes[0] = origin
 
-// 	res, err := ValidateUpdateMsg(message, []RouteFamily{RF_IPv4_UC,})
+// 	res, err := ValidateUpdateMsg(message, []Family{RF_IPv4_UC,})
 // 	assert.Equal(false, res)
 // 	assert.Error(err)
 // 	e := err.(*MessageError)
@@ -137,7 +137,7 @@ func Test_Validate_OK(t *testing.T) {
 // 	origin.DecodeFromBytes(originBytes)
 // 	message.PathAttributes[0] = origin
 
-// 	res, err := ValidateUpdateMsg(message, []RouteFamily{RF_IPv4_UC,})
+// 	res, err := ValidateUpdateMsg(message, []Family{RF_IPv4_UC,})
 // 	assert.Equal(false, res)
 // 	assert.Error(err)
 // 	e := err.(*MessageError)
@@ -155,7 +155,7 @@ func Test_Validate_duplicate_attribute(t *testing.T) {
 	origin.DecodeFromBytes(originBytes)
 	message.PathAttributes = append(message.PathAttributes, origin)
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
+	res, err := ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -169,7 +169,7 @@ func Test_Validate_mandatory_missing(t *testing.T) {
 	assert := assert.New(t)
 	message := bgpupdate().Body.(*BGPUpdate)
 	message.PathAttributes = message.PathAttributes[1:]
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
+	res, err := ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -186,7 +186,7 @@ func Test_Validate_mandatory_missing_nocheck(t *testing.T) {
 	message.PathAttributes = message.PathAttributes[1:]
 	message.NLRI = nil
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
+	res, err := ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
 	assert.Equal(true, res)
 	assert.NoError(err)
 }
@@ -200,7 +200,7 @@ func Test_Validate_invalid_origin(t *testing.T) {
 	origin.DecodeFromBytes(originBytes)
 	message.PathAttributes[0] = origin
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
+	res, err := ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -222,7 +222,7 @@ func Test_Validate_invalid_nexthop_zero(t *testing.T) {
 	nexthop.DecodeFromBytes(nexthopBytes)
 	message.PathAttributes[2] = nexthop
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
+	res, err := ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -260,7 +260,7 @@ func Test_Validate_invalid_nexthop_lo(t *testing.T) {
 			nexthop.DecodeFromBytes(nexthopBytes)
 			message.PathAttributes[2] = nexthop
 
-			res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, tt.inLoopbackAllowed)
+			res, err := ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, tt.inLoopbackAllowed)
 			if tt.wantErr {
 				assert.Equal(false, res)
 				assert.Error(err)
@@ -289,7 +289,7 @@ func Test_Validate_invalid_nexthop_de(t *testing.T) {
 	nexthop.DecodeFromBytes(nexthopBytes)
 	message.PathAttributes[2] = nexthop
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
+	res, err := ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -310,7 +310,7 @@ func Test_Validate_unrecognized_well_known(t *testing.T) {
 	unknown.DecodeFromBytes(unknownBytes)
 	message.PathAttributes = append(message.PathAttributes, unknown)
 
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
+	res, err := ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, false, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -325,7 +325,7 @@ func Test_Validate_aspath(t *testing.T) {
 	message := bgpupdate().Body.(*BGPUpdate)
 
 	// VALID AS_PATH
-	res, err := ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, false, false)
+	res, err := ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, false, false)
 	require.NoError(t, err)
 	assert.Equal(true, res)
 
@@ -344,7 +344,7 @@ func Test_Validate_aspath(t *testing.T) {
 	}
 
 	message.PathAttributes = newAttrs
-	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, false, false)
+	res, err = ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e := err.(*MessageError)
@@ -353,7 +353,7 @@ func Test_Validate_aspath(t *testing.T) {
 	assert.Equal(ERROR_HANDLING_TREAT_AS_WITHDRAW, e.ErrorHandling)
 	assert.Nil(e.Data)
 
-	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, true, false)
+	res, err = ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, true, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e = err.(*MessageError)
@@ -376,7 +376,7 @@ func Test_Validate_aspath(t *testing.T) {
 	}
 
 	message.PathAttributes = newAttrs
-	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, false, false)
+	res, err = ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, false, false)
 	assert.Equal(false, res)
 	assert.Error(err)
 	e = err.(*MessageError)
@@ -385,7 +385,7 @@ func Test_Validate_aspath(t *testing.T) {
 	assert.Equal(ERROR_HANDLING_TREAT_AS_WITHDRAW, e.ErrorHandling)
 	assert.Nil(e.Data)
 
-	res, err = ValidateUpdateMsg(message, map[RouteFamily]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, true, false)
+	res, err = ValidateUpdateMsg(message, map[Family]BGPAddPathMode{RF_IPv4_UC: BGP_ADD_PATH_BOTH}, true, true, false)
 	require.NoError(t, err)
 	assert.Equal(true, res)
 }
@@ -415,7 +415,7 @@ func Test_Validate_flowspec(t *testing.T) {
 	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_FRAGMENT, []*FlowSpecComponentItem{item7}))
 	n1 := NewFlowSpecIPv4Unicast(cmp)
 	a := NewPathAttributeMpReachNLRI("", []AddrPrefixInterface{n1})
-	m := map[RouteFamily]BGPAddPathMode{RF_FS_IPv4_UC: BGP_ADD_PATH_NONE}
+	m := map[Family]BGPAddPathMode{RF_FS_IPv4_UC: BGP_ADD_PATH_NONE}
 	_, err := ValidateAttribute(a, m, false, false, false)
 	assert.Nil(err)
 

--- a/pkg/packet/bmp/bmp_test.go
+++ b/pkg/packet/bmp/bmp_test.go
@@ -80,7 +80,7 @@ func Test_RouteMonitoringAdjRIBOut(t *testing.T) {
 
 func Test_RouteMonitoringAddPath(t *testing.T) {
 	opt := &bgp.MarshallingOption{
-		AddPath: map[bgp.RouteFamily]bgp.BGPAddPathMode{bgp.RF_IPv4_UC: bgp.BGP_ADD_PATH_BOTH},
+		AddPath: map[bgp.Family]bgp.BGPAddPathMode{bgp.RF_IPv4_UC: bgp.BGP_ADD_PATH_BOTH},
 	}
 	p1 := bgp.NewIPAddrPrefix(24, "10.10.10.0")
 	p1.SetPathLocalIdentifier(10)

--- a/pkg/packet/mrt/mrt.go
+++ b/pkg/packet/mrt/mrt.go
@@ -468,7 +468,7 @@ type Rib struct {
 	SequenceNumber uint32
 	Prefix         bgp.AddrPrefixInterface
 	Entries        []*RibEntry
-	RouteFamily    bgp.RouteFamily
+	Family         bgp.Family
 	isAddPath      bool
 }
 
@@ -478,13 +478,13 @@ func (u *Rib) DecodeFromBytes(data []byte) error {
 	}
 	u.SequenceNumber = binary.BigEndian.Uint32(data[:4])
 	data = data[4:]
-	afi, safi := bgp.RouteFamilyToAfiSafi(u.RouteFamily)
+	afi, safi := bgp.FamilyToAfiSafi(u.Family)
 	if afi == 0 && safi == 0 {
 		afi = binary.BigEndian.Uint16(data[:2])
 		safi = data[2]
 		data = data[3:]
 	}
-	prefix, err := bgp.NewPrefixFromRouteFamily(afi, safi)
+	prefix, err := bgp.NewPrefixFromFamily(afi, safi)
 	if err != nil {
 		return err
 	}
@@ -513,7 +513,7 @@ func (u *Rib) DecodeFromBytes(data []byte) error {
 func (u *Rib) Serialize() ([]byte, error) {
 	buf := make([]byte, 4)
 	binary.BigEndian.PutUint32(buf, u.SequenceNumber)
-	rf := bgp.AfiSafiToRouteFamily(u.Prefix.AFI(), u.Prefix.SAFI())
+	rf := bgp.AfiSafiToFamily(u.Prefix.AFI(), u.Prefix.SAFI())
 	switch rf {
 	case bgp.RF_IPv4_UC, bgp.RF_IPv4_MC, bgp.RF_IPv6_UC, bgp.RF_IPv6_MC:
 	default:
@@ -543,12 +543,12 @@ func (u *Rib) Serialize() ([]byte, error) {
 }
 
 func NewRib(seq uint32, prefix bgp.AddrPrefixInterface, entries []*RibEntry) *Rib {
-	rf := bgp.AfiSafiToRouteFamily(prefix.AFI(), prefix.SAFI())
+	rf := bgp.AfiSafiToFamily(prefix.AFI(), prefix.SAFI())
 	return &Rib{
 		SequenceNumber: seq,
 		Prefix:         prefix,
 		Entries:        entries,
-		RouteFamily:    rf,
+		Family:         rf,
 		isAddPath:      entries[0].isAddPath,
 	}
 }
@@ -928,7 +928,7 @@ func ParseMRTBody(h *MRTHeader, data []byte) (*MRTMessage, error) {
 	switch h.Type {
 	case TABLE_DUMPv2:
 		subType := MRTSubTypeTableDumpv2(h.SubType)
-		rf := bgp.RouteFamily(0)
+		rf := bgp.Family(0)
 		isAddPath := false
 		switch subType {
 		case PEER_INDEX_TABLE:
@@ -964,8 +964,8 @@ func ParseMRTBody(h *MRTHeader, data []byte) (*MRTMessage, error) {
 
 		if msg.Body == nil {
 			msg.Body = &Rib{
-				RouteFamily: rf,
-				isAddPath:   isAddPath,
+				Family:    rf,
+				isAddPath: isAddPath,
 			}
 		}
 	case BGP4MP:

--- a/pkg/packet/mrt/mrt_test.go
+++ b/pkg/packet/mrt/mrt_test.go
@@ -184,7 +184,7 @@ func TestMrtRib(t *testing.T) {
 		t.Fatal(err)
 	}
 	r2 := &Rib{
-		RouteFamily: bgp.RF_IPv4_UC,
+		Family: bgp.RF_IPv4_UC,
 	}
 	err = r2.DecodeFromBytes(b1)
 	if err != nil {
@@ -218,8 +218,8 @@ func TestMrtRibWithAddPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	r2 := &Rib{
-		RouteFamily: bgp.RF_IPv4_UC,
-		isAddPath:   true,
+		Family:    bgp.RF_IPv4_UC,
+		isAddPath: true,
 	}
 	err = r2.DecodeFromBytes(b1)
 	if err != nil {

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -134,7 +134,7 @@ func TestToPathApi(t *testing.T) {
 	}
 }
 
-func eor(f bgp.RouteFamily) *table.Path {
+func eor(f bgp.Family) *table.Path {
 	p := table.NewEOR(f)
 	p.SetSource(&table.PeerInfo{
 		ID:           net.IP{10, 10, 10, 10},
@@ -146,7 +146,7 @@ func eor(f bgp.RouteFamily) *table.Path {
 }
 
 func eorNlri(afi uint16, safi uint8) *api.NLRI {
-	n, _ := bgp.NewPrefixFromRouteFamily(afi, safi)
+	n, _ := bgp.NewPrefixFromFamily(afi, safi)
 	return nlri(n)
 }
 

--- a/pkg/server/mrt.go
+++ b/pkg/server/mrt.go
@@ -93,7 +93,7 @@ func (m *mrtWriter) loop() error {
 				}
 				mp := mrt.NewBGP4MPMessage(e.PeerAS, e.LocalAS, 0, e.PeerAddress.String(), e.LocalAddress.String(), e.FourBytesAs, nil)
 				mp.BGPMessagePayload = e.Payload
-				isAddPath := e.Neighbor.IsAddPathReceiveEnabled(e.PathList[0].GetRouteFamily())
+				isAddPath := e.Neighbor.IsAddPathReceiveEnabled(e.PathList[0].GetFamily())
 				subtype := mrt.MESSAGE
 				switch {
 				case isAddPath && e.FourBytesAs:
@@ -148,7 +148,7 @@ func (m *mrtWriter) loop() error {
 
 				subtype := func(p *table.Path, isAddPath bool) mrt.MRTSubTypeTableDumpv2 {
 					t := mrt.RIB_GENERIC
-					switch p.GetRouteFamily() {
+					switch p.GetFamily() {
 					case bgp.RF_IPv4_UC:
 						t = mrt.RIB_IPV4_UNICAST
 					case bgp.RF_IPv4_MC:
@@ -188,7 +188,7 @@ func (m *mrtWriter) loop() error {
 						if path.IsLocal() {
 							isAddPath = true
 						} else if neighbor, ok := neighborMap[path.GetSource().Address.String()]; ok {
-							isAddPath = neighbor.IsAddPathReceiveEnabled(path.GetRouteFamily())
+							isAddPath = neighbor.IsAddPathReceiveEnabled(path.GetFamily())
 						}
 						if !isAddPath {
 							entries = append(entries, mrt.NewRibEntry(idx(path), uint32(path.GetTimestamp().Unix()), 0, path.GetPathAttrs(), false))

--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -103,7 +103,7 @@ type peer struct {
 	adjRibIn          *table.AdjRib
 	policy            *table.RoutingPolicy
 	localRib          *table.TableManager
-	prefixLimitWarned map[bgp.RouteFamily]bool
+	prefixLimitWarned map[bgp.Family]bool
 	// map of path local identifiers sent for that prefix
 	sentPaths           map[table.PathDestLocalKey]map[uint32]struct{}
 	sendMaxPathFiltered map[table.PathLocalKey]struct{}
@@ -115,7 +115,7 @@ func newPeer(g *oc.Global, conf *oc.Neighbor, loc *table.TableManager, policy *t
 		localRib:            loc,
 		policy:              policy,
 		fsm:                 newFSM(g, conf, logger),
-		prefixLimitWarned:   make(map[bgp.RouteFamily]bool),
+		prefixLimitWarned:   make(map[bgp.Family]bool),
 		sentPaths:           make(map[table.PathDestLocalKey]map[uint32]struct{}),
 		sendMaxPathFiltered: make(map[table.PathLocalKey]struct{}),
 	}
@@ -194,7 +194,7 @@ func (peer *peer) isGracefulRestartEnabled() bool {
 	return peer.fsm.pConf.GracefulRestart.State.Enabled
 }
 
-func (peer *peer) getAddPathMode(family bgp.RouteFamily) bgp.BGPAddPathMode {
+func (peer *peer) getAddPathMode(family bgp.Family) bgp.BGPAddPathMode {
 	peer.fsm.lock.RLock()
 	defer peer.fsm.lock.RUnlock()
 	if mode, y := peer.fsm.rfMap[family]; y {
@@ -203,15 +203,15 @@ func (peer *peer) getAddPathMode(family bgp.RouteFamily) bgp.BGPAddPathMode {
 	return bgp.BGP_ADD_PATH_NONE
 }
 
-func (peer *peer) isAddPathReceiveEnabled(family bgp.RouteFamily) bool {
+func (peer *peer) isAddPathReceiveEnabled(family bgp.Family) bool {
 	return (peer.getAddPathMode(family) & bgp.BGP_ADD_PATH_RECEIVE) > 0
 }
 
-func (peer *peer) isAddPathSendEnabled(family bgp.RouteFamily) bool {
+func (peer *peer) isAddPathSendEnabled(family bgp.Family) bool {
 	return (peer.getAddPathMode(family) & bgp.BGP_ADD_PATH_SEND) > 0
 }
 
-func (peer *peer) getAddPathSendMax(family bgp.RouteFamily) uint8 {
+func (peer *peer) getAddPathSendMax(family bgp.Family) uint8 {
 	peer.fsm.lock.RLock()
 	defer peer.fsm.lock.RUnlock()
 	for _, a := range peer.fsm.pConf.AfiSafis {
@@ -222,7 +222,7 @@ func (peer *peer) getAddPathSendMax(family bgp.RouteFamily) uint8 {
 	return 0
 }
 
-func (peer *peer) getRoutesCount(family bgp.RouteFamily, dstPrefix string) uint8 {
+func (peer *peer) getRoutesCount(family bgp.Family, dstPrefix string) uint8 {
 	destLocalKey := table.NewPathDestLocalKey(family, dstPrefix)
 	if identifiers, ok := peer.sentPaths[*destLocalKey]; ok {
 		count := len(identifiers)
@@ -305,29 +305,29 @@ func (peer *peer) recvedAllEOR() bool {
 	return true
 }
 
-func (peer *peer) configuredRFlist() []bgp.RouteFamily {
+func (peer *peer) configuredRFlist() []bgp.Family {
 	peer.fsm.lock.RLock()
 	defer peer.fsm.lock.RUnlock()
 	rfs, _ := oc.AfiSafis(peer.fsm.pConf.AfiSafis).ToRfList()
 	return rfs
 }
 
-func (peer *peer) negotiatedRFList() []bgp.RouteFamily {
+func (peer *peer) negotiatedRFList() []bgp.Family {
 	peer.fsm.lock.RLock()
 	defer peer.fsm.lock.RUnlock()
-	l := make([]bgp.RouteFamily, 0, len(peer.fsm.rfMap))
+	l := make([]bgp.Family, 0, len(peer.fsm.rfMap))
 	for family := range peer.fsm.rfMap {
 		l = append(l, family)
 	}
 	return l
 }
 
-func (peer *peer) toGlobalFamilies(families []bgp.RouteFamily) []bgp.RouteFamily {
+func (peer *peer) toGlobalFamilies(families []bgp.Family) []bgp.Family {
 	id := peer.ID()
 	peer.fsm.lock.RLock()
 	defer peer.fsm.lock.RUnlock()
 	if peer.fsm.pConf.Config.Vrf != "" {
-		fs := make([]bgp.RouteFamily, 0, len(families))
+		fs := make([]bgp.Family, 0, len(families))
 		for _, f := range families {
 			switch f {
 			case bgp.RF_IPv4_UC:
@@ -352,9 +352,9 @@ func (peer *peer) toGlobalFamilies(families []bgp.RouteFamily) []bgp.RouteFamily
 	return families
 }
 
-func classifyFamilies(all, part []bgp.RouteFamily) ([]bgp.RouteFamily, []bgp.RouteFamily) {
-	a := []bgp.RouteFamily{}
-	b := []bgp.RouteFamily{}
+func classifyFamilies(all, part []bgp.Family) ([]bgp.Family, []bgp.Family) {
+	a := []bgp.Family{}
+	b := []bgp.Family{}
 	for _, f := range all {
 		p := true
 		for _, g := range part {
@@ -371,9 +371,9 @@ func classifyFamilies(all, part []bgp.RouteFamily) ([]bgp.RouteFamily, []bgp.Rou
 	return a, b
 }
 
-func (peer *peer) forwardingPreservedFamilies() ([]bgp.RouteFamily, []bgp.RouteFamily) {
+func (peer *peer) forwardingPreservedFamilies() ([]bgp.Family, []bgp.Family) {
 	peer.fsm.lock.RLock()
-	list := []bgp.RouteFamily{}
+	list := []bgp.Family{}
 	for _, a := range peer.fsm.pConf.AfiSafis {
 		if s := a.MpGracefulRestart.State; s.Enabled && s.Received {
 			list = append(list, a.State.Family)
@@ -383,9 +383,9 @@ func (peer *peer) forwardingPreservedFamilies() ([]bgp.RouteFamily, []bgp.RouteF
 	return classifyFamilies(peer.configuredRFlist(), list)
 }
 
-func (peer *peer) llgrFamilies() ([]bgp.RouteFamily, []bgp.RouteFamily) {
+func (peer *peer) llgrFamilies() ([]bgp.Family, []bgp.Family) {
 	peer.fsm.lock.RLock()
-	list := []bgp.RouteFamily{}
+	list := []bgp.Family{}
 	for _, a := range peer.fsm.pConf.AfiSafis {
 		if a.LongLivedGracefulRestart.State.Enabled {
 			list = append(list, a.State.Family)
@@ -395,7 +395,7 @@ func (peer *peer) llgrFamilies() ([]bgp.RouteFamily, []bgp.RouteFamily) {
 	return classifyFamilies(peer.configuredRFlist(), list)
 }
 
-func (peer *peer) isLLGREnabledFamily(family bgp.RouteFamily) bool {
+func (peer *peer) isLLGREnabledFamily(family bgp.Family) bool {
 	peer.fsm.lock.RLock()
 	llgrEnabled := peer.fsm.pConf.GracefulRestart.Config.LongLivedEnabled
 	peer.fsm.lock.RUnlock()
@@ -411,7 +411,7 @@ func (peer *peer) isLLGREnabledFamily(family bgp.RouteFamily) bool {
 	return false
 }
 
-func (peer *peer) llgrRestartTime(family bgp.RouteFamily) uint32 {
+func (peer *peer) llgrRestartTime(family bgp.Family) uint32 {
 	peer.fsm.lock.RLock()
 	defer peer.fsm.lock.RUnlock()
 	for _, a := range peer.fsm.pConf.AfiSafis {
@@ -422,7 +422,7 @@ func (peer *peer) llgrRestartTime(family bgp.RouteFamily) uint32 {
 	return 0
 }
 
-func (peer *peer) llgrRestartTimerExpired(family bgp.RouteFamily) bool {
+func (peer *peer) llgrRestartTimerExpired(family bgp.Family) bool {
 	peer.fsm.lock.RLock()
 	defer peer.fsm.lock.RUnlock()
 	all := true
@@ -438,7 +438,7 @@ func (peer *peer) llgrRestartTimerExpired(family bgp.RouteFamily) bool {
 	return all
 }
 
-func (peer *peer) markLLGRStale(fs []bgp.RouteFamily) []*table.Path {
+func (peer *peer) markLLGRStale(fs []bgp.Family) []*table.Path {
 	return peer.adjRibIn.MarkLLGRStaleOrDrop(fs)
 }
 
@@ -478,7 +478,7 @@ func (peer *peer) filterPathFromSourcePeer(path, old *table.Path) *table.Path {
 	// paths. In such case, gobgp sends duplicated update messages; withdraw
 	// messages for the same prefix.
 	if !peer.isRouteServerClient() {
-		if peer.isRouteReflectorClient() && path.GetRouteFamily() == bgp.RF_RTC_UC {
+		if peer.isRouteReflectorClient() && path.GetFamily() == bgp.RF_RTC_UC {
 			// When the peer is a Route Reflector client and the given path
 			// contains the Route Tartget Membership NLRI, the path should not
 			// be withdrawn in order to signal the client to distribute routes
@@ -505,9 +505,9 @@ func (peer *peer) filterPathFromSourcePeer(path, old *table.Path) *table.Path {
 	return nil
 }
 
-func (peer *peer) doPrefixLimit(k bgp.RouteFamily, c *oc.PrefixLimitConfig) *bgp.BGPMessage {
+func (peer *peer) doPrefixLimit(k bgp.Family, c *oc.PrefixLimitConfig) *bgp.BGPMessage {
 	if maxPrefixes := int(c.MaxPrefixes); maxPrefixes > 0 {
-		count := peer.adjRibIn.Count([]bgp.RouteFamily{k})
+		count := peer.adjRibIn.Count([]bgp.Family{k})
 		pct := int(c.ShutdownThresholdPct)
 		if pct > 0 && !peer.prefixLimitWarned[k] && count > (maxPrefixes*pct/100) {
 			peer.prefixLimitWarned[k] = true
@@ -538,7 +538,7 @@ func (peer *peer) updatePrefixLimitConfig(c []oc.AfiSafi) error {
 	if len(x) != len(y) {
 		return fmt.Errorf("changing supported afi-safi is not allowed")
 	}
-	m := make(map[bgp.RouteFamily]oc.PrefixLimitConfig)
+	m := make(map[bgp.Family]oc.PrefixLimitConfig)
 	for _, e := range x {
 		m[e.State.Family] = e.PrefixLimit.Config
 	}
@@ -567,7 +567,7 @@ func (peer *peer) updatePrefixLimitConfig(c []oc.AfiSafi) error {
 	return nil
 }
 
-func (peer *peer) handleUpdate(e *fsmMsg) ([]*table.Path, []bgp.RouteFamily, *bgp.BGPMessage) {
+func (peer *peer) handleUpdate(e *fsmMsg) ([]*table.Path, []bgp.Family, *bgp.BGPMessage) {
 	m := e.MsgData.(*bgp.BGPMessage)
 	update := m.Body.(*bgp.BGPUpdate)
 
@@ -586,10 +586,10 @@ func (peer *peer) handleUpdate(e *fsmMsg) ([]*table.Path, []bgp.RouteFamily, *bg
 	peer.fsm.lock.Unlock()
 	if len(e.PathList) > 0 {
 		paths := make([]*table.Path, 0, len(e.PathList))
-		eor := []bgp.RouteFamily{}
+		eor := []bgp.Family{}
 		for _, path := range e.PathList {
 			if path.IsEOR() {
-				family := path.GetRouteFamily()
+				family := path.GetFamily()
 				peer.fsm.logger.Debug("EOR received",
 					log.Fields{
 						"Topic":         "Peer",
@@ -654,7 +654,7 @@ func (peer *peer) startFSMHandler() {
 	peer.fsm.lock.Unlock()
 }
 
-func (peer *peer) StaleAll(rfList []bgp.RouteFamily) []*table.Path {
+func (peer *peer) StaleAll(rfList []bgp.Family) []*table.Path {
 	return peer.adjRibIn.StaleAll(rfList)
 }
 
@@ -670,6 +670,6 @@ func (peer *peer) PassConn(conn *net.TCPConn) {
 	}
 }
 
-func (peer *peer) DropAll(rfList []bgp.RouteFamily) []*table.Path {
+func (peer *peer) DropAll(rfList []bgp.Family) []*table.Path {
 	return peer.adjRibIn.Drop(rfList)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -957,7 +957,7 @@ func TestFilterpathWitheBGP(t *testing.T) {
 	as := uint32(65000)
 	p1As := uint32(65001)
 	p2As := uint32(65002)
-	rib := table.NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	rib := table.NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 	p1, pi1 := newPeerandInfo(as, p1As, "192.168.0.1", rib)
 	p2, pi2 := newPeerandInfo(as, p2As, "192.168.0.2", rib)
 
@@ -998,7 +998,7 @@ func TestFilterpathWitheBGP(t *testing.T) {
 func TestFilterpathWithiBGP(t *testing.T) {
 	as := uint32(65000)
 
-	rib := table.NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	rib := table.NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 	p1, pi1 := newPeerandInfo(as, as, "192.168.0.1", rib)
 	//p2, pi2 := newPeerandInfo(as, as, "192.168.0.2", rib)
 	p2, _ := newPeerandInfo(as, as, "192.168.0.2", rib)
@@ -1026,9 +1026,9 @@ func TestFilterpathWithiBGP(t *testing.T) {
 }
 
 func TestFilterpathWithRejectPolicy(t *testing.T) {
-	rib1 := table.NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	rib1 := table.NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 	_, pi1 := newPeerandInfo(1, 2, "192.168.0.1", rib1)
-	rib2 := table.NewTableManager(logger, []bgp.RouteFamily{bgp.RF_IPv4_UC})
+	rib2 := table.NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
 	p2, _ := newPeerandInfo(1, 3, "192.168.0.2", rib2)
 
 	comSet1 := oc.CommunitySet{
@@ -1453,7 +1453,7 @@ func TestTcpConnectionClosedAfterPeerDel(t *testing.T) {
 }
 
 func TestFamiliesForSoftreset(t *testing.T) {
-	f := func(f bgp.RouteFamily) oc.AfiSafi {
+	f := func(f bgp.Family) oc.AfiSafi {
 		return oc.AfiSafi{
 			State: oc.AfiSafiState{
 				Family: f,
@@ -1476,7 +1476,7 @@ func TestFamiliesForSoftreset(t *testing.T) {
 	assert.Equal(t, len(families), 1)
 	assert.Equal(t, families[0], bgp.RF_RTC_UC)
 
-	families = familiesForSoftreset(peer, bgp.RouteFamily(0))
+	families = familiesForSoftreset(peer, bgp.Family(0))
 	assert.Equal(t, len(families), 2)
 	assert.NotContains(t, families, bgp.RF_RTC_UC)
 }

--- a/pkg/server/zclient.go
+++ b/pkg/server/zclient.go
@@ -116,7 +116,7 @@ func filterOutExternalPath(paths []*table.Path) []*table.Path {
 }
 
 func addLabelToNexthop(path *table.Path, z *zebraClient, msgFlags *zebra.MessageFlag, nexthop *zebra.Nexthop) {
-	rf := path.GetRouteFamily()
+	rf := path.GetFamily()
 	if rf == bgp.RF_IPv4_VPN || rf == bgp.RF_IPv6_VPN {
 		z.client.SetLabelFlag(msgFlags, nexthop)
 		switch rf {
@@ -147,7 +147,7 @@ func newIPRouteBody(dst []*table.Path, vrfID uint32, z *zebraClient) (body *zebr
 	var nexthop zebra.Nexthop
 	nexthops := make([]zebra.Nexthop, 0, len(paths))
 	msgFlags := zebra.MessageNexthop
-	switch path.GetRouteFamily() {
+	switch path.GetFamily() {
 	case bgp.RF_IPv4_UC:
 		prefix = path.GetNlri().(*bgp.IPAddrPrefix).IPAddrPrefixDefault.Prefix.To4()
 	case bgp.RF_IPv4_VPN:
@@ -208,7 +208,7 @@ func newNexthopRegisterBody(paths []*table.Path, nexthopCache nexthopStateCache)
 	}
 	path := paths[0]
 
-	family := path.GetRouteFamily()
+	family := path.GetFamily()
 	nexthops := make([]*zebra.RegisteredNexthop, 0, len(paths))
 	for _, p := range paths {
 		nexthop := p.GetNexthop()
@@ -253,7 +253,7 @@ func newNexthopUnregisterBody(family uint16, prefix net.IP) *zebra.NexthopRegist
 func newPathFromIPRouteMessage(logger log.Logger, m *zebra.Message, version uint8, software zebra.Software) *table.Path {
 	header := m.Header
 	body := m.Body.(*zebra.IPRouteBody)
-	family := body.RouteFamily(logger, version, software)
+	family := body.Family(logger, version, software)
 	isWithdraw := body.IsWithdraw(version, software)
 
 	var nlri bgp.AddrPrefixInterface
@@ -322,15 +322,15 @@ type zebraClient struct {
 
 func (z *zebraClient) getPathListWithNexthopUpdate(body *zebra.NexthopUpdateBody) []*table.Path {
 	rib := &table.TableManager{
-		Tables: make(map[bgp.RouteFamily]*table.Table),
+		Tables: make(map[bgp.Family]*table.Table),
 	}
 
-	var rfList []bgp.RouteFamily
+	var rfList []bgp.Family
 	switch body.Prefix.Family {
 	case syscall.AF_INET:
-		rfList = []bgp.RouteFamily{bgp.RF_IPv4_UC, bgp.RF_IPv4_VPN}
+		rfList = []bgp.Family{bgp.RF_IPv4_UC, bgp.RF_IPv4_VPN}
 	case syscall.AF_INET6:
-		rfList = []bgp.RouteFamily{bgp.RF_IPv6_UC, bgp.RF_IPv6_VPN}
+		rfList = []bgp.Family{bgp.RF_IPv6_UC, bgp.RF_IPv6_VPN}
 	}
 
 	for _, rf := range rfList {

--- a/pkg/zebra/zapi.go
+++ b/pkg/zebra/zapi.go
@@ -228,7 +228,7 @@ var zapi4SafiMap = map[Safi]Safi{
 	zapi4SafiEncap:   safiEncap,
 	zapi4SafiEvpn:    safiEvpn,
 }
-var safiRouteFamilyIPv4Map = map[Safi]bgp.RouteFamily{
+var safiFamilyIPv4Map = map[Safi]bgp.Family{
 	safiUnspec:         bgp.RF_OPAQUE,
 	SafiUnicast:        bgp.RF_IPv4_UC,
 	safiMulticast:      bgp.RF_IPv4_MC,
@@ -237,7 +237,7 @@ var safiRouteFamilyIPv4Map = map[Safi]bgp.RouteFamily{
 	safiLabeledUnicast: bgp.RF_IPv4_MPLS,
 	safiFlowspec:       bgp.RF_FS_IPv4_UC,
 }
-var safiRouteFamilyIPv6Map = map[Safi]bgp.RouteFamily{
+var safiFamilyIPv6Map = map[Safi]bgp.Family{
 	safiUnspec:         bgp.RF_OPAQUE,
 	SafiUnicast:        bgp.RF_IPv6_UC,
 	safiMulticast:      bgp.RF_IPv6_MC,
@@ -1600,8 +1600,8 @@ func (c *Client) SendRedistribute(t RouteType, vrfID uint32) error {
 
 // SendIPRoute sends ROUTE message to zebra daemon.
 func (c *Client) SendIPRoute(vrfID uint32, body *IPRouteBody, isWithdraw bool) error {
-	routeFamily := body.RouteFamily(c.logger, c.Version, c.Software)
-	if vrfID == DefaultVrf && (routeFamily == bgp.RF_IPv4_VPN || routeFamily == bgp.RF_IPv6_VPN) {
+	Family := body.Family(c.logger, c.Version, c.Software)
+	if vrfID == DefaultVrf && (Family == bgp.RF_IPv4_VPN || Family == bgp.RF_IPv6_VPN) {
 		return fmt.Errorf("RF_IPv4_VPN or RF_IPv6_VPN are not suitable for Default VRF (default forwarding table)")
 	}
 	command := RouteAdd
@@ -2523,8 +2523,8 @@ func (b *IPRouteBody) safi(logger log.Logger, version uint8, software Software) 
 	return safi // success to convert
 }
 
-// RouteFamily is referred in zclient
-func (b *IPRouteBody) RouteFamily(logger log.Logger, version uint8, software Software) bgp.RouteFamily {
+// Family is referred in zclient
+func (b *IPRouteBody) Family(logger log.Logger, version uint8, software Software) bgp.Family {
 	if b == nil {
 		return bgp.RF_OPAQUE // fail
 	}
@@ -2539,11 +2539,11 @@ func (b *IPRouteBody) RouteFamily(logger log.Logger, version uint8, software Sof
 	if family == syscall.AF_UNSPEC { // familyFromPrefix returs AF_UNSPEC
 		return bgp.RF_OPAQUE // fail
 	}
-	safiRouteFamilyMap := safiRouteFamilyIPv4Map // syscall.AF_INET
+	safiFamilyMap := safiFamilyIPv4Map // syscall.AF_INET
 	if family == syscall.AF_INET6 {
-		safiRouteFamilyMap = safiRouteFamilyIPv6Map
+		safiFamilyMap = safiFamilyIPv6Map
 	}
-	rf, ok := safiRouteFamilyMap[safi]
+	rf, ok := safiFamilyMap[safi]
 	if !ok {
 		return bgp.RF_OPAQUE // fail
 	}

--- a/tools/pyang_plugins/bgpyang2golang.py
+++ b/tools/pyang_plugins/bgpyang2golang.py
@@ -729,7 +729,7 @@ _type_translation_map = {
     'yang:timeticks': 'int64',
     'ptypes:install-protocol-type': 'string',
     'binary': '[]byte',
-    'route-family': 'bgp.RouteFamily',
+    'route-family': 'bgp.Family',
     'bgp-capability': 'bgp.ParameterCapabilityInterface',
     'bgp-open-message': '*bgp.BGPMessage',
 }


### PR DESCRIPTION
Use "Family" for the Address Family, consistent with the definition in the proto file.