### PR TITLE
api: introduce new WatchEvent path(s) library mode API call

### DIFF
--- a/docs/sources/lib.md
+++ b/docs/sources/lib.md
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
 	"github.com/osrg/gobgp/v4/pkg/log"
 	"github.com/osrg/gobgp/v4/pkg/server"
 )
@@ -40,11 +41,12 @@ func main() {
 	}
 
 	// monitor the change of the peer state
-	if err := s.WatchEvent(context.Background(), &api.WatchEventRequest{Peer: &api.WatchEventRequest_Peer{},}, func(r *api.WatchEventResponse, when time.Time) {
-			if p := r.GetPeer(); p != nil && p.Type == api.WatchEventResponse_PeerEvent_TYPE_STATE {
-				log.Info(p)
+	if err := s.WatchEvent(context.Background(), server.WatchEventMessageCallbacks{
+		OnPeerUpdate: func(peer *apiutil.WatchEventMessage_PeerEvent, _ time.Time) {
+			if peer.Type == apiutil.PEER_EVENT_STATE {
+				log.Info(peer.Peer)
 			}
-		}); err != nil {
+		}}); err != nil {
 		log.Fatal(err)
 	}
 

--- a/pkg/apiutil/util.go
+++ b/pkg/apiutil/util.go
@@ -60,18 +60,18 @@ type Path struct {
 }
 
 type PeerConf struct {
-	PeerAsn           uint32
-	LocalAsn          uint32
+	PeerASN           uint32
+	LocalASN          uint32
 	NeighborAddress   net.IP
 	NeighborInterface string
 }
 type PeerState struct {
-	PeerAsn         uint32
-	LocalAsn        uint32
+	PeerASN         uint32
+	LocalASN        uint32
 	NeighborAddress net.IP
 	SessionState    bgp.FSMState
 	AdminState      api.PeerState_AdminState
-	RouterId        net.IP
+	RouterID        net.IP
 	RemoteCap       []bgp.ParameterCapabilityInterface
 }
 type Transport struct {

--- a/pkg/apiutil/util.go
+++ b/pkg/apiutil/util.go
@@ -38,22 +38,25 @@ const (
 // WatchEventMessages API type
 type WatchEventMessage_PeerEvent struct {
 	Type PeerEventType
-	Peer *Peer
+	Peer Peer
 }
 
 // used by server.WatchEventMessages API
 type Path struct {
-	Nlri  bgp.AddrPrefixInterface      `json:"nlri"`
-	Age   int64                        `json:"age"`
-	Best  bool                         `json:"best"`
-	Attrs []bgp.PathAttributeInterface `json:"attrs"`
-	Stale bool                         `json:"stale"`
-	// true if the path has been filtered out due to max path count reached
-	SendMaxFiltered bool   `json:"send-max-filtered,omitempty"`
-	Withdrawal      bool   `json:"withdrawal,omitempty"`
-	SourceASN       uint32 `json:"source-asn,omitempty"`
-	SourceID        net.IP `json:"source-id,omitempty"`
-	NeighborIP      net.IP `json:"neighbor-ip,omitempty"`
+	Nlri       bgp.AddrPrefixInterface      `json:"nlri"`
+	Age        int64                        `json:"age"`
+	Best       bool                         `json:"best"`
+	Attrs      []bgp.PathAttributeInterface `json:"attrs"`
+	Stale      bool                         `json:"stale"`
+	Withdrawal bool                         `json:"withdrawal,omitempty"`
+	SourceASN  uint32                       `json:"source-asn,omitempty"`
+	SourceID   net.IP                       `json:"source-id,omitempty"`
+	NeighborIP net.IP                       `json:"neighbor-ip,omitempty"`
+	// true if the path has been filtered out due to max path count reached (used by ListPath API)
+	SendMaxFiltered    bool `json:"send-max-filtered,omitempty"`
+	IsFromExternal     bool `json:"is-from-external,omitempty"`
+	NoImplicitWithdraw bool `json:"no-implicit-withdraw,omitempty"`
+	IsNexthopInvalid   bool `json:"is-nexthop-invalid,omitempty"`
 }
 
 type PeerConf struct {

--- a/pkg/apiutil/util.go
+++ b/pkg/apiutil/util.go
@@ -43,15 +43,15 @@ type WatchEventMessage_PeerEvent struct {
 
 // used by server.WatchEventMessages API
 type Path struct {
-	Nlri       bgp.AddrPrefixInterface      `json:"nlri"`
-	Age        int64                        `json:"age"`
-	Best       bool                         `json:"best"`
-	Attrs      []bgp.PathAttributeInterface `json:"attrs"`
-	Stale      bool                         `json:"stale"`
-	Withdrawal bool                         `json:"withdrawal,omitempty"`
-	SourceASN  uint32                       `json:"source-asn,omitempty"`
-	SourceID   net.IP                       `json:"source-id,omitempty"`
-	NeighborIP net.IP                       `json:"neighbor-ip,omitempty"`
+	Nlri        bgp.AddrPrefixInterface      `json:"nlri"`
+	Age         int64                        `json:"age"`
+	Best        bool                         `json:"best"`
+	Attrs       []bgp.PathAttributeInterface `json:"attrs"`
+	Stale       bool                         `json:"stale"`
+	Withdrawal  bool                         `json:"withdrawal,omitempty"`
+	PeerASN     uint32                       `json:"peer-asn,omitempty"`
+	PeerID      net.IP                       `json:"peer-id,omitempty"`
+	PeerAddress net.IP                       `json:"peer-address,omitempty"`
 	// true if the path has been filtered out due to max path count reached (used by ListPath API)
 	SendMaxFiltered    bool `json:"send-max-filtered,omitempty"`
 	IsFromExternal     bool `json:"is-from-external,omitempty"`
@@ -107,8 +107,8 @@ func NewDestination(dst *api.Destination) *Destination {
 			Stale:           p.Stale,
 			SendMaxFiltered: p.SendMaxFiltered,
 			Withdrawal:      p.IsWithdraw,
-			SourceID:        net.ParseIP(p.SourceId),
-			NeighborIP:      net.ParseIP(p.NeighborIp),
+			PeerID:          net.ParseIP(p.SourceId),
+			PeerAddress:     net.ParseIP(p.NeighborIp),
 		})
 	}
 	return &Destination{Paths: l}

--- a/pkg/apiutil/util.go
+++ b/pkg/apiutil/util.go
@@ -26,7 +26,22 @@ import (
 	tspb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// workaround. This for the json format compatibility. Once we update senario tests, we can remove this.
+type PeerEventType uint32
+
+const (
+	PEER_EVENT_UNKNOWN     PeerEventType = 0
+	PEER_EVENT_INIT        PeerEventType = 1
+	PEER_EVENT_END_OF_INIT PeerEventType = 2
+	PEER_EVENT_STATE       PeerEventType = 3
+)
+
+// WatchEventMessages API type
+type WatchEventMessage_PeerEvent struct {
+	Type PeerEventType
+	Peer *Peer
+}
+
+// used by server.WatchEventMessages API
 type Path struct {
 	Nlri  bgp.AddrPrefixInterface      `json:"nlri"`
 	Age   int64                        `json:"age"`
@@ -36,8 +51,36 @@ type Path struct {
 	// true if the path has been filtered out due to max path count reached
 	SendMaxFiltered bool   `json:"send-max-filtered,omitempty"`
 	Withdrawal      bool   `json:"withdrawal,omitempty"`
+	SourceASN       uint32 `json:"source-asn,omitempty"`
 	SourceID        net.IP `json:"source-id,omitempty"`
 	NeighborIP      net.IP `json:"neighbor-ip,omitempty"`
+}
+
+type PeerConf struct {
+	PeerAsn           uint32
+	LocalAsn          uint32
+	NeighborAddress   net.IP
+	NeighborInterface string
+}
+type PeerState struct {
+	PeerAsn         uint32
+	LocalAsn        uint32
+	NeighborAddress net.IP
+	SessionState    bgp.FSMState
+	AdminState      api.PeerState_AdminState
+	RouterId        net.IP
+	RemoteCap       []bgp.ParameterCapabilityInterface
+}
+type Transport struct {
+	LocalAddress net.IP
+	LocalPort    uint32
+	RemotePort   uint32
+}
+
+type Peer struct {
+	Conf      PeerConf
+	State     PeerState
+	Transport Transport
 }
 
 type Destination struct {

--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/osrg/gobgp/v4/api"
 	"github.com/osrg/gobgp/v4/internal/pkg/table"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
 	"github.com/osrg/gobgp/v4/pkg/config/oc"
 	"github.com/osrg/gobgp/v4/pkg/log"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
@@ -225,12 +226,12 @@ func (b *bmpClient) loop() {
 							}
 						}
 					case *watchEventPeer:
-						if msg.Type != PEER_EVENT_END_OF_INIT {
+						if msg.Type != apiutil.PEER_EVENT_END_OF_INIT {
 							if msg.State == bgp.BGP_FSM_ESTABLISHED {
 								if err := write(bmpPeerUp(msg, bmp.BMP_PEER_TYPE_GLOBAL, false, 0)); err != nil {
 									return false
 								}
-							} else if msg.Type != PEER_EVENT_INIT && msg.OldState == bgp.BGP_FSM_ESTABLISHED {
+							} else if msg.Type != apiutil.PEER_EVENT_INIT && msg.OldState == bgp.BGP_FSM_ESTABLISHED {
 								if err := write(bmpPeerDown(msg, bmp.BMP_PEER_TYPE_GLOBAL, false, 0)); err != nil {
 									return false
 								}

--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -129,18 +129,18 @@ func (b *bmpClient) loop() {
 			defer func() {
 				atomic.StoreInt64(&b.downtime, time.Now().Unix())
 			}()
-			ops := []watchOption{watchPeer()}
+			ops := []WatchOption{WatchPeer()}
 			if b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH {
 				b.s.logger.Warn("both option for route-monitoring-policy is obsoleted", log.Fields{"Topic": "bmp"})
 			}
 			if b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY || b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
-				ops = append(ops, watchUpdate(true, "", ""))
+				ops = append(ops, WatchUpdate(true, "", ""))
 			}
 			if b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY || b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
-				ops = append(ops, watchPostUpdate(true, "", ""))
+				ops = append(ops, WatchPostUpdate(true, "", ""))
 			}
 			if b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB || b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
-				ops = append(ops, watchBestPath(true))
+				ops = append(ops, WatchBestPath(true))
 			}
 			if b.c.RouteMirroringEnabled {
 				ops = append(ops, watchMessage(false))

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -365,18 +365,18 @@ func (s *server) watchEvent(ctx context.Context, r *api.WatchEventRequest, fn fu
 						Type: api.WatchEventResponse_PeerEvent_Type(peer.Type),
 						Peer: &api.Peer{
 							Conf: &api.PeerConf{
-								PeerAsn:           p.Conf.PeerAsn,
-								LocalAsn:          p.Conf.LocalAsn,
+								PeerAsn:           p.Conf.PeerASN,
+								LocalAsn:          p.Conf.LocalASN,
 								NeighborAddress:   p.Conf.NeighborAddress.String(),
 								NeighborInterface: p.Conf.NeighborInterface,
 							},
 							State: &api.PeerState{
-								PeerAsn:         p.State.PeerAsn,
-								LocalAsn:        p.State.LocalAsn,
+								PeerAsn:         p.State.PeerASN,
+								LocalAsn:        p.State.LocalASN,
 								NeighborAddress: p.State.NeighborAddress.String(),
 								SessionState:    api.PeerState_SessionState(int(p.State.SessionState) + 1),
 								AdminState:      p.State.AdminState,
-								RouterId:        p.State.RouterId.String(),
+								RouterId:        p.State.RouterID.String(),
 								RemoteCap:       remoteCaps,
 							},
 							Transport: &api.Transport{

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -215,9 +215,9 @@ func toPathAPI(binNlri []byte, binPattrs [][]byte, anyNlri *api.NLRI, anyPattrs 
 		LocalIdentifier:    nlri.PathLocalIdentifier(),
 		NlriBinary:         binNlri,
 		PattrsBinary:       binPattrs,
-		SourceAsn:          path.SourceASN,
-		SourceId:           path.SourceID.String(),
-		NeighborIp:         path.NeighborIP.String(),
+		SourceAsn:          path.PeerASN,
+		SourceId:           path.PeerID.String(),
+		NeighborIp:         path.PeerAddress.String(),
 	}
 	return p
 }

--- a/pkg/server/mrt.go
+++ b/pkg/server/mrt.go
@@ -47,10 +47,10 @@ func (m *mrtWriter) Stop() {
 }
 
 func (m *mrtWriter) loop() error {
-	ops := []watchOption{}
+	ops := []WatchOption{}
 	switch m.c.DumpType {
 	case oc.MRT_TYPE_UPDATES:
-		ops = append(ops, watchUpdate(false, "", ""))
+		ops = append(ops, WatchUpdate(false, "", ""))
 	case oc.MRT_TYPE_TABLE:
 		if len(m.c.TableName) > 0 {
 			ops = append(ops, watchTableName(m.c.TableName))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4395,9 +4395,9 @@ func toPathApiUtil(path *table.Path) *apiutil.Path {
 		IsNexthopInvalid:   path.IsNexthopInvalid,
 	}
 	if s := path.GetSource(); s != nil {
-		p.SourceASN = s.AS
-		p.SourceID = s.ID
-		p.NeighborIP = s.Address
+		p.PeerASN = s.AS
+		p.PeerID = s.ID
+		p.PeerAddress = s.Address
 	}
 	return p
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4482,18 +4482,18 @@ func (s *BgpServer) WatchEvent(ctx context.Context, callbacks WatchEventMessageC
 							Type: msg.Type,
 							Peer: apiutil.Peer{
 								Conf: apiutil.PeerConf{
-									PeerAsn:           msg.PeerAS,
-									LocalAsn:          msg.LocalAS,
+									PeerASN:           msg.PeerAS,
+									LocalASN:          msg.LocalAS,
 									NeighborAddress:   msg.PeerAddress,
 									NeighborInterface: msg.PeerInterface,
 								},
 								State: apiutil.PeerState{
-									PeerAsn:         msg.PeerAS,
-									LocalAsn:        msg.LocalAS,
+									PeerASN:         msg.PeerAS,
+									LocalASN:        msg.LocalAS,
 									NeighborAddress: msg.PeerAddress,
 									SessionState:    msg.State,
 									AdminState:      admin_state,
-									RouterId:        msg.PeerID,
+									RouterID:        msg.PeerID,
 									RemoteCap:       msg.RemoteCap,
 								},
 								Transport: apiutil.Transport{

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -224,45 +224,18 @@ func TestListPolicyAssignment(t *testing.T) {
 //nolint:errcheck // WatchEvent won't return an error here
 func waitState(s *BgpServer, state api.PeerState_SessionState, expectedFamilies ...bgp.Family) *sync.WaitGroup {
 	wg := &sync.WaitGroup{}
-
-	watchCtx, watchCancel := context.WithCancel(context.Background())
-	wg.Add(1)
-	s.WatchEvent(watchCtx, &api.WatchEventRequest{Peer: &api.WatchEventRequest_Peer{}}, func(r *api.WatchEventResponse, _ time.Time) {
-		if peer := r.GetPeer(); peer != nil {
-			if peer.Type == api.WatchEventResponse_PeerEvent_TYPE_STATE && peer.Peer.State.SessionState == state {
-				remoteCaps, err := apiutil.UnmarshalCapabilities(peer.Peer.GetState().GetRemoteCap())
-				if err != nil {
-					return
-				}
-				for _, rf := range expectedFamilies {
-					found := false
-					for _, cap := range remoteCaps {
-						if cap.Code() == bgp.BGP_CAP_MULTIPROTOCOL && cap.(*bgp.CapMultiProtocol).CapValue == rf {
-							found = true
-							break
-						}
-					}
-					if !found {
-						return
-					}
-				}
-				watchCancel()
-				wg.Done()
-			}
-		}
-	})
-
 	watchCtxMsg, watchCancelMsg := context.WithCancel(context.Background())
 	wg.Add(1)
+
 	opts := make([]WatchOption, 0)
 	opts = append(opts, WatchPeer())
-	s.WatchEventMessages(watchCtxMsg,
+	s.WatchEvent(watchCtxMsg,
 		WatchEventMessageCallbacks{
 			OnPeerUpdate: func(peer *apiutil.WatchEventMessage_PeerEvent, _ time.Time) {
 				if peer == nil {
 					return
 				}
-				apiPeerSessionState := func(peer *apiutil.Peer) api.PeerState_SessionState {
+				apiPeerSessionState := func(peer apiutil.Peer) api.PeerState_SessionState {
 					return api.PeerState_SessionState(int(peer.State.SessionState) + 1)
 				}
 				if peer.Type == apiutil.PEER_EVENT_STATE && apiPeerSessionState(peer.Peer) == state {
@@ -2652,200 +2625,6 @@ func TestWatchEvent(test *testing.T) {
 			},
 		},
 	}
-
-	establishedWg := waitEstablished(s, bgp.RF_IPv4_UC, bgp.RF_IPv6_UC)
-
-	err = t.AddPeer(context.Background(), &api.AddPeerRequest{Peer: peer2})
-	assert.NoError(err)
-
-	establishedWg.Wait()
-
-	count := 0
-	tableCh := make(chan any)
-	watchCtx, watchCancel := context.WithCancel(context.Background())
-	err = s.WatchEvent(watchCtx, &api.WatchEventRequest{
-		Table: &api.WatchEventRequest_Table{
-			Filters: []*api.WatchEventRequest_Table_Filter{
-				{
-					Type:        api.WatchEventRequest_Table_Filter_TYPE_ADJIN,
-					PeerAddress: "127.0.0.1",
-					Init:        true,
-				},
-			},
-		},
-	}, func(resp *api.WatchEventResponse, _ time.Time) {
-		t := resp.Event.(*api.WatchEventResponse_Table)
-		count += len(t.Table.Paths)
-		if len(t.Table.Paths) > 0 && count == 2 {
-			watchCancel()
-			close(tableCh)
-		}
-	})
-	assert.NoError(err)
-	<-tableCh
-
-	assert.Equal(2, count)
-}
-
-func TestWatchEventMessages(test *testing.T) {
-	assert := assert.New(test)
-	s := NewBgpServer()
-	go s.Serve()
-	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
-		Global: &api.Global{
-			Asn:        1,
-			RouterId:   "1.1.1.1",
-			ListenPort: 10179,
-		},
-	})
-	assert.NoError(err)
-	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
-
-	peer1 := &api.Peer{
-		Conf: &api.PeerConf{
-			NeighborAddress: "127.0.0.1",
-			PeerAsn:         2,
-		},
-		Transport: &api.Transport{
-			PassiveMode: true,
-		},
-	}
-	err = s.AddPeer(context.Background(), &api.AddPeerRequest{Peer: peer1})
-	assert.NoError(err)
-
-	d1 := &api.DefinedSet{
-		DefinedType: api.DefinedType_DEFINED_TYPE_PREFIX,
-		Name:        "d1",
-		Prefixes: []*api.Prefix{
-			{
-				IpPrefix:      "10.1.0.0/24",
-				MaskLengthMax: 24,
-				MaskLengthMin: 24,
-			},
-		},
-	}
-	s1 := &api.Statement{
-		Name: "s1",
-		Conditions: &api.Conditions{
-			PrefixSet: &api.MatchSet{
-				Name: "d1",
-				Type: api.MatchSet_TYPE_ANY,
-			},
-		},
-		Actions: &api.Actions{
-			RouteAction: api.RouteAction_ROUTE_ACTION_REJECT,
-		},
-	}
-	err = s.AddDefinedSet(context.Background(), &api.AddDefinedSetRequest{DefinedSet: d1})
-	assert.NoError(err)
-	p1 := &api.Policy{
-		Name:       "p1",
-		Statements: []*api.Statement{s1},
-	}
-	err = s.AddPolicy(context.Background(), &api.AddPolicyRequest{Policy: p1})
-	assert.NoError(err)
-	err = s.AddPolicyAssignment(context.Background(), &api.AddPolicyAssignmentRequest{
-		Assignment: &api.PolicyAssignment{
-			Name:          table.GLOBAL_RIB_NAME,
-			Direction:     api.PolicyDirection_POLICY_DIRECTION_IMPORT,
-			Policies:      []*api.Policy{p1},
-			DefaultAction: api.RouteAction_ROUTE_ACTION_ACCEPT,
-		},
-	})
-	assert.NoError(err)
-
-	t := NewBgpServer()
-	go t.Serve()
-	err = t.StartBgp(context.Background(), &api.StartBgpRequest{
-		Global: &api.Global{
-			Asn:        2,
-			RouterId:   "2.2.2.2",
-			ListenPort: -1,
-		},
-	})
-	assert.NoError(err)
-	defer t.StopBgp(context.Background(), &api.StopBgpRequest{})
-
-	family := &api.Family{
-		Afi:  api.Family_AFI_IP,
-		Safi: api.Family_SAFI_UNICAST,
-	}
-
-	nlri1 := &api.NLRI{Nlri: &api.NLRI_Prefix{Prefix: &api.IPAddressPrefix{
-		Prefix:    "10.1.0.0",
-		PrefixLen: 24,
-	}}}
-
-	attrs := []*api.Attribute{
-		{
-			Attr: &api.Attribute_Origin{Origin: &api.OriginAttribute{
-				Origin: 0,
-			}},
-		},
-		{
-			Attr: &api.Attribute_NextHop{NextHop: &api.NextHopAttribute{
-				NextHop: "10.0.0.1",
-			}},
-		},
-	}
-
-	_, err = t.AddPath(context.Background(), &api.AddPathRequest{
-		TableType: api.TableType_TABLE_TYPE_GLOBAL,
-		Path: &api.Path{
-			Family: family,
-			Nlri:   nlri1,
-			Pattrs: attrs,
-		},
-	})
-	assert.NoError(err)
-
-	nlri2 := &api.NLRI{Nlri: &api.NLRI_Prefix{Prefix: &api.IPAddressPrefix{
-		Prefix:    "10.2.0.0",
-		PrefixLen: 24,
-	}}}
-	_, err = t.AddPath(context.Background(), &api.AddPathRequest{
-		TableType: api.TableType_TABLE_TYPE_GLOBAL,
-		Path: &api.Path{
-			Family: family,
-			Nlri:   nlri2,
-			Pattrs: attrs,
-		},
-	})
-	assert.NoError(err)
-
-	peer2 := &api.Peer{
-		Conf: &api.PeerConf{
-			NeighborAddress: "127.0.0.1",
-			PeerAsn:         1,
-		},
-		Transport: &api.Transport{
-			RemotePort: 10179,
-		},
-		Timers: &api.Timers{
-			Config: &api.TimersConfig{
-				ConnectRetry:           1,
-				IdleHoldTimeAfterReset: 1,
-			},
-		},
-		AfiSafis: []*api.AfiSafi{
-			{
-				Config: &api.AfiSafiConfig{
-					Family: &api.Family{
-						Afi:  api.Family_AFI_IP,
-						Safi: api.Family_SAFI_UNICAST,
-					},
-				},
-			},
-			{
-				Config: &api.AfiSafiConfig{
-					Family: &api.Family{
-						Afi:  api.Family_AFI_IP6,
-						Safi: api.Family_SAFI_UNICAST,
-					},
-				},
-			},
-		},
-	}
 	watchers := waitEstablished(s, bgp.RF_IPv4_UC, bgp.RF_IPv6_UC)
 
 	err = t.AddPeer(context.Background(), &api.AddPeerRequest{Peer: peer2})
@@ -2862,7 +2641,7 @@ func TestWatchEventMessages(test *testing.T) {
 	}
 	opts := make([]WatchOption, 0)
 	opts = append(opts, WatchUpdate(true, "127.0.0.1", ""))
-	err = s.WatchEventMessages(context.Background(), WatchEventMessageCallbacks{
+	err = s.WatchEvent(context.Background(), WatchEventMessageCallbacks{
 		OnPathUpdate: f,
 	}, opts...)
 	assert.NoError(err)

--- a/pkg/server/zclient.go
+++ b/pkg/server/zclient.go
@@ -370,9 +370,9 @@ func (z *zebraClient) updatePathByNexthopCache(paths []*table.Path) {
 }
 
 func (z *zebraClient) loop() {
-	w := z.server.watch([]watchOption{
-		watchBestPath(true),
-		watchPostUpdate(true, "", ""),
+	w := z.server.watch([]WatchOption{
+		WatchBestPath(true),
+		WatchPostUpdate(true, "", ""),
 	}...)
 	defer w.Stop()
 

--- a/test/scenario_test/bgp_router_test.py
+++ b/test/scenario_test/bgp_router_test.py
@@ -347,10 +347,10 @@ class GoBGPTestBase(unittest.TestCase):
 
         paths = g1.get_adj_rib_out(q1, '30.0.0.0/24')
         self.assertEqual(len(paths), 1)
-        self.assertNotIn('source-id', paths[0])
+        self.assertNotIn('peer-id', paths[0])
         paths = g1.get_adj_rib_out(q2, '30.0.0.0/24')
         self.assertEqual(len(paths), 1)
-        self.assertNotIn('source-id', paths[0])
+        self.assertNotIn('peer-id', paths[0])
 
         g1.local('gobgp global rib del 30.0.0.0/24')
 
@@ -359,7 +359,7 @@ class GoBGPTestBase(unittest.TestCase):
             self.assertEqual(len(paths), 0)
             paths = g1.get_adj_rib_out(q2, '30.0.0.0/24')
             self.assertEqual(len(paths), 1)
-            self.assertEqual(paths[0]['source-id'], '192.168.0.2')
+            self.assertEqual(paths[0]['peer-id'], '192.168.0.2')
 
         assert_several_times(f)
 
@@ -461,13 +461,13 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertEqual(len(paths), 0)
         paths = g1.get_adj_rib_out(g4, '50.0.0.0/24')
         self.assertEqual(len(paths), 1)
-        self.assertEqual(paths[0]['source-id'], '192.168.0.8')
+        self.assertEqual(paths[0]['peer-id'], '192.168.0.8')
 
         g3.local('gobgp global rib del 50.0.0.0/24')
 
         paths = g1.get_adj_rib_out(g3, '50.0.0.0/24')
         self.assertEqual(len(paths), 1)
-        self.assertEqual(paths[0]['source-id'], '192.168.0.9')
+        self.assertEqual(paths[0]['peer-id'], '192.168.0.9')
         paths = g1.get_adj_rib_out(g4, '50.0.0.0/24')
         self.assertEqual(len(paths), 0)
 


### PR DESCRIPTION
```
WatchEvent(ctx, api.request, WatchEventMessageCallbacks{
	OnPathUpdate func([]*apiutil.Path, time.Time)
	OnBestPath   func([]*apiutil.Path, time.Time)
	OnPathEor    func([]*apiutil.Path, time.Time)
	OnPeerUpdate func(*apiutil.WatchEventMessage_PeerEvent, time.Time)
})
```

This will expose the simple and light `apiutil.Path` aim to
get access events without a big overhead, just a translation
from internal table.Path to flat apiutil.Path type.Introducing a new API call, that would give us access to the Events without exposing the watch() method.

Overall, this will give us access to fast BGP info, by removing the protobuf serialization (and object size) overhead.
Please note that GRPC similar API name, relay on bgpServer.API
