### PR TITLE
pkg/packet/bgp: use netip for IPAddrPrefix and IPv6AddrPrefix

### DIFF
--- a/internal/pkg/table/message_test.go
+++ b/internal/pkg/table/message_test.go
@@ -616,7 +616,7 @@ func TestMergeV4NLRIs(t *testing.T) {
 
 	assert.Equal(t, len(l), nr)
 	for i, addr := range addrs {
-		assert.Equal(t, addr, l[i].Prefix.String())
+		assert.Equal(t, addr, l[i].Prefix.Addr().String())
 	}
 	for _, msg := range msgs {
 		d, _ := msg.Serialize()
@@ -686,7 +686,7 @@ func TestMergeV4Withdraw(t *testing.T) {
 	}
 	assert.Equal(t, len(l), nr)
 	for i, addr := range addrs {
-		assert.Equal(t, addr, l[i].Prefix.String())
+		assert.Equal(t, addr, l[i].Prefix.Addr().String())
 	}
 
 	for _, msg := range msgs {

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -1142,7 +1142,7 @@ func (v *Vrf) ToGlobalPath(path *Path) error {
 	case bgp.RF_IPv4_UC:
 		n := nlri.(*bgp.IPAddrPrefix)
 		pathIdentifier := path.GetNlri().PathIdentifier()
-		path.OriginInfo().nlri = bgp.NewLabeledVPNIPAddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(v.MplsLabel), v.Rd)
+		path.OriginInfo().nlri = bgp.NewLabeledVPNIPAddrPrefix(uint8(n.Prefix.Bits()), n.Prefix.Addr().String(), *bgp.NewMPLSLabelStack(v.MplsLabel), v.Rd)
 		path.GetNlri().SetPathIdentifier(pathIdentifier)
 	case bgp.RF_FS_IPv4_UC:
 		n := nlri.(*bgp.FlowSpecIPv4Unicast)
@@ -1152,7 +1152,7 @@ func (v *Vrf) ToGlobalPath(path *Path) error {
 	case bgp.RF_IPv6_UC:
 		n := nlri.(*bgp.IPv6AddrPrefix)
 		pathIdentifier := path.GetNlri().PathIdentifier()
-		path.OriginInfo().nlri = bgp.NewLabeledVPNIPv6AddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(v.MplsLabel), v.Rd)
+		path.OriginInfo().nlri = bgp.NewLabeledVPNIPv6AddrPrefix(uint8(n.Prefix.Bits()), n.Prefix.Addr().String(), *bgp.NewMPLSLabelStack(v.MplsLabel), v.Rd)
 		path.GetNlri().SetPathIdentifier(pathIdentifier)
 	case bgp.RF_FS_IPv6_UC:
 		n := nlri.(*bgp.FlowSpecIPv6Unicast)
@@ -1193,11 +1193,11 @@ func (p *Path) ToGlobal(vrf *Vrf) *Path {
 	switch rf := p.GetFamily(); rf {
 	case bgp.RF_IPv4_UC:
 		n := nlri.(*bgp.IPAddrPrefix)
-		nlri = bgp.NewLabeledVPNIPAddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(vrf.MplsLabel), vrf.Rd)
+		nlri = bgp.NewLabeledVPNIPAddrPrefix(uint8(n.Prefix.Bits()), n.Prefix.Addr().String(), *bgp.NewMPLSLabelStack(vrf.MplsLabel), vrf.Rd)
 		nlri.SetPathIdentifier(pathId)
 	case bgp.RF_IPv6_UC:
 		n := nlri.(*bgp.IPv6AddrPrefix)
-		nlri = bgp.NewLabeledVPNIPv6AddrPrefix(n.Length, n.Prefix.String(), *bgp.NewMPLSLabelStack(vrf.MplsLabel), vrf.Rd)
+		nlri = bgp.NewLabeledVPNIPv6AddrPrefix(uint8(n.Prefix.Bits()), n.Prefix.Addr().String(), *bgp.NewMPLSLabelStack(vrf.MplsLabel), vrf.Rd)
 		nlri.SetPathIdentifier(pathId)
 	case bgp.RF_EVPN:
 		n := nlri.(*bgp.EVPNNLRI)
@@ -1340,13 +1340,13 @@ func nlriToIPNet(nlri bgp.AddrPrefixInterface) *net.IPNet {
 	switch T := nlri.(type) {
 	case *bgp.IPAddrPrefix:
 		return &net.IPNet{
-			IP:   T.Prefix.To4(),
-			Mask: net.CIDRMask(int(T.Length), 32),
+			IP:   T.Prefix.Addr().AsSlice(),
+			Mask: net.CIDRMask(T.Prefix.Bits(), 32),
 		}
 	case *bgp.IPv6AddrPrefix:
 		return &net.IPNet{
-			IP:   T.Prefix.To16(),
-			Mask: net.CIDRMask(int(T.Length), 128),
+			IP:   T.Prefix.Addr().AsSlice(),
+			Mask: net.CIDRMask(T.Prefix.Bits(), 128),
 		}
 	case *bgp.LabeledIPAddrPrefix:
 		return &net.IPNet{

--- a/internal/pkg/table/policy.go
+++ b/internal/pkg/table/policy.go
@@ -285,11 +285,11 @@ func (p *Prefix) Match(path *Path) bool {
 	var pMasklen uint8
 	switch rf {
 	case bgp.RF_IPv4_UC:
-		pAddr = path.GetNlri().(*bgp.IPAddrPrefix).Prefix
-		pMasklen = path.GetNlri().(*bgp.IPAddrPrefix).Length
+		pAddr = net.IP(path.GetNlri().(*bgp.IPAddrPrefix).Prefix.Addr().AsSlice())
+		pMasklen = uint8(path.GetNlri().(*bgp.IPAddrPrefix).Prefix.Bits())
 	case bgp.RF_IPv6_UC:
-		pAddr = path.GetNlri().(*bgp.IPv6AddrPrefix).Prefix
-		pMasklen = path.GetNlri().(*bgp.IPv6AddrPrefix).Length
+		pAddr = net.IP(path.GetNlri().(*bgp.IPv6AddrPrefix).Prefix.Addr().AsSlice())
+		pMasklen = uint8(path.GetNlri().(*bgp.IPv6AddrPrefix).Prefix.Bits())
 	default:
 		return false
 	}

--- a/internal/pkg/table/policy_test.go
+++ b/internal/pkg/table/policy_test.go
@@ -3850,7 +3850,7 @@ func TestAfiSafiInMatchPath(t *testing.T) {
 	prefixVPNv4 := bgp.NewLabeledVPNIPAddrPrefix(0, "1.1.1.0/24", *bgp.NewMPLSLabelStack(), bgp.NewRouteDistinguisherTwoOctetAS(100, 100))
 	prefixVPNv6 := bgp.NewLabeledVPNIPv6AddrPrefix(0, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", *bgp.NewMPLSLabelStack(), bgp.NewRouteDistinguisherTwoOctetAS(200, 200))
 	prefixRTC := bgp.NewRouteTargetMembershipNLRI(100, nil)
-	prefixv4 := bgp.NewIPAddrPrefix(0, "1.1.1.0/24")
+	prefixv4 := bgp.NewIPAddrPrefix(24, "1.1.1.0")
 	prefixv6 := bgp.NewIPv6AddrPrefix(0, "2001:0db8:85a3:0000:0000:8a2e:0370:7334")
 
 	pathVPNv4 := NewPath(nil, prefixVPNv4, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rtExtCom})}, time.Time{}, false)

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -52,11 +52,11 @@ func tableKey(nlri bgp.AddrPrefixInterface) addrPrefixKey {
 	h := fnv1a.Init64
 	switch T := nlri.(type) {
 	case *bgp.IPAddrPrefix:
-		h = fnv1a.AddBytes64(h, T.Prefix.To4())
-		h = fnv1a.AddBytes64(h, []byte{T.Length})
+		h = fnv1a.AddBytes64(h, T.Prefix.Addr().AsSlice())
+		h = fnv1a.AddBytes64(h, []byte{uint8(T.Prefix.Bits())})
 	case *bgp.IPv6AddrPrefix:
-		h = fnv1a.AddBytes64(h, T.Prefix.To16())
-		h = fnv1a.AddBytes64(h, []byte{T.Length})
+		h = fnv1a.AddBytes64(h, T.Prefix.Addr().AsSlice())
+		h = fnv1a.AddBytes64(h, []byte{uint8(T.Prefix.Bits())})
 	case *bgp.LabeledVPNIPAddrPrefix:
 		serializedRD, _ := T.RD.Serialize()
 		h = fnv1a.AddBytes64(h, serializedRD)

--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -542,27 +542,27 @@ func MarshalFlowSpecRules(values []bgp.FlowSpecComponentInterface) ([]*api.FlowS
 		case *bgp.FlowSpecDestinationPrefix:
 			rule.Rule = &api.FlowSpecRule_IpPrefix{IpPrefix: &api.FlowSpecIPPrefix{
 				Type:      uint32(bgp.FLOW_SPEC_TYPE_DST_PREFIX),
-				PrefixLen: uint32(v.Prefix.(*bgp.IPAddrPrefix).Length),
-				Prefix:    v.Prefix.(*bgp.IPAddrPrefix).Prefix.String(),
+				PrefixLen: uint32(v.Prefix.(*bgp.IPAddrPrefix).Prefix.Bits()),
+				Prefix:    v.Prefix.(*bgp.IPAddrPrefix).Prefix.Addr().String(),
 			}}
 		case *bgp.FlowSpecSourcePrefix:
 			rule.Rule = &api.FlowSpecRule_IpPrefix{IpPrefix: &api.FlowSpecIPPrefix{
 				Type:      uint32(bgp.FLOW_SPEC_TYPE_SRC_PREFIX),
-				PrefixLen: uint32(v.Prefix.(*bgp.IPAddrPrefix).Length),
-				Prefix:    v.Prefix.(*bgp.IPAddrPrefix).Prefix.String(),
+				PrefixLen: uint32(v.Prefix.(*bgp.IPAddrPrefix).Prefix.Bits()),
+				Prefix:    v.Prefix.(*bgp.IPAddrPrefix).Prefix.Addr().String(),
 			}}
 		case *bgp.FlowSpecDestinationPrefix6:
 			rule.Rule = &api.FlowSpecRule_IpPrefix{IpPrefix: &api.FlowSpecIPPrefix{
 				Type:      uint32(bgp.FLOW_SPEC_TYPE_DST_PREFIX),
-				PrefixLen: uint32(v.Prefix.(*bgp.IPv6AddrPrefix).Length),
-				Prefix:    v.Prefix.(*bgp.IPv6AddrPrefix).Prefix.String(),
+				PrefixLen: uint32(v.Prefix.(*bgp.IPv6AddrPrefix).Prefix.Bits()),
+				Prefix:    v.Prefix.(*bgp.IPv6AddrPrefix).Prefix.Addr().String(),
 				Offset:    uint32(v.Offset),
 			}}
 		case *bgp.FlowSpecSourcePrefix6:
 			rule.Rule = &api.FlowSpecRule_IpPrefix{IpPrefix: &api.FlowSpecIPPrefix{
 				Type:      uint32(bgp.FLOW_SPEC_TYPE_SRC_PREFIX),
-				PrefixLen: uint32(v.Prefix.(*bgp.IPv6AddrPrefix).Length),
-				Prefix:    v.Prefix.(*bgp.IPv6AddrPrefix).Prefix.String(),
+				PrefixLen: uint32(v.Prefix.(*bgp.IPv6AddrPrefix).Prefix.Bits()),
+				Prefix:    v.Prefix.(*bgp.IPv6AddrPrefix).Prefix.Addr().String(),
 				Offset:    uint32(v.Offset),
 			}}
 		case *bgp.FlowSpecSourceMac:
@@ -1142,13 +1142,13 @@ func MarshalNLRI(value bgp.AddrPrefixInterface) (*api.NLRI, error) {
 	switch v := value.(type) {
 	case *bgp.IPAddrPrefix:
 		nlri.Nlri = &api.NLRI_Prefix{Prefix: &api.IPAddressPrefix{
-			PrefixLen: uint32(v.Length),
-			Prefix:    v.Prefix.String(),
+			PrefixLen: uint32(v.Prefix.Bits()),
+			Prefix:    v.Prefix.Addr().String(),
 		}}
 	case *bgp.IPv6AddrPrefix:
 		nlri.Nlri = &api.NLRI_Prefix{Prefix: &api.IPAddressPrefix{
-			PrefixLen: uint32(v.Length),
-			Prefix:    v.Prefix.String(),
+			PrefixLen: uint32(v.Prefix.Bits()),
+			Prefix:    v.Prefix.Addr().String(),
 		}}
 	case *bgp.LabeledIPAddrPrefix:
 		nlri.Nlri = &api.NLRI_LabeledPrefix{LabeledPrefix: &api.LabeledIPAddressPrefix{

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1690,11 +1690,11 @@ func TestDoNotReactToDuplicateRTCMemberships(t *testing.T) {
 				for _, path := range msg.PathList {
 					t.Logf("tester received path: %s", path.String())
 					if vpnPath, ok := path.GetNlri().(*bgp.LabeledVPNIPAddrPrefix); ok {
-						if vpnPath.Prefix.Equal(prefix.Prefix) {
+						if vpnPath.Prefix.Equal(net.IP(prefix.Prefix.Addr().AsSlice())) {
 							t.Logf("tester found expected prefix: %s", vpnPath.Prefix)
 							found = true
 						} else {
-							t.Logf("unknown prefix %s != %s", vpnPath.Prefix, prefix.Prefix)
+							t.Logf("unknown prefix %s != %s", vpnPath.Prefix, prefix.Prefix.Addr())
 						}
 					}
 				}
@@ -1794,11 +1794,11 @@ func TestDelVrfWithRTC(t *testing.T) {
 				for _, path := range msg.PathList {
 					t.Logf("tester received path: %s", path.String())
 					if vpnPath, ok := path.GetNlri().(*bgp.LabeledVPNIPAddrPrefix); ok {
-						if vpnPath.Prefix.Equal(prefix.Prefix) {
+						if vpnPath.Prefix.Equal(net.IP(prefix.Prefix.Addr().AsSlice())) {
 							t.Logf("tester found expected prefix: %s", vpnPath.Prefix)
 							found = true
 						} else {
-							t.Logf("unknown prefix %s != %s", vpnPath.Prefix, prefix.Prefix)
+							t.Logf("unknown prefix %s != %s", vpnPath.Prefix, prefix.Prefix.Addr())
 						}
 					}
 				}
@@ -1827,11 +1827,11 @@ func TestDelVrfWithRTC(t *testing.T) {
 				for _, path := range msg.PathList {
 					t.Logf("tester received path: %s", path.String())
 					if vpnPath, ok := path.GetNlri().(*bgp.LabeledVPNIPAddrPrefix); ok {
-						if vpnPath.Prefix.Equal(prefix.Prefix) && path.IsWithdraw {
+						if vpnPath.Prefix.Equal(net.IP(prefix.Prefix.Addr().AsSlice())) && path.IsWithdraw {
 							t.Logf("tester found expected withdrawn prefix: %s", vpnPath.Prefix)
 							withdrawVPN = true
 						} else {
-							t.Logf("unknown prefix %s != %s", vpnPath.Prefix, prefix.Prefix)
+							t.Logf("unknown prefix %s != %s", vpnPath.Prefix, prefix.Prefix.Addr())
 						}
 					}
 				}

--- a/pkg/server/zclient.go
+++ b/pkg/server/zclient.go
@@ -153,11 +153,11 @@ func newIPRouteBody(dst []*table.Path, vrfID uint32, z *zebraClient) (body *zebr
 	msgFlags := zebra.MessageNexthop
 	switch path.GetFamily() {
 	case bgp.RF_IPv4_UC:
-		prefix = path.GetNlri().(*bgp.IPAddrPrefix).Prefix.To4()
+		prefix = path.GetNlri().(*bgp.IPAddrPrefix).Prefix.Addr().AsSlice()
 	case bgp.RF_IPv4_VPN:
 		prefix = path.GetNlri().(*bgp.LabeledVPNIPAddrPrefix).Prefix.To4()
 	case bgp.RF_IPv6_UC:
-		prefix = path.GetNlri().(*bgp.IPv6AddrPrefix).Prefix.To16()
+		prefix = path.GetNlri().(*bgp.IPv6AddrPrefix).Prefix.Addr().AsSlice()
 	case bgp.RF_IPv6_VPN:
 		prefix = path.GetNlri().(*bgp.LabeledVPNIPv6AddrPrefix).Prefix.To16()
 	default:


### PR DESCRIPTION
Replace uses of net.IP with netip.Prefix for IPAddrPrefix and IPv6AddrPrefix.

When GoBGP was started, the net/netip package did not exist and net.IP was the standard type for representing IP addresses. However, with the introduction of netip.Addr in Go 1.18, we now have a more efficient and type-safe alternative.

Although netip.Addr may use slightly more memory for IPv4 addresses (as it always reserves space for IPv6), it eliminates the need for memory allocation on the heap, which is expected to improve performance, especially in high-throughput paths.

This patch replaces uses of net.IP with netip.Prefix type implemented by using netip.Addr for IPAddrPrefix and IPv6AddrPrefix.

We should use netip for IpAddrPrefixDefault however it means that this patch becomes much larger since we also update all labeled addrprefix types. There will be some temporary code duplication, but I plan to gradually proceed with the replacement.