### PR TITLE
perf: optimize retrieving the set of equally best paths 

### DIFF
--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -1095,6 +1095,9 @@ func (path *Path) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// Return > 0 if lhs is preferred over the rhs
+// Return 0 if they are equal
+// Return < 0 if rhs is preferred over the lhs
 func (lhs *Path) Compare(rhs *Path) int {
 	if lhs.IsLocal() && !rhs.IsLocal() {
 		return 1
@@ -1111,24 +1114,24 @@ func (lhs *Path) Compare(rhs *Path) int {
 	lp1, _ := lhs.GetLocalPref()
 	lp2, _ := rhs.GetLocalPref()
 	if lp1 != lp2 {
-		return int(lp1 - lp2)
+		return int(lp1) - int(lp2)
 	}
 
 	l1 := lhs.GetAsPathLen()
 	l2 := rhs.GetAsPathLen()
 	if l1 != l2 {
-		return int(l2 - l1)
+		return int(l2) - int(l1)
 	}
 
 	o1, _ := lhs.GetOrigin()
 	o2, _ := rhs.GetOrigin()
 	if o1 != o2 {
-		return int(o2 - o1)
+		return int(o2) - int(o1)
 	}
 
 	m1, _ := lhs.GetMed()
 	m2, _ := rhs.GetMed()
-	return int(m2 - m1)
+	return int(m2) - int(m1)
 }
 
 func (v *Vrf) ToGlobalPath(path *Path) error {


### PR DESCRIPTION
* Fix the `Compare` function of two paths, which previously had an incorrect subtraction of two uint32 numbers that led to an overflow. This caused the `Compare` function to never say the `lhs` was better. 
* Optimize the `getMultiBestPath` function, which determines the set of *reachable* equally best paths for a global RIB's destination. Instead of iterating over each element, instead use `sort.Search` to binary search the smallest index that is worse than the `best` path. This is feasible, since the passed in array of paths is already sorted in descending order of preference.
 
# Test

```
$  go test -race -timeout 240s ./...
go: downloading github.com/stretchr/testify v1.8.4
go: downloading github.com/go-test/deep v1.1.0
go: downloading github.com/google/go-cmp v0.6.0
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/pmezard/go-difflib v1.0.0
?       github.com/osrg/gobgp/v4/api    [no test files]
ok      github.com/osrg/gobgp/v4/cmd/gobgp      1.026s
?       github.com/osrg/gobgp/v4/cmd/gobgpd     [no test files]
ok      github.com/osrg/gobgp/v4/internal/pkg/table     1.111s
?       github.com/osrg/gobgp/v4/internal/pkg/version   [no test files]
ok      github.com/osrg/gobgp/v4/pkg/apiutil    1.042s
ok      github.com/osrg/gobgp/v4/pkg/config     1.030s
ok      github.com/osrg/gobgp/v4/pkg/config/oc  1.042s
?       github.com/osrg/gobgp/v4/pkg/log        [no test files]
ok      github.com/osrg/gobgp/v4/pkg/metrics    3.382s
ok      github.com/osrg/gobgp/v4/pkg/packet/bgp 2.046s
ok      github.com/osrg/gobgp/v4/pkg/packet/bmp 1.021s
ok      github.com/osrg/gobgp/v4/pkg/packet/mrt 1.018s
ok      github.com/osrg/gobgp/v4/pkg/packet/rtr 1.017s
ok      github.com/osrg/gobgp/v4/pkg/server     54.132s
ok      github.com/osrg/gobgp/v4/pkg/zebra      1.022s
?       github.com/osrg/gobgp/v4/tools/config   [no test files]
```

# Benchmark

### 4 paths
```
branch master
goos: darwin
goarch: arm64
pkg: github.com/osrg/gobgp/v4/internal/pkg/table
cpu: Apple M2 Pro
BenchmarkGetChanges-12    	 2255676	       538.1 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/osrg/gobgp/v4/internal/pkg/table	143.898s

Post-changes
goos: darwin
goarch: arm64
pkg: github.com/osrg/gobgp/v4/internal/pkg/table
cpu: Apple M2 Pro
BenchmarkGetChanges-12    	 4479884	       265.3 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/osrg/gobgp/v4/internal/pkg/table	249.756s
```

### 20 paths
```
branch master
goos: darwin
goarch: arm64
pkg: github.com/osrg/gobgp/v4/internal/pkg/table
cpu: Apple M2 Pro
BenchmarkGetChanges-12    	  593184	      1945 ns/op	     160 B/op	       1 allocs/op
PASS
ok  	github.com/osrg/gobgp/v4/internal/pkg/table	27.960s

Post-changes
goos: darwin
goarch: arm64
pkg: github.com/osrg/gobgp/v4/internal/pkg/table
cpu: Apple M2 Pro
BenchmarkGetChanges-12    	 2810139	       427.2 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/osrg/gobgp/v4/internal/pkg/table	168.790s
```
