### PR TITLE
Improve dest.Calculate() and dest.GetMultiBestPath() performance

### DIFF
--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -692,12 +692,11 @@ func compareByMED(path1, path2 *Path) *Path {
 		firstAS := func(path *Path) uint32 {
 			if asPath := path.GetAsPath(); asPath != nil {
 				for _, v := range asPath.Value {
-					segType := v.GetType()
 					asList := v.GetAS()
 					if len(asList) == 0 {
 						continue
 					}
-					switch segType {
+					switch v.GetType() {
 					case bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET, bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
 						continue
 					}

--- a/internal/pkg/table/message.go
+++ b/internal/pkg/table/message.go
@@ -352,7 +352,7 @@ func newPackerMP(f bgp.Family) *packerMP {
 
 type packerV4 struct {
 	packer
-	hashmap     map[uint32][]*cage
+	hashmap     map[uint64][]*cage
 	mpPaths     []*Path
 	withdrawals []*Path
 }
@@ -488,7 +488,7 @@ func newPackerV4(f bgp.Family) *packerV4 {
 		packer: packer{
 			family: f,
 		},
-		hashmap:     make(map[uint32][]*cage),
+		hashmap:     make(map[uint64][]*cage),
 		withdrawals: make([]*Path, 0),
 		mpPaths:     make([]*Path, 0),
 	}

--- a/internal/pkg/table/path_test.go
+++ b/internal/pkg/table/path_test.go
@@ -253,6 +253,49 @@ func TestGetPathAttrs(t *testing.T) {
 	assert.NotNil(t, path2.getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP))
 }
 
+/*
+func TestGetTransversalPathAttrs(t *testing.T) {
+	checkTransversalPathAttrs := func(t *testing.T, path *Path, expectedAttr bgp.BGPAttrType, checkIsNotExist ...bool) {
+		for _, attr := range path.GetTransversalPathAttrs() {
+			assert.NotNil(t, attr)
+		}
+		if len(checkIsNotExist) > 0 && checkIsNotExist[0] {
+			assert.Nil(t, path.GetTransversalPathAttrs()[expectedAttr])
+		} else {
+			assert.NotNil(t, path.GetTransversalPathAttrs()[expectedAttr])
+		}
+	}
+	paths := PathCreatePath(PathCreatePeer())
+	path0 := paths[0]
+	checkTransversalPathAttrs(t, path0, bgp.BGP_ATTR_TYPE_ORIGIN)
+	nextHop := path0.getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
+	assert.NotNil(t, nextHop)
+	assert.Equal(t, nextHop.(*bgp.PathAttributeNextHop).Value.String(), "192.168.50.1")
+
+	path1 := path0.Clone(false)
+	path1.setPathAttr(bgp.NewPathAttributeNextHop("192.168.98.1"))
+	nextHop = path1.getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
+	assert.NotNil(t, nextHop)
+	assert.Equal(t, nextHop.(*bgp.PathAttributeNextHop).Value.String(), "192.168.98.1")
+	path1.delPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
+	assert.NotNil(t, path1.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGIN))
+	checkTransversalPathAttrs(t, path1, bgp.BGP_ATTR_TYPE_ORIGIN)
+	checkTransversalPathAttrs(t, path1, bgp.BGP_ATTR_TYPE_NEXT_HOP, true)
+
+	path2 := path1.Clone(false)
+	assert.NotNil(t, path2.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGIN))
+	path2.delPathAttr(bgp.BGP_ATTR_TYPE_ORIGIN)
+	// adding an attribute that has been deleted previously by underlayer, is not allowed
+	path2.setPathAttr(bgp.NewPathAttributeNextHop("192.168.99.1"))
+	checkTransversalPathAttrs(t, path2, bgp.BGP_ATTR_TYPE_ORIGIN, true)
+	checkTransversalPathAttrs(t, path2, bgp.BGP_ATTR_TYPE_NEXT_HOP, true)
+
+	nextHop = path2.getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
+	assert.NotNil(t, nextHop)
+	assert.Equal(t, nextHop.(*bgp.PathAttributeNextHop).Value.String(), "192.168.99.1")
+}
+*/
+
 func PathCreatePeer() []*PeerInfo {
 	peerP1 := &PeerInfo{AS: 65000}
 	peerP2 := &PeerInfo{AS: 65001}
@@ -393,4 +436,30 @@ func TestNLRIToIPNet(t *testing.T) {
 	_, n6, _ := net.ParseCIDR("2001:db8:53::/64")
 	ipNet = nlriToIPNet(bgp.NewLabeledVPNIPv6AddrPrefix(64, "2001:db8:53::", *labels, rd))
 	assert.Equal(t, n6, ipNet)
+}
+
+func TestUnknownPathAttributes(t *testing.T) {
+	peerP := PathCreatePeer()
+	pathP := PathCreatePath(peerP)
+
+	type255 := bgp.BGPAttrType(255)
+	unknownAttr := bgp.NewPathAttributeUnknown(bgp.BGPAttrFlag(0), type255, []byte{0x01, 0x02, 0x03})
+	pathP[0].setPathAttr(unknownAttr)
+
+	// Check if the unknown attribute is present
+	assert.NotNil(t, pathP[0].getPathAttr(type255))
+
+	found255 := false
+	var last bgp.BGPAttrType
+	for _, attr := range pathP[0].GetPathAttrs() {
+		assert.NotNil(t, attr)
+		if last >= attr.GetType() {
+			t.Errorf("Path attributes are not sorted: %v >= %v", last, attr.GetType())
+		}
+		last = attr.GetType()
+		if attr.GetType() == type255 {
+			found255 = true
+		}
+	}
+	assert.True(t, found255, "Unknown attribute of type 255 should be present in the path attributes list")
 }

--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -21,8 +21,7 @@ import (
 	"net"
 	"time"
 
-	farm "github.com/dgryski/go-farm"
-
+	"github.com/dgryski/go-farm"
 	"github.com/osrg/gobgp/v4/pkg/log"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
@@ -71,14 +70,14 @@ func ProcessMessage(m *bgp.BGPMessage, peerInfo *PeerInfo, timestamp time.Time) 
 		listLen += len(reach.Value)
 	}
 
-	var hash uint32
+	var hash uint64
 	if len(adds) > 0 || reach != nil {
 		total := bytes.NewBuffer(make([]byte, 0))
 		for _, a := range attrs {
 			b, _ := a.Serialize()
 			total.Write(b)
 		}
-		hash = farm.Hash32(total.Bytes())
+		hash = farm.Hash64(total.Bytes())
 	}
 
 	pathList := make([]*Path, 0, listLen)
@@ -120,7 +119,6 @@ func makeAttributeList(
 	copy(reachAttrs, attrs)
 	// we sort attributes when creating a bgp message from paths
 	reachAttrs[len(reachAttrs)-1] = reach
-
 	return reachAttrs
 }
 

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -573,7 +573,7 @@ func api2Path(resource api.TableType, path *api.Path, isWithdraw bool) (*table.P
 			b, _ := a.Serialize()
 			total.Write(b)
 		}
-		newPath.SetHash(farm.Hash32(total.Bytes()))
+		newPath.SetHash(farm.Hash64(total.Bytes()))
 	}
 	newPath.SetIsFromExternal(path.IsFromExternal)
 	return newPath, nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2395,7 +2395,7 @@ func apiutil2Path(path *apiutil.Path, isVRFTable bool, isWithdraw ...bool) (*tab
 			b, _ := a.Serialize()
 			total.Write(b)
 		}
-		p.SetHash(farm.Hash32(total.Bytes()))
+		p.SetHash(farm.Hash64(total.Bytes()))
 	}
 	p.SetIsFromExternal(path.IsFromExternal)
 	return p, nil


### PR DESCRIPTION
Improve performance by 10% ish by caching path attributes via a path attributes hash if needed

```
Before
BenchmarkMultiPath/Benchmark_Calculate-12                 598702              1837 ns/op             376 B/op         14 allocs/op
BenchmarkMultiPath/Benchmark_GetMultiBestPath-12         3420961               343.5 ns/op             0 B/op          0 allocs/op

After
BenchmarkMultiPath/Benchmark_Calculate-12         	  637652	      1764 ns/op	     376 B/op	      14 allocs/op
BenchmarkMultiPath/Benchmark_GetMultiBestPath-12  	 4771671	       298.0 ns/op	       0 B/op	       0 allocs/op
