### PR TITLE
netip: table/policy use github.com/gaissmai/bart Trie

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,10 @@ require (
 	github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da
 	github.com/eapache/channels v1.1.0
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/gaissmai/bart v0.26.1
 	github.com/getsentry/sentry-go v0.34.1
 	github.com/go-test/deep v1.1.1
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
@@ -20,7 +22,6 @@ require (
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/segmentio/fasthash v1.0.3
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
@@ -37,7 +38,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/gaissmai/bart v0.26.1 h1:+w4rnLGNlA2GDVn382Tfe3jOsK5vOr5n4KmigJ9lbTo=
+github.com/gaissmai/bart v0.26.1/go.mod h1:GREWQfTLRWz/c5FTOsIw+KkscuFkIV5t8Rp7Nd1Td5c=
 github.com/getsentry/sentry-go v0.34.1 h1:HSjc1C/OsnZttohEPrrqKH42Iud0HuLCXpv8cU1pWcw=
 github.com/getsentry/sentry-go v0.34.1/go.mod h1:C55omcY9ChRQIUcVcGcs+Zdy4ZpQGvNJ7JYHIoSWOtE=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
@@ -82,8 +84,6 @@ github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsF
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
 github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
@@ -98,7 +98,6 @@ github.com/spf13/viper v1.20.1 h1:ZMi+z/lvLyPSCoNtFCpqjy0S4kPbirhpTMwl8BkW9X4=
 github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqjJvu4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
@@ -128,7 +127,6 @@ go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTV
 golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
 golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
@@ -146,6 +144,5 @@ google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -1385,3 +1385,15 @@ func nlriToIPNet(nlri bgp.NLRI) *net.IPNet {
 	}
 	return nil
 }
+
+func nlriToPrefix(nlri bgp.NLRI) netip.Prefix {
+	switch T := nlri.(type) {
+	case *bgp.IPAddrPrefix:
+		return T.Prefix
+	case *bgp.LabeledIPAddrPrefix:
+		return T.Prefix
+	case *bgp.LabeledVPNIPAddrPrefix:
+		return T.Prefix
+	}
+	return netip.Prefix{}
+}

--- a/internal/pkg/table/policy.go
+++ b/internal/pkg/table/policy.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/k-sone/critbitgo"
+	"github.com/gaissmai/bart"
 	"github.com/osrg/gobgp/v4/api"
 	"github.com/osrg/gobgp/v4/pkg/config/oc"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
@@ -270,7 +270,7 @@ func (l DefinedSetList) Less(i, j int) bool {
 }
 
 type Prefix struct {
-	Prefix             *net.IPNet
+	Prefix             netip.Prefix
 	AddressFamily      bgp.Family
 	MasklengthRangeMax uint8
 	MasklengthRangeMin uint8
@@ -282,11 +282,11 @@ func (p *Prefix) Match(path *Path) bool {
 		return false
 	}
 
-	var pAddr net.IP
+	var pAddr netip.Addr
 	var pMasklen uint8
 	switch rf {
 	case bgp.RF_IPv4_UC, bgp.RF_IPv6_UC:
-		pAddr = net.IP(path.GetNlri().(*bgp.IPAddrPrefix).Prefix.Addr().AsSlice())
+		pAddr = path.GetNlri().(*bgp.IPAddrPrefix).Prefix.Addr()
 		pMasklen = uint8(path.GetNlri().(*bgp.IPAddrPrefix).Prefix.Bits())
 	default:
 		return false
@@ -306,30 +306,13 @@ func (lhs *Prefix) Equal(rhs *Prefix) bool {
 }
 
 func (p *Prefix) PrefixString() string {
-	isZeros := func(p net.IP) bool {
-		for i := range p {
-			if p[i] != 0 {
-				return false
-			}
-		}
-		return true
-	}
-
-	ip := p.Prefix.IP
-	if p.AddressFamily == bgp.RF_IPv6_UC && isZeros(ip[:10]) && ip[10] == 0xff && ip[11] == 0xff {
-		m, _ := p.Prefix.Mask.Size()
-		return fmt.Sprintf("::FFFF:%s/%d", ip.To16(), m)
-	}
 	return p.Prefix.String()
 }
 
 var _regexpPrefixRange = regexp.MustCompile(`(\d+)\.\.(\d+)`)
 
 func NewPrefix(c oc.Prefix) (*Prefix, error) {
-	_, prefix, err := net.ParseCIDR(c.IpPrefix.String())
-	if err != nil {
-		return nil, err
-	}
+	prefix := c.IpPrefix
 
 	rf := bgp.RF_IPv4_UC
 	if strings.Contains(c.IpPrefix.String(), ":") {
@@ -342,7 +325,7 @@ func NewPrefix(c oc.Prefix) (*Prefix, error) {
 	maskRange := c.MasklengthRange
 
 	if maskRange == "" {
-		l, _ := prefix.Mask.Size()
+		l := prefix.Bits()
 		maskLength := uint8(l)
 		p.MasklengthRangeMax = maskLength
 		p.MasklengthRangeMin = maskLength
@@ -364,7 +347,7 @@ func NewPrefix(c oc.Prefix) (*Prefix, error) {
 
 type PrefixSet struct {
 	name   string
-	tree   *critbitgo.Net
+	tree   *bart.Table[[]*Prefix]
 	family bgp.Family
 }
 
@@ -388,18 +371,15 @@ func (lhs *PrefixSet) Append(arg DefinedSet) error {
 	} else if lhs.tree.Size() != 0 && rhs.family != lhs.family {
 		return fmt.Errorf("can't append different family")
 	}
-	//nolint:errcheck // tree.Add won't return an error
-	rhs.tree.Walk(nil, func(r *net.IPNet, v any) bool {
-		w, ok, _ := lhs.tree.Get(r)
-		if ok {
-			rp := v.([]*Prefix)
-			lp := w.([]*Prefix)
-			lhs.tree.Add(r, append(lp, rp...))
-		} else {
-			lhs.tree.Add(r, v)
-		}
-		return true
-	})
+
+	for r, v := range rhs.tree.All() {
+		lhs.tree.Modify(r, func(val []*Prefix, ok bool) ([]*Prefix, bool) {
+			if ok {
+				return append(val, v...), false
+			}
+			return v, false
+		})
+	}
 	lhs.family = rhs.family
 	return nil
 }
@@ -409,14 +389,11 @@ func (lhs *PrefixSet) Remove(arg DefinedSet) error {
 	if !ok {
 		return fmt.Errorf("type cast failed")
 	}
-	//nolint:errcheck // tree.Delete/tree.Add won't return an error
-	rhs.tree.Walk(nil, func(r *net.IPNet, v any) bool {
-		w, ok, _ := lhs.tree.Get(r)
+	for r, rp := range rhs.tree.All() {
+		lp, ok := lhs.tree.Get(r)
 		if !ok {
-			return true
+			continue
 		}
-		rp := v.([]*Prefix)
-		lp := w.([]*Prefix)
 		new := make([]*Prefix, 0, len(lp))
 		for _, lp := range lp {
 			delete := slices.ContainsFunc(rp, lp.Equal)
@@ -427,10 +404,9 @@ func (lhs *PrefixSet) Remove(arg DefinedSet) error {
 		if len(new) == 0 {
 			lhs.tree.Delete(r)
 		} else {
-			lhs.tree.Add(r, new)
+			lhs.tree.Insert(r, new)
 		}
-		return true
-	})
+	}
 	return nil
 }
 
@@ -446,25 +422,21 @@ func (lhs *PrefixSet) Replace(arg DefinedSet) error {
 
 func (s *PrefixSet) List() []string {
 	var list []string
-	s.tree.Walk(nil, func(_ *net.IPNet, v any) bool {
-		ps := v.([]*Prefix)
+	for _, ps := range s.tree.All() {
 		for _, p := range ps {
 			list = append(list, fmt.Sprintf("%s %d..%d", p.PrefixString(), p.MasklengthRangeMin, p.MasklengthRangeMax))
 		}
-		return true
-	})
+	}
 	return list
 }
 
 func (s *PrefixSet) ToConfig() *oc.PrefixSet {
 	list := make([]oc.Prefix, 0, s.tree.Size())
-	s.tree.Walk(nil, func(_ *net.IPNet, v any) bool {
-		ps := v.([]*Prefix)
+	for _, ps := range s.tree.All() {
 		for _, p := range ps {
 			list = append(list, oc.Prefix{IpPrefix: netip.MustParsePrefix(p.PrefixString()), MasklengthRange: fmt.Sprintf("%d..%d", p.MasklengthRangeMin, p.MasklengthRangeMax)})
 		}
-		return true
-	})
+	}
 	return &oc.PrefixSet{
 		PrefixSetName: s.name,
 		PrefixList:    list,
@@ -483,7 +455,7 @@ func NewPrefixSetFromApiStruct(name string, prefixes []*Prefix) (*PrefixSet, err
 	if name == "" {
 		return nil, fmt.Errorf("empty prefix set name")
 	}
-	tree := critbitgo.NewNet()
+	tree := new(bart.Table[[]*Prefix])
 	var family bgp.Family
 	for i, x := range prefixes {
 		if i == 0 {
@@ -491,15 +463,12 @@ func NewPrefixSetFromApiStruct(name string, prefixes []*Prefix) (*PrefixSet, err
 		} else if family != x.AddressFamily {
 			return nil, fmt.Errorf("multiple families")
 		}
-		d, ok, _ := tree.Get(x.Prefix)
-		if ok {
-			ps := d.([]*Prefix)
-			if err := tree.Add(x.Prefix, append(ps, x)); err != nil {
-				return nil, fmt.Errorf("failed to add prefix %s: %w", x.PrefixString(), err)
+		tree.Modify(x.Prefix, func(val []*Prefix, ok bool) ([]*Prefix, bool) {
+			if ok {
+				return append(val, x), false
 			}
-		} else if err := tree.Add(x.Prefix, []*Prefix{x}); err != nil {
-			return nil, fmt.Errorf("failed to add prefix %s: %w", x.PrefixString(), err)
-		}
+			return []*Prefix{x}, false
+		})
 	}
 	return &PrefixSet{
 		name:   name,
@@ -516,7 +485,7 @@ func NewPrefixSet(c oc.PrefixSet) (*PrefixSet, error) {
 		}
 		return nil, fmt.Errorf("empty prefix set name")
 	}
-	tree := critbitgo.NewNet()
+	tree := new(bart.Table[[]*Prefix])
 	var family bgp.Family
 	for i, x := range c.PrefixList {
 		y, err := NewPrefix(x)
@@ -528,14 +497,11 @@ func NewPrefixSet(c oc.PrefixSet) (*PrefixSet, error) {
 		} else if family != y.AddressFamily {
 			return nil, fmt.Errorf("multiple families")
 		}
-		d, ok, _ := tree.Get(y.Prefix)
+		ps, ok := tree.Get(y.Prefix)
 		if ok {
-			ps := d.([]*Prefix)
-			if err := tree.Add(y.Prefix, append(ps, y)); err != nil {
-				return nil, fmt.Errorf("failed to add prefix %s: %w", y.PrefixString(), err)
-			}
-		} else if err := tree.Add(y.Prefix, []*Prefix{y}); err != nil {
-			return nil, fmt.Errorf("failed to add prefix %s: %w", y.PrefixString(), err)
+			tree.Insert(y.Prefix, append(ps, y))
+		} else {
+			tree.Insert(y.Prefix, []*Prefix{y})
 		}
 	}
 	return &PrefixSet{
@@ -1452,19 +1418,23 @@ func (c *PrefixCondition) Evaluate(path *Path, _ *PolicyOptions) bool {
 		return false
 	}
 
-	r := nlriToIPNet(path.GetNlri())
-	if r == nil {
+	r := nlriToPrefix(path.GetNlri())
+	if !r.IsValid() {
 		return false
 	}
-	ones, _ := r.Mask.Size()
-	masklen := uint8(ones)
+	addr := r.Masked().Addr()
+	masklen := uint8(r.Bits())
 	result := false
-	if _, ps, _ := c.set.tree.Match(r); ps != nil {
-		for _, p := range ps.([]*Prefix) {
-			if p.MasklengthRangeMin <= masklen && masklen <= p.MasklengthRangeMax {
+	// Iterate all prefixes in the set and check supernet containment with mask-length range
+	for _, ps := range c.set.tree.Supernets(r) {
+		for _, p := range ps {
+			if p.MasklengthRangeMin <= masklen && masklen <= p.MasklengthRangeMax && p.Prefix.Contains(addr) {
 				result = true
 				break
 			}
+		}
+		if result {
+			break
 		}
 	}
 

--- a/internal/pkg/table/prefix_ops_bench_test.go
+++ b/internal/pkg/table/prefix_ops_bench_test.go
@@ -1,0 +1,497 @@
+// Copyright (C) 2014-2016 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"fmt"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/osrg/gobgp/v4/pkg/config/oc"
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+)
+
+// Implementation-agnostic benchmarks that test GoBGP operations
+// These benchmarks work on both critbitgo (old) and BART (new) implementations
+// Run on both branches to compare performance
+
+// prevent optimization
+var globalResult any
+
+// ============================================================================
+// Helper Functions - Implementation Agnostic
+// ============================================================================
+
+func createPrefixSetFromCIDRs(name string, cidrs []string, family bgp.Family) (*PrefixSet, error) {
+	prefixes := make([]*Prefix, len(cidrs))
+	for i, cidr := range cidrs {
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			return nil, err
+		}
+		masklen := prefix.Bits()
+		p, err := NewPrefix(oc.Prefix{
+			IpPrefix:        prefix,
+			MasklengthRange: fmt.Sprintf("%d..%d", masklen, masklen+8),
+		})
+		if err != nil {
+			return nil, err
+		}
+		prefixes[i] = p
+	}
+
+	return NewPrefixSetFromApiStruct(name, prefixes)
+}
+
+func generateTestCIDRs(count int, family bgp.Family) []string {
+	cidrs := make([]string, count)
+	if family == bgp.RF_IPv4_UC {
+		for i := range count {
+			octet2 := i >> 8 & 0xff
+			octet3 := i & 0xff
+			cidrs[i] = fmt.Sprintf("10.%d.%d.0/24", octet2, octet3)
+		}
+	} else {
+		for i := range count {
+			byte6 := i >> 8 & 0xff
+			byte7 := i & 0xff
+			cidrs[i] = fmt.Sprintf("2001:db8:%x:%x::/64", byte6, byte7)
+		}
+	}
+	return cidrs
+}
+
+func createTestPath(prefix string, family bgp.Family) *Path {
+	p := netip.MustParsePrefix(prefix)
+	nlri, _ := bgp.NewIPAddrPrefix(p)
+
+	nexthop, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("10.0.0.1"))
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		nexthop,
+	}
+
+	return NewPath(family, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
+}
+
+func createTestTable(family bgp.Family, count int) *Table {
+	table := NewTable(logger, family)
+	cidrs := generateTestCIDRs(count, family)
+
+	for _, cidr := range cidrs {
+		path := createTestPath(cidr, family)
+		table.update(path)
+	}
+
+	return table
+}
+
+// ============================================================================
+// Benchmark: PrefixSet Operations (Policy)
+// ============================================================================
+
+func BenchmarkPrefixSetCreation(b *testing.B) {
+	scenarios := []struct {
+		name   string
+		count  int
+		family bgp.Family
+	}{
+		{"IPv4/100", 100, bgp.RF_IPv4_UC},
+		{"IPv4/1K", 1000, bgp.RF_IPv4_UC},
+		{"IPv4/10K", 10000, bgp.RF_IPv4_UC},
+		{"IPv6/100", 100, bgp.RF_IPv6_UC},
+		{"IPv6/1K", 1000, bgp.RF_IPv6_UC},
+		{"IPv6/10K", 10000, bgp.RF_IPv6_UC},
+	}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			cidrs := generateTestCIDRs(sc.count, sc.family)
+
+			b.ResetTimer()
+			for range b.N {
+				ps, err := createPrefixSetFromCIDRs("test", cidrs, sc.family)
+				if err != nil {
+					b.Fatal(err)
+				}
+				globalResult = ps
+			}
+		})
+	}
+}
+
+func BenchmarkPrefixSetMerge(b *testing.B) {
+	scenarios := []struct {
+		name         string
+		count        int
+		collisionPct int
+		family       bgp.Family
+	}{
+		{"IPv4/1K/NoCollision", 1000, 0, bgp.RF_IPv4_UC},
+		{"IPv4/1K/50%Collision", 1000, 50, bgp.RF_IPv4_UC},
+		{"IPv4/10K/NoCollision", 10000, 0, bgp.RF_IPv4_UC},
+		{"IPv4/10K/50%Collision", 10000, 50, bgp.RF_IPv4_UC},
+		{"IPv6/1K/NoCollision", 1000, 0, bgp.RF_IPv6_UC},
+		{"IPv6/1K/50%Collision", 1000, 50, bgp.RF_IPv6_UC},
+		{"IPv6/10K/NoCollision", 10000, 0, bgp.RF_IPv6_UC},
+		{"IPv6/10K/50%Collision", 10000, 50, bgp.RF_IPv6_UC},
+	}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			lhsCIDRs := generateTestCIDRs(sc.count, sc.family)
+
+			// Generate RHS with controlled collision
+			offset := sc.count * (100 - sc.collisionPct) / 100
+			allRHS := generateTestCIDRs(offset+sc.count, sc.family)
+			rhsCIDRs := allRHS[offset:]
+
+			rhs, err := createPrefixSetFromCIDRs("rhs", rhsCIDRs, sc.family)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			for range b.N {
+				b.StopTimer()
+				// Create fresh copy for each iteration
+				lhsCopy, _ := createPrefixSetFromCIDRs("lhs", lhsCIDRs, sc.family)
+				b.StartTimer()
+
+				err := lhsCopy.Append(rhs)
+				if err != nil {
+					b.Fatal(err)
+				}
+				globalResult = lhsCopy
+			}
+		})
+	}
+}
+
+func BenchmarkPrefixSetRemove(b *testing.B) {
+	scenarios := []struct {
+		name      string
+		count     int
+		removePct int
+		family    bgp.Family
+	}{
+		{"IPv4/1K/Remove10%", 1000, 10, bgp.RF_IPv4_UC},
+		{"IPv4/1K/Remove50%", 1000, 50, bgp.RF_IPv4_UC},
+		{"IPv4/10K/Remove10%", 10000, 10, bgp.RF_IPv4_UC},
+		{"IPv4/10K/Remove50%", 10000, 50, bgp.RF_IPv4_UC},
+		{"IPv6/1K/Remove10%", 1000, 10, bgp.RF_IPv6_UC},
+		{"IPv6/1K/Remove50%", 1000, 50, bgp.RF_IPv6_UC},
+		{"IPv6/10K/Remove10%", 10000, 10, bgp.RF_IPv6_UC},
+		{"IPv6/10K/Remove50%", 10000, 50, bgp.RF_IPv6_UC},
+	}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			lhsCIDRs := generateTestCIDRs(sc.count, sc.family)
+			removeCount := sc.count * sc.removePct / 100
+			rhsCIDRs := lhsCIDRs[:removeCount]
+
+			rhs, err := createPrefixSetFromCIDRs("rhs", rhsCIDRs, sc.family)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			for range b.N {
+				b.StopTimer()
+				lhsCopy, _ := createPrefixSetFromCIDRs("lhs", lhsCIDRs, sc.family)
+				b.StartTimer()
+
+				err := lhsCopy.Remove(rhs)
+				if err != nil {
+					b.Fatal(err)
+				}
+				globalResult = lhsCopy
+			}
+		})
+	}
+}
+
+func BenchmarkPrefixSetList(b *testing.B) {
+	scenarios := []struct {
+		name   string
+		count  int
+		family bgp.Family
+	}{
+		{"IPv4/1K", 1000, bgp.RF_IPv4_UC},
+		{"IPv4/10K", 10000, bgp.RF_IPv4_UC},
+		{"IPv4/100K", 100000, bgp.RF_IPv4_UC},
+		{"IPv6/1K", 1000, bgp.RF_IPv6_UC},
+		{"IPv6/10K", 10000, bgp.RF_IPv6_UC},
+		{"IPv6/100K", 100000, bgp.RF_IPv6_UC},
+	}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			cidrs := generateTestCIDRs(sc.count, sc.family)
+			ps, err := createPrefixSetFromCIDRs("test", cidrs, sc.family)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			for range b.N {
+				list := ps.List()
+				globalResult = list
+			}
+		})
+	}
+}
+
+// ============================================================================
+// Benchmark: Policy Evaluation (Critical Path)
+// ============================================================================
+
+func BenchmarkPolicyPrefixMatch(b *testing.B) {
+	scenarios := []struct {
+		name   string
+		count  int
+		family bgp.Family
+	}{
+		{"IPv4/100", 100, bgp.RF_IPv4_UC},
+		{"IPv4/1K", 1000, bgp.RF_IPv4_UC},
+		{"IPv4/10K", 10000, bgp.RF_IPv4_UC},
+		{"IPv6/100", 100, bgp.RF_IPv6_UC},
+		{"IPv6/1K", 1000, bgp.RF_IPv6_UC},
+		{"IPv6/10K", 10000, bgp.RF_IPv6_UC},
+	}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name+"/Match", func(b *testing.B) {
+			cidrs := generateTestCIDRs(sc.count, sc.family)
+			ps, err := createPrefixSetFromCIDRs("test", cidrs, sc.family)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			// Create a matching path
+			testCIDR := cidrs[sc.count/2]
+			path := createTestPath(testCIDR, sc.family)
+
+			cond := &PrefixCondition{
+				set:    ps,
+				option: MATCH_OPTION_ANY,
+			}
+
+			b.ResetTimer()
+			for range b.N {
+				result := cond.Evaluate(path, nil)
+				globalResult = result
+			}
+		})
+
+		b.Run(sc.name+"/NoMatch", func(b *testing.B) {
+			cidrs := generateTestCIDRs(sc.count, sc.family)
+			ps, err := createPrefixSetFromCIDRs("test", cidrs, sc.family)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			// Create a non-matching path
+			var testCIDR string
+			if sc.family == bgp.RF_IPv4_UC {
+				testCIDR = "192.168.1.0/24"
+			} else {
+				testCIDR = "fc00::1/64"
+			}
+			path := createTestPath(testCIDR, sc.family)
+
+			cond := &PrefixCondition{
+				set:    ps,
+				option: MATCH_OPTION_ANY,
+			}
+
+			b.ResetTimer()
+			for range b.N {
+				result := cond.Evaluate(path, nil)
+				globalResult = result
+			}
+		})
+	}
+}
+
+// ============================================================================
+// Benchmark: Table Operations
+// ============================================================================
+
+func BenchmarkTableInsert(b *testing.B) {
+	scenarios := []struct {
+		name   string
+		count  int
+		family bgp.Family
+	}{
+		{"IPv4/1K", 1000, bgp.RF_IPv4_UC},
+		{"IPv4/10K", 10000, bgp.RF_IPv4_UC},
+		{"IPv4/100K", 100000, bgp.RF_IPv4_UC},
+		{"IPv6/1K", 1000, bgp.RF_IPv6_UC},
+		{"IPv6/10K", 10000, bgp.RF_IPv6_UC},
+		{"IPv6/100K", 100000, bgp.RF_IPv6_UC},
+	}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			cidrs := generateTestCIDRs(sc.count, sc.family)
+			paths := make([]*Path, len(cidrs))
+			for i, cidr := range cidrs {
+				paths[i] = createTestPath(cidr, sc.family)
+			}
+
+			b.ResetTimer()
+			for range b.N {
+				table := NewTable(logger, sc.family)
+				for _, path := range paths {
+					table.update(path)
+				}
+				globalResult = table
+			}
+		})
+	}
+}
+
+func BenchmarkTableGetDestinations(b *testing.B) {
+	scenarios := []struct {
+		name   string
+		count  int
+		family bgp.Family
+	}{
+		{"IPv4/1K", 1000, bgp.RF_IPv4_UC},
+		{"IPv4/10K", 10000, bgp.RF_IPv4_UC},
+		{"IPv4/100K", 100000, bgp.RF_IPv4_UC},
+		{"IPv6/1K", 1000, bgp.RF_IPv6_UC},
+		{"IPv6/10K", 10000, bgp.RF_IPv6_UC},
+		{"IPv6/100K", 100000, bgp.RF_IPv6_UC},
+	}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			table := createTestTable(sc.family, sc.count)
+
+			b.ResetTimer()
+			for range b.N {
+				dests := table.GetDestinations()
+				globalResult = dests
+			}
+		})
+	}
+}
+
+func BenchmarkTableGetLongerPrefixDestinations(b *testing.B) {
+	scenarios := []struct {
+		name      string
+		count     int
+		lookupKey string
+		family    bgp.Family
+	}{
+		{"IPv4/1K/Lookup16", 1000, "10.1.0.0/16", bgp.RF_IPv4_UC},
+		{"IPv4/10K/Lookup16", 10000, "10.1.0.0/16", bgp.RF_IPv4_UC},
+		{"IPv4/10K/Lookup20", 10000, "10.1.1.0/20", bgp.RF_IPv4_UC},
+		{"IPv4/100K/Lookup8", 100000, "10.0.0.0/8", bgp.RF_IPv4_UC},
+		{"IPv6/1K/Lookup32", 1000, "2001:db8::/32", bgp.RF_IPv6_UC},
+		{"IPv6/10K/Lookup32", 10000, "2001:db8::/32", bgp.RF_IPv6_UC},
+		{"IPv6/10K/Lookup40", 10000, "2001:db8:1::/40", bgp.RF_IPv6_UC},
+	}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			table := createTestTable(sc.family, sc.count)
+
+			b.ResetTimer()
+			for range b.N {
+				dests, err := table.GetLongerPrefixDestinations(sc.lookupKey)
+				if err != nil {
+					b.Fatal(err)
+				}
+				globalResult = dests
+			}
+		})
+	}
+}
+
+// ============================================================================
+// Benchmark: End-to-End Policy Application
+// ============================================================================
+
+func BenchmarkPolicyApplicationComplete(b *testing.B) {
+	// This benchmark simulates a complete policy evaluation cycle:
+	// 1. Create prefix sets (policy configuration)
+	// 2. Create paths (BGP updates)
+	// 3. Evaluate policy against paths (the hot path)
+
+	scenarios := []struct {
+		name        string
+		prefixCount int
+		pathCount   int
+		family      bgp.Family
+	}{
+		{"IPv4/100Prefixes/100Paths", 100, 100, bgp.RF_IPv4_UC},
+		{"IPv4/1KPrefixes/100Paths", 1000, 100, bgp.RF_IPv4_UC},
+		{"IPv4/10KPrefixes/100Paths", 10000, 100, bgp.RF_IPv4_UC},
+		{"IPv6/100Prefixes/100Paths", 100, 100, bgp.RF_IPv6_UC},
+		{"IPv6/1KPrefixes/100Paths", 1000, 100, bgp.RF_IPv6_UC},
+		{"IPv6/10KPrefixes/100Paths", 10000, 100, bgp.RF_IPv6_UC},
+	}
+
+	for _, sc := range scenarios {
+		b.Run(sc.name, func(b *testing.B) {
+			// Setup: Create prefix set (policy config)
+			policyCIDRs := generateTestCIDRs(sc.prefixCount, sc.family)
+			ps, err := createPrefixSetFromCIDRs("policy", policyCIDRs, sc.family)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			cond := &PrefixCondition{
+				set:    ps,
+				option: MATCH_OPTION_ANY,
+			}
+
+			// Setup: Create test paths (50% match, 50% don't match)
+			paths := make([]*Path, sc.pathCount)
+			for i := range sc.pathCount {
+				var cidr string
+				if i%2 == 0 {
+					// Matching path
+					cidr = policyCIDRs[i%sc.prefixCount]
+				} else {
+					// Non-matching path
+					if sc.family == bgp.RF_IPv4_UC {
+						cidr = fmt.Sprintf("192.168.%d.0/24", i)
+					} else {
+						cidr = fmt.Sprintf("fc00::%x/64", i)
+					}
+				}
+				paths[i] = createTestPath(cidr, sc.family)
+			}
+
+			b.ResetTimer()
+			for range b.N {
+				matchCount := 0
+				for _, path := range paths {
+					if cond.Evaluate(path, nil) {
+						matchCount++
+					}
+				}
+				globalResult = matchCount
+			}
+		})
+	}
+}

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/k-sone/critbitgo"
+	"github.com/gaissmai/bart"
 	"github.com/segmentio/fasthash/fnv1a"
 
 	"github.com/osrg/gobgp/v4/pkg/apiutil"
