### PR TITLE
apiutil: Add Family argument to NewPath function

### DIFF
--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -2253,7 +2253,7 @@ func parsePath(rf bgp.Family, args []string) (*api.Path, error) {
 	}
 	sort.Slice(attrs, func(i, j int) bool { return attrs[i].GetType() < attrs[j].GetType() })
 
-	return apiutil.NewPath(nlri, false, attrs, time.Now())
+	return apiutil.NewPath(rf, nlri, false, attrs, time.Now())
 }
 
 func showGlobalRib(args []string) error {

--- a/cmd/gobgp/mrt.go
+++ b/cmd/gobgp/mrt.go
@@ -167,7 +167,7 @@ func injectMrt() error {
 						}
 					}
 
-					path, _ := apiutil.NewPath(nlri, false, attrs, time.Unix(int64(e.OriginatedTime), 0))
+					path, _ := apiutil.NewPath(rib.Family, nlri, false, attrs, time.Unix(int64(e.OriginatedTime), 0))
 					path.SourceAsn = peers[e.PeerIndex].AS
 					path.SourceId = peers[e.PeerIndex].BgpId.String()
 

--- a/pkg/apiutil/util.go
+++ b/pkg/apiutil/util.go
@@ -161,7 +161,7 @@ func NewDestination(dst *api.Destination) *Destination {
 	return &Destination{Paths: l}
 }
 
-func NewPath(nlri bgp.AddrPrefixInterface, isWithdraw bool, attrs []bgp.PathAttributeInterface, age time.Time) (*api.Path, error) {
+func NewPath(family bgp.Family, nlri bgp.AddrPrefixInterface, isWithdraw bool, attrs []bgp.PathAttributeInterface, age time.Time) (*api.Path, error) {
 	n, err := MarshalNLRI(nlri)
 	if err != nil {
 		return nil, err
@@ -175,7 +175,7 @@ func NewPath(nlri bgp.AddrPrefixInterface, isWithdraw bool, attrs []bgp.PathAttr
 		Pattrs:     a,
 		Age:        tspb.New(age),
 		IsWithdraw: isWithdraw,
-		Family:     ToApiFamily(nlri.AFI(), nlri.SAFI()),
+		Family:     ToApiFamily(family.Afi(), family.Safi()),
 		Identifier: nlri.PathIdentifier(),
 	}, nil
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -792,7 +792,7 @@ func TestMonitor(test *testing.T) {
 		bgp.NewPathAttributeNextHop("10.0.0.1"),
 	}
 	prefix := bgp.NewIPAddrPrefix(24, "10.0.0.0")
-	path, _ := apiutil.NewPath(prefix, false, attrs, time.Now())
+	path, _ := apiutil.NewPath(bgp.RF_IPv4_UC, prefix, false, attrs, time.Now())
 	_, err = t.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{
 		mustApi2apiutilPath(path),
 	}})
@@ -1670,7 +1670,7 @@ func TestDoNotReactToDuplicateRTCMemberships(t *testing.T) {
 		bgp.NewPathAttributeNextHop("2.2.2.2"),
 	}
 	prefix := bgp.NewIPAddrPrefix(24, "10.30.2.0")
-	path, _ := apiutil.NewPath(prefix, false, attrs, time.Now())
+	path, _ := apiutil.NewPath(bgp.RF_IPv4_UC, prefix, false, attrs, time.Now())
 
 	if _, err := s2.AddPath(
 		apiutil.AddPathRequest{
@@ -1778,7 +1778,7 @@ func TestDelVrfWithRTC(t *testing.T) {
 		}),
 	}
 	prefix := bgp.NewIPAddrPrefix(24, "10.30.2.0")
-	path, _ := apiutil.NewPath(prefix, false, attrs, time.Now())
+	path, _ := apiutil.NewPath(bgp.RF_IPv4_UC, prefix, false, attrs, time.Now())
 
 	if _, err := s2.AddPath(apiutil.AddPathRequest{VRFID: "vrf1", Paths: []*apiutil.Path{mustApi2apiutilPath(path)}}); err != nil {
 		t.Fatal(err)
@@ -1882,7 +1882,7 @@ func TestSameRTCMessagesWithOneDifferrence(t *testing.T) {
 	rd, _ := bgp.ParseRouteDistinguisher("100:100")
 	labels := bgp.NewMPLSLabelStack(100, 200)
 	prefix := bgp.NewLabeledVPNIPAddrPrefix(24, "10.30.2.0", *labels, rd)
-	path, _ := apiutil.NewPath(prefix, false, attrs, time.Now())
+	path, _ := apiutil.NewPath(bgp.RF_IPv4_VPN, prefix, false, attrs, time.Now())
 
 	if _, err := s2.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(path)}}); err != nil {
 		t.Fatal(err)
@@ -1892,7 +1892,7 @@ func TestSameRTCMessagesWithOneDifferrence(t *testing.T) {
 		bgp.NewPathAttributeOrigin(0),
 		bgp.NewPathAttributeNextHop("0.0.0.0"),
 	}
-	pathRtc0, _ := apiutil.NewPath(bgp.NewRouteTargetMembershipNLRI(1, rt), false, attrsNH0, time.Now())
+	pathRtc0, _ := apiutil.NewPath(bgp.RF_RTC_UC, bgp.NewRouteTargetMembershipNLRI(1, rt), false, attrsNH0, time.Now())
 	if _, err := s1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc0)}}); err != nil {
 		t.Fatal(err)
 	}
@@ -1929,7 +1929,7 @@ func TestSameRTCMessagesWithOneDifferrence(t *testing.T) {
 		bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rt200}),
 		bgp.NewPathAttributeNextHop("0.0.0.0"),
 	}
-	pathRtc1, _ := apiutil.NewPath(bgp.NewRouteTargetMembershipNLRI(1, rt), false, attrsNH1, time.Now())
+	pathRtc1, _ := apiutil.NewPath(bgp.RF_RTC_UC, bgp.NewRouteTargetMembershipNLRI(1, rt), false, attrsNH1, time.Now())
 	if _, err := s1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc1)}}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Add Family argument to NewPath function in order to avoid getting Family from NLRI. The NLRI type and Family do not have a one-to-one correspondence, we can only obtain an incomplete value for Family.