### PR TITLE
pkg/packet/bgp: use netip for LsPrefixDescriptor

### DIFF
--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -874,10 +874,10 @@ func UnmarshalLsLinkDescriptor(ld *api.LsLinkDescriptor) (*bgp.LsLinkDescriptor,
 }
 
 func UnmarshalPrefixDescriptor(pd *api.LsPrefixDescriptor) (*bgp.LsPrefixDescriptor, error) {
-	ipReachability := []net.IPNet{}
+	ipReachability := []netip.Prefix{}
 	for _, reach := range pd.IpReachability {
-		_, ipnet, _ := net.ParseCIDR(reach)
-		ipReachability = append(ipReachability, *ipnet)
+		ipnet, _ := netip.ParsePrefix(reach)
+		ipReachability = append(ipReachability, ipnet)
 	}
 
 	ospfRouteType := bgp.LsOspfRouteType(pd.OspfRouteType)

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -2302,9 +2302,9 @@ func Test_LsTLVIPReachabilityToIPNet(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got := test.tlv.ToIPNet(test.ipv6)
-		assert.Equal(test.want.IP.String(), got.IP.String())
-		assert.Equal(test.want.Mask.String(), got.Mask.String())
+		got := test.tlv.toPrefix(test.ipv6)
+		assert.Equal(test.want.IP.String(), got.Addr().String())
+		assert.Equal(test.want.Mask.String(), net.CIDRMask(got.Bits(), got.Addr().BitLen()).String())
 	}
 }
 


### PR DESCRIPTION
Replace net.IP with netip.Addr for LsPrefixDescriptor.