### PR TITLE
packet/bgp: simplify MUPNLRI handling in NLRIFromSlice()

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -10156,20 +10156,11 @@ func NLRIFromSlice(family Family, buf []byte, options ...*MarshallingOption) (nl
 			return nil, err
 		}
 		return nlri, nil
-	case RF_MUP_IPv4:
+	case RF_MUP_IPv4, RF_MUP_IPv6:
 		nlri := &MUPNLRI{
-			Afi: AFI_IP,
+			Afi: family.Afi(),
 		}
-		err := nlri.DecodeFromBytes(buf, options...)
-		if err != nil {
-			return nil, err
-		}
-		return nlri, nil
-	case RF_MUP_IPv6:
-		nlri := &MUPNLRI{
-			Afi: AFI_IP6,
-		}
-		err := nlri.DecodeFromBytes(buf, options...)
+		err := nlri.decodeFromBytes(buf, options...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -3775,7 +3775,7 @@ func FuzzParseFlowSpecComponents(f *testing.F) {
 //nolint:errcheck
 func FuzzDecodeFromBytes(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		(&MUPNLRI{}).DecodeFromBytes(data)
+		(&MUPNLRI{}).decodeFromBytes(data)
 		if len(data) >= 2 {
 			l := len(data)
 			afi := binary.BigEndian.Uint16(data[l-2 : l])

--- a/pkg/packet/bgp/mup.go
+++ b/pkg/packet/bgp/mup.go
@@ -129,7 +129,7 @@ type MUPNLRI struct {
 	RouteTypeData    MUPRouteTypeInterface
 }
 
-func (n *MUPNLRI) DecodeFromBytes(data []byte, options ...*MarshallingOption) error {
+func (n *MUPNLRI) decodeFromBytes(data []byte, options ...*MarshallingOption) error {
 	if len(data) < 4 {
 		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all MUPNLRI bytes available")
 	}


### PR DESCRIPTION
We can handle RF_MUP_IPv4 and RF_MUP_IPv6 in a single case.

Also make decodeFromBytes private.