### PR TITLE
packet/mrt: update mrt APIs

### DIFF
--- a/cmd/gobgp/mrt.go
+++ b/cmd/gobgp/mrt.go
@@ -79,10 +79,9 @@ func injectMrt() error {
 				exitWithError(fmt.Errorf("failed to read: %s", err))
 			}
 
-			h := &mrt.MRTHeader{}
-			err = h.DecodeFromBytes(buf)
+			h, err := mrt.ParseHeader(buf)
 			if err != nil {
-				exitWithError(fmt.Errorf("failed to parse"))
+				exitWithError(fmt.Errorf("failed to parse: %s", err))
 			}
 
 			buf = make([]byte, h.Len)
@@ -91,7 +90,7 @@ func injectMrt() error {
 				exitWithError(fmt.Errorf("failed to read"))
 			}
 
-			msg, err := mrt.ParseMRTBody(h, buf)
+			msg, err := mrt.ParseBody(buf, h)
 			if err != nil {
 				printError(fmt.Errorf("failed to parse: %s", err))
 				continue


### PR DESCRIPTION
This avoids the current pattern of creating an uninitialized mrt objects and then mutating it via parsing, which is error-prone.

Additionally, since parsing Rib and RibEntry may require information from the header, we will update the API so that parsing them also requires the header.