### PR TITLE
fix covert withdraw of an updated rtc path

### DIFF
--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -291,7 +291,7 @@ func (dest *Destination) explicitWithdraw(logger log.Logger, withdraw *Path) *Pa
 	isFound := -1
 	for i, path := range dest.knownPathList {
 		// We have a match if the source and path-id are same.
-		if path.GetSource().Equal(withdraw.GetSource()) && path.GetNlri().PathIdentifier() == withdraw.GetNlri().PathIdentifier() {
+		if path.EqualByNlri(withdraw) {
 			isFound = i
 			withdraw.GetNlri().SetPathLocalIdentifier(path.GetNlri().PathLocalIdentifier())
 		}
@@ -326,7 +326,7 @@ func (dest *Destination) implicitWithdraw(logger log.Logger, newPath *Path) {
 		// version num. as newPaths are implicit withdrawal of old
 		// paths and when doing RouteRefresh (not EnhancedRouteRefresh)
 		// we get same paths again.
-		if newPath.GetSource().Equal(path.GetSource()) && newPath.GetNlri().PathIdentifier() == path.GetNlri().PathIdentifier() {
+		if newPath.EqualByNlri(path) {
 			if logger.GetLevel() >= log.DebugLevel {
 				logger.Debug("Implicit withdrawal of old path, since we have learned new path from the same peer",
 					log.Fields{

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -1033,6 +1033,21 @@ func (path *Path) GetLocalPref() (uint32, error) {
 	return lp, nil
 }
 
+func (lhs *Path) EqualByNlri(rhs *Path) bool {
+	if rhs == nil {
+		return false
+	}
+	if lhs == rhs {
+		return true
+	}
+
+	if !lhs.GetSource().Equal(rhs.GetSource()) {
+		return false
+	}
+
+	return lhs.GetNlri().PathIdentifier() == rhs.GetNlri().PathIdentifier()
+}
+
 func (lhs *Path) Equal(rhs *Path) bool {
 	if rhs == nil {
 		return false

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -738,8 +738,10 @@ func (s *BgpServer) prePolicyFilterpath(peer *peer, path, old *table.Path) (*tab
 		}
 
 		if old != nil && old.IsLocal() {
-			// We assumes VRF with the specific RT is deleted.
-			path = old.Clone(true)
+			// If path == nil it will be set to old.Clone(true) in the
+			// func (s *BgpServer) filterpath(peer *peer, path, old *table.Path).
+			// Otherwise this is the local path changing without rt change. We
+			// need to update path or do nothing if path == old.
 		} else if peer.isRouteReflectorClient() {
 			// We need to send the path even if the peer is originator of the
 			// path in order to signal that the client should distribute route


### PR DESCRIPTION
1. Fix covert withdraw of an updated rtc path and it's responses.
2. Add tests for this problem and for the reason why deleted string had been added.