### PR TITLE
pkg/packet/bgp: use netip for IPAddressSpecificExtended

### DIFF
--- a/internal/pkg/table/policy_test.go
+++ b/internal/pkg/table/policy_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 	"testing"
@@ -2582,7 +2583,7 @@ func TestExtCommunityConditionEvaluate(t *testing.T) {
 	}
 	eComIpPrefix1 := &bgp.IPv4AddressSpecificExtended{
 		SubType:      bgp.EC_SUBTYPE_ROUTE_TARGET,
-		IPv4:         net.ParseIP("10.0.0.1"),
+		IPv4:         netip.MustParseAddr("10.0.0.1"),
 		LocalAdmin:   300,
 		IsTransitive: true,
 	}
@@ -2600,7 +2601,7 @@ func TestExtCommunityConditionEvaluate(t *testing.T) {
 	}
 	eComIpPrefix2 := &bgp.IPv4AddressSpecificExtended{
 		SubType:      bgp.EC_SUBTYPE_ROUTE_TARGET,
-		IPv4:         net.ParseIP("10.0.0.2"),
+		IPv4:         netip.MustParseAddr("10.0.0.2"),
 		LocalAdmin:   300,
 		IsTransitive: false,
 	}
@@ -2618,7 +2619,7 @@ func TestExtCommunityConditionEvaluate(t *testing.T) {
 	}
 	eComIpPrefix3 := &bgp.IPv4AddressSpecificExtended{
 		SubType:      bgp.EC_SUBTYPE_ROUTE_ORIGIN,
-		IPv4:         net.ParseIP("10.0.10.10"),
+		IPv4:         netip.MustParseAddr("10.0.10.10"),
 		LocalAdmin:   400,
 		IsTransitive: true,
 	}
@@ -2768,7 +2769,7 @@ func TestExtCommunityConditionEvaluateWithOtherCondition(t *testing.T) {
 	}
 	eComIpPrefix1 := &bgp.IPv4AddressSpecificExtended{
 		SubType:      bgp.EC_SUBTYPE_ROUTE_TARGET,
-		IPv4:         net.ParseIP("10.0.0.1"),
+		IPv4:         netip.MustParseAddr("10.0.0.1"),
 		LocalAdmin:   300,
 		IsTransitive: true,
 	}
@@ -2786,7 +2787,7 @@ func TestExtCommunityConditionEvaluateWithOtherCondition(t *testing.T) {
 	}
 	eComIpPrefix2 := &bgp.IPv4AddressSpecificExtended{
 		SubType:      bgp.EC_SUBTYPE_ROUTE_TARGET,
-		IPv4:         net.ParseIP("10.0.0.2"),
+		IPv4:         netip.MustParseAddr("10.0.0.2"),
 		LocalAdmin:   300,
 		IsTransitive: false,
 	}
@@ -2804,7 +2805,7 @@ func TestExtCommunityConditionEvaluateWithOtherCondition(t *testing.T) {
 	}
 	eComIpPrefix3 := &bgp.IPv4AddressSpecificExtended{
 		SubType:      bgp.EC_SUBTYPE_ROUTE_ORIGIN,
-		IPv4:         net.ParseIP("10.0.10.10"),
+		IPv4:         netip.MustParseAddr("10.0.10.10"),
 		LocalAdmin:   400,
 		IsTransitive: true,
 	}

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -12096,7 +12096,7 @@ func NewTwoOctetAsSpecificExtended(subtype ExtendedCommunityAttrSubType, as uint
 
 type IPv4AddressSpecificExtended struct {
 	SubType      ExtendedCommunityAttrSubType
-	IPv4         net.IP
+	IPv4         netip.Addr
 	LocalAdmin   uint16
 	IsTransitive bool
 }
@@ -12109,7 +12109,7 @@ func (e *IPv4AddressSpecificExtended) Serialize() ([]byte, error) {
 		buf[0] = byte(EC_TYPE_NON_TRANSITIVE_IP4_SPECIFIC)
 	}
 	buf[1] = byte(e.SubType)
-	copy(buf[2:6], e.IPv4)
+	copy(buf[2:6], e.IPv4.AsSlice())
 	binary.BigEndian.PutUint16(buf[6:], e.LocalAdmin)
 	return buf[:], nil
 }
@@ -12140,13 +12140,13 @@ func (e *IPv4AddressSpecificExtended) GetTypes() (ExtendedCommunityAttrType, Ext
 }
 
 func NewIPv4AddressSpecificExtended(subtype ExtendedCommunityAttrSubType, ip string, localAdmin uint16, isTransitive bool) *IPv4AddressSpecificExtended {
-	ipv4 := net.ParseIP(ip)
-	if ipv4.To4() == nil {
+	ipv4, err := netip.ParseAddr(ip)
+	if err != nil || !ipv4.Is4() {
 		return nil
 	}
 	return &IPv4AddressSpecificExtended{
 		SubType:      subtype,
-		IPv4:         ipv4.To4(),
+		IPv4:         ipv4,
 		LocalAdmin:   localAdmin,
 		IsTransitive: isTransitive,
 	}
@@ -12154,7 +12154,7 @@ func NewIPv4AddressSpecificExtended(subtype ExtendedCommunityAttrSubType, ip str
 
 type IPv6AddressSpecificExtended struct {
 	SubType      ExtendedCommunityAttrSubType
-	IPv6         net.IP
+	IPv6         netip.Addr
 	LocalAdmin   uint16
 	IsTransitive bool
 }
@@ -12167,7 +12167,7 @@ func (e *IPv6AddressSpecificExtended) Serialize() ([]byte, error) {
 		buf[0] = byte(EC_TYPE_NON_TRANSITIVE_IP6_SPECIFIC)
 	}
 	buf[1] = byte(e.SubType)
-	copy(buf[2:18], e.IPv6)
+	copy(buf[2:18], e.IPv6.AsSlice())
 	binary.BigEndian.PutUint16(buf[18:], e.LocalAdmin)
 	return buf, nil
 }
@@ -12198,13 +12198,13 @@ func (e *IPv6AddressSpecificExtended) GetTypes() (ExtendedCommunityAttrType, Ext
 }
 
 func NewIPv6AddressSpecificExtended(subtype ExtendedCommunityAttrSubType, ip string, localAdmin uint16, isTransitive bool) *IPv6AddressSpecificExtended {
-	ipv6 := net.ParseIP(ip)
-	if ipv6.To16() == nil {
+	ipv6, err := netip.ParseAddr(ip)
+	if err != nil || !ipv6.Is6() {
 		return nil
 	}
 	return &IPv6AddressSpecificExtended{
 		SubType:      subtype,
-		IPv6:         ipv6.To16(),
+		IPv6:         ipv6,
 		LocalAdmin:   localAdmin,
 		IsTransitive: isTransitive,
 	}


### PR DESCRIPTION
Replace net.IP with netip.Addr for IPAddressSpecificExtended.