### PR TITLE
path: optimize by caching bgp.COMMUNITY_LLGR_STALE attribute

### DIFF
--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -594,7 +594,7 @@ func compareByLLGRStaleCommunity(path1, path2 *Path) *Path {
 	p2 := path2.IsLLGRStale()
 	if p1 == p2 {
 		return nil
-	} else if p1 {
+	} else if p1 { // if path1 is stale then path2 is better
 		return path2
 	}
 	return path1

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -432,6 +432,17 @@ func (path *Path) HasNoLLGR() bool {
 }
 
 func (path *Path) IsLLGRStale() bool {
+
+	slow := false
+	for _, c := range path.GetCommunities() {
+		if c == uint32(bgp.COMMUNITY_LLGR_STALE) {
+			slow = true
+		}
+	}
+	if slow != path.cache.IsLLGRStale {
+		panic("inconsistent LLGR stale state")
+	}
+
 	return path.cache.IsLLGRStale
 }
 


### PR DESCRIPTION
Currently a lookup of all the attributes is done to know if the COMMUNITY_LLGR_STALE is set.
This PR will cache it in the path.cache.IsLLGRStale