### PR TITLE
pip-requires: Remove Ryu

### DIFF
--- a/test/pip-requires.txt
+++ b/test/pip-requires.txt
@@ -5,7 +5,6 @@ fabric == 2.4.0
 netaddr
 nsenter
 docker-py
-ryu
 colored
 invoke == 1.2.0
 requests <= 2.25.1


### PR DESCRIPTION
Remove unused Ryu Python module. A long time ago, we used to use Ryu’s packet library, but now there’s no such test code.