### PR TITLE
packet/bgp: Update NewBGPOpenMessage()

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -1367,13 +1367,14 @@ func (msg *BGPOpen) Serialize(options ...*MarshallingOption) ([]byte, error) {
 	return append(buf, pbuf...), nil
 }
 
-func NewBGPOpenMessage(myas uint16, holdtime uint16, idstring string, optparams []OptionParameterInterface) *BGPMessage {
-	// TODO: return an error
-	id, _ := netip.ParseAddr(idstring)
+func NewBGPOpenMessage(myas uint16, holdtime uint16, id netip.Addr, optparams []OptionParameterInterface) (*BGPMessage, error) {
+	if !id.Is4() {
+		return nil, fmt.Errorf("invalid address")
+	}
 	return &BGPMessage{
 		Header: BGPHeader{Type: BGP_MSG_OPEN},
 		Body:   &BGPOpen{4, myas, holdtime, id, 0, optparams},
-	}
+	}, nil
 }
 
 type AddrPrefixInterface interface {

--- a/pkg/packet/bgp/helper.go
+++ b/pkg/packet/bgp/helper.go
@@ -32,8 +32,9 @@ func NewTestBGPOpenMessage() *BGPMessage {
 		[]ParameterCapabilityInterface{NewCapFourOctetASNumber(100000)})
 	p5 := NewOptionParameterCapability(
 		[]ParameterCapabilityInterface{NewCapAddPath([]*CapAddPathTuple{NewCapAddPathTuple(RF_IPv4_UC, BGP_ADD_PATH_BOTH)})})
-	return NewBGPOpenMessage(11033, 303, "100.4.10.3",
+	msg, _ := NewBGPOpenMessage(11033, 303, netip.MustParseAddr("100.4.10.3"),
 		[]OptionParameterInterface{p1, p2, p3, p4, p5})
+	return msg
 }
 
 func NewTestBGPUpdateMessage() *BGPMessage {

--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -848,8 +848,9 @@ func buildopen(gConf *oc.Global, pConf *oc.Neighbor) *bgp.BGPMessage {
 	if as > 1<<16-1 {
 		as = bgp.AS_TRANS
 	}
-	return bgp.NewBGPOpenMessage(uint16(as), holdTime, gConf.Config.RouterId,
+	msg, _ := bgp.NewBGPOpenMessage(uint16(as), holdTime, netip.MustParseAddr(gConf.Config.RouterId),
 		[]bgp.OptionParameterInterface{opt})
+	return msg
 }
 
 func readAll(conn net.Conn, length int) ([]byte, error) {

--- a/pkg/server/fsm_test.go
+++ b/pkg/server/fsm_test.go
@@ -142,6 +142,7 @@ func TestFSMHandlerOpensent_HoldTimerExpired(t *testing.T) {
 
 	// set holdtime
 	p.fsm.opensentHoldTime = 2
+	p.fsm.gConf.Config.RouterId = "1.1.1.1"
 
 	state, reason := h.opensent(t.Context())
 
@@ -356,16 +357,19 @@ func open() *bgp.BGPMessage {
 			[]*bgp.CapGracefulRestartTuple{g})})
 	p4 := bgp.NewOptionParameterCapability(
 		[]bgp.ParameterCapabilityInterface{bgp.NewCapFourOctetASNumber(100000)})
-	return bgp.NewBGPOpenMessage(11033, 303, "100.4.10.3",
+	msg, _ := bgp.NewBGPOpenMessage(11033, 303, netip.MustParseAddr("100.4.10.3"),
 		[]bgp.OptionParameterInterface{p1, p2, p3, p4})
+	return msg
 }
 
 func openWithBadBGPIdentifierZero() *bgp.BGPMessage {
-	return bgp.NewBGPOpenMessage(65000, 303, "0.0.0.0",
+	msg, _ := bgp.NewBGPOpenMessage(65000, 303, netip.MustParseAddr("0.0.0.0"),
 		[]bgp.OptionParameterInterface{})
+	return msg
 }
 
 func openWithBadBGPIdentifierSame() *bgp.BGPMessage {
-	return bgp.NewBGPOpenMessage(65000, 303, "192.168.1.1",
+	msg, _ := bgp.NewBGPOpenMessage(65000, 303, netip.MustParseAddr("192.168.1.1"),
 		[]bgp.OptionParameterInterface{})
+	return msg
 }


### PR DESCRIPTION
Update NewBGPOpenMessage()

- use netip.Prefix
- return error