### PR TITLE
path: fixup destination implicitWithdraw()

### DIFF
--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -318,7 +318,7 @@ func (dest *Destination) explicitWithdraw(logger log.Logger, withdraw *Path) *Pa
 func (dest *Destination) implicitWithdraw(logger log.Logger, newPath *Path) {
 	found := -1
 	for i, path := range dest.knownPathList {
-		if newPath.NoImplicitWithdraw() {
+		if path.NoImplicitWithdraw() {
 			continue
 		}
 		// Here we just check if source is same and not check if path


### PR DESCRIPTION
destination.Calculate() should not replace a path that has been marked "no implicit withdraw"
Added some unit tests.