### PR TITLE
ci: enable verbose output for Go tests in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
         with:
           go-version: "stable"
       - run: |
-          go test -race -timeout 240s ./...
-          if [ "$(go env GOARCH)" = "amd64" ]; then go test -race github.com/osrg/gobgp/v4/pkg/packet/bgp -run ^Test_RaceCondition$; else echo 'skip'; fi
+          go test -v -race -timeout 240s ./...
+          if [ "$(go env GOARCH)" = "amd64" ]; then go test -v -race github.com/osrg/gobgp/v4/pkg/packet/bgp -run ^Test_RaceCondition$; else echo 'skip'; fi
 
   unit386:
     name: unit386


### PR DESCRIPTION
Add the `-v` flag to all `go test` invocations in the GitHub Actions CI workflow (`ci.yml`). This provides verbose output during test execution, which helps with debugging and tracking progress.