### PR TITLE
pkg/packet/bgp: use netip for EVPN related structures

### DIFF
--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -579,7 +579,7 @@ func getPathAttributeString(nlri bgp.AddrPrefixInterface, attrs []bgp.PathAttrib
 			s = append(s, fmt.Sprintf("[ESI: %s]", route.ESI.String()))
 		case *bgp.EVPNIPPrefixRoute:
 			s = append(s, fmt.Sprintf("[ESI: %s]", route.ESI.String()))
-			if route.GWIPAddress != nil {
+			if route.GWIPAddress.IsValid() {
 				s = append(s, fmt.Sprintf("[GW: %s]", route.GWIPAddress.String()))
 			}
 		}

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -707,8 +707,8 @@ func Test_EVPNIPPrefixRoute(t *testing.T) {
 		},
 		ETag:           10,
 		IPPrefixLength: 24,
-		IPPrefix:       net.IP{10, 10, 10, 0},
-		GWIPAddress:    net.IP{10, 10, 10, 10},
+		IPPrefix:       netip.AddrFrom4([4]byte{10, 10, 10, 0}),
+		GWIPAddress:    netip.AddrFrom4([4]byte{10, 10, 10, 10}),
 		Label:          1000,
 	}
 	n1 := NewEVPNNLRI(EVPN_IP_PREFIX, r)


### PR DESCRIPTION
Replace net.IP with netip.Addr for EVPNMacIPAdvertisementRoute, etc.