### PR TITLE
server: move peerinfo from fsm to peer

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -191,7 +191,6 @@ type fsm struct {
 	rtcEORWait           bool
 	capMap               map[bgp.BGPCapabilityCode][]bgp.ParameterCapabilityInterface
 	recvOpen             *bgp.BGPMessage
-	peerInfo             *table.PeerInfo
 	gracefulRestartTimer *time.Timer
 	twoByteAsTrans       bool
 	marshallingOptions   *bgp.MarshallingOption

--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -107,6 +107,7 @@ type peer struct {
 	adjRibIn          *table.AdjRib
 	policy            *table.RoutingPolicy
 	localRib          *table.TableManager
+	peerInfo          *table.PeerInfo
 	prefixLimitWarned map[bgp.Family]bool
 	// map of path local identifiers sent for that prefix
 	sentPaths           map[table.PathDestLocalKey]map[uint32]struct{}
@@ -623,10 +624,9 @@ func (peer *peer) handleUpdate(e *fsmMsg) ([]*table.Path, []bgp.Family, *bgp.BGP
 
 	peer.fsm.lock.Lock()
 	peer.fsm.pConf.Timers.State.UpdateRecvTime = time.Now().Unix()
-	peerInfo := peer.fsm.peerInfo
 	peer.fsm.lock.Unlock()
 
-	pathList := table.ProcessMessage(m, peerInfo, e.timestamp)
+	pathList := table.ProcessMessage(m, peer.peerInfo, e.timestamp)
 	if len(pathList) > 0 {
 		paths := make([]*table.Path, 0, len(pathList))
 		eor := []bgp.Family{}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -976,7 +976,7 @@ func newPeerandInfo(t *testing.T, myAs, as uint32, address string, rib *table.Ta
 	remoteAddr := netip.MustParseAddr(address)
 	localAddr := netip.MustParseAddr("1.1.1.1")
 	info := table.NewPeerInfo(gConf, nConf, as, myAs, remoteAddr, localAddr, remoteAddr, localAddr)
-	p.fsm.peerInfo = info
+	p.peerInfo = info
 	return p
 }
 
@@ -1005,8 +1005,8 @@ func TestFilterpathWitheBGP(t *testing.T) {
 	pa1 := []bgp.PathAttributeInterface{bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{p1As})}), bgp.NewPathAttributeLocalPref(200)}
 	pa2 := []bgp.PathAttributeInterface{bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{p2As})})}
 
-	path1 := table.NewPath(bgp.RF_IPv4_UC, p1.fsm.peerInfo, nlri, false, pa1, time.Now(), false)
-	path2 := table.NewPath(bgp.RF_IPv4_UC, p2.fsm.peerInfo, nlri, false, pa2, time.Now(), false)
+	path1 := table.NewPath(bgp.RF_IPv4_UC, p1.peerInfo, nlri, false, pa1, time.Now(), false)
+	path2 := table.NewPath(bgp.RF_IPv4_UC, p2.peerInfo, nlri, false, pa2, time.Now(), false)
 	rib.Update(path2)
 	d := rib.Update(path1)
 	new, old, _ := d[0].GetChanges(table.GLOBAL_RIB_NAME, 0, false)
@@ -1047,7 +1047,7 @@ func TestFilterpathWithiBGP(t *testing.T) {
 	pa1 := []bgp.PathAttributeInterface{bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{as})}), bgp.NewPathAttributeLocalPref(200)}
 	// pa2 := []bgp.PathAttributeInterface{bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{as})})}
 
-	path1 := table.NewPath(bgp.RF_IPv4_UC, p1.fsm.peerInfo, nlri, false, pa1, time.Now(), false)
+	path1 := table.NewPath(bgp.RF_IPv4_UC, p1.peerInfo, nlri, false, pa1, time.Now(), false)
 	// path2 := table.NewPath(bgp.RF_IPv4_UC, pi2, nlri, false, pa2, time.Now(), false)
 
 	new, old := process(rib, []*table.Path{path1})
@@ -1113,7 +1113,7 @@ func TestFilterpathWithRejectPolicy(t *testing.T) {
 		if addCommunity {
 			pa1 = append(pa1, bgp.NewPathAttributeCommunities([]uint32{100<<16 | 100}))
 		}
-		path1 := table.NewPath(bgp.RF_IPv4_UC, p1.fsm.peerInfo, nlri, false, pa1, time.Now(), false)
+		path1 := table.NewPath(bgp.RF_IPv4_UC, p1.peerInfo, nlri, false, pa1, time.Now(), false)
 		new, old := process(rib2, []*table.Path{path1})
 		assert.Equal(t, new, path1)
 		s := NewBgpServer()


### PR DESCRIPTION
Move peerinfo from fsm to peer. fsm doesn't use it so peer can use it without fsm's lock.