### PR TITLE
Count advertised-routes only when ESTABLISHED

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3162,12 +3162,19 @@ func (s *BgpServer) ListPeer(ctx context.Context, r *api.ListPeerRequest, fn fun
 					c := afisafi.Config
 					if c.Family != nil && c.Family.Afi == api.Family_Afi(afi) && c.Family.Safi == api.Family_Safi(safi) {
 						flist := []bgp.Family{family}
-						received := uint64(peer.adjRibIn.Count(flist))
-						accepted := uint64(peer.adjRibIn.Accepted(flist))
+						peer.fsm.lock.RLock()
+						sesstionState := peer.fsm.state
+						peer.fsm.lock.RUnlock()
+						received := uint64(0)
+						accepted := uint64(0)
 						advertised := uint64(0)
-						if getAdvertised {
-							pathList, _ := s.getBestFromLocal(peer, flist)
-							advertised = uint64(len(pathList))
+						if sesstionState == bgp.BGP_FSM_ESTABLISHED {
+							received = uint64(peer.adjRibIn.Count(flist))
+							accepted = uint64(peer.adjRibIn.Accepted(flist))
+							if getAdvertised {
+								pathList, _ := s.getBestFromLocal(peer, flist)
+								advertised = uint64(len(pathList))
+							}
 						}
 						p.AfiSafis[i].State = &api.AfiSafiState{
 							Family:     c.Family,


### PR DESCRIPTION
Cilium has this issue.
https://github.com/cilium/cilium/issues/39861
The problem is to display the number of advertised routes, even for disconnected peers.
The cause seems to be in `ListPeer()` in GoBGP.

`ListPeer()` is used for getting information about peers.
In this function, the number of advertised-routes should be shown only about ESTABLISHED peers, but currently advertised-routes of other state peers are counted.
In this commit, ListPeer() is changed it.

Honestly, I'm not sure that the _if-condition filter_ in this commit is necessary and sufficient to achieve this purpose.
I think that it may be better to insert _if-condition filter_ at an earlier stage, or insert _if-condition filter_ in `getBestFromLocal()`.
I want to discuss it more.
However, it is for sure that this patch resolves the above issue.