### PR TITLE
packet/bgp: update NewRouteDistinguisherIPAddressAS()

### DIFF
--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -507,8 +507,9 @@ func UnmarshalRD(rd *api.RouteDistinguisher) (bgp.RouteDistinguisherInterface, e
 	case *api.RouteDistinguisher_TwoOctetAsn:
 		return bgp.NewRouteDistinguisherTwoOctetAS(uint16(v.TwoOctetAsn.Admin), v.TwoOctetAsn.Assigned), nil
 	case *api.RouteDistinguisher_IpAddress:
-		rd := bgp.NewRouteDistinguisherIPAddressAS(v.IpAddress.Admin, uint16(v.IpAddress.Assigned))
-		if rd == nil {
+		addr, _ := netip.ParseAddr(v.IpAddress.Admin)
+		rd, err := bgp.NewRouteDistinguisherIPAddressAS(addr, uint16(v.IpAddress.Assigned))
+		if err != nil {
 			return nil, fmt.Errorf("invalid address for route distinguisher: %s", v.IpAddress.Admin)
 		}
 		return rd, nil

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -1195,6 +1195,7 @@ func Test_ParseRouteDistinguisher(t *testing.T) {
 }
 
 func TestParseVPNPrefix(t *testing.T) {
+	rdip, _ := NewRouteDistinguisherIPAddressAS(netip.MustParseAddr("1.1.1.1"), uint16(100))
 	tests := []struct {
 		name     string
 		prefix   string
@@ -1213,7 +1214,7 @@ func TestParseVPNPrefix(t *testing.T) {
 			name:     "test valid RD type 1 VPNv4 prefix",
 			prefix:   "1.1.1.1:100:10.0.0.1/32",
 			valid:    true,
-			rd:       NewRouteDistinguisherIPAddressAS("1.1.1.1", uint16(100)),
+			rd:       rdip,
 			ipPrefix: "10.0.0.1/32",
 		},
 		{
@@ -1241,7 +1242,7 @@ func TestParseVPNPrefix(t *testing.T) {
 			name:     "test valid RD type 1 VPNv6 prefix",
 			prefix:   "1.1.1.1:100:100:1::/64",
 			valid:    true,
-			rd:       NewRouteDistinguisherIPAddressAS("1.1.1.1", uint16(100)),
+			rd:       rdip,
 			ipPrefix: "100:1::/64",
 		},
 		{

--- a/pkg/packet/bgp/helper.go
+++ b/pkg/packet/bgp/helper.go
@@ -76,8 +76,8 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 
 	vpn1, _ := NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("192.0.9.0/24"), *NewMPLSLabelStack(1, 2, 3),
 		NewRouteDistinguisherTwoOctetAS(256, 10000))
-	vpn2, _ := NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("192.10.8.0/24"), *NewMPLSLabelStack(5, 6, 7, 8),
-		NewRouteDistinguisherIPAddressAS("10.0.1.1", 10001))
+	rd, _ := NewRouteDistinguisherIPAddressAS(netip.MustParseAddr("10.0.1.1"), 10001)
+	vpn2, _ := NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("192.10.8.0/24"), *NewMPLSLabelStack(5, 6, 7, 8), rd)
 	prefixes1 := []AddrPrefixInterface{vpn1, vpn2}
 
 	nlri, _ := NewIPAddrPrefix(netip.MustParsePrefix("fe80:1234:1234:5667:8967:af12:8912:1023/128"))


### PR DESCRIPTION
Update NewRouteDistinguisherIPAddressAS()

- use netip.Addr
- return error