### PR TITLE
lintdoc: make markdownlint happy

### DIFF
--- a/docs/sources/metrics.md
+++ b/docs/sources/metrics.md
@@ -100,4 +100,4 @@ Some labels can have specific values depending on the state of GoBGP or of the p
 
 ## Grafana dashboard
 
-There is an example Grafana panel to display some metrics about GoBGP available [here](https://grafana.com/grafana/dashboards/22061-gobgp/)
+There is an example [Grafana panel to display some metrics](https://grafana.com/grafana/dashboards/22061-gobgp/) about GoBGP available


### PR DESCRIPTION
make markdownlint happy MD059/descriptive-link-text Link text should be descriptive