### PR TITLE
pkg/packet/bgp: use netip for ParseVPNPrefix

### DIFF
--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -436,11 +436,12 @@ func (t *Table) GetLongerPrefixDestinations(key string) ([]*Destination, error) 
 			return true
 		})
 	case bgp.RF_IPv4_VPN, bgp.RF_IPv6_VPN:
-		prefixRd, _, network, err := bgp.ParseVPNPrefix(key)
+		prefixRd, prefix, err := bgp.ParseVPNPrefix(key)
 		if err != nil {
 			return nil, err
 		}
-		ones, bits := network.Mask.Size()
+		ones := prefix.Bits()
+		bits := prefix.Addr().BitLen()
 
 		r := critbitgo.NewNet()
 		for _, dst := range t.GetDestinations() {
@@ -460,7 +461,7 @@ func (t *Table) GetLongerPrefixDestinations(key string) ([]*Destination, error) 
 		}
 
 		p := &net.IPNet{
-			IP:   network.IP,
+			IP:   prefix.Addr().AsSlice(),
 			Mask: net.CIDRMask(ones>>3<<3, bits),
 		}
 

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -1313,7 +1313,7 @@ func TestParseVPNPrefix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rd, _, network, err := ParseVPNPrefix(tt.prefix)
+			rd, prefix, err := ParseVPNPrefix(tt.prefix)
 			if !tt.valid {
 				assert.NotNil(t, err)
 				return
@@ -1321,7 +1321,7 @@ func TestParseVPNPrefix(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, tt.rd, rd)
-			assert.Equal(t, tt.ipPrefix, network.String())
+			assert.Equal(t, tt.ipPrefix, prefix.String())
 		})
 	}
 }


### PR DESCRIPTION
Replace net.IP with netip.Addr for ParseVPNPrefix.