### PR TITLE
packet/mrt: Add Family argument to NewRib

### DIFF
--- a/pkg/packet/mrt/mrt.go
+++ b/pkg/packet/mrt/mrt.go
@@ -586,13 +586,12 @@ func (u *Rib) Serialize() ([]byte, error) {
 	return buf, nil
 }
 
-func NewRib(seq uint32, prefix bgp.AddrPrefixInterface, entries []*RibEntry) *Rib {
-	rf := bgp.NewFamily(prefix.AFI(), prefix.SAFI())
+func NewRib(seq uint32, family bgp.Family, prefix bgp.AddrPrefixInterface, entries []*RibEntry) *Rib {
 	return &Rib{
 		SequenceNumber: seq,
 		Prefix:         prefix,
 		Entries:        entries,
-		Family:         rf,
+		Family:         family,
 		isAddPath:      entries[0].isAddPath,
 	}
 }

--- a/pkg/packet/mrt/mrt_test.go
+++ b/pkg/packet/mrt/mrt_test.go
@@ -187,7 +187,7 @@ func TestMrtRib(t *testing.T) {
 	e2 := NewRibEntry(2, uint32(time.Now().Unix()), 0, p, false)
 	e3 := NewRibEntry(3, uint32(time.Now().Unix()), 0, p, false)
 
-	r1 := NewRib(1, bgp.NewIPAddrPrefix(24, "192.168.0.0"), []*RibEntry{e1, e2, e3})
+	r1 := NewRib(1, bgp.RF_IPv4_UC, bgp.NewIPAddrPrefix(24, "192.168.0.0"), []*RibEntry{e1, e2, e3})
 	b1, err := r1.Serialize()
 	if err != nil {
 		t.Fatal(err)
@@ -221,7 +221,7 @@ func TestMrtRibWithAddPath(t *testing.T) {
 	e2 := NewRibEntry(2, uint32(time.Now().Unix()), 200, p, true)
 	e3 := NewRibEntry(3, uint32(time.Now().Unix()), 300, p, true)
 
-	r1 := NewRib(1, bgp.NewIPAddrPrefix(24, "192.168.0.0"), []*RibEntry{e1, e2, e3})
+	r1 := NewRib(1, bgp.RF_IPv4_UC, bgp.NewIPAddrPrefix(24, "192.168.0.0"), []*RibEntry{e1, e2, e3})
 	b1, err := r1.Serialize()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/server/mrt.go
+++ b/pkg/server/mrt.go
@@ -170,7 +170,7 @@ func (m *mrtWriter) loop() error {
 				seq := uint32(0)
 				appendTableDumpMsg := func(path *table.Path, entries []*mrt.RibEntry, isAddPath bool) {
 					st := subtype(path, isAddPath)
-					if bm, err := mrt.NewMRTMessage(t, mrt.TABLE_DUMPv2, st, mrt.NewRib(seq, path.GetNlri(), entries)); err != nil {
+					if bm, err := mrt.NewMRTMessage(t, mrt.TABLE_DUMPv2, st, mrt.NewRib(seq, path.GetFamily(), path.GetNlri(), entries)); err != nil {
 						m.s.logger.Warn("Failed to create MRT TABLE_DUMPv2 message",
 							log.Fields{
 								"Topic":   "mrt",


### PR DESCRIPTION
Add Family argument to NewRib function in order to avoid getting Family from NLRI. The NLRI type and Family do not have a one-to-one correspondence, we can only obtain an incomplete value for Family.