### PR TITLE
Reduce randomness in active connect retry delay

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	minConnectRetryInterval = 1
+	minConnectRetryInterval = 2
 )
 
 type fsmStateReasonType uint8
@@ -528,8 +528,7 @@ func (h *fsmHandler) connectLoop(ctx context.Context, wg *sync.WaitGroup) {
 
 	tick := minConnectRetryInterval
 	for {
-		r := rand.New(rand.NewSource(time.Now().UnixNano()))
-		timer := time.NewTimer(time.Duration(r.Intn(tick*1000)+tick*1000) * time.Millisecond)
+		timer := time.NewTimer(time.Duration((0.75+rand.Float64()*0.25)*float64(tick)*1000) * time.Millisecond)
 		select {
 		case <-ctx.Done():
 			fsm.logger.Debug("stop connect loop",


### PR DESCRIPTION
In the current implementation, the wait time before the next active connection attempt can be up to twice the user-specified connect-retry interval. For example, if connect-retry is set to 10 seconds, the actual wait time can range from 10 to 20 seconds due to an added random delay.

While the retry algorithm for active connections is not defined in the BGP RFCs and is implementation-specific, BIRD simply uses the specified interval without adding randomness.

This patch adjusts the logic to reduce the delay and make it closer to the configured interval. Specifically, it uses the connect-retry interval plus a random delay of up to 2000 milliseconds. The 2000 milliseconds was chosen arbitrarily, based on the assumption that most GoBGP use cases are within data centers, where long timeouts are undesirable.

This change is expected to reduce the likelihood of peer connection timeouts in CI environments.