### PR TITLE
several small clarifications in 4ca2099fee19d043704ff04ddfe38f9294ca86be

### DIFF
--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -291,7 +291,7 @@ func (dest *Destination) explicitWithdraw(logger log.Logger, withdraw *Path) *Pa
 	isFound := -1
 	for i, path := range dest.knownPathList {
 		// We have a match if the source and path-id are same.
-		if path.EqualByNlri(withdraw) {
+		if path.EqualBySourceAndPathID(withdraw) {
 			isFound = i
 			withdraw.GetNlri().SetPathLocalIdentifier(path.GetNlri().PathLocalIdentifier())
 		}
@@ -326,7 +326,7 @@ func (dest *Destination) implicitWithdraw(logger log.Logger, newPath *Path) {
 		// version num. as newPaths are implicit withdrawal of old
 		// paths and when doing RouteRefresh (not EnhancedRouteRefresh)
 		// we get same paths again.
-		if newPath.EqualByNlri(path) {
+		if newPath.EqualBySourceAndPathID(path) {
 			if logger.GetLevel() >= log.DebugLevel {
 				logger.Debug("Implicit withdrawal of old path, since we have learned new path from the same peer",
 					log.Fields{

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -1033,7 +1033,7 @@ func (path *Path) GetLocalPref() (uint32, error) {
 	return lp, nil
 }
 
-func (lhs *Path) EqualByNlri(rhs *Path) bool {
+func (lhs *Path) EqualBySourceAndPathID(rhs *Path) bool {
 	if rhs == nil {
 		return false
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -738,10 +738,10 @@ func (s *BgpServer) prePolicyFilterpath(peer *peer, path, old *table.Path) (*tab
 		}
 
 		if old != nil && old.IsLocal() {
-			// If path == nil it will be set to old.Clone(true) in the
-			// func (s *BgpServer) filterpath(peer *peer, path, old *table.Path).
-			// Otherwise this is the local path changing without rt change. We
-			// need to update path or do nothing if path == old.
+			// If it is vrf or rtc route deleting, it will work via explicitWithdraw
+			// and make old.Clone(true). The only way to get path != nil and old != nil
+			// is to change the path without changing rt. Then we need to update path or
+			// do nothing if path == old.
 		} else if peer.isRouteReflectorClient() {
 			// We need to send the path even if the peer is originator of the
 			// path in order to signal that the client should distribute route


### PR DESCRIPTION
more correct naming
more adequate tests