### PR TITLE
server: disable tcpkeepalive

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -557,6 +557,7 @@ func (h *fsmHandler) connectLoop(ctx context.Context, wg *sync.WaitGroup) {
 			d := net.Dialer{
 				LocalAddr: laddr,
 				Timeout:   time.Duration(max(retryInterval-1, minConnectRetryInterval)) * time.Second,
+				KeepAlive: -1,
 				Control: func(network, address string, c syscall.RawConn) error {
 					return dialerControl(fsm.logger, network, address, c, ttl, ttlMin, mss, password, bindInterface)
 				},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -143,6 +143,19 @@ func newTCPListener(logger log.Logger, address string, port uint32, bindToDev st
 				}
 				return err
 			}
+
+			err = conn.SetKeepAlive(false)
+			if err != nil {
+				conn.Close()
+				close(closeCh)
+				logger.Warn("Failed to SetKeepAlive",
+					log.Fields{
+						"Topic": "Peer",
+						"Key":   addr,
+						"Error": err})
+				return err
+			}
+
 			select {
 			case ch <- conn:
 			case <-listenerCtx.Done():


### PR DESCRIPTION
The default value for tcpkeepalive in the standard net package is 15 seconds, while the default value for BGP keepalive is 30 seconds. If the network is not good, the TCP connection is disconnected before BGP can send keepalive messages.

Therefore, BGP keepalive is effectively invalid.

The solution is that since we have BGP keepalive, we don't need to open tcp keepalive.