### PR TITLE
fix: stop io loop when context is cancelled

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,8 @@ linters:
         - (*os.File).Close
         - (net.Conn).Close
         - (*net.conn).Close
+        - (net.Conn).SetReadDeadline
+        - (net.Conn).SetWriteDeadline
         - (net.Listener).Close
         - (*google.golang.org/grpc.ClientConn).Close
         - (net.Conn).Write


### PR DESCRIPTION
If NegotiatedHoldTime is zero we would never be able to send a message as the write deadline would be set to now. Remove this write deadline and add one only when we are stopping the send goroutine.

In case of hold timer expiration, we need to send the notification straight away and avoid pushing it to the outgoing channel, since there is a race between the closing of the sendMessageloop and the sending of the notification.