### PR TITLE
pkg/packet/bgp: use netip for Ls structures

### DIFF
--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -1475,13 +1475,14 @@ func parseLsLinkNLRIType(args []string) (bgp.AddrPrefixInterface, *bgp.PathAttri
 	if err != nil {
 		return nil, nil, err
 	}
+	id, _ := netip.ParseAddr(m["local-bgp-router-id"][0])
 	lnd := &bgp.LsNodeDescriptor{
 		Asn:                    uint32(localAsn),
 		BGPLsID:                uint32(localBgpLsId),
 		OspfAreaID:             0,
 		PseudoNode:             false,
 		IGPRouterID:            "",
-		BGPRouterID:            net.ParseIP(m["local-bgp-router-id"][0]).To4(),
+		BGPRouterID:            id,
 		BGPConfederationMember: uint32(localBgpConfederationMember),
 	}
 	RemoteAsn, err := strconv.ParseUint(m["remote-asn"][0], 10, 64)
@@ -1496,25 +1497,26 @@ func parseLsLinkNLRIType(args []string) (bgp.AddrPrefixInterface, *bgp.PathAttri
 	if err != nil {
 		return nil, nil, err
 	}
+	remoteId, _ := netip.ParseAddr(m["remote-bgp-router-id"][0])
 	rnd := &bgp.LsNodeDescriptor{
 		Asn:                    uint32(RemoteAsn),
 		BGPLsID:                uint32(RemoteBgpLsId),
 		OspfAreaID:             0,
 		PseudoNode:             false,
 		IGPRouterID:            "",
-		BGPRouterID:            net.ParseIP(m["remote-bgp-router-id"][0]),
+		BGPRouterID:            remoteId,
 		BGPConfederationMember: uint32(RemoteBgpConfederationMember),
 	}
 
-	var interfaceAddrIPv4 net.IP
-	var neighborAddrIPv4 net.IP
-	var interfaceAddrIPv6 net.IP
-	var neighborAddrIPv6 net.IP
+	var interfaceAddrIPv4 netip.Addr
+	var neighborAddrIPv4 netip.Addr
+	var interfaceAddrIPv6 netip.Addr
+	var neighborAddrIPv6 netip.Addr
 
-	interfaceAddrIPv4 = net.ParseIP(m["ipv4-interface-address"][0]).To4()
-	neighborAddrIPv4 = net.ParseIP(m["ipv4-neighbor-address"][0]).To4()
-	interfaceAddrIPv6 = net.ParseIP(m["ipv6-interface-address"][0]).To16()
-	neighborAddrIPv6 = net.ParseIP(m["ipv6-neighbor-address"][0]).To16()
+	interfaceAddrIPv4, _ = netip.ParseAddr(m["ipv4-interface-address"][0])
+	neighborAddrIPv4, _ = netip.ParseAddr(m["ipv4-neighbor-address"][0])
+	interfaceAddrIPv6, _ = netip.ParseAddr(m["ipv6-interface-address"][0])
+	neighborAddrIPv6, _ = netip.ParseAddr(m["ipv6-neighbor-address"][0])
 
 	ld := &bgp.LsLinkDescriptor{
 		LinkLocalID:       new(uint32),
@@ -1674,13 +1676,14 @@ func parseLsSRv6SIDNLRIType(args []string) (bgp.AddrPrefixInterface, *bgp.PathAt
 	if err != nil {
 		return nil, nil, err
 	}
+	id, _ := netip.ParseAddr(m["local-bgp-router-id"][0])
 	lnd := &bgp.LsNodeDescriptor{
 		Asn:                    uint32(localAsn),
 		BGPLsID:                uint32(localBgpLsId),
 		OspfAreaID:             0,
 		PseudoNode:             false,
 		IGPRouterID:            "",
-		BGPRouterID:            net.ParseIP(m["local-bgp-router-id"][0]).To4(),
+		BGPRouterID:            id,
 		BGPConfederationMember: uint32(localBgpConfederationMember),
 	}
 	lndTLV := bgp.NewLsTLVNodeDescriptor(lnd, bgp.LS_TLV_LOCAL_NODE_DESC)

--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -832,34 +832,35 @@ func UnmarshalLsBgpPeerSegmentSid(a *api.LsBgpPeerSegmentSID) (*bgp.LsBgpPeerSeg
 }
 
 func UnmarshalLsNodeDescriptor(nd *api.LsNodeDescriptor) (*bgp.LsNodeDescriptor, error) {
+	bgpRouterId, _ := netip.ParseAddr(nd.BgpRouterId)
 	return &bgp.LsNodeDescriptor{
 		Asn:                    nd.Asn,
 		BGPLsID:                nd.BgpLsId,
 		OspfAreaID:             nd.OspfAreaId,
 		PseudoNode:             nd.Pseudonode,
 		IGPRouterID:            nd.IgpRouterId,
-		BGPRouterID:            net.ParseIP(nd.BgpRouterId),
+		BGPRouterID:            bgpRouterId,
 		BGPConfederationMember: nd.BgpConfederationMember,
 	}, nil
 }
 
 func UnmarshalLsLinkDescriptor(ld *api.LsLinkDescriptor) (*bgp.LsLinkDescriptor, error) {
-	ifAddrIPv4 := net.IP{}
-	neiAddrIPv4 := net.IP{}
-	ifAddrIPv6 := net.IP{}
-	neiAddrIPv6 := net.IP{}
+	ifAddrIPv4 := netip.Addr{}
+	neiAddrIPv4 := netip.Addr{}
+	ifAddrIPv6 := netip.Addr{}
+	neiAddrIPv6 := netip.Addr{}
 
 	if ld.GetInterfaceAddrIpv4() != "" {
-		ifAddrIPv4 = net.ParseIP(ld.InterfaceAddrIpv4).To4()
+		ifAddrIPv4, _ = netip.ParseAddr(ld.InterfaceAddrIpv4)
 	}
 	if ld.GetNeighborAddrIpv4() != "" {
-		neiAddrIPv4 = net.ParseIP(ld.NeighborAddrIpv4).To4()
+		neiAddrIPv4, _ = netip.ParseAddr(ld.NeighborAddrIpv4)
 	}
 	if ld.GetInterfaceAddrIpv6() != "" {
-		ifAddrIPv6 = net.ParseIP(ld.InterfaceAddrIpv6).To16()
+		ifAddrIPv6, _ = netip.ParseAddr(ld.InterfaceAddrIpv6)
 	}
 	if ld.GetNeighborAddrIpv6() != "" {
-		neiAddrIPv6 = net.ParseIP(ld.NeighborAddrIpv6).To16()
+		neiAddrIPv6, _ = netip.ParseAddr(ld.NeighborAddrIpv6)
 	}
 
 	return &bgp.LsLinkDescriptor{
@@ -959,14 +960,14 @@ func UnmarshalLsAttribute(a *api.LsAttribute) (*bgp.LsAttribute, error) {
 
 	// For AttributeNode
 	if a.Node != nil {
-		nodeLocalRouterID := (*net.IP)(nil)
+		nodeLocalRouterID := (*netip.Addr)(nil)
 		if a.Node.LocalRouterId != "" {
-			localRouterID := net.ParseIP(a.Node.LocalRouterId).To4()
+			localRouterID, _ := netip.ParseAddr(a.Node.LocalRouterId)
 			nodeLocalRouterID = &localRouterID
 		}
-		nodeLocalRouterIDv6 := (*net.IP)(nil)
+		nodeLocalRouterIDv6 := (*netip.Addr)(nil)
 		if a.Node.LocalRouterIdV6 != "" {
-			localRouterIDv6 := net.ParseIP(a.Node.LocalRouterIdV6).To16()
+			localRouterIDv6, _ := netip.ParseAddr(a.Node.LocalRouterIdV6)
 			nodeLocalRouterIDv6 = &localRouterIDv6
 		}
 
@@ -1028,24 +1029,24 @@ func UnmarshalLsAttribute(a *api.LsAttribute) (*bgp.LsAttribute, error) {
 		if a.Link.Name != "" {
 			linkName = &a.Link.Name
 		}
-		linkLocalRouterID := (*net.IP)(nil)
+		linkLocalRouterID := (*netip.Addr)(nil)
 		if a.Link.LocalRouterId != "" {
-			localRouterID := net.ParseIP(a.Link.LocalRouterId)
+			localRouterID, _ := netip.ParseAddr(a.Link.LocalRouterId)
 			linkLocalRouterID = &localRouterID
 		}
-		linkLocalRouterIDv6 := (*net.IP)(nil)
+		linkLocalRouterIDv6 := (*netip.Addr)(nil)
 		if a.Link.LocalRouterIdV6 != "" {
-			localRouterIDv6 := net.ParseIP(a.Link.LocalRouterIdV6)
+			localRouterIDv6, _ := netip.ParseAddr(a.Link.LocalRouterIdV6)
 			linkLocalRouterIDv6 = &localRouterIDv6
 		}
-		linkRemoteRouterID := (*net.IP)(nil)
+		linkRemoteRouterID := (*netip.Addr)(nil)
 		if a.Link.RemoteRouterId != "" {
-			remoteRouterID := net.ParseIP(a.Link.RemoteRouterId)
+			remoteRouterID, _ := netip.ParseAddr(a.Link.RemoteRouterId)
 			linkRemoteRouterID = &remoteRouterID
 		}
-		linkRemoteRouterIDv6 := (*net.IP)(nil)
+		linkRemoteRouterIDv6 := (*netip.Addr)(nil)
 		if a.Link.RemoteRouterIdV6 != "" {
-			remoteRouterIDv6 := net.ParseIP(a.Link.RemoteRouterIdV6)
+			remoteRouterIDv6, _ := netip.ParseAddr(a.Link.RemoteRouterIdV6)
 			linkRemoteRouterIDv6 = &remoteRouterIDv6
 		}
 		var linkAdminGroup *uint32
@@ -2524,7 +2525,7 @@ func bytesOrDefault(b *[]byte) []byte {
 	return *b
 }
 
-func ipOrDefault(ip *net.IP) string {
+func ipOrDefault(ip *netip.Addr) string {
 	if ip == nil {
 		return ""
 	}

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -5437,10 +5437,10 @@ func (l *LsNodeNLRI) MarshalJSON() ([]byte, error) {
 type LsLinkDescriptor struct {
 	LinkLocalID       *uint32
 	LinkRemoteID      *uint32
-	InterfaceAddrIPv4 *net.IP
-	NeighborAddrIPv4  *net.IP
-	InterfaceAddrIPv6 *net.IP
-	NeighborAddrIPv6  *net.IP
+	InterfaceAddrIPv4 *netip.Addr
+	NeighborAddrIPv4  *netip.Addr
+	InterfaceAddrIPv6 *netip.Addr
+	NeighborAddrIPv6  *netip.Addr
 }
 
 func (l *LsLinkDescriptor) ParseTLVs(tlvs []LsTLVInterface) {
@@ -6318,10 +6318,10 @@ func NewLsAttributeTLVs(lsAttr *LsAttribute) []LsTLVInterface {
 	if lsAttr.Node.IsisArea != nil {
 		tlvs = append(tlvs, NewLsTLVIsisArea(lsAttr.Node.IsisArea))
 	}
-	if lsAttr.Node.LocalRouterID != (*net.IP)(nil) {
+	if lsAttr.Node.LocalRouterID != nil {
 		tlvs = append(tlvs, NewLsTLVLocalIPv4RouterID(lsAttr.Node.LocalRouterID))
 	}
-	if lsAttr.Node.LocalRouterIDv6 != (*net.IP)(nil) {
+	if lsAttr.Node.LocalRouterIDv6 != nil {
 		tlvs = append(tlvs, NewLsTLVLocalIPv6RouterID(lsAttr.Node.LocalRouterIDv6))
 	}
 	if lsAttr.Node.SrCapabilties != nil {
@@ -6337,16 +6337,16 @@ func NewLsAttributeTLVs(lsAttr *LsAttribute) []LsTLVInterface {
 	if lsAttr.Link.Name != nil {
 		tlvs = append(tlvs, NewLsTLVLinkName(lsAttr.Link.Name))
 	}
-	if lsAttr.Link.LocalRouterID != (*net.IP)(nil) {
+	if lsAttr.Link.LocalRouterID != nil {
 		tlvs = append(tlvs, NewLsTLVLocalIPv4RouterID(lsAttr.Link.LocalRouterID))
 	}
-	if lsAttr.Link.LocalRouterIDv6 != (*net.IP)(nil) {
+	if lsAttr.Link.LocalRouterIDv6 != nil {
 		tlvs = append(tlvs, NewLsTLVLocalIPv6RouterID(lsAttr.Link.LocalRouterIDv6))
 	}
-	if lsAttr.Link.RemoteRouterID != (*net.IP)(nil) {
+	if lsAttr.Link.RemoteRouterID != nil {
 		tlvs = append(tlvs, NewLsTLVRemoteIPv4RouterID(lsAttr.Link.RemoteRouterID))
 	}
-	if lsAttr.Link.RemoteRouterIDv6 != (*net.IP)(nil) {
+	if lsAttr.Link.RemoteRouterIDv6 != nil {
 		tlvs = append(tlvs, NewLsTLVRemoteIPv6RouterID(lsAttr.Link.RemoteRouterIDv6))
 	}
 	if lsAttr.Link.AdminGroup != nil {
@@ -6499,7 +6499,7 @@ func (l *LsTLVLinkID) GetLsTLV() LsTLV {
 
 type LsTLVIPv4InterfaceAddr struct {
 	LsTLV
-	IP net.IP
+	IP netip.Addr
 }
 
 func (l *LsTLVIPv4InterfaceAddr) DecodeFromBytes(data []byte) error {
@@ -6517,13 +6517,13 @@ func (l *LsTLVIPv4InterfaceAddr) DecodeFromBytes(data []byte) error {
 		return malformedAttrListErr("Unexpected address size")
 	}
 
-	l.IP = net.IP(value)
+	l.IP, _ = netip.AddrFromSlice(value)
 
 	return nil
 }
 
 func (l *LsTLVIPv4InterfaceAddr) Serialize() ([]byte, error) {
-	return l.LsTLV.Serialize(l.IP)
+	return l.LsTLV.Serialize(l.IP.AsSlice())
 }
 
 func (l *LsTLVIPv4InterfaceAddr) String() string {
@@ -6546,7 +6546,7 @@ func (l *LsTLVIPv4InterfaceAddr) GetLsTLV() LsTLV {
 
 type LsTLVIPv4NeighborAddr struct {
 	LsTLV
-	IP net.IP
+	IP netip.Addr
 }
 
 func (l *LsTLVIPv4NeighborAddr) DecodeFromBytes(data []byte) error {
@@ -6564,13 +6564,13 @@ func (l *LsTLVIPv4NeighborAddr) DecodeFromBytes(data []byte) error {
 		return malformedAttrListErr("Unexpected address size")
 	}
 
-	l.IP = net.IP(value)
+	l.IP, _ = netip.AddrFromSlice(value)
 
 	return nil
 }
 
 func (l *LsTLVIPv4NeighborAddr) Serialize() ([]byte, error) {
-	return l.LsTLV.Serialize(l.IP)
+	return l.LsTLV.Serialize(l.IP.AsSlice())
 }
 
 func (l *LsTLVIPv4NeighborAddr) String() string {
@@ -6593,7 +6593,7 @@ func (l *LsTLVIPv4NeighborAddr) GetLsTLV() LsTLV {
 
 type LsTLVIPv6InterfaceAddr struct {
 	LsTLV
-	IP net.IP
+	IP netip.Addr
 }
 
 func (l *LsTLVIPv6InterfaceAddr) DecodeFromBytes(data []byte) error {
@@ -6611,7 +6611,7 @@ func (l *LsTLVIPv6InterfaceAddr) DecodeFromBytes(data []byte) error {
 		return malformedAttrListErr("Unexpected address size")
 	}
 
-	l.IP = net.IP(value)
+	l.IP, _ = netip.AddrFromSlice(value)
 
 	if l.IP.IsLinkLocalUnicast() {
 		return malformedAttrListErr("Unexpected link local address")
@@ -6621,7 +6621,7 @@ func (l *LsTLVIPv6InterfaceAddr) DecodeFromBytes(data []byte) error {
 }
 
 func (l *LsTLVIPv6InterfaceAddr) Serialize() ([]byte, error) {
-	return l.LsTLV.Serialize(l.IP)
+	return l.LsTLV.Serialize(l.IP.AsSlice())
 }
 
 func (l *LsTLVIPv6InterfaceAddr) String() string {
@@ -6644,7 +6644,7 @@ func (l *LsTLVIPv6InterfaceAddr) GetLsTLV() LsTLV {
 
 type LsTLVIPv6NeighborAddr struct {
 	LsTLV
-	IP net.IP
+	IP netip.Addr
 }
 
 func (l *LsTLVIPv6NeighborAddr) DecodeFromBytes(data []byte) error {
@@ -6662,7 +6662,7 @@ func (l *LsTLVIPv6NeighborAddr) DecodeFromBytes(data []byte) error {
 		return malformedAttrListErr("Unexpected address size")
 	}
 
-	l.IP = net.IP(value)
+	l.IP, _ = netip.AddrFromSlice(value)
 
 	if l.IP.IsLinkLocalUnicast() {
 		return malformedAttrListErr("Unexpected link local address")
@@ -6672,7 +6672,7 @@ func (l *LsTLVIPv6NeighborAddr) DecodeFromBytes(data []byte) error {
 }
 
 func (l *LsTLVIPv6NeighborAddr) Serialize() ([]byte, error) {
-	return l.LsTLV.Serialize(l.IP)
+	return l.LsTLV.Serialize(l.IP.AsSlice())
 }
 
 func (l *LsTLVIPv6NeighborAddr) String() string {
@@ -6916,10 +6916,10 @@ func (l *LsTLVIsisArea) GetLsTLV() LsTLV {
 
 type LsTLVLocalIPv4RouterID struct {
 	LsTLV
-	IP net.IP
+	IP netip.Addr
 }
 
-func NewLsTLVLocalIPv4RouterID(l *net.IP) *LsTLVLocalIPv4RouterID {
+func NewLsTLVLocalIPv4RouterID(l *netip.Addr) *LsTLVLocalIPv4RouterID {
 	return &LsTLVLocalIPv4RouterID{
 		LsTLV: LsTLV{
 			Type:   LS_TLV_IPV4_LOCAL_ROUTER_ID,
@@ -6944,13 +6944,13 @@ func (l *LsTLVLocalIPv4RouterID) DecodeFromBytes(data []byte) error {
 		return malformedAttrListErr("Unexpected address size")
 	}
 
-	l.IP = net.IP(value)
+	l.IP, _ = netip.AddrFromSlice(value)
 
 	return nil
 }
 
 func (l *LsTLVLocalIPv4RouterID) Serialize() ([]byte, error) {
-	return l.LsTLV.Serialize(l.IP)
+	return l.LsTLV.Serialize(l.IP.AsSlice())
 }
 
 func (l *LsTLVLocalIPv4RouterID) String() string {
@@ -6973,10 +6973,10 @@ func (l *LsTLVLocalIPv4RouterID) GetLsTLV() LsTLV {
 
 type LsTLVRemoteIPv4RouterID struct {
 	LsTLV
-	IP net.IP
+	IP netip.Addr
 }
 
-func NewLsTLVRemoteIPv4RouterID(l *net.IP) *LsTLVRemoteIPv4RouterID {
+func NewLsTLVRemoteIPv4RouterID(l *netip.Addr) *LsTLVRemoteIPv4RouterID {
 	return &LsTLVRemoteIPv4RouterID{
 		LsTLV: LsTLV{
 			Type:   LS_TLV_IPV4_REMOTE_ROUTER_ID,
@@ -7001,13 +7001,13 @@ func (l *LsTLVRemoteIPv4RouterID) DecodeFromBytes(data []byte) error {
 		return malformedAttrListErr("Unexpected address size")
 	}
 
-	l.IP = net.IP(value)
+	l.IP, _ = netip.AddrFromSlice(value)
 
 	return nil
 }
 
 func (l *LsTLVRemoteIPv4RouterID) Serialize() ([]byte, error) {
-	return l.LsTLV.Serialize(l.IP)
+	return l.LsTLV.Serialize(l.IP.AsSlice())
 }
 
 func (l *LsTLVRemoteIPv4RouterID) String() string {
@@ -7030,10 +7030,10 @@ func (l *LsTLVRemoteIPv4RouterID) GetLsTLV() LsTLV {
 
 type LsTLVLocalIPv6RouterID struct {
 	LsTLV
-	IP net.IP
+	IP netip.Addr
 }
 
-func NewLsTLVLocalIPv6RouterID(l *net.IP) *LsTLVLocalIPv6RouterID {
+func NewLsTLVLocalIPv6RouterID(l *netip.Addr) *LsTLVLocalIPv6RouterID {
 	return &LsTLVLocalIPv6RouterID{
 		LsTLV: LsTLV{
 			Type:   LS_TLV_IPV6_LOCAL_ROUTER_ID,
@@ -7058,13 +7058,13 @@ func (l *LsTLVLocalIPv6RouterID) DecodeFromBytes(data []byte) error {
 		return malformedAttrListErr("Unexpected address size")
 	}
 
-	l.IP = net.IP(value)
+	l.IP, _ = netip.AddrFromSlice(value)
 
 	return nil
 }
 
 func (l *LsTLVLocalIPv6RouterID) Serialize() ([]byte, error) {
-	return l.LsTLV.Serialize(l.IP)
+	return l.LsTLV.Serialize(l.IP.AsSlice())
 }
 
 func (l *LsTLVLocalIPv6RouterID) String() string {
@@ -7087,10 +7087,10 @@ func (l *LsTLVLocalIPv6RouterID) GetLsTLV() LsTLV {
 
 type LsTLVRemoteIPv6RouterID struct {
 	LsTLV
-	IP net.IP
+	IP netip.Addr
 }
 
-func NewLsTLVRemoteIPv6RouterID(l *net.IP) *LsTLVRemoteIPv6RouterID {
+func NewLsTLVRemoteIPv6RouterID(l *netip.Addr) *LsTLVRemoteIPv6RouterID {
 	return &LsTLVRemoteIPv6RouterID{
 		LsTLV: LsTLV{
 			Type:   LS_TLV_IPV6_REMOTE_ROUTER_ID,
@@ -7115,13 +7115,13 @@ func (l *LsTLVRemoteIPv6RouterID) DecodeFromBytes(data []byte) error {
 		return malformedAttrListErr("Unexpected address size")
 	}
 
-	l.IP = net.IP(value)
+	l.IP, _ = netip.AddrFromSlice(value)
 
 	return nil
 }
 
 func (l *LsTLVRemoteIPv6RouterID) Serialize() ([]byte, error) {
-	return l.LsTLV.Serialize(l.IP)
+	return l.LsTLV.Serialize(l.IP.AsSlice())
 }
 
 func (l *LsTLVRemoteIPv6RouterID) String() string {
@@ -7397,7 +7397,7 @@ func (l *LsTLVOspfAreaID) GetLsTLV() LsTLV {
 
 type LsTLVBgpRouterID struct {
 	LsTLV
-	RouterID net.IP
+	RouterID netip.Addr
 }
 
 func (l *LsTLVBgpRouterID) DecodeFromBytes(data []byte) error {
@@ -7416,20 +7416,20 @@ func (l *LsTLVBgpRouterID) DecodeFromBytes(data []byte) error {
 		return malformedAttrListErr(fmt.Sprintf("Incorrect BGP Router ID length: %d", len(value)))
 	}
 
-	l.RouterID = net.IP(value)
+	l.RouterID = netip.AddrFrom4([4]byte(value))
 
 	return nil
 }
 
 func (l *LsTLVBgpRouterID) Serialize() ([]byte, error) {
 	tmpaddr := l.RouterID
-	if tmpaddr.To4() != nil {
+	if tmpaddr.Is4() {
 		var buf [4]byte
-		copy(buf[:], l.RouterID.To4())
+		copy(buf[:], l.RouterID.AsSlice())
 		return l.LsTLV.Serialize(buf[:])
 	}
 	var buf [16]byte
-	copy(buf[:], l.RouterID.To16())
+	copy(buf[:], l.RouterID.AsSlice())
 	return l.LsTLV.Serialize(buf[:])
 }
 
@@ -9506,13 +9506,13 @@ func (l *LsTLVNodeDescriptor) String() string {
 }
 
 type LsNodeDescriptor struct {
-	Asn                    uint32 `json:"asn"`
-	BGPLsID                uint32 `json:"bgp_ls_id"`
-	OspfAreaID             uint32 `json:"ospf_area_id"`
-	PseudoNode             bool   `json:"pseudo_node"`
-	IGPRouterID            string `json:"igp_router_id"`
-	BGPRouterID            net.IP `json:"bgp_router_id"`
-	BGPConfederationMember uint32 `json:"bgp_confederation_member"`
+	Asn                    uint32     `json:"asn"`
+	BGPLsID                uint32     `json:"bgp_ls_id"`
+	OspfAreaID             uint32     `json:"ospf_area_id"`
+	PseudoNode             bool       `json:"pseudo_node"`
+	IGPRouterID            string     `json:"igp_router_id"`
+	BGPRouterID            netip.Addr `json:"bgp_router_id"`
+	BGPConfederationMember uint32     `json:"bgp_confederation_member"`
 }
 
 func (l *LsTLVNodeDescriptor) GetLsTLV() LsTLV {
@@ -9520,7 +9520,7 @@ func (l *LsTLVNodeDescriptor) GetLsTLV() LsTLV {
 }
 
 func (l *LsNodeDescriptor) String() string {
-	if l.BGPRouterID == nil {
+	if !l.BGPRouterID.IsValid() || !l.BGPRouterID.Is4() {
 		return fmt.Sprintf("{ASN: %v, BGP LS ID: %v, OSPF AREA: %v, IGP ROUTER ID: %v}", l.Asn, l.BGPLsID, l.OspfAreaID, l.IGPRouterID)
 	}
 
@@ -9601,7 +9601,7 @@ func NewLsTLVNodeDescriptor(nd *LsNodeDescriptor, tlvType LsTLVType) LsTLVNodeDe
 
 	// For BGP
 	// TLV Code Point 516 BGP Router-ID
-	if nd.BGPRouterID != nil {
+	if nd.BGPRouterID.IsValid() && nd.BGPRouterID.Is4() {
 		subTLVs = append(subTLVs,
 			&LsTLVBgpRouterID{
 				LsTLV: LsTLV{
@@ -9767,8 +9767,8 @@ type LsAttributeNode struct {
 	Opaque          *[]byte      `json:"opaque,omitempty"`
 	Name            *string      `json:"name,omitempty"`
 	IsisArea        *[]byte      `json:"isis_area,omitempty"`
-	LocalRouterID   *net.IP      `json:"local_router_id_ipv4,omitempty"`
-	LocalRouterIDv6 *net.IP      `json:"local_router_id_ipv6,omitempty"`
+	LocalRouterID   *netip.Addr  `json:"local_router_id_ipv4,omitempty"`
+	LocalRouterIDv6 *netip.Addr  `json:"local_router_id_ipv6,omitempty"`
 
 	// Segment Routing
 	SrCapabilties *LsSrCapabilities `json:"sr_capabilities,omitempty"`
@@ -9777,15 +9777,15 @@ type LsAttributeNode struct {
 }
 
 type LsAttributeLink struct {
-	Name             *string `json:"name,omitempty"`
-	LocalRouterID    *net.IP `json:"local_router_id_ipv4,omitempty"`
-	LocalRouterIDv6  *net.IP `json:"local_router_id_ipv6,omitempty"`
-	RemoteRouterID   *net.IP `json:"remote_router_id_ipv4,omitempty"`
-	RemoteRouterIDv6 *net.IP `json:"remote_router_id_ipv6,omitempty"`
-	AdminGroup       *uint32 `json:"admin_group,omitempty"`
-	DefaultTEMetric  *uint32 `json:"default_te_metric,omitempty"`
-	IGPMetric        *uint32 `json:"igp_metric,omitempty"`
-	Opaque           *[]byte `json:"opaque,omitempty"`
+	Name             *string     `json:"name,omitempty"`
+	LocalRouterID    *netip.Addr `json:"local_router_id_ipv4,omitempty"`
+	LocalRouterIDv6  *netip.Addr `json:"local_router_id_ipv6,omitempty"`
+	RemoteRouterID   *netip.Addr `json:"remote_router_id_ipv4,omitempty"`
+	RemoteRouterIDv6 *netip.Addr `json:"remote_router_id_ipv6,omitempty"`
+	AdminGroup       *uint32     `json:"admin_group,omitempty"`
+	DefaultTEMetric  *uint32     `json:"default_te_metric,omitempty"`
+	IGPMetric        *uint32     `json:"igp_metric,omitempty"`
+	Opaque           *[]byte     `json:"opaque,omitempty"`
 
 	// Bandwidth is expressed in bytes (not bits) per second.
 	Bandwidth           *float32    `json:"bandwidth,omitempty"`


### PR DESCRIPTION
Replace net.IP with netip.Addr for Ls structures.