### PR TITLE
packet/bgp: Update NewPathAttributeMpReachNLRI()

### DIFF
--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -2221,7 +2221,8 @@ func parsePath(rf bgp.Family, args []string) (*api.Path, error) {
 	if rf == bgp.RF_IPv4_UC && net.ParseIP(nexthop).To4() != nil {
 		attrs = append(attrs, bgp.NewPathAttributeNextHop(nexthop))
 	} else {
-		mpreach := bgp.NewPathAttributeMpReachNLRI(nexthop, nlri)
+		nh, _ := netip.ParseAddr(nexthop)
+		mpreach, _ := bgp.NewPathAttributeMpReachNLRI(rf, []bgp.AddrPrefixInterface{nlri}, nh)
 		attrs = append(attrs, mpreach)
 	}
 

--- a/cmd/gobgp/mrt.go
+++ b/cmd/gobgp/mrt.go
@@ -20,6 +20,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"net/netip"
 	"os"
 	"strconv"
 	"strings"
@@ -158,11 +159,12 @@ func injectMrt() error {
 								attrs = append(attrs, attr)
 							} else {
 								a := attr.(*bgp.PathAttributeMpReachNLRI)
-								nexthop := a.Nexthop.String()
+								nexthop := a.Nexthop
 								if mrtOpts.NextHop != nil {
-									nexthop = mrtOpts.NextHop.String()
+									nexthop = netip.MustParseAddr(mrtOpts.NextHop.String())
 								}
-								attrs = append(attrs, bgp.NewPathAttributeMpReachNLRI(nexthop, nlri))
+								attr, _ := bgp.NewPathAttributeMpReachNLRI(rib.Family, []bgp.AddrPrefixInterface{nlri}, nexthop)
+								attrs = append(attrs, attr)
 							}
 						}
 					}

