### PR TITLE
packet/bgp: make DecodeFromBytes private

### DIFF
--- a/internal/pkg/table/table_test.go
+++ b/internal/pkg/table/table_test.go
@@ -731,10 +731,9 @@ func Test_RouteTargetKey(t *testing.T) {
 	buf[6] = byte(bgp.EC_SUBTYPE_ROUTE_TARGET)                  // subtype
 	binary.BigEndian.PutUint16(buf[7:9], 0x1314)
 	binary.BigEndian.PutUint32(buf[9:], 0x15161718)
-	r := &bgp.RouteTargetMembershipNLRI{}
-	err := r.DecodeFromBytes(buf)
+	r, err := bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	key, err := extCommRouteTargetKey(r.RouteTarget)
+	key, err := extCommRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI).RouteTarget)
 	assert.NoError(err)
 	assert.Equal(uint64(0x0002131415161718), key)
 
@@ -747,10 +746,9 @@ func Test_RouteTargetKey(t *testing.T) {
 	ip := net.ParseIP("10.1.2.3").To4()
 	copy(buf[7:11], []byte(ip))
 	binary.BigEndian.PutUint16(buf[11:], 0x1314)
-	r = &bgp.RouteTargetMembershipNLRI{}
-	err = r.DecodeFromBytes(buf)
+	r, err = bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	key, err = extCommRouteTargetKey(r.RouteTarget)
+	key, err = extCommRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI).RouteTarget)
 	assert.NoError(err)
 	assert.Equal(uint64(0x01020a0102031314), key)
 
@@ -762,10 +760,9 @@ func Test_RouteTargetKey(t *testing.T) {
 	buf[6] = byte(bgp.EC_SUBTYPE_ROUTE_TARGET)                   // subtype
 	binary.BigEndian.PutUint32(buf[7:], 0x15161718)
 	binary.BigEndian.PutUint16(buf[11:], 0x1314)
-	r = &bgp.RouteTargetMembershipNLRI{}
-	err = r.DecodeFromBytes(buf)
+	r, err = bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	key, err = extCommRouteTargetKey(r.RouteTarget)
+	key, err = extCommRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI).RouteTarget)
 	assert.NoError(err)
 	assert.Equal(uint64(0x0202151617181314), key)
 
@@ -775,10 +772,9 @@ func Test_RouteTargetKey(t *testing.T) {
 	binary.BigEndian.PutUint32(buf[1:5], 65546)
 	buf[5] = byte(bgp.EC_TYPE_TRANSITIVE_OPAQUE) // typehigh
 	binary.BigEndian.PutUint32(buf[9:], 1000000)
-	r = &bgp.RouteTargetMembershipNLRI{}
-	err = r.DecodeFromBytes(buf)
+	r, err = bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	_, err = extCommRouteTargetKey(r.RouteTarget)
+	_, err = extCommRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI).RouteTarget)
 	assert.NotNil(err)
 }
 

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -2250,7 +2250,7 @@ type RouteTargetMembershipNLRI struct {
 	RouteTarget ExtendedCommunityInterface
 }
 
