### PR TITLE
table: remove bgp.NewPrefixFromFamily usage

### DIFF
--- a/internal/pkg/table/table_test.go
+++ b/internal/pkg/table/table_test.go
@@ -130,9 +130,11 @@ func TestTableGetDestinations(t *testing.T) {
 
 func TestTableKey(t *testing.T) {
 	tb := NewTable(logger, bgp.RF_IPv4_UC)
-	n1, _ := bgp.NewPrefixFromFamily(bgp.RF_IPv4_UC, "0.0.0.0/0")
+	prefix := netip.MustParsePrefix("0.0.0.0/0")
+	n1 := bgp.NewIPAddrPrefix(uint8(prefix.Bits()), prefix.Addr().String())
 	d1 := NewDestination(n1, 0)
-	n2, _ := bgp.NewPrefixFromFamily(bgp.RF_IPv4_UC, "0.0.0.0/1")
+	prefix = netip.MustParsePrefix("0.0.0.0/1")
+	n2 := bgp.NewIPAddrPrefix(uint8(prefix.Bits()), prefix.Addr().String())
 	d2 := NewDestination(n2, 0)
 
 	assert.NotEqual(t, tableKey(d1.GetNlri()), tableKey(d2.GetNlri()))
@@ -264,7 +266,8 @@ func TestTableSelectVPNv4(t *testing.T) {
 
 	table := NewTable(logger, bgp.RF_IPv4_VPN)
 	for _, prefix := range prefixes {
-		nlri, _ := bgp.NewPrefixFromFamily(bgp.RF_IPv4_VPN, prefix)
+		rd, p, _ := bgp.ParseVPNPrefix(prefix)
+		nlri := bgp.NewLabeledVPNIPAddrPrefix(uint8(p.Bits()), p.Addr().String(), *bgp.NewMPLSLabelStack(), rd)
 
 		destination := NewDestination(nlri, 0, NewPath(nil, nlri, false, nil, time.Now(), false))
 		table.setDestination(destination)
@@ -371,7 +374,8 @@ func TestTableSelectVPNv6(t *testing.T) {
 
 	table := NewTable(logger, bgp.RF_IPv6_VPN)
 	for _, prefix := range prefixes {
-		nlri, _ := bgp.NewPrefixFromFamily(bgp.RF_IPv6_VPN, prefix)
+		rd, p, _ := bgp.ParseVPNPrefix(prefix)
+		nlri := bgp.NewLabeledVPNIPv6AddrPrefix(uint8(p.Bits()), p.Addr().String(), *bgp.NewMPLSLabelStack(), rd)
 
 		destination := NewDestination(nlri, 0, NewPath(nil, nlri, false, nil, time.Now(), false))
 		table.setDestination(destination)


### PR DESCRIPTION
Remove bgp.NewPrefixFromFamily() usage because NewPrefixFromFamily() is useful only for families that use a prefix. Thus for such families, NewPrefixFromFamily() is called with empty prefix string to create an uninitialized object. That's error-prone.

This is preparation for removing bgp.NewPrefixFromFamily() completely.