### PR TITLE
ci: enable verbose output for unit386

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           go-version: "stable"
       - run: |
           go env GOARCH
-          go test -timeout 240s ./...
+          go test -v -timeout 240s ./...
 
   protobuf-check:
     name: protobuf lint and format check


### PR DESCRIPTION
Add the `-v` flag to unit386.

The commit fe53aad5 ("ci: enable verbose output for Go tests in CI workflow") were supposed to add this.