### PR TITLE
packet/bgp: add FlowSpecNLRI struct

### DIFF
--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -506,16 +506,10 @@ func parseFlowSpecArgs(rf bgp.Family, args []string) (bgp.AddrPrefixInterface, *
 
 	var nlri bgp.AddrPrefixInterface
 	switch rf {
-	case bgp.RF_FS_IPv4_UC:
-		nlri = bgp.NewFlowSpecIPv4Unicast(rules)
-	case bgp.RF_FS_IPv6_UC:
-		nlri = bgp.NewFlowSpecIPv6Unicast(rules)
-	case bgp.RF_FS_IPv4_VPN:
-		nlri = bgp.NewFlowSpecIPv4VPN(rd, rules)
-	case bgp.RF_FS_IPv6_VPN:
-		nlri = bgp.NewFlowSpecIPv6VPN(rd, rules)
-	case bgp.RF_FS_L2_VPN:
-		nlri = bgp.NewFlowSpecL2VPN(rd, rules)
+	case bgp.RF_FS_IPv4_UC, bgp.RF_FS_IPv6_UC:
+		nlri, _ = bgp.NewFlowSpecUnicast(rf, rules)
+	case bgp.RF_FS_IPv4_VPN, bgp.RF_FS_IPv6_VPN, bgp.RF_FS_L2_VPN:
+		nlri, _ = bgp.NewFlowSpecVPN(rf, rd, rules)
 	default:
 		return nil, nil, nil, fmt.Errorf("invalid route family")
 	}

--- a/pkg/packet/bgp/validate.go
+++ b/pkg/packet/bgp/validate.go
@@ -101,20 +101,7 @@ func ValidateAttribute(a PathAttributeInterface, rfs map[Family]BGPAddPathMode, 
 			switch family {
 			case RF_FS_IPv4_UC, RF_FS_IPv6_UC, RF_FS_IPv4_VPN, RF_FS_IPv6_VPN, RF_FS_L2_VPN:
 				t := BGPFlowSpecType(0)
-				value := make([]FlowSpecComponentInterface, 0)
-				switch family {
-				case RF_FS_IPv4_UC:
-					value = prefix.(*FlowSpecIPv4Unicast).Value
-				case RF_FS_IPv6_UC:
-					value = prefix.(*FlowSpecIPv6Unicast).Value
-				case RF_FS_IPv4_VPN:
-					value = prefix.(*FlowSpecIPv4VPN).Value
-				case RF_FS_IPv6_VPN:
-					value = prefix.(*FlowSpecIPv6VPN).Value
-				case RF_FS_L2_VPN:
-					value = prefix.(*FlowSpecL2VPN).Value
-				}
-				for _, v := range value {
+				for _, v := range prefix.(*FlowSpecNLRI).Value {
 					if v.Type() <= t {
 						return NewMessageError(0, 0, nil, fmt.Sprintf("%s nlri violate strict type ordering", family))
 					}

--- a/pkg/packet/bgp/validate_test.go
+++ b/pkg/packet/bgp/validate_test.go
@@ -416,7 +416,7 @@ func Test_Validate_flowspec(t *testing.T) {
 	isFragment := uint64(0x02)
 	item7 := NewFlowSpecComponentItem(BITMASK_FLAG_OP_MATCH, isFragment)
 	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_FRAGMENT, []*FlowSpecComponentItem{item7}))
-	n1 := NewFlowSpecIPv4Unicast(cmp)
+	n1, _ := NewFlowSpecUnicast(RF_FS_IPv4_UC, cmp)
 	a, _ := NewPathAttributeMpReachNLRI(RF_FS_IPv4_UC, []AddrPrefixInterface{n1}, netip.IPv4Unspecified())
 	m := map[Family]BGPAddPathMode{RF_FS_IPv4_UC: BGP_ADD_PATH_NONE}
 	_, err := ValidateAttribute(a, m, false, false, false)
@@ -427,7 +427,7 @@ func Test_Validate_flowspec(t *testing.T) {
 	cmp = append(cmp, NewFlowSpecSourcePrefix(srcPrefix2))
 	destPrefix2, _ := NewIPAddrPrefix(netip.MustParsePrefix("10.0.0.0/24"))
 	cmp = append(cmp, NewFlowSpecDestinationPrefix(destPrefix2))
-	n1 = NewFlowSpecIPv4Unicast(cmp)
+	n1, _ = NewFlowSpecUnicast(RF_FS_IPv4_UC, cmp)
 	a, _ = NewPathAttributeMpReachNLRI(RF_FS_IPv4_UC, []AddrPrefixInterface{n1}, netip.IPv4Unspecified())
 	// Swaps components order to reproduce the rules order violation.
 	n1.Value[0], n1.Value[1] = n1.Value[1], n1.Value[0]


### PR DESCRIPTION
Use new FlowSpecNLRI struct for all the flowspec NLRI types.

This removes the followings:

FlowSpecIPv4Unicast
FlowSpecIPv6Unicast
FlowSpecIPv4VPN
FlowSpecIPv6VPN
FlowSpecL2VPN