### PR TITLE
fix: create MacOS equivalent for getting available memory

### DIFF
--- a/internal/pkg/table/util.go
+++ b/internal/pkg/table/util.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build linux
+// +build linux
 
 package table
 

--- a/internal/pkg/table/util_darwin.go
+++ b/internal/pkg/table/util_darwin.go
@@ -1,0 +1,48 @@
+//go:build darwin
+// +build darwin
+
+package table
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework CoreServices -framework IOKit
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/sysctl.h>
+#include <mach/mach.h>
+
+int get_page_size() {
+	int mib[2] = {CTL_HW, HW_PAGESIZE};
+	int pagesize = 0;
+	size_t length = sizeof(pagesize);
+
+	if (sysctl(mib, 2, &pagesize, &length, NULL, 0) < 0) {
+		return -1;
+	}
+	return pagesize;
+}
+
+int get_vm_stats(vm_statistics_data_t *vmstat_out) {
+	mach_msg_type_number_t count = HOST_VM_INFO_COUNT;
+	return host_statistics(mach_host_self(), HOST_VM_INFO, (host_info_t)vmstat_out, &count);
+}
+*/
+import "C"
+
+func SystemMemoryAvailableMiB() uint64 {
+	// Get page size
+	pageSize := C.get_page_size()
+	if pageSize < 0 {
+		return 0
+	}
+
+	// Get VM statistics
+	var vmstat C.vm_statistics_data_t
+	if C.get_vm_stats(&vmstat) != C.KERN_SUCCESS {
+		return 0
+	}
+
+	// Compute total and usage breakdown
+	return (uint64(vmstat.free_count) * uint64(pageSize)) >> 20 // Convert to MiB
+}


### PR DESCRIPTION
# Description

Running golang unit tests using gobgp on MacOS is failing due to the `TestTableDestinationsCollisionAttack` unit test, which queries for the system's available memory. This PR introduces a MacOS equivalent for retrieving this stat.

```
$ CGO_ENABLED=1 go vet ./...
# github.com/osrg/gobgp/v4/internal/pkg/table
../../go/src/pkg/mod/github.com/osrg/gobgp/v4@v4.0.0-20250713044257-e168c66818bd/internal/pkg/table/util.go:10:26: could not determine what C._SC_AVPHYS_PAGES refers to
```

# Test

Verified that the value returned by `SystemMemoryAvailableMiB` roughly matches the output of `vm_stat`'s `Free Pages * Page Size in Bytes`