### PR TITLE
path: fast path attributes O(1) and hash optimization

### DIFF
--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -692,11 +692,11 @@ func compareByMED(path1, path2 *Path) *Path {
 		firstAS := func(path *Path) uint32 {
 			if asPath := path.GetAsPath(); asPath != nil {
 				for _, v := range asPath.Value {
-					segType := v.GetType()
 					asList := v.GetAS()
 					if len(asList) == 0 {
 						continue
 					}
+					segType := v.GetType()
 					switch segType {
 					case bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET, bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
 						continue

--- a/internal/pkg/table/path_test.go
+++ b/internal/pkg/table/path_test.go
@@ -253,6 +253,47 @@ func TestGetPathAttrs(t *testing.T) {
 	assert.NotNil(t, path2.getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP))
 }
 
+func TestGetTransversalPathAttrs(t *testing.T) {
+	checkTransversalPathAttrs := func(t *testing.T, path *Path, expectedAttr bgp.BGPAttrType, checkIsNotExist ...bool) {
+		for _, attr := range path.GetTransversalPathAttrs() {
+			assert.NotNil(t, attr)
+		}
+		if len(checkIsNotExist) > 0 && checkIsNotExist[0] {
+			assert.Nil(t, path.GetTransversalPathAttrs()[expectedAttr])
+		} else {
+			assert.NotNil(t, path.GetTransversalPathAttrs()[expectedAttr])
+		}
+	}
+	paths := PathCreatePath(PathCreatePeer())
+	path0 := paths[0]
+	checkTransversalPathAttrs(t, path0, bgp.BGP_ATTR_TYPE_ORIGIN)
+	nextHop := path0.getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
+	assert.NotNil(t, nextHop)
+	assert.Equal(t, nextHop.(*bgp.PathAttributeNextHop).Value.String(), "192.168.50.1")
+
+	path1 := path0.Clone(false)
+	path1.setPathAttr(bgp.NewPathAttributeNextHop("192.168.98.1"))
+	nextHop = path1.getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
+	assert.NotNil(t, nextHop)
+	assert.Equal(t, nextHop.(*bgp.PathAttributeNextHop).Value.String(), "192.168.98.1")
+	path1.delPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
+	assert.NotNil(t, path1.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGIN))
+	checkTransversalPathAttrs(t, path1, bgp.BGP_ATTR_TYPE_ORIGIN)
+	checkTransversalPathAttrs(t, path1, bgp.BGP_ATTR_TYPE_NEXT_HOP, true)
+
+	path2 := path1.Clone(false)
+	assert.NotNil(t, path2.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGIN))
+	path2.delPathAttr(bgp.BGP_ATTR_TYPE_ORIGIN)
+	// adding an attribute that has been deleted previously by underlayer, is not allowed
+	path2.setPathAttr(bgp.NewPathAttributeNextHop("192.168.99.1"))
+	checkTransversalPathAttrs(t, path2, bgp.BGP_ATTR_TYPE_ORIGIN, true)
+	checkTransversalPathAttrs(t, path2, bgp.BGP_ATTR_TYPE_NEXT_HOP, true)
+
+	nextHop = path2.getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
+	assert.NotNil(t, nextHop)
+	assert.Equal(t, nextHop.(*bgp.PathAttributeNextHop).Value.String(), "192.168.99.1")
+}
+
 func PathCreatePeer() []*PeerInfo {
 	peerP1 := &PeerInfo{AS: 65000}
 	peerP2 := &PeerInfo{AS: 65001}
@@ -393,4 +434,36 @@ func TestNLRIToIPNet(t *testing.T) {
 	_, n6, _ := net.ParseCIDR("2001:db8:53::/64")
 	ipNet = nlriToIPNet(bgp.NewLabeledVPNIPv6AddrPrefix(64, "2001:db8:53::", *labels, rd))
 	assert.Equal(t, n6, ipNet)
+}
+
+func TestUnknownPathAttributes(t *testing.T) {
+	peerP := PathCreatePeer()
+	pathP := PathCreatePath(peerP)
+
+	type255 := bgp.BGPAttrType(255)
+	unknownAttr := bgp.NewPathAttributeUnknown(bgp.BGPAttrFlag(0), type255, []byte{0x01, 0x02, 0x03})
+	pathP[0].setPathAttr(unknownAttr)
+
+	// Check if the unknown attribute is present
+	assert.NotNil(t, pathP[0].getPathAttr(type255))
+
+	transversalAttrs := pathP[0].GetTransversalPathAttrs()
+	assert.NotNil(t, transversalAttrs[type255])
+	for _, a := range transversalAttrs {
+		assert.NotNil(t, a)
+	}
+
+	found255 := false
+	var last bgp.BGPAttrType
+	for _, attr := range pathP[0].GetPathAttrs() {
+		assert.NotNil(t, attr)
+		if last >= attr.GetType() {
+			t.Errorf("Path attributes are not sorted: %v >= %v", last, attr.GetType())
+		}
+		last = attr.GetType()
+		if attr.GetType() == type255 {
+			found255 = true
+		}
+	}
+	assert.True(t, found255, "Unknown attribute of type 255 should be present in the path attributes list")
 }

--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -113,15 +113,9 @@ func ProcessMessage(m *bgp.BGPMessage, peerInfo *PeerInfo, timestamp time.Time) 
 	return pathList
 }
 
-func makeAttributeList(
-	attrs []bgp.PathAttributeInterface, reach *bgp.PathAttributeMpReachNLRI,
+func makeAttributeList(attrs []bgp.PathAttributeInterface, reach *bgp.PathAttributeMpReachNLRI,
 ) []bgp.PathAttributeInterface {
-	reachAttrs := make([]bgp.PathAttributeInterface, len(attrs)+1)
-	copy(reachAttrs, attrs)
-	// we sort attributes when creating a bgp message from paths
-	reachAttrs[len(reachAttrs)-1] = reach
-
-	return reachAttrs
+	return append(attrs, reach)
 }
 
 type TableManager struct {


### PR DESCRIPTION
The general goal of this PR is optimize access to path attributes and path compare, aim to have fast table.destination.computeKnownBestPath()

This PR introduce 
* O(1) access to path attributes
* fast path compare (no need to sort attributes anymore)
  * attribute hash
  * path attributes hash
* GetTransversalPathAttrs() will solve the path attributes if path is cloned

Running the recent unit test benchmark form @joeahn-sbg-cisco merged in gobgp
This PR we can see 10% improvement.

```
go test -benchmem -run=^$ -bench ^BenchmarkCalculate$ github.com/osrg/gobgp/v4/internal/pkg/table

Before : BenchmarkCalculate-12          519141          2225 ns/op         376 B/op          14 allocs/op
After  : BenchmarkCalculate-12          602040          2013 ns/op         376 B/op          14 allocs/op   
```