-func (n *RouteTargetMembershipNLRI) DecodeFromBytes(data []byte, options ...*MarshallingOption) error {
+func (n *RouteTargetMembershipNLRI) decodeFromBytes(data []byte, options ...*MarshallingOption) error {
 	if IsAddPathEnabled(true, RF_RTC_UC, options) {
 		var err error
 		data, err = n.decodePathIdentifier(data)
@@ -3367,7 +3367,7 @@ type EVPNNLRI struct {
 	RouteTypeData EVPNRouteTypeInterface
 }
 
-func (n *EVPNNLRI) DecodeFromBytes(data []byte, options ...*MarshallingOption) error {
+func (n *EVPNNLRI) decodeFromBytes(data []byte, options ...*MarshallingOption) error {
 	if IsAddPathEnabled(true, RF_EVPN, options) {
 		var err error
 		data, err = n.decodePathIdentifier(data)
@@ -4994,7 +4994,7 @@ type OpaqueNLRI struct {
 	Value  []byte
 }
 
-func (n *OpaqueNLRI) DecodeFromBytes(data []byte, options ...*MarshallingOption) error {
+func (n *OpaqueNLRI) decodeFromBytes(data []byte, options ...*MarshallingOption) error {
 	if len(data) < 2 {
 		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all OpaqueNLRI bytes available")
 	}
@@ -9437,7 +9437,7 @@ func (l *LsAddrPrefix) Len(...*MarshallingOption) int {
 	return 4 + int(l.Length)
 }
 
-func (l *LsAddrPrefix) DecodeFromBytes(data []byte, options ...*MarshallingOption) error {
+func (l *LsAddrPrefix) decodeFromBytes(data []byte, options ...*MarshallingOption) error {
 	if len(data) < 4 {
 		return malformedAttrListErr("Malformed BGP-LS Address Prefix")
 	}
@@ -9992,14 +9992,14 @@ func NLRIFromSlice(family Family, buf []byte, options ...*MarshallingOption) (nl
 		return nlri, nil
 	case RF_EVPN:
 		nlri := &EVPNNLRI{}
-		err := nlri.DecodeFromBytes(buf, options...)
+		err := nlri.decodeFromBytes(buf, options...)
 		if err != nil {
 			return nil, err
 		}
 		return nlri, nil
 	case RF_VPLS:
 		nlri := &VPLSNLRI{}
-		err := nlri.DecodeFromBytes(buf, options...)
+		err := nlri.decodeFromBytes(buf, options...)
 		if err != nil {
 			return nil, err
 		}
@@ -10016,7 +10016,7 @@ func NLRIFromSlice(family Family, buf []byte, options ...*MarshallingOption) (nl
 		return nlri, nil
 	case RF_RTC_UC:
 		nlri := &RouteTargetMembershipNLRI{}
-		err := nlri.DecodeFromBytes(buf, options...)
+		err := nlri.decodeFromBytes(buf, options...)
 		if err != nil {
 			return nil, err
 		}
@@ -10040,14 +10040,14 @@ func NLRIFromSlice(family Family, buf []byte, options ...*MarshallingOption) (nl
 		return nlri, nil
 	case RF_OPAQUE:
 		nlri := &OpaqueNLRI{}
-		err := nlri.DecodeFromBytes(buf, options...)
+		err := nlri.decodeFromBytes(buf, options...)
 		if err != nil {
 			return nil, err
 		}
 		return nlri, nil
 	case RF_LS:
 		nlri := &LsAddrPrefix{}
-		err := nlri.DecodeFromBytes(buf, options...)
+		err := nlri.decodeFromBytes(buf, options...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -121,12 +121,12 @@ func Test_RouteTargetMembershipNLRIString(t *testing.T) {
 	binary.BigEndian.PutUint16(buf[7:9], 65000)
 	binary.BigEndian.PutUint32(buf[9:], 65546)
 	r := &RouteTargetMembershipNLRI{}
-	err := r.DecodeFromBytes(buf)
+	err := r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("65546:65000:65546", r.String())
 	buf, err = r.Serialize()
 	assert.NoError(err)
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("65546:65000:65546", r.String())
 
@@ -139,12 +139,12 @@ func Test_RouteTargetMembershipNLRIString(t *testing.T) {
 	copy(buf[7:11], []byte(ip))
 	binary.BigEndian.PutUint16(buf[11:], 65000)
 	r = &RouteTargetMembershipNLRI{}
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("65546:10.0.0.1:65000", r.String())
 	buf, err = r.Serialize()
 	assert.NoError(err)
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("65546:10.0.0.1:65000", r.String())
 
@@ -157,12 +157,12 @@ func Test_RouteTargetMembershipNLRIString(t *testing.T) {
 	binary.BigEndian.PutUint32(buf[7:], 65546)
 	binary.BigEndian.PutUint16(buf[11:], 65000)
 	r = &RouteTargetMembershipNLRI{}
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("65546:1.10:65000", r.String())
 	buf, err = r.Serialize()
 	assert.NoError(err)
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("65546:1.10:65000", r.String())
 
@@ -173,12 +173,12 @@ func Test_RouteTargetMembershipNLRIString(t *testing.T) {
 	buf[5] = byte(EC_TYPE_TRANSITIVE_OPAQUE) // typehigh
 	binary.BigEndian.PutUint32(buf[9:], 1000000)
 	r = &RouteTargetMembershipNLRI{}
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("65546:1000000", r.String())
 	buf, err = r.Serialize()
 	assert.NoError(err)
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("65546:1000000", r.String())
 
@@ -189,12 +189,12 @@ func Test_RouteTargetMembershipNLRIString(t *testing.T) {
 	buf[5] = 0x04 // typehigh
 	binary.BigEndian.PutUint32(buf[9:], 1000000)
 	r = &RouteTargetMembershipNLRI{}
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("65546:1000000", r.String())
 	buf, err = r.Serialize()
 	assert.NoError(err)
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("65546:1000000", r.String())
 
@@ -202,18 +202,18 @@ func Test_RouteTargetMembershipNLRIString(t *testing.T) {
 	buf = make([]byte, 1)
 	buf[0] = 0 // in bit length
 	r = &RouteTargetMembershipNLRI{}
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("default", r.String())
 	buf, err = r.Serialize()
 	assert.NoError(err)
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("default", r.String())
 	r = NewRouteTargetMembershipNLRI(0, nil)
 	buf, err = r.Serialize()
 	assert.NoError(err)
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("default", r.String())
 
@@ -222,13 +222,13 @@ func Test_RouteTargetMembershipNLRIString(t *testing.T) {
 	buf[0] = 32 // in bit length
 	binary.BigEndian.PutUint32(buf[1:5], 65546)
 	r = &RouteTargetMembershipNLRI{}
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("65546:0:0", r.String())
 	r = NewRouteTargetMembershipNLRI(65546, nil)
 	buf, err = r.Serialize()
 	assert.NoError(err)
-	err = r.DecodeFromBytes(buf)
+	err = r.decodeFromBytes(buf)
 	assert.NoError(err)
 	assert.Equal("65546:0:0", r.String())
 }
@@ -787,7 +787,7 @@ func Test_AddPath(t *testing.T) {
 		bits, err := n1.Serialize(opt)
 		assert.NoError(err)
 		n2 := NewRouteTargetMembershipNLRI(0, nil)
-		err = n2.DecodeFromBytes(bits, opt)
+		err = n2.decodeFromBytes(bits, opt)
 		assert.NoError(err)
 		assert.Equal(n2.PathIdentifier(), uint32(30))
 	}
@@ -803,7 +803,7 @@ func Test_AddPath(t *testing.T) {
 		bits, err := n1.Serialize(opt)
 		assert.NoError(err)
 		n2 := NewEVPNNLRI(0, nil)
-		err = n2.DecodeFromBytes(bits, opt)
+		err = n2.decodeFromBytes(bits, opt)
 		assert.NoError(err)
 		assert.Equal(n2.PathIdentifier(), uint32(40))
 	}
@@ -835,7 +835,7 @@ func Test_AddPath(t *testing.T) {
 		bits, err := n1.Serialize(opt)
 		assert.NoError(err)
 		n2 := &OpaqueNLRI{}
-		err = n2.DecodeFromBytes(bits, opt)
+		err = n2.decodeFromBytes(bits, opt)
 		assert.NoError(err)
 		assert.Equal(n2.PathIdentifier(), uint32(70))
 	}
@@ -3513,9 +3513,9 @@ func Test_LsAddrPrefix(t *testing.T) {
 	for _, test := range tests {
 		nlri := LsAddrPrefix{}
 		if test.err {
-			assert.Error(nlri.DecodeFromBytes(test.in))
+			assert.Error(nlri.decodeFromBytes(test.in))
 		} else {
-			assert.NoError(nlri.DecodeFromBytes(test.in))
+			assert.NoError(nlri.decodeFromBytes(test.in))
 			assert.Equal(test.str, nlri.String())
 			if test.serialize {
 				got, err := nlri.Serialize()
@@ -3802,7 +3802,7 @@ func FuzzDecodeFromBytes(f *testing.F) {
 		(&MPLSLabelStack{}).DecodeFromBytes(data)
 		(&LabeledVPNIPAddrPrefix{}).decodeFromBytes(data)
 		(&LabeledIPAddrPrefix{}).decodeFromBytes(data)
-		(&RouteTargetMembershipNLRI{}).DecodeFromBytes(data)
+		(&RouteTargetMembershipNLRI{}).decodeFromBytes(data)
 		(&EthernetSegmentIdentifier{}).DecodeFromBytes(data)
 		(&EVPNEthernetAutoDiscoveryRoute{}).DecodeFromBytes(data)
 		(&EVPNMacIPAdvertisementRoute{}).DecodeFromBytes(data)
@@ -3810,7 +3810,7 @@ func FuzzDecodeFromBytes(f *testing.F) {
 		(&EVPNEthernetSegmentRoute{}).DecodeFromBytes(data)
 		(&EVPNIPPrefixRoute{}).DecodeFromBytes(data)
 		(&EVPNIPMSIRoute{}).DecodeFromBytes(data)
-		(&EVPNNLRI{}).DecodeFromBytes(data)
+		(&EVPNNLRI{}).decodeFromBytes(data)
 		(&EncapNLRI{}).decodeFromBytes(data)
 		(&flowSpecPrefix{}).DecodeFromBytes(data)
 		(&flowSpecPrefix6{}).DecodeFromBytes(data)
@@ -3822,7 +3822,7 @@ func FuzzDecodeFromBytes(f *testing.F) {
 		(&FlowSpecNLRI{rf: RF_FS_IPv4_VPN}).decodeFromBytes(data)
 		(&FlowSpecNLRI{rf: RF_FS_IPv6_VPN}).decodeFromBytes(data)
 		(&FlowSpecNLRI{rf: RF_FS_L2_VPN}).decodeFromBytes(data)
-		(&OpaqueNLRI{}).DecodeFromBytes(data)
+		(&OpaqueNLRI{}).decodeFromBytes(data)
 		(&LsNLRI{}).DecodeFromBytes(data)
 		(&LsNodeNLRI{}).DecodeFromBytes(data)
 		(&LsLinkNLRI{}).DecodeFromBytes(data)
@@ -3875,7 +3875,7 @@ func FuzzDecodeFromBytes(f *testing.F) {
 		(&LsTLVIGPFlags{}).DecodeFromBytes(data)
 		(&LsTLVOpaquePrefixAttr{}).DecodeFromBytes(data)
 		(&LsTLVNodeDescriptor{}).DecodeFromBytes(data)
-		(&LsAddrPrefix{}).DecodeFromBytes(data)
+		(&LsAddrPrefix{}).decodeFromBytes(data)
 		(&PathAttributeLs{}).DecodeFromBytes(data)
 		(&PathAttribute{}).DecodeFromBytes(data)
 		(&PathAttributeOrigin{}).DecodeFromBytes(data)
@@ -3927,7 +3927,7 @@ func FuzzDecodeFromBytes(f *testing.F) {
 		(&SRv6EndpointBehaviorStructure{}).DecodeFromBytes(data)
 		(&SegmentTypeB{}).DecodeFromBytes(data)
 		(&TunnelEncapSubTLVSRSegmentList{}).DecodeFromBytes(data)
-		(&VPLSNLRI{}).DecodeFromBytes(data)
+		(&VPLSNLRI{}).decodeFromBytes(data)
 		(&TLV{}).DecodeFromBytes(data)
 		(&PathAttributePrefixSID{}).DecodeFromBytes(data)
 		(&SRv6L3ServiceAttribute{}).DecodeFromBytes(data)

--- a/pkg/packet/bgp/vpls.go
+++ b/pkg/packet/bgp/vpls.go
@@ -36,7 +36,7 @@ type VPLSNLRI struct {
 	rd RouteDistinguisherInterface
 }
 
-func (n *VPLSNLRI) DecodeFromBytes(data []byte, options ...*MarshallingOption) error {
+func (n *VPLSNLRI) decodeFromBytes(data []byte, options ...*MarshallingOption) error {
 	/*
 		RFC6074 Section 7 BGP-AD and VPLS-BGP Interoperability
 		Both BGP-AD and VPLS-BGP [RFC4761] use the same AFI/SAFI.  In order

--- a/pkg/packet/bgp/vpls_test.go
+++ b/pkg/packet/bgp/vpls_test.go
@@ -49,7 +49,7 @@ func Test_VPLSNLRI(t *testing.T) {
 	buf1, err := n1.Serialize()
 	assert.NoError(err)
 	n2 := &VPLSNLRI{}
-	err = n2.DecodeFromBytes(buf1)
+	err = n2.decodeFromBytes(buf1)
 	assert.NoError(err)
 
 	t.Logf("%s", n1)


### PR DESCRIPTION
This avoids the current pattern of creating an uninitialized AddrPrefix objects and then mutating it via parsing, which is error-prone.