### PR TITLE
packet/bgp: update NewIPv4AddressSpecificExtended() and NewIPv6Addres…

### DIFF
--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -142,11 +142,13 @@ func redirectParser(args []string) ([]bgp.ExtendedCommunityInterface, error) {
 	case *bgp.TwoOctetAsSpecificExtended:
 		return []bgp.ExtendedCommunityInterface{bgp.NewRedirectTwoOctetAsSpecificExtended(r.AS, r.LocalAdmin)}, nil
 	case *bgp.IPv4AddressSpecificExtended:
-		return []bgp.ExtendedCommunityInterface{bgp.NewRedirectIPv4AddressSpecificExtended(r.IPv4.String(), r.LocalAdmin)}, nil
+		ex, _ := bgp.NewRedirectIPv4AddressSpecificExtended(r.IPv4, r.LocalAdmin)
+		return []bgp.ExtendedCommunityInterface{ex}, nil
 	case *bgp.FourOctetAsSpecificExtended:
 		return []bgp.ExtendedCommunityInterface{bgp.NewRedirectFourOctetAsSpecificExtended(r.AS, r.LocalAdmin)}, nil
 	case *bgp.IPv6AddressSpecificExtended:
-		return []bgp.ExtendedCommunityInterface{bgp.NewRedirectIPv6AddressSpecificExtended(r.IPv6.String(), r.LocalAdmin)}, nil
+		ex, _ := bgp.NewRedirectIPv6AddressSpecificExtended(r.IPv6, r.LocalAdmin)
+		return []bgp.ExtendedCommunityInterface{ex}, nil
 	}
 	return nil, fmt.Errorf("invalid redirect")
 }

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -535,7 +535,8 @@ func Test_FlowSpecExtended(t *testing.T) {
 	exts = append(exts, NewTrafficRateExtended(100, 9600.0))
 	exts = append(exts, NewTrafficActionExtended(true, false))
 	exts = append(exts, NewRedirectTwoOctetAsSpecificExtended(1000, 1000))
-	exts = append(exts, NewRedirectIPv4AddressSpecificExtended("10.0.0.1", 1000))
+	ex, _ := NewRedirectIPv4AddressSpecificExtended(netip.MustParseAddr("10.0.0.1"), 1000)
+	exts = append(exts, ex)
 	exts = append(exts, NewRedirectFourOctetAsSpecificExtended(10000000, 1000))
 	exts = append(exts, NewTrafficRemarkExtended(10))
 	m1 := NewPathAttributeExtendedCommunities(exts)
@@ -554,7 +555,8 @@ func Test_FlowSpecExtended(t *testing.T) {
 
 func Test_IP6FlowSpecExtended(t *testing.T) {
 	exts := make([]ExtendedCommunityInterface, 0)
-	exts = append(exts, NewRedirectIPv6AddressSpecificExtended("2001:db8::68", 1000))
+	ex, _ := NewRedirectIPv6AddressSpecificExtended(netip.MustParseAddr("2001:db8::68"), 1000)
+	exts = append(exts, ex)
 	m1 := NewPathAttributeIP6ExtendedCommunities(exts)
 	buf1, err := m1.Serialize()
 	require.NoError(t, err)

--- a/pkg/packet/bgp/helper.go
+++ b/pkg/packet/bgp/helper.go
@@ -62,10 +62,11 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 
 	isTransitive := true
 
+	ex3, _ := NewIPv4AddressSpecificExtended(EC_SUBTYPE_ROUTE_TARGET, netip.MustParseAddr("192.2.1.2"), 3000, isTransitive)
 	ecommunities := []ExtendedCommunityInterface{
 		NewTwoOctetAsSpecificExtended(EC_SUBTYPE_ROUTE_TARGET, 10003, 3<<20, isTransitive),
 		NewFourOctetAsSpecificExtended(EC_SUBTYPE_ROUTE_TARGET, 1<<20, 300, isTransitive),
-		NewIPv4AddressSpecificExtended(EC_SUBTYPE_ROUTE_TARGET, "192.2.1.2", 3000, isTransitive),
+		ex3,
 		NewOpaqueExtended(false, []byte{1, 2, 3, 4, 5, 6, 7}),
 		NewValidationExtended(VALIDATION_STATE_INVALID),
 		NewUnknownExtended(99, []byte{0, 1, 2, 3, 4, 5, 6, 7}),


### PR DESCRIPTION
…sSpecificExtended()

NewIPv4AddressSpecificExtended()
NewIPv6AddressSpecificExtended()
NewRedirectIPv4AddressSpecificExtended()
NewRedirectIPv6AddressSpecificExtended()

- use netip.Addr
- return error