### PR TITLE
pkg/table: make AddrPrefixOnlyCompare private

### DIFF
--- a/internal/pkg/table/table_test.go
+++ b/internal/pkg/table/table_test.go
@@ -98,11 +98,11 @@ func TestTableSetDestinations(t *testing.T) {
 	}
 	// make them comparable
 	slices.SortFunc(destinations, func(a, b *Destination) int {
-		return bgp.AddrPrefixOnlyCompare(a.GetNlri(), b.GetNlri())
+		return AddrPrefixOnlyCompare(a.GetNlri(), b.GetNlri())
 	})
 	ds := ipv4t.GetDestinations()
 	slices.SortFunc(ds, func(a, b *Destination) int {
-		return bgp.AddrPrefixOnlyCompare(a.GetNlri(), b.GetNlri())
+		return AddrPrefixOnlyCompare(a.GetNlri(), b.GetNlri())
 	})
 	assert.Equal(t, ds, destinations)
 }
@@ -119,11 +119,11 @@ func TestTableGetDestinations(t *testing.T) {
 	}
 	// make them comparable
 	slices.SortFunc(destinations, func(a, b *Destination) int {
-		return bgp.AddrPrefixOnlyCompare(a.GetNlri(), b.GetNlri())
+		return AddrPrefixOnlyCompare(a.GetNlri(), b.GetNlri())
 	})
 	ds := ipv4t.GetDestinations()
 	slices.SortFunc(ds, func(a, b *Destination) int {
-		return bgp.AddrPrefixOnlyCompare(a.GetNlri(), b.GetNlri())
+		return AddrPrefixOnlyCompare(a.GetNlri(), b.GetNlri())
 	})
 	assert.Equal(t, ds, destinations)
 }

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -1379,40 +1379,6 @@ type AddrPrefixInterface interface {
 	SetPathLocalIdentifier(uint32)
 }
 
-func addrPrefixOnlySerialize(nlri AddrPrefixInterface) []byte {
-	switch T := nlri.(type) {
-	case *IPAddrPrefix:
-		b := make([]byte, 5)
-		copy(b, T.Prefix.Addr().AsSlice())
-		b[4] = uint8(T.Prefix.Bits())
-		return b
-	case *IPv6AddrPrefix:
-		b := make([]byte, 17)
-		copy(b, T.Prefix.Addr().AsSlice())
-		b[16] = uint8(T.Prefix.Bits())
-		return b
-	case *LabeledVPNIPAddrPrefix:
-		b := make([]byte, 13)
-		serializedRD, _ := T.RD.Serialize()
-		copy(b, serializedRD)
-		copy(b[8:12], T.Prefix.Addr().AsSlice())
-		b[12] = uint8(T.Prefix.Bits())
-		return b
-	case *LabeledVPNIPv6AddrPrefix:
-		b := make([]byte, 25)
-		serializedRD, _ := T.RD.Serialize()
-		copy(b, serializedRD)
-		copy(b[8:24], T.Prefix.Addr().AsSlice())
-		b[24] = uint8(T.Prefix.Bits())
-		return b
-	}
-	return []byte(nlri.String())
-}
-
-func AddrPrefixOnlyCompare(a, b AddrPrefixInterface) int {
-	return bytes.Compare(addrPrefixOnlySerialize(a), addrPrefixOnlySerialize(b))
-}
-
 func LabelString(nlri AddrPrefixInterface) string {
 	label := ""
 	switch n := nlri.(type) {


### PR DESCRIPTION
Move AddrPrefixOnlyCompare from bgp to table package; make it private function.

Public API interface is written in stone. It cannot be changed without the major version updated. Currently, AddrPrefixOnlyCompare is used only by table package so let's keep it in the table package. We can always make it public in the future when needed.