### PR TITLE
api: Fix Enum prefix

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -312,22 +312,22 @@ func (RouteOriginType) EnumDescriptor() ([]byte, []int) {
 type RouteAction int32
 
 const (
-	RouteAction_NONE   RouteAction = 0
-	RouteAction_ACCEPT RouteAction = 1
-	RouteAction_REJECT RouteAction = 2
+	RouteAction_ROUTE_ACTION_UNSPECIFIED RouteAction = 0
+	RouteAction_ROUTE_ACTION_ACCEPT      RouteAction = 1
+	RouteAction_ROUTE_ACTION_REJECT      RouteAction = 2
 )
 
 // Enum value maps for RouteAction.
 var (
 	RouteAction_name = map[int32]string{
-		0: "NONE",
-		1: "ACCEPT",
-		2: "REJECT",
+		0: "ROUTE_ACTION_UNSPECIFIED",
+		1: "ROUTE_ACTION_ACCEPT",
+		2: "ROUTE_ACTION_REJECT",
 	}
 	RouteAction_value = map[string]int32{
-		"NONE":   0,
-		"ACCEPT": 1,
-		"REJECT": 2,
+		"ROUTE_ACTION_UNSPECIFIED": 0,
+		"ROUTE_ACTION_ACCEPT":      1,
+		"ROUTE_ACTION_REJECT":      2,
 	}
 )
 
@@ -361,22 +361,22 @@ func (RouteAction) EnumDescriptor() ([]byte, []int) {
 type PolicyDirection int32
 
 const (
-	PolicyDirection_UNKNOWN PolicyDirection = 0
-	PolicyDirection_IMPORT  PolicyDirection = 1
-	PolicyDirection_EXPORT  PolicyDirection = 2
+	PolicyDirection_POLICY_DIRECTION_UNSPECIFIED PolicyDirection = 0
+	PolicyDirection_POLICY_DIRECTION_IMPORT      PolicyDirection = 1
+	PolicyDirection_POLICY_DIRECTION_EXPORT      PolicyDirection = 2
 )
 
 // Enum value maps for PolicyDirection.
 var (
 	PolicyDirection_name = map[int32]string{
-		0: "UNKNOWN",
-		1: "IMPORT",
-		2: "EXPORT",
+		0: "POLICY_DIRECTION_UNSPECIFIED",
+		1: "POLICY_DIRECTION_IMPORT",
+		2: "POLICY_DIRECTION_EXPORT",
 	}
 	PolicyDirection_value = map[string]int32{
-		"UNKNOWN": 0,
-		"IMPORT":  1,
-		"EXPORT":  2,
+		"POLICY_DIRECTION_UNSPECIFIED": 0,
+		"POLICY_DIRECTION_IMPORT":      1,
+		"POLICY_DIRECTION_EXPORT":      2,
 	}
 )
 
@@ -462,25 +462,25 @@ func (WatchEventRequest_Table_Filter_Type) EnumDescriptor() ([]byte, []int) {
 type WatchEventResponse_PeerEvent_Type int32
 
 const (
-	WatchEventResponse_PeerEvent_UNKNOWN     WatchEventResponse_PeerEvent_Type = 0
-	WatchEventResponse_PeerEvent_INIT        WatchEventResponse_PeerEvent_Type = 1
-	WatchEventResponse_PeerEvent_END_OF_INIT WatchEventResponse_PeerEvent_Type = 2
-	WatchEventResponse_PeerEvent_STATE       WatchEventResponse_PeerEvent_Type = 3
+	WatchEventResponse_PeerEvent_TYPE_UNSPECIFIED WatchEventResponse_PeerEvent_Type = 0
+	WatchEventResponse_PeerEvent_TYPE_INIT        WatchEventResponse_PeerEvent_Type = 1
+	WatchEventResponse_PeerEvent_TYPE_END_OF_INIT WatchEventResponse_PeerEvent_Type = 2
+	WatchEventResponse_PeerEvent_TYPE_STATE       WatchEventResponse_PeerEvent_Type = 3
 )
 
 // Enum value maps for WatchEventResponse_PeerEvent_Type.
 var (
 	WatchEventResponse_PeerEvent_Type_name = map[int32]string{
-		0: "UNKNOWN",
-		1: "INIT",
-		2: "END_OF_INIT",
-		3: "STATE",
+		0: "TYPE_UNSPECIFIED",
+		1: "TYPE_INIT",
+		2: "TYPE_END_OF_INIT",
+		3: "TYPE_STATE",
 	}
 	WatchEventResponse_PeerEvent_Type_value = map[string]int32{
-		"UNKNOWN":     0,
-		"INIT":        1,
-		"END_OF_INIT": 2,
-		"STATE":       3,
+		"TYPE_UNSPECIFIED": 0,
+		"TYPE_INIT":        1,
+		"TYPE_END_OF_INIT": 2,
+		"TYPE_STATE":       3,
 	}
 )
 
@@ -613,19 +613,19 @@ func (TableLookupPrefix_Type) EnumDescriptor() ([]byte, []int) {
 type ListPathRequest_SortType int32
 
 const (
-	ListPathRequest_NONE   ListPathRequest_SortType = 0
-	ListPathRequest_PREFIX ListPathRequest_SortType = 1
+	ListPathRequest_SORT_TYPE_UNSPECIFIED ListPathRequest_SortType = 0
+	ListPathRequest_SORT_TYPE_PREFIX      ListPathRequest_SortType = 1
 )
 
 // Enum value maps for ListPathRequest_SortType.
 var (
 	ListPathRequest_SortType_name = map[int32]string{
-		0: "NONE",
-		1: "PREFIX",
+		0: "SORT_TYPE_UNSPECIFIED",
+		1: "SORT_TYPE_PREFIX",
 	}
 	ListPathRequest_SortType_value = map[string]int32{
-		"NONE":   0,
-		"PREFIX": 1,
+		"SORT_TYPE_UNSPECIFIED": 0,
+		"SORT_TYPE_PREFIX":      1,
 	}
 )
 
@@ -3384,7 +3384,7 @@ func (x *ListPathRequest) GetSortType() ListPathRequest_SortType {
 	if x != nil {
 		return x.SortType
 	}
-	return ListPathRequest_NONE
+	return ListPathRequest_SORT_TYPE_UNSPECIFIED
 }
 
 func (x *ListPathRequest) GetEnableFiltered() bool {
@@ -5047,7 +5047,7 @@ func (x *ListPolicyAssignmentRequest) GetDirection() PolicyDirection {
 	if x != nil {
 		return x.Direction
 	}
-	return PolicyDirection_UNKNOWN
+	return PolicyDirection_POLICY_DIRECTION_UNSPECIFIED
 }
 
 type ListPolicyAssignmentResponse struct {
@@ -11007,7 +11007,7 @@ func (x *Actions) GetRouteAction() RouteAction {
 	if x != nil {
 		return x.RouteAction
 	}
-	return RouteAction_NONE
+	return RouteAction_ROUTE_ACTION_UNSPECIFIED
 }
 
 func (x *Actions) GetCommunity() *CommunityAction {
@@ -11229,7 +11229,7 @@ func (x *PolicyAssignment) GetDirection() PolicyDirection {
 	if x != nil {
 		return x.Direction
 	}
-	return PolicyDirection_UNKNOWN
+	return PolicyDirection_POLICY_DIRECTION_UNSPECIFIED
 }
 
 func (x *PolicyAssignment) GetPolicies() []*Policy {
@@ -11243,7 +11243,7 @@ func (x *PolicyAssignment) GetDefaultAction() RouteAction {
 	if x != nil {
 		return x.DefaultAction
 	}
-	return RouteAction_NONE
+	return RouteAction_ROUTE_ACTION_UNSPECIFIED
 }
 
 type RoutingPolicy struct {
@@ -12240,7 +12240,7 @@ func (x *WatchEventResponse_PeerEvent) GetType() WatchEventResponse_PeerEvent_Ty
 	if x != nil {
 		return x.Type
 	}
-	return WatchEventResponse_PeerEvent_UNKNOWN
+	return WatchEventResponse_PeerEvent_TYPE_UNSPECIFIED
 }
 
 func (x *WatchEventResponse_PeerEvent) GetPeer() *Peer {
@@ -12481,18 +12481,19 @@ const file_api_gobgp_proto_rawDesc = "" +
 	"\x04BEST\x10\x00\x12\t\n" +
 	"\x05ADJIN\x10\x01\x12\x0f\n" +
 	"\vPOST_POLICY\x10\x02\x12\a\n" +
-	"\x03EOR\x10\x03\"\xe5\x02\n" +
+	"\x03EOR\x10\x03\"\xfd\x02\n" +
 	"\x12WatchEventResponse\x127\n" +
 	"\x04peer\x18\x02 \x01(\v2!.api.WatchEventResponse.PeerEventH\x00R\x04peer\x12:\n" +
-	"\x05table\x18\x03 \x01(\v2\".api.WatchEventResponse.TableEventH\x00R\x05table\x1a\xa1\x01\n" +
+	"\x05table\x18\x03 \x01(\v2\".api.WatchEventResponse.TableEventH\x00R\x05table\x1a\xb9\x01\n" +
 	"\tPeerEvent\x12:\n" +
 	"\x04type\x18\x01 \x01(\x0e2&.api.WatchEventResponse.PeerEvent.TypeR\x04type\x12\x1d\n" +
-	"\x04peer\x18\x02 \x01(\v2\t.api.PeerR\x04peer\"9\n" +
-	"\x04Type\x12\v\n" +
-	"\aUNKNOWN\x10\x00\x12\b\n" +
-	"\x04INIT\x10\x01\x12\x0f\n" +
-	"\vEND_OF_INIT\x10\x02\x12\t\n" +
-	"\x05STATE\x10\x03\x1a-\n" +
+	"\x04peer\x18\x02 \x01(\v2\t.api.PeerR\x04peer\"Q\n" +
+	"\x04Type\x12\x14\n" +
+	"\x10TYPE_UNSPECIFIED\x10\x00\x12\r\n" +
+	"\tTYPE_INIT\x10\x01\x12\x14\n" +
+	"\x10TYPE_END_OF_INIT\x10\x02\x12\x0e\n" +
+	"\n" +
+	"TYPE_STATE\x10\x03\x1a-\n" +
 	"\n" +
 	"TableEvent\x12\x1f\n" +
 	"\x05paths\x18\x02 \x03(\v2\t.api.PathR\x05pathsB\a\n" +
@@ -12589,7 +12590,7 @@ const file_api_gobgp_proto_rawDesc = "" +
 	"\x05EXACT\x10\x00\x12\n" +
 	"\n" +
 	"\x06LONGER\x10\x01\x12\v\n" +
-	"\aSHORTER\x10\x02\"\xe7\x03\n" +
+	"\aSHORTER\x10\x02\"\x82\x04\n" +
 	"\x0fListPathRequest\x12-\n" +
 	"\n" +
 	"table_type\x18\x01 \x01(\x0e2\x0e.api.TableTypeR\ttableType\x12\x12\n" +
@@ -12603,11 +12604,10 @@ const file_api_gobgp_proto_rawDesc = "" +
 	"\x12enable_only_binary\x18\t \x01(\bR\x10enableOnlyBinary\x12\x1d\n" +
 	"\n" +
 	"batch_size\x18\n" +
-	" \x01(\x04R\tbatchSize\" \n" +
-	"\bSortType\x12\b\n" +
-	"\x04NONE\x10\x00\x12\n" +
-	"\n" +
-	"\x06PREFIX\x10\x01\"F\n" +
+	" \x01(\x04R\tbatchSize\";\n" +
+	"\bSortType\x12\x19\n" +
+	"\x15SORT_TYPE_UNSPECIFIED\x10\x00\x12\x14\n" +
+	"\x10SORT_TYPE_PREFIX\x10\x01\"F\n" +
 	"\x10ListPathResponse\x122\n" +
 	"\vdestination\x18\x01 \x01(\v2\x10.api.DestinationR\vdestination\"}\n" +
 	"\x14AddPathStreamRequest\x12-\n" +
@@ -13374,19 +13374,15 @@ const file_api_gobgp_proto_rawDesc = "" +
 	"ORIGIN_IGP\x10\x01\x12\x0e\n" +
 	"\n" +
 	"ORIGIN_EGP\x10\x02\x12\x15\n" +
-	"\x11ORIGIN_INCOMPLETE\x10\x03*/\n" +
-	"\vRouteAction\x12\b\n" +
-	"\x04NONE\x10\x00\x12\n" +
-	"\n" +
-	"\x06ACCEPT\x10\x01\x12\n" +
-	"\n" +
-	"\x06REJECT\x10\x02*6\n" +
-	"\x0fPolicyDirection\x12\v\n" +
-	"\aUNKNOWN\x10\x00\x12\n" +
-	"\n" +
-	"\x06IMPORT\x10\x01\x12\n" +
-	"\n" +
-	"\x06EXPORT\x10\x022\x94\x1d\n" +
+	"\x11ORIGIN_INCOMPLETE\x10\x03*]\n" +
+	"\vRouteAction\x12\x1c\n" +
+	"\x18ROUTE_ACTION_UNSPECIFIED\x10\x00\x12\x17\n" +
+	"\x13ROUTE_ACTION_ACCEPT\x10\x01\x12\x17\n" +
+	"\x13ROUTE_ACTION_REJECT\x10\x02*m\n" +
+	"\x0fPolicyDirection\x12 \n" +
+	"\x1cPOLICY_DIRECTION_UNSPECIFIED\x10\x00\x12\x1b\n" +
+	"\x17POLICY_DIRECTION_IMPORT\x10\x01\x12\x1b\n" +
+	"\x17POLICY_DIRECTION_EXPORT\x10\x022\x94\x1d\n" +
 	"\fGoBgpService\x127\n" +
 	"\bStartBgp\x12\x14.api.StartBgpRequest\x1a\x15.api.StartBgpResponse\x124\n" +
 	"\aStopBgp\x12\x13.api.StopBgpRequest\x1a\x14.api.StopBgpResponse\x121\n" +

--- a/cmd/gobgp/monitor.go
+++ b/cmd/gobgp/monitor.go
@@ -169,7 +169,7 @@ func newMonitorCmd() *cobra.Command {
 				} else if err != nil {
 					exitWithError(err)
 				}
-				if p := r.GetPeer(); p != nil && p.Type == api.WatchEventResponse_PeerEvent_STATE {
+				if p := r.GetPeer(); p != nil && p.Type == api.WatchEventResponse_PeerEvent_TYPE_STATE {
 					s := p.Peer
 					if s.Conf.NeighborAddress == name {
 						if globalOpts.Json {

--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -972,7 +972,7 @@ func showNeighborRib(r string, name string, args []string) error {
 		Family:         family,
 		Name:           name,
 		Prefixes:       filter,
-		SortType:       api.ListPathRequest_PREFIX,
+		SortType:       api.ListPathRequest_SORT_TYPE_PREFIX,
 		EnableFiltered: enableFiltered,
 		BatchSize:      subOpts.BatchSize,
 	})
@@ -1146,9 +1146,9 @@ func showNeighborPolicy(remoteIP, policyType string, indent int) error {
 
 	switch strings.ToLower(policyType) {
 	case "import":
-		dir = api.PolicyDirection_IMPORT
+		dir = api.PolicyDirection_POLICY_DIRECTION_IMPORT
 	case "export":
-		dir = api.PolicyDirection_EXPORT
+		dir = api.PolicyDirection_POLICY_DIRECTION_EXPORT
 	default:
 		return fmt.Errorf("invalid policy type: choose from (import|export)")
 	}
@@ -1189,20 +1189,20 @@ func extractDefaultAction(args []string) ([]string, api.RouteAction, error) {
 	for idx, arg := range args {
 		if arg == "default" {
 			if len(args) < (idx + 2) {
-				return nil, api.RouteAction_NONE, fmt.Errorf("specify default action [accept|reject]")
+				return nil, api.RouteAction_ROUTE_ACTION_UNSPECIFIED, fmt.Errorf("specify default action [accept|reject]")
 			}
 			typ := args[idx+1]
 			switch strings.ToLower(typ) {
 			case "accept":
-				return append(args[:idx], args[idx+2:]...), api.RouteAction_ACCEPT, nil
+				return append(args[:idx], args[idx+2:]...), api.RouteAction_ROUTE_ACTION_ACCEPT, nil
 			case "reject":
-				return append(args[:idx], args[idx+2:]...), api.RouteAction_REJECT, nil
+				return append(args[:idx], args[idx+2:]...), api.RouteAction_ROUTE_ACTION_REJECT, nil
 			default:
-				return nil, api.RouteAction_NONE, fmt.Errorf("invalid default action")
+				return nil, api.RouteAction_ROUTE_ACTION_UNSPECIFIED, fmt.Errorf("invalid default action")
 			}
 		}
 	}
-	return args, api.RouteAction_NONE, nil
+	return args, api.RouteAction_ROUTE_ACTION_UNSPECIFIED, nil
 }
 
 func modNeighborPolicy(remoteIP, policyType, cmdType string, args []string) error {
@@ -1216,9 +1216,9 @@ func modNeighborPolicy(remoteIP, policyType, cmdType string, args []string) erro
 
 	switch strings.ToLower(policyType) {
 	case "import":
-		assign.Direction = api.PolicyDirection_IMPORT
+		assign.Direction = api.PolicyDirection_POLICY_DIRECTION_IMPORT
 	case "export":
-		assign.Direction = api.PolicyDirection_EXPORT
+		assign.Direction = api.PolicyDirection_POLICY_DIRECTION_EXPORT
 	}
 
 	usage := fmt.Sprintf("usage: gobgp neighbor %s policy %s %s", remoteIP, policyType, cmdType)

--- a/cmd/gobgp/policy.go
+++ b/cmd/gobgp/policy.go
@@ -500,9 +500,9 @@ func printStatement(indent int, s *api.Statement) {
 		fmt.Println(ind, "Nexthop: ", prettyString(a.Nexthop))
 	}
 
-	if a.RouteAction != api.RouteAction_NONE {
+	if a.RouteAction != api.RouteAction_ROUTE_ACTION_UNSPECIFIED {
 		action := "accept"
-		if a.RouteAction == api.RouteAction_REJECT {
+		if a.RouteAction == api.RouteAction_ROUTE_ACTION_REJECT {
 			action = "reject"
 		}
 		fmt.Println(ind, action)
@@ -849,9 +849,9 @@ func modAction(name, op string, args []string) error {
 	cmd := "{ add | remove | replace } <value>..."
 	switch typ {
 	case "reject":
-		stmt.Actions.RouteAction = api.RouteAction_REJECT
+		stmt.Actions.RouteAction = api.RouteAction_ROUTE_ACTION_REJECT
 	case "accept":
-		stmt.Actions.RouteAction = api.RouteAction_ACCEPT
+		stmt.Actions.RouteAction = api.RouteAction_ROUTE_ACTION_ACCEPT
 	case "community":
 		stmt.Actions.Community = &api.CommunityAction{}
 		if len(args) < 1 {

--- a/docs/sources/bgp-ls.md
+++ b/docs/sources/bgp-ls.md
@@ -115,7 +115,7 @@ func main() {
 				},
 			},
 		},}, func(r *api.WatchEventResponse) {
-			if p := r.GetPeer(); p != nil && p.Type == api.WatchEventResponse_PeerEvent_STATE {
+			if p := r.GetPeer(); p != nil && p.Type == api.WatchEventResponse_PeerEvent_TYPE_STATE {
 				log.Info(p)
 			} else if t := r.GetTable(); t != nil {
 				// Your application should do something useful with the BGP-LS path here.
@@ -135,10 +135,10 @@ func main() {
 		},
 		ApplyPolicy: &api.ApplyPolicy{
 			ImportPolicy: &api.PolicyAssignment{
-				DefaultAction: api.RouteAction_ACCEPT,
+				DefaultAction: api.RouteAction_ROUTE_ACTION_ACCEPT,
 			},
 			ExportPolicy: &api.PolicyAssignment{
-				DefaultAction: api.RouteAction_REJECT,
+				DefaultAction: api.RouteAction_ROUTE_ACTION_REJECT,
 			},
 		},
 		AfiSafis: []*api.AfiSafi{

--- a/docs/sources/lib.md
+++ b/docs/sources/lib.md
@@ -41,7 +41,7 @@ func main() {
 
 	// monitor the change of the peer state
 	if err := s.WatchEvent(context.Background(), &api.WatchEventRequest{Peer: &api.WatchEventRequest_Peer{},}, func(r *api.WatchEventResponse) {
-			if p := r.GetPeer(); p != nil && p.Type == api.WatchEventResponse_PeerEvent_STATE {
+			if p := r.GetPeer(); p != nil && p.Type == api.WatchEventResponse_PeerEvent_TYPE_STATE {
 				log.Info(p)
 			}
 		}); err != nil {

--- a/internal/pkg/table/policy.go
+++ b/internal/pkg/table/policy.go
@@ -4165,11 +4165,11 @@ func toStatementApi(s *oc.Statement) *api.Statement {
 		RouteAction: func() api.RouteAction {
 			switch s.Actions.RouteDisposition {
 			case oc.ROUTE_DISPOSITION_ACCEPT_ROUTE:
-				return api.RouteAction_ACCEPT
+				return api.RouteAction_ROUTE_ACTION_ACCEPT
 			case oc.ROUTE_DISPOSITION_REJECT_ROUTE:
-				return api.RouteAction_REJECT
+				return api.RouteAction_ROUTE_ACTION_REJECT
 			}
-			return api.RouteAction_NONE
+			return api.RouteAction_ROUTE_ACTION_UNSPECIFIED
 		}(),
 		Community: func() *api.CommunityAction {
 			if len(s.Actions.BgpActions.SetCommunity.SetCommunityMethod.CommunitiesList) == 0 {
@@ -4313,20 +4313,20 @@ func NewAPIPolicyAssignmentFromTableStruct(t *PolicyAssignment) *api.PolicyAssig
 		Direction: func() api.PolicyDirection {
 			switch t.Type {
 			case POLICY_DIRECTION_IMPORT:
-				return api.PolicyDirection_IMPORT
+				return api.PolicyDirection_POLICY_DIRECTION_IMPORT
 			case POLICY_DIRECTION_EXPORT:
-				return api.PolicyDirection_EXPORT
+				return api.PolicyDirection_POLICY_DIRECTION_EXPORT
 			}
-			return api.PolicyDirection_UNKNOWN
+			return api.PolicyDirection_POLICY_DIRECTION_UNSPECIFIED
 		}(),
 		DefaultAction: func() api.RouteAction {
 			switch t.Default {
 			case ROUTE_TYPE_ACCEPT:
-				return api.RouteAction_ACCEPT
+				return api.RouteAction_ROUTE_ACTION_ACCEPT
 			case ROUTE_TYPE_REJECT:
-				return api.RouteAction_REJECT
+				return api.RouteAction_ROUTE_ACTION_REJECT
 			}
-			return api.RouteAction_NONE
+			return api.RouteAction_ROUTE_ACTION_UNSPECIFIED
 		}(),
 		Name: t.Name,
 		Policies: func() []*api.Policy {

--- a/pkg/config/oc/util.go
+++ b/pkg/config/oc/util.go
@@ -301,19 +301,19 @@ func newAfiSafiConfigFromConfigStruct(c *AfiSafi) *api.AfiSafiConfig {
 func newApplyPolicyFromConfigStruct(c *ApplyPolicy) *api.ApplyPolicy {
 	f := func(t DefaultPolicyType) api.RouteAction {
 		if t == DEFAULT_POLICY_TYPE_ACCEPT_ROUTE {
-			return api.RouteAction_ACCEPT
+			return api.RouteAction_ROUTE_ACTION_ACCEPT
 		} else if t == DEFAULT_POLICY_TYPE_REJECT_ROUTE {
-			return api.RouteAction_REJECT
+			return api.RouteAction_ROUTE_ACTION_REJECT
 		}
-		return api.RouteAction_NONE
+		return api.RouteAction_ROUTE_ACTION_UNSPECIFIED
 	}
 	applyPolicy := &api.ApplyPolicy{
 		ImportPolicy: &api.PolicyAssignment{
-			Direction:     api.PolicyDirection_IMPORT,
+			Direction:     api.PolicyDirection_POLICY_DIRECTION_IMPORT,
 			DefaultAction: f(c.Config.DefaultImportPolicy),
 		},
 		ExportPolicy: &api.PolicyAssignment{
-			Direction:     api.PolicyDirection_EXPORT,
+			Direction:     api.PolicyDirection_POLICY_DIRECTION_EXPORT,
 			DefaultAction: f(c.Config.DefaultExportPolicy),
 		},
 	}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -75,7 +75,7 @@ func TestMetrics(test *testing.T) {
 	ch := make(chan struct{})
 	s.WatchEvent(context.Background(), &api.WatchEventRequest{Peer: &api.WatchEventRequest_Peer{}}, func(r *api.WatchEventResponse) {
 		if peer := r.GetPeer(); peer != nil {
-			if peer.Type == api.WatchEventResponse_PeerEvent_STATE && peer.Peer.State.SessionState == api.PeerState_ESTABLISHED {
+			if peer.Type == api.WatchEventResponse_PeerEvent_TYPE_STATE && peer.Peer.State.SessionState == api.PeerState_ESTABLISHED {
 				close(ch)
 			}
 		}

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -578,9 +578,9 @@ func readApplyPolicyFromAPIStruct(c *oc.ApplyPolicy, a *api.ApplyPolicy) {
 		return
 	}
 	f := func(a api.RouteAction) oc.DefaultPolicyType {
-		if a == api.RouteAction_ACCEPT {
+		if a == api.RouteAction_ROUTE_ACTION_ACCEPT {
 			return oc.DEFAULT_POLICY_TYPE_ACCEPT_ROUTE
-		} else if a == api.RouteAction_REJECT {
+		} else if a == api.RouteAction_ROUTE_ACTION_REJECT {
 			return oc.DEFAULT_POLICY_TYPE_REJECT_ROUTE
 		}
 		return ""
@@ -1179,11 +1179,11 @@ func toStatementApi(s *oc.Statement) *api.Statement {
 		RouteAction: func() api.RouteAction {
 			switch s.Actions.RouteDisposition {
 			case oc.ROUTE_DISPOSITION_ACCEPT_ROUTE:
-				return api.RouteAction_ACCEPT
+				return api.RouteAction_ROUTE_ACTION_ACCEPT
 			case oc.ROUTE_DISPOSITION_REJECT_ROUTE:
-				return api.RouteAction_REJECT
+				return api.RouteAction_ROUTE_ACTION_REJECT
 			}
-			return api.RouteAction_NONE
+			return api.RouteAction_ROUTE_ACTION_UNSPECIFIED
 		}(),
 		Community: func() *api.CommunityAction {
 			if len(s.Actions.BgpActions.SetCommunity.SetCommunityMethod.CommunitiesList) == 0 {
@@ -1504,11 +1504,11 @@ func newAfiSafiInConditionFromApiStruct(a []*api.Family) (*table.AfiSafiInCondit
 }
 
 func newRoutingActionFromApiStruct(a api.RouteAction) (*table.RoutingAction, error) {
-	if a == api.RouteAction_NONE {
+	if a == api.RouteAction_ROUTE_ACTION_UNSPECIFIED {
 		return nil, nil
 	}
 	accept := false
-	if a == api.RouteAction_ACCEPT {
+	if a == api.RouteAction_ROUTE_ACTION_ACCEPT {
 		accept = true
 	}
 	return &table.RoutingAction{
@@ -1847,9 +1847,9 @@ func (s *server) ListPolicyAssignment(r *api.ListPolicyAssignmentRequest, stream
 
 func defaultRouteType(d api.RouteAction) table.RouteType {
 	switch d {
-	case api.RouteAction_ACCEPT:
+	case api.RouteAction_ROUTE_ACTION_ACCEPT:
 		return table.ROUTE_TYPE_ACCEPT
-	case api.RouteAction_REJECT:
+	case api.RouteAction_ROUTE_ACTION_REJECT:
 		return table.ROUTE_TYPE_REJECT
 	default:
 		return table.ROUTE_TYPE_NONE

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4055,9 +4055,9 @@ func (s *BgpServer) toPolicyInfo(name string, dir api.PolicyDirection) (string, 
 		name = peer.ID()
 	}
 	switch dir {
-	case api.PolicyDirection_IMPORT:
+	case api.PolicyDirection_POLICY_DIRECTION_IMPORT:
 		return name, table.POLICY_DIRECTION_IMPORT, nil
-	case api.PolicyDirection_EXPORT:
+	case api.PolicyDirection_POLICY_DIRECTION_EXPORT:
 		return name, table.POLICY_DIRECTION_EXPORT, nil
 	}
 	return "", table.POLICY_DIRECTION_NONE, fmt.Errorf("invalid policy type")
@@ -4081,8 +4081,8 @@ func (s *BgpServer) ListPolicyAssignment(ctx context.Context, r *api.ListPolicyA
 			names = append(names, r.Name)
 		}
 		dirs := make([]api.PolicyDirection, 0, 2)
-		if r.Direction == api.PolicyDirection_UNKNOWN {
-			dirs = []api.PolicyDirection{api.PolicyDirection_EXPORT, api.PolicyDirection_IMPORT}
+		if r.Direction == api.PolicyDirection_POLICY_DIRECTION_UNSPECIFIED {
+			dirs = []api.PolicyDirection{api.PolicyDirection_POLICY_DIRECTION_EXPORT, api.PolicyDirection_POLICY_DIRECTION_IMPORT}
 		} else {
 			dirs = append(dirs, r.Direction)
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -115,26 +115,26 @@ func TestModPolicyAssign(t *testing.T) {
 	}
 
 	r := f([]*oc.PolicyDefinition{{Name: "p1"}, {Name: "p2"}, {Name: "p3"}})
-	r.Direction = api.PolicyDirection_IMPORT
-	r.DefaultAction = api.RouteAction_ACCEPT
+	r.Direction = api.PolicyDirection_POLICY_DIRECTION_IMPORT
+	r.DefaultAction = api.RouteAction_ROUTE_ACTION_ACCEPT
 	r.Name = table.GLOBAL_RIB_NAME
 	err = s.AddPolicyAssignment(context.Background(), &api.AddPolicyAssignmentRequest{Assignment: r})
 	assert.Nil(err)
 
-	r.Direction = api.PolicyDirection_EXPORT
+	r.Direction = api.PolicyDirection_POLICY_DIRECTION_EXPORT
 	err = s.AddPolicyAssignment(context.Background(), &api.AddPolicyAssignmentRequest{Assignment: r})
 	assert.Nil(err)
 
 	var ps []*api.PolicyAssignment
 	err = s.ListPolicyAssignment(context.Background(), &api.ListPolicyAssignmentRequest{
 		Name:      table.GLOBAL_RIB_NAME,
-		Direction: api.PolicyDirection_IMPORT}, func(p *api.PolicyAssignment) { ps = append(ps, p) })
+		Direction: api.PolicyDirection_POLICY_DIRECTION_IMPORT}, func(p *api.PolicyAssignment) { ps = append(ps, p) })
 	assert.Nil(err)
 	assert.Equal(len(ps[0].Policies), 3)
 
 	r = f([]*oc.PolicyDefinition{{Name: "p1"}})
-	r.Direction = api.PolicyDirection_IMPORT
-	r.DefaultAction = api.RouteAction_ACCEPT
+	r.Direction = api.PolicyDirection_POLICY_DIRECTION_IMPORT
+	r.DefaultAction = api.RouteAction_ROUTE_ACTION_ACCEPT
 	r.Name = table.GLOBAL_RIB_NAME
 	err = s.DeletePolicyAssignment(context.Background(), &api.DeletePolicyAssignmentRequest{Assignment: r})
 	assert.Nil(err)
@@ -142,7 +142,7 @@ func TestModPolicyAssign(t *testing.T) {
 	ps = []*api.PolicyAssignment{}
 	s.ListPolicyAssignment(context.Background(), &api.ListPolicyAssignmentRequest{
 		Name:      table.GLOBAL_RIB_NAME,
-		Direction: api.PolicyDirection_IMPORT}, func(p *api.PolicyAssignment) { ps = append(ps, p) })
+		Direction: api.PolicyDirection_POLICY_DIRECTION_IMPORT}, func(p *api.PolicyAssignment) { ps = append(ps, p) })
 	assert.Equal(len(ps[0].Policies), 2)
 
 	ps = []*api.PolicyAssignment{}
@@ -186,8 +186,8 @@ func TestListPolicyAssignment(t *testing.T) {
 		assert.Nil(err)
 
 		pa := &api.PolicyAssignment{
-			Direction:     api.PolicyDirection_IMPORT,
-			DefaultAction: api.RouteAction_ACCEPT,
+			Direction:     api.PolicyDirection_POLICY_DIRECTION_IMPORT,
+			DefaultAction: api.RouteAction_ROUTE_ACTION_ACCEPT,
 			Name:          addr,
 			Policies:      []*api.Policy{{Name: fmt.Sprintf("p%d", i)}},
 		}
@@ -209,7 +209,7 @@ func TestListPolicyAssignment(t *testing.T) {
 
 	ps = []*api.PolicyAssignment{}
 	err = s.ListPolicyAssignment(context.Background(), &api.ListPolicyAssignmentRequest{
-		Direction: api.PolicyDirection_EXPORT,
+		Direction: api.PolicyDirection_POLICY_DIRECTION_EXPORT,
 	}, func(p *api.PolicyAssignment) { ps = append(ps, p) })
 	assert.Nil(err)
 	assert.Equal(4, len(ps))
@@ -219,7 +219,7 @@ func waitState(s *BgpServer, ch chan struct{}, state api.PeerState_SessionState)
 	watchCtx, watchCancel := context.WithCancel(context.Background())
 	s.WatchEvent(watchCtx, &api.WatchEventRequest{Peer: &api.WatchEventRequest_Peer{}}, func(r *api.WatchEventResponse) {
 		if peer := r.GetPeer(); peer != nil {
-			if peer.Type == api.WatchEventResponse_PeerEvent_STATE && peer.Peer.State.SessionState == state {
+			if peer.Type == api.WatchEventResponse_PeerEvent_TYPE_STATE && peer.Peer.State.SessionState == state {
 				close(ch)
 				watchCancel()
 			}
@@ -317,7 +317,7 @@ func TestListPathEnableFiltered(test *testing.T) {
 			},
 		},
 		Actions: &api.Actions{
-			RouteAction: api.RouteAction_REJECT,
+			RouteAction: api.RouteAction_ROUTE_ACTION_REJECT,
 		},
 	}
 	err = server1.AddDefinedSet(context.Background(), &api.AddDefinedSetRequest{DefinedSet: d1})
@@ -331,9 +331,9 @@ func TestListPathEnableFiltered(test *testing.T) {
 	err = server1.AddPolicyAssignment(context.Background(), &api.AddPolicyAssignmentRequest{
 		Assignment: &api.PolicyAssignment{
 			Name:          table.GLOBAL_RIB_NAME,
-			Direction:     api.PolicyDirection_IMPORT,
+			Direction:     api.PolicyDirection_POLICY_DIRECTION_IMPORT,
 			Policies:      []*api.Policy{p1},
-			DefaultAction: api.RouteAction_ACCEPT,
+			DefaultAction: api.RouteAction_ROUTE_ACTION_ACCEPT,
 		},
 	})
 	assert.Nil(err)
@@ -614,7 +614,7 @@ func TestListPathEnableFiltered(test *testing.T) {
 			},
 		},
 		Actions: &api.Actions{
-			RouteAction: api.RouteAction_REJECT,
+			RouteAction: api.RouteAction_ROUTE_ACTION_REJECT,
 		},
 	}
 	err = server1.AddDefinedSet(context.Background(), &api.AddDefinedSetRequest{DefinedSet: d2})
@@ -628,9 +628,9 @@ func TestListPathEnableFiltered(test *testing.T) {
 	err = server1.AddPolicyAssignment(context.Background(), &api.AddPolicyAssignmentRequest{
 		Assignment: &api.PolicyAssignment{
 			Name:          table.GLOBAL_RIB_NAME,
-			Direction:     api.PolicyDirection_EXPORT,
+			Direction:     api.PolicyDirection_POLICY_DIRECTION_EXPORT,
 			Policies:      []*api.Policy{p2},
-			DefaultAction: api.RouteAction_ACCEPT,
+			DefaultAction: api.RouteAction_ROUTE_ACTION_ACCEPT,
 		},
 	})
 	assert.Nil(err)
@@ -2201,7 +2201,7 @@ func TestWatchEvent(test *testing.T) {
 			},
 		},
 		Actions: &api.Actions{
-			RouteAction: api.RouteAction_REJECT,
+			RouteAction: api.RouteAction_ROUTE_ACTION_REJECT,
 		},
 	}
 	err = s.AddDefinedSet(context.Background(), &api.AddDefinedSetRequest{DefinedSet: d1})
@@ -2215,9 +2215,9 @@ func TestWatchEvent(test *testing.T) {
 	err = s.AddPolicyAssignment(context.Background(), &api.AddPolicyAssignmentRequest{
 		Assignment: &api.PolicyAssignment{
 			Name:          table.GLOBAL_RIB_NAME,
-			Direction:     api.PolicyDirection_IMPORT,
+			Direction:     api.PolicyDirection_POLICY_DIRECTION_IMPORT,
 			Policies:      []*api.Policy{p1},
-			DefaultAction: api.RouteAction_ACCEPT,
+			DefaultAction: api.RouteAction_ROUTE_ACTION_ACCEPT,
 		},
 	})
 	assert.Nil(err)

--- a/proto/api/gobgp.proto
+++ b/proto/api/gobgp.proto
@@ -151,10 +151,10 @@ message WatchEventRequest {
 message WatchEventResponse {
   message PeerEvent {
     enum Type {
-      UNKNOWN = 0;
-      INIT = 1;
-      END_OF_INIT = 2;
-      STATE = 3;
+      TYPE_UNSPECIFIED = 0;
+      TYPE_INIT = 1;
+      TYPE_END_OF_INIT = 2;
+      TYPE_STATE = 3;
     }
     Type type = 1;
     Peer peer = 2;
@@ -329,8 +329,8 @@ message ListPathRequest {
   Family family = 3;
   repeated TableLookupPrefix prefixes = 4;
   enum SortType {
-    NONE = 0;
-    PREFIX = 1;
+    SORT_TYPE_UNSPECIFIED = 0;
+    SORT_TYPE_PREFIX = 1;
   }
   SortType sort_type = 5;
   bool enable_filtered = 6;
@@ -1161,9 +1161,9 @@ message Conditions {
 }
 
 enum RouteAction {
-  NONE = 0;
-  ACCEPT = 1;
-  REJECT = 2;
+  ROUTE_ACTION_UNSPECIFIED = 0;
+  ROUTE_ACTION_ACCEPT = 1;
+  ROUTE_ACTION_REJECT = 2;
 }
 
 message CommunityAction {
@@ -1230,9 +1230,9 @@ message Policy {
 }
 
 enum PolicyDirection {
-  UNKNOWN = 0;
-  IMPORT = 1;
-  EXPORT = 2;
+  POLICY_DIRECTION_UNSPECIFIED = 0;
+  POLICY_DIRECTION_IMPORT = 1;
+  POLICY_DIRECTION_EXPORT = 2;
 }
 
 message PolicyAssignment {


### PR DESCRIPTION
Use _UNSPECIFIED prefix for Enum zero value name:

PeerEvent::Type
ListPathRequest::SortType
RouteAction
PolicyDirection

Fix buf lint warnings.