@@ -520,80 +520,36 @@ func (t *Table) GetLongerPrefixDestinations(key string) ([]*destination, error) 
 	results := make([]*destination, 0, len(destinations))
 	switch t.Family {
 	case bgp.RF_IPv4_UC, bgp.RF_IPv6_UC, bgp.RF_IPv4_MPLS, bgp.RF_IPv6_MPLS:
-		_, prefix, err := net.ParseCIDR(key)
+		prefix, err := netip.ParsePrefix(key)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing cidr %s: %v", key, err)
 		}
-		ones, bits := prefix.Mask.Size()
 
-		r := critbitgo.NewNet()
-		for _, dst := range destinations {
-			_ = r.Add(nlriToIPNet(dst.nlri), dst)
+		r := new(bart.Table[*destination])
+		for _, dst := range t.GetDestinations() {
+			r.Insert(nlriToPrefix(dst.nlri), dst)
 		}
-		p := &net.IPNet{
-			IP:   prefix.IP,
-			Mask: net.CIDRMask(ones>>3<<3, bits),
+		for _, d := range r.Subnets(prefix) {
+			results = append(results, d)
 		}
-		mask := 0
-		div := 0
-		if ones%8 != 0 {
-			mask = 8 - ones&0x7
-			div = ones >> 3
-		}
-		r.WalkPrefix(p, func(n *net.IPNet, v any) bool {
-			if mask != 0 && n.IP[div]>>mask != p.IP[div]>>mask {
-				return true
-			}
-			l, _ := n.Mask.Size()
-
-			if ones > l {
-				return true
-			}
-			results = append(results, v.(*destination))
-			return true
-		})
 	case bgp.RF_IPv4_VPN, bgp.RF_IPv6_VPN:
 		prefixRd, prefix, err := bgp.ParseVPNPrefix(key)
 		if err != nil {
 			return nil, err
 		}
-		ones := prefix.Bits()
-		bits := prefix.Addr().BitLen()
 
-		r := critbitgo.NewNet()
-		for _, dst := range destinations {
+		r := new(bart.Table[*destination])
+		for _, dst := range t.GetDestinations() {
 			dstRD := dst.nlri.(*bgp.LabeledVPNIPAddrPrefix).RD
 			if prefixRd.String() != dstRD.String() {
 				continue
 			}
 
-			_ = r.Add(nlriToIPNet(dst.nlri), dst)
+			r.Insert(nlriToPrefix(dst.nlri), dst)
 		}
-
-		p := &net.IPNet{
-			IP:   prefix.Addr().AsSlice(),
-			Mask: net.CIDRMask(ones>>3<<3, bits),
+		for _, d := range r.Subnets(prefix) {
+			results = append(results, d)
 		}
-
-		mask := 0
-		div := 0
-		if ones%8 != 0 {
-			mask = 8 - ones&0x7
-			div = ones >> 3
-		}
-
-		r.WalkPrefix(p, func(n *net.IPNet, v any) bool {
-			if mask != 0 && n.IP[div]>>mask != p.IP[div]>>mask {
-				return true
-			}
-			l, _ := n.Mask.Size()
-
-			if ones > l {
-				return true
-			}
-			results = append(results, v.(*destination))
-			return true
-		})
 	default:
 		results = append(results, t.GetDestinations()...)
 	}

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -1276,12 +1276,12 @@ func (s *server) DeleteDynamicNeighbor(ctx context.Context, r *api.DeleteDynamic
 }
 
 func newPrefixFromApiStruct(a *api.Prefix) (*table.Prefix, error) {
-	_, prefix, err := net.ParseCIDR(a.IpPrefix)
+	prefix, err := netip.ParsePrefix(a.IpPrefix)
 	if err != nil {
 		return nil, err
 	}
 	rf := bgp.RF_IPv4_UC
-	if strings.Contains(a.IpPrefix, ":") {
+	if prefix.Addr().Is6() {
 		rf = bgp.RF_IPv6_UC
 	}
 	return &table.Prefix{


### PR DESCRIPTION

<img width="4171" height="3001" alt="image" src="https://github.com/user-attachments/assets/be71c847-798e-471d-aa73-7d23f6e3b45e" />
<img width="4171" height="1486" alt="image" src="https://github.com/user-attachments/assets/49981bb5-592e-4511-8b7a-98f279f0c010" />


benchmark
`go test -benchmem -bench="BenchmarkPolicyPrefixMatch/IPv4/1K" -benchtime=3s ./internal/pkg/table/`

old
```
BenchmarkPolicyPrefixMatch/IPv4/100/Match-12         	16386170	       262.2 ns/op	     120 B/op	       6 allocs/op
BenchmarkPolicyPrefixMatch/IPv4/100/NoMatch-12       	17901081	       206.0 ns/op	      64 B/op	       4 allocs/op
BenchmarkPolicyPrefixMatch/IPv4/1K/Match-12          	 7850575	       395.0 ns/op	     120 B/op	       6 allocs/op
BenchmarkPolicyPrefixMatch/IPv4/1K/NoMatch-12        	12341060	       267.3 ns/op	      64 B/op	       4 allocs/op
BenchmarkPolicyPrefixMatch/IPv4/10K/Match-12         	 9956816	       464.2 ns/op	     120 B/op	       6 allocs/op
BenchmarkPolicyPrefixMatch/IPv4/10K/NoMatch-12       	12371900	       280.7 ns/op	      64 B/op	       4 allocs/op
BenchmarkPolicyPrefixMatch/IPv6/100/Match-12         	 8824754	       382.6 ns/op	     176 B/op	       6 allocs/op
BenchmarkPolicyPrefixMatch/IPv6/100/NoMatch-12       	13862186	       261.1 ns/op	     112 B/op	       4 allocs/op
BenchmarkPolicyPrefixMatch/IPv6/1K/Match-12          	 8671737	       393.1 ns/op	     176 B/op	       6 allocs/op
BenchmarkPolicyPrefixMatch/IPv6/1K/NoMatch-12        	13722524	       284.5 ns/op	     112 B/op	       4 allocs/op
BenchmarkPolicyPrefixMatch/IPv6/10K/Match-12         	 8157162	       459.5 ns/op	     176 B/op	       6 allocs/op
BenchmarkPolicyPrefixMatch/IPv6/10K/NoMatch-12       	11865584	       309.6 ns/op	     112 B/op	       4 allocs/op

```
new (BART)
```
BenchmarkPolicyPrefixMatch/IPv4/100/Match-12         	53936118	        60.63 ns/op	       0 B/op	       0 allocs/op
BenchmarkPolicyPrefixMatch/IPv4/100/NoMatch-12       	151547805	        26.07 ns/op	       0 B/op	       0 allocs/op
BenchmarkPolicyPrefixMatch/IPv4/1K/Match-12          	67433356	        54.17 ns/op	       0 B/op	       0 allocs/op
BenchmarkPolicyPrefixMatch/IPv4/1K/NoMatch-12        	144172502	        28.61 ns/op	       0 B/op	       0 allocs/op
BenchmarkPolicyPrefixMatch/IPv4/10K/Match-12         	63421544	        56.80 ns/op	       0 B/op	       0 allocs/op
BenchmarkPolicyPrefixMatch/IPv4/10K/NoMatch-12       	134879209	        27.37 ns/op	       0 B/op	       0 allocs/op
BenchmarkPolicyPrefixMatch/IPv6/100/Match-12         	41109109	        91.81 ns/op	       0 B/op	       0 allocs/op
BenchmarkPolicyPrefixMatch/IPv6/100/NoMatch-12       	140465936	        27.17 ns/op	       0 B/op	       0 allocs/op
BenchmarkPolicyPrefixMatch/IPv6/1K/Match-12          	34256880	       100.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkPolicyPrefixMatch/IPv6/1K/NoMatch-12        	153586796	        24.98 ns/op	       0 B/op	       0 allocs/op
BenchmarkPolicyPrefixMatch/IPv6/10K/Match-12         	38009024	        90.43 ns/op	       0 B/op	       0 allocs/op
BenchmarkPolicyPrefixMatch/IPv6/10K/NoMatch-12       	151826331	        25.59 ns/op	       0 B/op	       0 allocs/op


```