### PR TITLE
don't answer for rt's while waiting for rtc eor

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -188,6 +188,7 @@ type fsm struct {
 	adminStateCh         chan adminStateOperation
 	h                    *fsmHandler
 	rfMap                map[bgp.Family]bgp.BGPAddPathMode
+	rtcEORWait           bool
 	capMap               map[bgp.BGPCapabilityCode][]bgp.ParameterCapabilityInterface
 	recvOpen             *bgp.BGPMessage
 	peerInfo             *table.PeerInfo

--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -297,6 +297,31 @@ func (peer *peer) isDynamicNeighbor() bool {
 	return peer.fsm.pConf.Config.NeighborAddress == "" && peer.fsm.pConf.Config.NeighborInterface == ""
 }
 
+func (peer *peer) getRtcEORWait() bool {
+	peer.fsm.lock.RLock()
+	defer peer.fsm.lock.RUnlock()
+	peer.fsm.logger.Debug("Get rtcEORWait",
+		log.Fields{
+			"Topic": "Peer",
+			"Key":   peer.fsm.pConf.State.NeighborAddress,
+			"Data":  peer.fsm.rtcEORWait,
+		})
+
+	return peer.fsm.rtcEORWait
+}
+
+func (peer *peer) setRtcEORWait(waiting bool) {
+	peer.fsm.lock.Lock()
+	defer peer.fsm.lock.Unlock()
+	peer.fsm.rtcEORWait = waiting
+	peer.fsm.logger.Debug("Set rtcEORWait",
+		log.Fields{
+			"Topic": "Peer",
+			"Key":   peer.fsm.pConf.State.NeighborAddress,
+			"Data":  peer.fsm.rtcEORWait,
+		})
+}
+
 func (peer *peer) recvedAllEOR() bool {
 	peer.fsm.lock.RLock()
 	defer peer.fsm.lock.RUnlock()

--- a/test/scenario_test/rtc_test.py
+++ b/test/scenario_test/rtc_test.py
@@ -221,8 +221,15 @@ class GoBGPTestBase(unittest.TestCase):
         # Check the counts of the sent UPDATE messages in order to detect the
         # infinite RTC UPDATE loop.
         # https://github.com/osrg/gobgp/issues/1630
-        self.assert_upd_count(self.g4, self.g3, sent=1, received=2)
-        self.assert_upd_count(self.g5, self.g3, sent=1, received=2)
+        #
+        # Do not forget to add RTC EOR:
+        # RFC 4684 6
+        # As a hint that initial RT membership exchange is complete,
+        # implementations SHOULD generate an End-of-RIB marker, as defined in
+        # [8], for the Route Target membership (afi, safi), regardless of
+        # whether graceful-restart is enabled on the BGP session.
+        self.assert_upd_count(self.g4, self.g3, sent=1+1, received=2+1)
+        self.assert_upd_count(self.g5, self.g3, sent=1+1, received=2+1)
 
         def check_rtc(client):
             rib = self.g3.get_adj_rib_out(client, rf='rtc')
@@ -861,8 +868,15 @@ class GoBGPTestBase(unittest.TestCase):
 
         # Check the counts of the sent UPDATE messages in order to detect the
         # infinite RTC UPDATE loop.
-        self.assert_upd_count(self.g4, self.g3, sent=1, received=2)
-        self.assert_upd_count(self.g5, self.g3, sent=1, received=2)
+        #
+        # Do not forget to add RTC EOR:
+        # RFC 4684 6
+        # As a hint that initial RT membership exchange is complete,
+        # implementations SHOULD generate an End-of-RIB marker, as defined in
+        # [8], for the Route Target membership (afi, safi), regardless of
+        # whether graceful-restart is enabled on the BGP session.
+        self.assert_upd_count(self.g4, self.g3, sent=1+1, received=2+1)
+        self.assert_upd_count(self.g5, self.g3, sent=1+1, received=2+1)
 
         def check_rtc(client):
             rib = self.g3.get_adj_rib_out(client, rf='rtc')


### PR DESCRIPTION
1. Add a test for correct message sequencing: VPN paths must precede VPN EoR.  
While in the rtc deferral-time == 0 case, the VPN EoR is sent immediately after peering (because the RT list is empty), it is important to verify that with rtc deferral-time > 0, the VPN EoR is sent after all VPN routes. This test case checks for the correct order of route advertisement versus End-of-RIB signaling.

2. Fix double-sending of paths with rtc deferral-time > 0.  
The test also tracks the number of received messages and has revealed that each VPN route is sent twice: once as a reply to an RT, and then again in the full set of VPN paths after RTC EoR is received.  
To address this duplication, new VPN paths should not be sent in response to RTs during the initial state. In this model, GoBGP waits for RTC EoR before sending the complete list of VPN paths. In the propagateUpdate function if a route is added during the initial exchange, GoBGP still announces it immediately to the peer, and not as an RT response.  
As a result, for VPN paths already present when the session is established, GoBGP will not send them before either RTC EoR is received or the rtc deferral-time expires. This behavior integrates well with graceful restart and RTC EoR signaling, but otherwise may introduce a delay up to the configured rtc deferral-time. That's why:

3. Always send RTC EoR, regardless of graceful-restart.  
Previously, RTC EoR was sent only if graceful-restart was enabled. According to RFC 4684, section 6:  
> "As a hint that initial RT membership exchange is complete, implementations SHOULD generate an End-of-RIB marker, as defined in [8], for the Route Target membership (AFI, SAFI), regardless of whether graceful-restart is enabled on the BGP session."

RTC EoR is now sent unconditionally after the initial RT membership exchange.
