### PR TITLE
server: move longLivedRunning from fsm to peer

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -197,7 +197,6 @@ type fsm struct {
 	marshallingOptions   *bgp.MarshallingOption
 	notification         chan *bgp.BGPMessage
 	logger               log.Logger
-	longLivedRunning     bool
 }
 
 func (fsm *fsm) bgpMessageStateUpdate(MessageType uint8, isIn bool) {

--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -114,6 +114,7 @@ type peer struct {
 	sentPaths           map[table.PathDestLocalKey]map[uint32]struct{}
 	sendMaxPathFiltered map[table.PathLocalKey]struct{}
 	llgrEndChs          []chan struct{}
+	longLivedRunning    bool
 }
 
 func newPeer(g *oc.Global, conf *oc.Neighbor, loc *table.TableManager, policy *table.RoutingPolicy, logger log.Logger) *peer {
@@ -487,7 +488,7 @@ func (peer *peer) stopPeerRestarting() {
 		close(ch)
 	}
 	peer.llgrEndChs = make([]chan struct{}, 0)
-	peer.fsm.longLivedRunning = false
+	peer.longLivedRunning = false
 }
 
 // Returns true if the peer is interested in this path according to BGP RTC

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1505,14 +1505,14 @@ func (s *BgpServer) handleFSMMessage(e *fsmMsg) {
 		} else if nextStateIdle {
 			peer.fsm.lock.RLock()
 			longLivedEnabled := peer.fsm.pConf.GracefulRestart.State.LongLivedEnabled
-			longLivedRunning := peer.fsm.longLivedRunning
+			longLivedRunning := peer.longLivedRunning
 			peer.fsm.lock.RUnlock()
 			// We must not restart LLGR timer until we have syncronized with
 			// the peer. Routes also need to be marked wit LLGR comm just once.
 			// https://datatracker.ietf.org/doc/html/rfc9494#session_resetsnever
 			if longLivedEnabled && !longLivedRunning {
 				peer.fsm.lock.Lock()
-				peer.fsm.longLivedRunning = true
+				peer.longLivedRunning = true
 				peer.fsm.lock.Unlock()
 				llgr, no_llgr := peer.llgrFamilies()
 


### PR DESCRIPTION
fsm doesn't use longLivedRunning. Better to have it in Peer.