--- a/docs/sources/lib.md
+++ b/docs/sources/lib.md
@@ -13,6 +13,7 @@ package main
 
 import (
 	"context"
+	"net/netip"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -82,7 +83,7 @@ func main() {
 
 	// add v6 route
 	v6Nlri := bgp.NewIPv6AddrPrefix(64, "2001:db8:1::")
-	aMpr := bgp.NewPathAttributeMpReachNLRI("2001:db8::1", v6Nlri)
+	aMpr, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv4_UC, []bgp.AddrPrefixInterface{v6Nlri}, netip.MustParseAddr("2001:db8::1"))
 	aC := bgp.NewPathAttributeCommunities([]uint32{100, 200})
 	attrs = []bgp.PathAttributeInterface{aMpr, aC}
 

--- a/internal/pkg/table/message.go
+++ b/internal/pkg/table/message.go
@@ -314,7 +314,8 @@ func createMPReachMessage(path *Path) *bgp.BGPMessage {
 	attrs := make([]bgp.PathAttributeInterface, 0, len(oattrs))
 	for _, a := range oattrs {
 		if a.GetType() == bgp.BGP_ATTR_TYPE_MP_REACH_NLRI {
-			attrs = append(attrs, bgp.NewPathAttributeMpReachNLRI(path.GetNexthop().String(), path.GetNlri()))
+			attr, _ := bgp.NewPathAttributeMpReachNLRI(path.GetFamily(), []bgp.AddrPrefixInterface{path.GetNlri()}, path.GetNexthop())
+			attrs = append(attrs, attr)
 		} else {
 			attrs = append(attrs, a)
 		}

--- a/internal/pkg/table/message_test.go
+++ b/internal/pkg/table/message_test.go
@@ -17,6 +17,7 @@ package table
 
 import (
 	"fmt"
+	"net/netip"
 	"reflect"
 	"testing"
 	"time"
@@ -534,9 +535,9 @@ func TestMixedMPReachMPUnreach(t *testing.T) {
 	p := []bgp.PathAttributeInterface{
 		bgp.NewPathAttributeOrigin(0),
 		bgp.NewPathAttributeAsPath(aspath1),
-		bgp.NewPathAttributeMpReachNLRI("1::1", nlri1),
-		bgp.NewPathAttributeMpUnreachNLRI(nlri2),
 	}
+	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri1}, netip.MustParseAddr("1::1"))
+	p = append(p, mpreach, bgp.NewPathAttributeMpUnreachNLRI(nlri2))
 	msg := bgp.NewBGPUpdateMessage(nil, p, nil)
 	pList := ProcessMessage(msg, peerR1(), time.Now())
 	assert.Equal(t, len(pList), 2)

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -458,7 +458,7 @@ func (path *Path) GetNexthop() netip.Addr {
 func (path *Path) SetNexthop(nexthop net.IP) {
 	if path.GetFamily() == bgp.RF_IPv4_UC && nexthop.To4() == nil {
 		path.delPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
-		mpreach := bgp.NewPathAttributeMpReachNLRI(nexthop.String(), path.GetNlri())
+		mpreach, _ := bgp.NewPathAttributeMpReachNLRI(path.GetFamily(), []bgp.AddrPrefixInterface{path.GetNlri()}, netip.MustParseAddr(nexthop.String()))
 		path.setPathAttr(mpreach)
 		return
 	}
@@ -469,7 +469,8 @@ func (path *Path) SetNexthop(nexthop net.IP) {
 	attr = path.getPathAttr(bgp.BGP_ATTR_TYPE_MP_REACH_NLRI)
 	if attr != nil {
 		oldNlri := attr.(*bgp.PathAttributeMpReachNLRI)
-		path.setPathAttr(bgp.NewPathAttributeMpReachNLRI(nexthop.String(), oldNlri.Value...))
+		mpreach, _ := bgp.NewPathAttributeMpReachNLRI(path.GetFamily(), oldNlri.Value, netip.MustParseAddr(nexthop.String()))
+		path.setPathAttr(mpreach)
 	}
 }
 
@@ -1141,6 +1142,8 @@ func (lhs *Path) Compare(rhs *Path) int {
 
 func (v *Vrf) ToGlobalPath(path *Path) error {
 	nlri := path.GetNlri()
+	nh := path.GetNexthop()
+
 	switch rf := path.GetFamily(); rf {
 	case bgp.RF_IPv4_UC:
 		n := nlri.(*bgp.IPAddrPrefix)
@@ -1190,6 +1193,10 @@ func (v *Vrf) ToGlobalPath(path *Path) error {
 		return fmt.Errorf("unsupported route family for vrf: %s", rf)
 	}
 	path.SetExtCommunities(v.ExportRt, false)
+	// FIXME: we should not need to keep mp reach in Path.
+	path.delPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
+	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(path.family, []bgp.AddrPrefixInterface{path.OriginInfo().nlri}, nh)
+	path.setPathAttr(mpreach)
 	return nil
 }
 
@@ -1259,7 +1266,8 @@ func (p *Path) ToGlobal(vrf *Vrf) *Path {
 	path := NewPath(newFamily, p.OriginInfo().source, nlri, p.IsWithdraw, p.GetPathAttrs(), p.GetTimestamp(), false)
 	path.SetExtCommunities(vrf.ExportRt, false)
 	path.delPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
-	path.setPathAttr(bgp.NewPathAttributeMpReachNLRI(nh.String(), nlri))
+	attr, _ := bgp.NewPathAttributeMpReachNLRI(newFamily, []bgp.AddrPrefixInterface{nlri}, nh)
+	path.setPathAttr(attr)
 	return path
 }
 

--- a/internal/pkg/table/policy_test.go
+++ b/internal/pkg/table/policy_test.go
@@ -148,7 +148,7 @@ func TestPrefixCalcurateNoRangeIPv6(t *testing.T) {
 	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	mpnlri := bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")
-	mpreach := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1", mpnlri)
+	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{mpnlri}, netip.MustParseAddr("2001::192:168:50:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{mpreach, origin, aspath, med}
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, nil)
@@ -172,7 +172,7 @@ func TestPrefixCalcurateAddressIPv6(t *testing.T) {
 	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	mpnlri := bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")
-	mpreach := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1", mpnlri)
+	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{mpnlri}, netip.MustParseAddr("2001::192:168:50:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{mpreach, origin, aspath, med}
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, nil)
@@ -193,7 +193,7 @@ func TestPrefixCalcurateLengthIPv6(t *testing.T) {
 	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	mpnlri := bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")
-	mpreach := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1", mpnlri)
+	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{mpnlri}, netip.MustParseAddr("2001::192:168:50:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{mpreach, origin, aspath, med}
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, nil)
@@ -214,7 +214,7 @@ func TestPrefixCalcurateLengthRangeIPv6(t *testing.T) {
 	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	mpnlri := bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")
-	mpreach := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1", mpnlri)
+	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{mpnlri}, netip.MustParseAddr("2001::192:168:50:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{mpreach, origin, aspath, med}
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, nil)
@@ -436,7 +436,7 @@ func TestPolicyDifferentRoutefamilyOfPathAndPolicy(t *testing.T) {
 	aspathParamIPv6 := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
 	aspathIPv6 := bgp.NewPathAttributeAsPath(aspathParamIPv6)
 	mpnlriIPv6 := bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")
-	mpreachIPv6 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1", mpnlriIPv6)
+	mpreachIPv6, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{mpnlriIPv6}, netip.MustParseAddr("2001::192:168:50:1"))
 	medIPv6 := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributesIPv6 := []bgp.PathAttributeInterface{mpreachIPv6, originIPv6, aspathIPv6, medIPv6}
 	updateMsgIPv6 := bgp.NewBGPUpdateMessage(nil, pathAttributesIPv6, nil)

--- a/internal/pkg/table/table_manager_test.go
+++ b/internal/pkg/table/table_manager_test.go
@@ -256,8 +256,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv6(t *testing.T) {
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
-	mpReach1 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(100)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -269,8 +268,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv6(t *testing.T) {
 
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{65100, 65000})
-	mpReach2 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:100:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:100:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(100)
 	localpref2 := bgp.NewPathAttributeLocalPref(200)
 
@@ -416,8 +414,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv6(t *testing.T) {
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
-	mpReach1 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(100)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -429,8 +426,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv6(t *testing.T) {
 
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{})
-	mpReach2 := bgp.NewPathAttributeMpReachNLRI("::",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("::"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(100)
 	localpref2 := bgp.NewPathAttributeLocalPref(100)
 
@@ -685,8 +681,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv6(t *testing.T) {
 
 	origin1 := bgp.NewPathAttributeOrigin(1)
 	aspath1 := createAsPathAttribute([]uint32{65200, 65000})
-	mpReach1 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(100)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -698,8 +693,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv6(t *testing.T) {
 
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{65100, 65000})
-	mpReach2 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:100:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:100:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(100)
 	localpref2 := bgp.NewPathAttributeLocalPref(200)
 
@@ -843,8 +837,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv6(t *testing.T) {
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65200, 65000})
-	mpReach1 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(500)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -856,8 +849,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv6(t *testing.T) {
 
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{65100, 65000})
-	mpReach2 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:100:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:100:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref2 := bgp.NewPathAttributeLocalPref(100)
 
@@ -1001,8 +993,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000, 65200})
-	mpReach1 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -1014,8 +1005,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{65100, 65200})
-	mpReach2 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:100:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:100:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref2 := bgp.NewPathAttributeLocalPref(100)
 
@@ -1162,8 +1152,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv6(t *testing.T) {
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000, 65200})
-	mpReach1 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -1175,8 +1164,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv6(t *testing.T) {
 
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{65100, 65200})
-	mpReach2 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:100:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:100:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref2 := bgp.NewPathAttributeLocalPref(100)
 
@@ -1344,8 +1332,7 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
-	mpReach1 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -1357,8 +1344,7 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{65100, 65000})
-	mpReach2 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:100:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:100:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref2 := bgp.NewPathAttributeLocalPref(200)
 
@@ -1539,8 +1525,7 @@ func TestProcessBGPUpdate_bestpath_lost_ipv6(t *testing.T) {
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
-	mpReach1 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -1688,8 +1673,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv6(t *testing.T) {
 
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000, 65100, 65200})
-	mpReach1 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref1 := bgp.NewPathAttributeLocalPref(200)
 
@@ -1701,8 +1685,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv6(t *testing.T) {
 
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{65000, 65100})
-	mpReach2 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")}, netip.MustParseAddr("2001::192:168:50:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref2 := bgp.NewPathAttributeLocalPref(200)
 
@@ -1939,9 +1922,10 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 	checkPattr := func(expected *bgp.BGPMessage, actual *Path) {
 		bgpPathAttributes := expected.Body.(*bgp.BGPUpdate).PathAttributes
 		bgpUpdateNexthop := bgpPathAttributes[4]
-		expectedNexthopAttr := bgp.NewPathAttributeMpReachNLRI(
-			bgpUpdateNexthop.(*bgp.PathAttributeMpReachNLRI).Nexthop.String(),
-			actual.GetNlri())
+		nexthopStr := bgpUpdateNexthop.(*bgp.PathAttributeMpReachNLRI).Nexthop.String()
+		expectedNexthopAttr, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC,
+			[]bgp.AddrPrefixInterface{actual.GetNlri()},
+			netip.MustParseAddr(nexthopStr))
 		attr := actual.getPathAttr(bgp.BGP_ATTR_TYPE_MP_REACH_NLRI)
 		pathNexthop := attr.(*bgp.PathAttributeMpReachNLRI)
 		assert.Equal(t, expectedNexthopAttr, pathNexthop)
@@ -1981,39 +1965,33 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 
 	// path1
 	pathAttributes1 := createPathAttr([]uint32{65000, 65100, 65200})
-	mpreach1 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:1210:11::"),
-		bgp.NewIPv6AddrPrefix(64, "2001:123:1220:11::"),
-		bgp.NewIPv6AddrPrefix(64, "2001:123:1230:11::"),
-		bgp.NewIPv6AddrPrefix(64, "2001:123:1240:11::"),
-		bgp.NewIPv6AddrPrefix(64, "2001:123:1250:11::"),
-	)
+	mpreach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC,
+		[]bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:1210:11::"), bgp.NewIPv6AddrPrefix(64, "2001:123:1220:11::"), bgp.NewIPv6AddrPrefix(64, "2001:123:1230:11::"), bgp.NewIPv6AddrPrefix(64, "2001:123:1240:11::"), bgp.NewIPv6AddrPrefix(64, "2001:123:1250:11::")},
+		netip.MustParseAddr("2001::192:168:50:1"))
+
 	pathAttributes1 = append(pathAttributes1, mpreach1)
 	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, nil)
 
 	// path2
 	pathAttributes2 := createPathAttr([]uint32{65000, 65100, 65300})
-	mpreach2 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:1211:11::"),
-		bgp.NewIPv6AddrPrefix(64, "2001:123:1222:11::"),
-		bgp.NewIPv6AddrPrefix(64, "2001:123:1233:11::"),
-		bgp.NewIPv6AddrPrefix(64, "2001:123:1244:11::"),
-		bgp.NewIPv6AddrPrefix(64, "2001:123:1255:11::"),
-	)
+	mpreach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC,
+		[]bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:1211:11::"), bgp.NewIPv6AddrPrefix(64, "2001:123:1222:11::"), bgp.NewIPv6AddrPrefix(64, "2001:123:1233:11::"), bgp.NewIPv6AddrPrefix(64, "2001:123:1244:11::"), bgp.NewIPv6AddrPrefix(64, "2001:123:1255:11::")},
+		netip.MustParseAddr("2001::192:168:50:1"))
+
 	pathAttributes2 = append(pathAttributes2, mpreach2)
 	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, nil)
 
 	// path3
 	pathAttributes3 := createPathAttr([]uint32{65000, 65100, 65400})
-	mpreach3 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2001:123:1277:11::"),
-		bgp.NewIPv6AddrPrefix(64, "2001:123:1288:11::"))
+	mpreach3, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC,
+		[]bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:1277:11::"), bgp.NewIPv6AddrPrefix(64, "2001:123:1288:11::")},
+		netip.MustParseAddr("2001::192:168:50:1"))
 	pathAttributes3 = append(pathAttributes3, mpreach3)
 	bgpMessage3 := bgp.NewBGPUpdateMessage(nil, pathAttributes3, nil)
 
 	// path4
 	pathAttributes4 := createPathAttr([]uint32{65000, 65100, 65500})
-	mpreach4 := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1", bgp.NewIPv6AddrPrefix(64, "2001:123:1299:11::"))
+	mpreach4, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2001:123:1299:11::")}, netip.MustParseAddr("2001::192:168:50:1"))
 	pathAttributes4 = append(pathAttributes4, mpreach4)
 	bgpMessage4 := bgp.NewBGPUpdateMessage(nil, pathAttributes4, nil)
 
@@ -2066,11 +2044,9 @@ func TestProcessBGPUpdate_multiple_nlri_ipv4_split(t *testing.T) {
 
 	origin := bgp.NewPathAttributeOrigin(0)
 	aspath := createAsPathAttribute([]uint32{65000, 65100, 65200})
-	mpReach := bgp.NewPathAttributeMpReachNLRI("10.50.60.70",
-		bgp.NewIPAddrPrefix(32, "10.0.0.1"),
-		bgp.NewIPAddrPrefix(32, "10.0.0.2"),
-		bgp.NewIPAddrPrefix(32, "10.0.0.3"),
-	)
+	mpReach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv4_UC,
+		[]bgp.AddrPrefixInterface{bgp.NewIPAddrPrefix(32, "10.0.0.1"), bgp.NewIPAddrPrefix(32, "10.0.0.2"), bgp.NewIPAddrPrefix(32, "10.0.0.3")},
+		netip.MustParseAddr("10.50.60.70"))
 	med := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref := bgp.NewPathAttributeLocalPref(200)
 	pathAttributes := []bgp.PathAttributeInterface{
@@ -2166,7 +2142,7 @@ func update_fromR1_ipv6() *bgp.BGPMessage {
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 
 	mp_nlri := bgp.NewIPv6AddrPrefix(64, "2001:123:123:1::")
-	mpReach := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1", mp_nlri)
+	mpReach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{mp_nlri}, netip.MustParseAddr("2001::192:168:50:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 
 	pathAttributes := []bgp.PathAttributeInterface{
@@ -2199,8 +2175,7 @@ func update_fromR2() *bgp.BGPMessage {
 func update_fromR2_ipv6() *bgp.BGPMessage {
 	origin := bgp.NewPathAttributeOrigin(0)
 	aspath := createAsPathAttribute([]uint32{65100})
-	mpReach := bgp.NewPathAttributeMpReachNLRI("2001::192:168:100:1",
-		bgp.NewIPv6AddrPrefix(64, "2002:223:123:1::"))
+	mpReach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2002:223:123:1::")}, netip.MustParseAddr("2001::192:168:100:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(100)
 
 	pathAttributes := []bgp.PathAttributeInterface{
@@ -2243,8 +2218,7 @@ func update_fromR2viaR1() *bgp.BGPMessage {
 func update_fromR2viaR1_ipv6() *bgp.BGPMessage {
 	origin := bgp.NewPathAttributeOrigin(0)
 	aspath := createAsPathAttribute([]uint32{65000, 65100})
-	mpReach := bgp.NewPathAttributeMpReachNLRI("2001::192:168:50:1",
-		bgp.NewIPv6AddrPrefix(64, "2002:223:123:1::"))
+	mpReach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(64, "2002:223:123:1::")}, netip.MustParseAddr("2001::192:168:50:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(100)
 
 	pathAttributes := []bgp.PathAttributeInterface{

--- a/pkg/packet/bgp/helper.go
+++ b/pkg/packet/bgp/helper.go
@@ -15,6 +15,8 @@
 
 package bgp
 
+import "net/netip"
+
 func NewTestBGPOpenMessage() *BGPMessage {
 	p1 := NewOptionParameterCapability(
 		[]ParameterCapabilityInterface{NewCapRouteRefresh()})
@@ -113,17 +115,22 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 		NewPathAttributeExtendedCommunities(ecommunities),
 		NewPathAttributeAs4Path(aspath3),
 		NewPathAttributeAs4Aggregator(10000, "112.22.2.1"),
-		NewPathAttributeMpReachNLRI("112.22.2.0", prefixes1...),
-		NewPathAttributeMpReachNLRI("1023::", prefixes2...),
-		NewPathAttributeMpReachNLRI("fe80::", prefixes3...),
-		NewPathAttributeMpReachNLRI("129.1.1.1", prefixes4...),
-		NewPathAttributeMpReachNLRI("129.1.1.1", prefixes5...),
-		NewPathAttributeMpReachNLRI("135.1.1.1", prefixes6...),
+	}
+
+	// Create MP_REACH_NLRI attributes with error handling
+	mp1, _ := NewPathAttributeMpReachNLRI(RF_IPv4_VPN, prefixes1, netip.MustParseAddr("112.22.2.0"))
+	mp2, _ := NewPathAttributeMpReachNLRI(RF_IPv6_UC, prefixes2, netip.MustParseAddr("1023::"))
+	mp3, _ := NewPathAttributeMpReachNLRI(RF_IPv6_VPN, prefixes3, netip.MustParseAddr("fe80::"))
+	mp4, _ := NewPathAttributeMpReachNLRI(RF_IPv4_MPLS, prefixes4, netip.MustParseAddr("129.1.1.1"))
+	mp5, _ := NewPathAttributeMpReachNLRI(RF_EVPN, prefixes5, netip.MustParseAddr("129.1.1.1"))
+	mp6, _ := NewPathAttributeMpReachNLRI(RF_VPLS, prefixes6, netip.MustParseAddr("135.1.1.1"))
+
+	p = append(p, mp1, mp2, mp3, mp4, mp5, mp6,
 		NewPathAttributeMpUnreachNLRI(prefixes1...),
 		// NewPathAttributeMpReachNLRI("112.22.2.0", []AddrPrefixInterface{}),
 		// NewPathAttributeMpUnreachNLRI([]AddrPrefixInterface{}),
 		NewPathAttributeUnknown(BGP_ATTR_FLAG_TRANSITIVE, 100, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
-	}
+	)
 	n := []*IPAddrPrefix{NewIPAddrPrefix(24, "13.2.3.1")}
 	return NewBGPUpdateMessage(w, p, n)
 }

--- a/pkg/packet/bgp/validate_test.go
+++ b/pkg/packet/bgp/validate_test.go
@@ -3,6 +3,7 @@ package bgp
 import (
 	"encoding/binary"
 	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,8 +36,9 @@ func bgpupdateV6() *BGPMessage {
 	p := []PathAttributeInterface{
 		NewPathAttributeOrigin(1),
 		NewPathAttributeAsPath(aspath),
-		NewPathAttributeMpReachNLRI("1023::", prefixes...),
 	}
+	mpreach, _ := NewPathAttributeMpReachNLRI(RF_IPv6_UC, prefixes, netip.MustParseAddr("1023::"))
+	p = append(p, mpreach)
 	return NewBGPUpdateMessage(nil, p, nil)
 }
 
@@ -411,7 +413,7 @@ func Test_Validate_flowspec(t *testing.T) {
 	item7 := NewFlowSpecComponentItem(BITMASK_FLAG_OP_MATCH, isFragment)
 	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_FRAGMENT, []*FlowSpecComponentItem{item7}))
 	n1 := NewFlowSpecIPv4Unicast(cmp)
-	a := NewPathAttributeMpReachNLRI("", n1)
+	a, _ := NewPathAttributeMpReachNLRI(RF_FS_IPv4_UC, []AddrPrefixInterface{n1}, netip.IPv4Unspecified())
 	m := map[Family]BGPAddPathMode{RF_FS_IPv4_UC: BGP_ADD_PATH_NONE}
 	_, err := ValidateAttribute(a, m, false, false, false)
 	assert.NoError(err)
@@ -420,7 +422,7 @@ func Test_Validate_flowspec(t *testing.T) {
 	cmp = append(cmp, NewFlowSpecSourcePrefix(NewIPAddrPrefix(24, "10.0.0.0")))
 	cmp = append(cmp, NewFlowSpecDestinationPrefix(NewIPAddrPrefix(24, "10.0.0.0")))
 	n1 = NewFlowSpecIPv4Unicast(cmp)
-	a = NewPathAttributeMpReachNLRI("", n1)
+	a, _ = NewPathAttributeMpReachNLRI(RF_FS_IPv4_UC, []AddrPrefixInterface{n1}, netip.IPv4Unspecified())
 	// Swaps components order to reproduce the rules order violation.
 	n1.Value[0], n1.Value[1] = n1.Value[1], n1.Value[0]
 	_, err = ValidateAttribute(a, m, false, false, false)

--- a/pkg/packet/bgp/vpls_test.go
+++ b/pkg/packet/bgp/vpls_test.go
@@ -1,6 +1,7 @@
 package bgp
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,7 +71,7 @@ func Test_VPLSNLRI_decoding(t *testing.T) {
 
 	rd := NewRouteDistinguisherTwoOctetAS(65017, 104)
 	nlri := NewVPLSNLRI(rd, 1, 1, 8, 800000)
-	m2 := NewPathAttributeMpReachNLRI("192.0.2.7", nlri)
+	m2, _ := NewPathAttributeMpReachNLRI(RF_VPLS, []AddrPrefixInterface{nlri}, netip.MustParseAddr("192.0.2.7"))
 	m2.Flags |= BGP_ATTR_FLAG_EXTENDED_LENGTH
 
 	assert.Equal(m1, m2)


### PR DESCRIPTION
Update NewPathAttributeMpReachNLRI():

- handle two next hops.
- use netip.Addr instead of string for next hop
- return error

In MP_REACH, the Next Hop format varies by address family. We could introduce an MpReachNextHop interface and define per‑family Next Hop structs. However, the currently supported families can be handled with just two IP addresses, so let's keep the simpler implementation.