### PR TITLE
bgp,mrt: Replace ImplicitPrefix with HeaderContext for accurate Famil…

### DIFF
--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -1178,7 +1178,10 @@ func Test_MpReachNLRIWithImplicitPrefix(t *testing.T) {
 	prefix := NewIPAddrPrefix(24, "192.168.10.0")
 	// Test DecodeFromBytes()
 	p := &PathAttributeMpReachNLRI{}
-	option := &MarshallingOption{ImplicitPrefix: prefix}
+	option := &MarshallingOption{HeaderPrefix: &HeaderContext{
+		Family: RF_IPv4_UC,
+		Prefix: prefix,
+	}}
 	err := p.DecodeFromBytes(bufin, option)
 	assert.NoError(err)
 	// Test decoded values

--- a/pkg/packet/mrt/mrt_test.go
+++ b/pkg/packet/mrt/mrt_test.go
@@ -125,13 +125,13 @@ func TestMrtRibEntry(t *testing.T) {
 	}
 
 	e1 := NewRibEntry(1, uint32(time.Now().Unix()), 0, p, false)
-	b1, err := e1.Serialize()
+	b1, err := e1.Serialize(bgp.RF_IPv4_UC)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	e2 := &RibEntry{}
-	rest, err := e2.DecodeFromBytes(b1)
+	rest, err := e2.DecodeFromBytes(b1, bgp.RF_IPv4_UC)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,13 +154,13 @@ func TestMrtRibEntryWithAddPath(t *testing.T) {
 		bgp.NewPathAttributeLocalPref(1 << 22),
 	}
 	e1 := NewRibEntry(1, uint32(time.Now().Unix()), 200, p, true)
-	b1, err := e1.Serialize()
+	b1, err := e1.Serialize(bgp.RF_IPv4_UC)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	e2 := &RibEntry{isAddPath: true}
-	rest, err := e2.DecodeFromBytes(b1)
+	rest, err := e2.DecodeFromBytes(b1, bgp.RF_IPv4_UC)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -335,8 +335,8 @@ func FuzzDecodeFromBytes(f *testing.F) {
 		(&MRTHeader{}).DecodeFromBytes(data)
 		(&Peer{}).DecodeFromBytes(data)
 		(&PeerIndexTable{}).DecodeFromBytes(data)
-		(&RibEntry{}).DecodeFromBytes(data)
-		(&RibEntry{isAddPath: true}).DecodeFromBytes(data)
+		(&RibEntry{}).DecodeFromBytes(data, bgp.RF_IPv4_UC)
+		(&RibEntry{isAddPath: true}).DecodeFromBytes(data, bgp.RF_IPv4_UC)
 		(&Rib{}).DecodeFromBytes(data)
 		(&Rib{isAddPath: true}).DecodeFromBytes(data)
 		(&GeoPeer{}).DecodeFromBytes(data)


### PR DESCRIPTION
…y handling

Replace the misleading ImplicitPrefix concept with HeaderContext structure that explicitly holds both Family and prefix information from RIB Entry Headers. This change addresses fundamental limitations in Family derivation and aligns terminology with RFC 6396.

Problems addressed:

1. Inaccurate Family derivation**: AddrPrefixInterface.AFI()/SAFI() methods cannot reliably provide correct Family information for complex address families where the same prefix structure may represent different address families.

2. Non-RFC terminology**: "ImplicitPrefix" is not a term used in RFC 6396. The RFC describes using "RIB Entry Header" context to provide AFI/SAFI/NLRI information that is omitted from the wire format (Section 4.3.4).