### PR TITLE
packet/bgp: remove AddPath methods in AddrPrefixInterface

### DIFF
--- a/cmd/gobgp/mrt.go
+++ b/cmd/gobgp/mrt.go
@@ -162,7 +162,7 @@ func injectMrt() error {
 								if mrtOpts.NextHop != nil {
 									nexthop = netip.MustParseAddr(mrtOpts.NextHop.String())
 								}
-								attr, _ := bgp.NewPathAttributeMpReachNLRI(rib.Family, []bgp.AddrPrefixInterface{nlri}, nexthop)
+								attr, _ := bgp.NewPathAttributeMpReachNLRI(rib.Family, []bgp.PathNLRI{{NLRI: nlri}}, nexthop)
 								attrs = append(attrs, attr)
 							}
 						}

--- a/docs/sources/lib.md
+++ b/docs/sources/lib.md
@@ -83,7 +83,7 @@ func main() {
 
 	// add v6 route
 	v6Nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:db8:1::/64"))
-	aMpr, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv4_UC, []bgp.AddrPrefixInterface{v6Nlri}, netip.MustParseAddr("2001:db8::1"))
+	aMpr, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv4_UC, []bgp.PathNLRI{{NLRI: v6Nlri}}, netip.MustParseAddr("2001:db8::1"))
 	aC := bgp.NewPathAttributeCommunities([]uint32{100, 200})
 	attrs = []bgp.PathAttributeInterface{aMpr, aC}
 

--- a/internal/pkg/table/adj.go
+++ b/internal/pkg/table/adj.go
@@ -51,7 +51,7 @@ func (adj *AdjRib) Update(pathList []*Path) {
 		var old *Path
 		idx := -1
 		for i, p := range d.knownPathList {
-			if p.GetNlri().PathIdentifier() == path.GetNlri().PathIdentifier() {
+			if p.remoteID == path.remoteID {
 				idx = i
 				break
 			}

--- a/internal/pkg/table/adj_test.go
+++ b/internal/pkg/table/adj_test.go
@@ -30,11 +30,11 @@ func TestAddPath(t *testing.T) {
 	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
 
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
-	nlri1.SetPathIdentifier(1)
-	p1 := NewPath(bgp.RF_IPv4_UC, pi, nlri1, false, attrs, time.Now(), false)
+	p1 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri1}, false, attrs, time.Now(), false)
+	p1.remoteID = 1
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
-	nlri2.SetPathIdentifier(2)
-	p2 := NewPath(bgp.RF_IPv4_UC, pi, nlri2, false, attrs, time.Now(), false)
+	p2 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri2}, false, attrs, time.Now(), false)
+	p2.remoteID = 2
 	family := p1.GetFamily()
 	families := []bgp.Family{family}
 
@@ -43,13 +43,14 @@ func TestAddPath(t *testing.T) {
 	assert.Equal(t, len(adj.table[family].GetDestinations()), 1)
 	assert.Equal(t, adj.Count([]bgp.Family{family}), 2)
 
-	p3 := NewPath(bgp.RF_IPv4_UC, pi, nlri2, false, attrs, time.Now(), false)
+	p3 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri2}, false, attrs, time.Now(), false)
+	p3.remoteID = 2
 	adj.Update([]*Path{p3})
 
 	var found *Path
 	for _, d := range adj.table[family].GetDestinations() {
 		for _, p := range d.knownPathList {
-			if p.GetNlri().PathIdentifier() == nlri2.PathIdentifier() {
+			if p.remoteID == 2 {
 				found = p
 				break
 			}
@@ -67,21 +68,21 @@ func TestAddPathAdjOut(t *testing.T) {
 	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
 
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
-	nlri1.SetPathIdentifier(1)
-	nlri1.SetPathLocalIdentifier(1)
-	p1 := NewPath(bgp.RF_IPv4_UC, pi, nlri1, false, attrs, time.Now(), false)
+	p1 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri1}, false, attrs, time.Now(), false)
+	p1.localID = 1
+	p1.remoteID = 1
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
-	nlri2.SetPathIdentifier(1)
-	nlri2.SetPathLocalIdentifier(2)
-	p2 := NewPath(bgp.RF_IPv4_UC, pi, nlri2, false, attrs, time.Now(), false)
+	p2 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri2}, false, attrs, time.Now(), false)
+	p2.localID = 2
+	p2.remoteID = 1
 	nlri3, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
-	nlri3.SetPathIdentifier(2)
-	nlri3.SetPathLocalIdentifier(3)
-	p3 := NewPath(bgp.RF_IPv4_UC, pi, nlri3, false, attrs, time.Now(), false)
+	p3 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri3}, false, attrs, time.Now(), false)
+	p3.localID = 3
+	p3.remoteID = 2
 	nlri4, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
-	nlri4.SetPathIdentifier(3)
-	nlri4.SetPathLocalIdentifier(4)
-	p4 := NewPath(bgp.RF_IPv4_UC, pi, nlri4, false, attrs, time.Now(), false)
+	p4 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri4}, false, attrs, time.Now(), false)
+	p4.localID = 4
+	p4.remoteID = 3
 	family := p1.GetFamily()
 	families := []bgp.Family{family}
 
@@ -96,9 +97,9 @@ func TestStale(t *testing.T) {
 	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
 
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.10.0/24"))
-	p1 := NewPath(bgp.RF_IPv4_UC, pi, nlri1, false, attrs, time.Now(), false)
+	p1 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri1}, false, attrs, time.Now(), false)
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
-	p2 := NewPath(bgp.RF_IPv4_UC, pi, nlri2, false, attrs, time.Now(), false)
+	p2 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri2}, false, attrs, time.Now(), false)
 	p2.SetRejected(true)
 
 	family := p1.GetFamily()
@@ -118,7 +119,7 @@ func TestStale(t *testing.T) {
 	}
 
 	nlri3, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.30.0/24"))
-	p3 := NewPath(bgp.RF_IPv4_UC, pi, nlri3, false, attrs, time.Now(), false)
+	p3 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri3}, false, attrs, time.Now(), false)
 	adj.Update([]*Path{p1, p3})
 
 	droppedPathList := adj.DropStale(families)
@@ -132,20 +133,20 @@ func TestLLGRStale(t *testing.T) {
 	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
 
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.10.0/24"))
-	p1 := NewPath(bgp.RF_IPv4_UC, pi, nlri1, false, attrs, time.Now(), false)
+	p1 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri1}, false, attrs, time.Now(), false)
 
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
-	p2 := NewPath(bgp.RF_IPv4_UC, pi, nlri2, false, attrs, time.Now(), false)
+	p2 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri2}, false, attrs, time.Now(), false)
 	p2.SetRejected(true) // Not accepted
 
 	nlri3, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.30.0/24"))
-	p3 := NewPath(bgp.RF_IPv4_UC, pi, nlri3, false, attrs, time.Now(), false)
+	p3 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri3}, false, attrs, time.Now(), false)
 	p3.SetRejected(true)
 	// Not accepted and then dropped on MarkLLGRStaleOrDrop
 	p3.SetCommunities([]uint32{uint32(bgp.COMMUNITY_NO_LLGR)}, false)
 
 	nlri4, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.40.0/24"))
-	p4 := NewPath(bgp.RF_IPv4_UC, pi, nlri4, false, attrs, time.Now(), false)
+	p4 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri4}, false, attrs, time.Now(), false)
 	// dropped on MarkLLGRStaleOrDrop
 	p4.SetCommunities([]uint32{uint32(bgp.COMMUNITY_NO_LLGR)}, false)
 

--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -220,7 +220,7 @@ func (dest *Destination) Calculate(logger log.Logger, newPath *Path) *Update {
 	if newPath.IsWithdraw {
 		p := dest.explicitWithdraw(logger, newPath)
 		if p != nil && newPath.IsDropped() {
-			if id := p.GetNlri().PathLocalIdentifier(); id != 0 {
+			if id := p.localID; id != 0 {
 				dest.localIdMap.Unflag(uint(id))
 			}
 		}
@@ -230,13 +230,13 @@ func (dest *Destination) Calculate(logger log.Logger, newPath *Path) *Update {
 	}
 
 	for _, path := range dest.knownPathList {
-		if path.GetNlri().PathLocalIdentifier() == 0 {
+		if path.localID == 0 {
 			id, err := dest.localIdMap.FindandSetZeroBit()
 			if err != nil {
 				dest.localIdMap.Expand()
 				id, _ = dest.localIdMap.FindandSetZeroBit()
 			}
-			path.GetNlri().SetPathLocalIdentifier(uint32(id))
+			path.localID = uint32(id)
 		}
 	}
 
@@ -281,7 +281,7 @@ func (dest *Destination) explicitWithdraw(logger log.Logger, withdraw *Path) *Pa
 		// We have a match if the source and path-id are same.
 		if path.EqualBySourceAndPathID(withdraw) {
 			isFound = i
-			withdraw.GetNlri().SetPathLocalIdentifier(path.GetNlri().PathLocalIdentifier())
+			withdraw.localID = path.localID
 		}
 	}
 
@@ -326,7 +326,7 @@ func (dest *Destination) implicitWithdraw(logger log.Logger, newPath *Path) {
 			}
 
 			found = i
-			newPath.GetNlri().SetPathLocalIdentifier(path.GetNlri().PathLocalIdentifier())
+			newPath.localID = path.localID
 			break
 		}
 	}

--- a/internal/pkg/table/path_test.go
+++ b/internal/pkg/table/path_test.go
@@ -16,14 +16,14 @@ import (
 func TestPathNewIPv4(t *testing.T) {
 	peerP := PathCreatePeer()
 	pathP := PathCreatePath(peerP)
-	ipv4p := NewPath(bgp.RF_IPv4_UC, pathP[0].GetSource(), pathP[0].GetNlri(), true, pathP[0].GetPathAttrs(), time.Now(), false)
+	ipv4p := NewPath(bgp.RF_IPv4_UC, pathP[0].GetSource(), bgp.PathNLRI{NLRI: pathP[0].GetNlri()}, true, pathP[0].GetPathAttrs(), time.Now(), false)
 	assert.NotNil(t, ipv4p)
 }
 
 func TestPathNewIPv6(t *testing.T) {
 	peerP := PathCreatePeer()
 	pathP := PathCreatePath(peerP)
-	ipv6p := NewPath(bgp.RF_IPv4_UC, pathP[0].GetSource(), pathP[0].GetNlri(), true, pathP[0].GetPathAttrs(), time.Now(), false)
+	ipv6p := NewPath(bgp.RF_IPv4_UC, pathP[0].GetSource(), bgp.PathNLRI{NLRI: pathP[0].GetNlri()}, true, pathP[0].GetPathAttrs(), time.Now(), false)
 	assert.NotNil(t, ipv6p)
 }
 
@@ -45,7 +45,7 @@ func TestPathCreatePath(t *testing.T) {
 	nlriList := updateMsgP.NLRI
 	pathAttributes := updateMsgP.PathAttributes
 	nlri_info := nlriList[0]
-	path := NewPath(bgp.RF_IPv4_UC, peerP[0], nlri_info, false, pathAttributes, time.Now(), false)
+	path := NewPath(bgp.RF_IPv4_UC, peerP[0], bgp.PathNLRI{NLRI: nlri_info.NLRI}, false, pathAttributes, time.Now(), false)
 	assert.NotNil(t, path)
 }
 
@@ -87,11 +87,11 @@ func TestASPathLen(t *testing.T) {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpmsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	bgpmsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	update := bgpmsg.Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(logger, update)
 	peer := PathCreatePeer()
-	p := NewPath(bgp.RF_IPv4_UC, peer[0], update.NLRI[0], false, update.PathAttributes, time.Now(), false)
+	p := NewPath(bgp.RF_IPv4_UC, peer[0], bgp.PathNLRI{NLRI: update.NLRI[0].NLRI}, false, update.PathAttributes, time.Now(), false)
 	assert.Equal(10, p.GetAsPathLen())
 }
 
@@ -114,11 +114,11 @@ func TestPathPrependAsnToExistingSeqAttr(t *testing.T) {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpmsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	bgpmsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	update := bgpmsg.Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(logger, update)
 	peer := PathCreatePeer()
-	p := NewPath(bgp.RF_IPv4_UC, peer[0], update.NLRI[0], false, update.PathAttributes, time.Now(), false)
+	p := NewPath(bgp.RF_IPv4_UC, peer[0], bgp.PathNLRI{NLRI: update.NLRI[0].NLRI}, false, update.PathAttributes, time.Now(), false)
 
 	p.PrependAsn(65000, 1, false)
 	assert.Equal([]uint32{65000, 65001, 65002, 65003, 65004, 65005, 0, 0, 0}, p.GetAsSeqList())
@@ -135,11 +135,11 @@ func TestPathPrependAsnToNewAsPathAttr(t *testing.T) {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpmsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	bgpmsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	update := bgpmsg.Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(logger, update)
 	peer := PathCreatePeer()
-	p := NewPath(bgp.RF_IPv4_UC, peer[0], update.NLRI[0], false, update.PathAttributes, time.Now(), false)
+	p := NewPath(bgp.RF_IPv4_UC, peer[0], bgp.PathNLRI{NLRI: update.NLRI[0].NLRI}, false, update.PathAttributes, time.Now(), false)
 
 	asn := uint32(65000)
 	p.PrependAsn(asn, 1, false)
@@ -164,11 +164,11 @@ func TestPathPrependAsnToNewAsPathSeq(t *testing.T) {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpmsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	bgpmsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	update := bgpmsg.Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(logger, update)
 	peer := PathCreatePeer()
-	p := NewPath(bgp.RF_IPv4_UC, peer[0], update.NLRI[0], false, update.PathAttributes, time.Now(), false)
+	p := NewPath(bgp.RF_IPv4_UC, peer[0], bgp.PathNLRI{NLRI: update.NLRI[0].NLRI}, false, update.PathAttributes, time.Now(), false)
 
 	asn := uint32(65000)
 	p.PrependAsn(asn, 1, false)
@@ -194,11 +194,11 @@ func TestPathPrependAsnToEmptyAsPathAttr(t *testing.T) {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpmsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	bgpmsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	update := bgpmsg.Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(logger, update)
 	peer := PathCreatePeer()
-	p := NewPath(bgp.RF_IPv4_UC, peer[0], update.NLRI[0], false, update.PathAttributes, time.Now(), false)
+	p := NewPath(bgp.RF_IPv4_UC, peer[0], bgp.PathNLRI{NLRI: update.NLRI[0].NLRI}, false, update.PathAttributes, time.Now(), false)
 
 	asn := uint32(65000)
 	p.PrependAsn(asn, 1, false)
@@ -230,11 +230,11 @@ func TestPathPrependAsnToFullPathAttr(t *testing.T) {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpmsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	bgpmsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	update := bgpmsg.Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(logger, update)
 	peer := PathCreatePeer()
-	p := NewPath(bgp.RF_IPv4_UC, peer[0], update.NLRI[0], false, update.PathAttributes, time.Now(), false)
+	p := NewPath(bgp.RF_IPv4_UC, peer[0], bgp.PathNLRI{NLRI: update.NLRI[0].NLRI}, false, update.PathAttributes, time.Now(), false)
 
 	expected := []uint32{65000, 65000}
 	for _, v := range asns {
@@ -316,7 +316,7 @@ func PathCreatePath(peerP []*PeerInfo) []*Path {
 		nlriList := updateMsgP.NLRI
 		pathAttributes := updateMsgP.PathAttributes
 		nlri_info := nlriList[0]
-		pathP[i] = NewPath(bgp.RF_IPv4_UC, peerP[i], nlri_info, false, pathAttributes, time.Now(), false)
+		pathP[i] = NewPath(bgp.RF_IPv4_UC, peerP[i], bgp.PathNLRI{NLRI: nlri_info.NLRI}, false, pathAttributes, time.Now(), false)
 	}
 	return pathP
 }
@@ -336,7 +336,7 @@ func updateMsgP1() *bgp.BGPMessage {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 }
 
 func updateMsgP2() *bgp.BGPMessage {
@@ -354,7 +354,7 @@ func updateMsgP2() *bgp.BGPMessage {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
-	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 }
 
 func updateMsgP3() *bgp.BGPMessage {
@@ -373,22 +373,22 @@ func updateMsgP3() *bgp.BGPMessage {
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("30.30.30.0/24"))
 	w1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("40.40.40.0/23"))
-	withdrawnRoutes := []*bgp.IPAddrPrefix{w1}
-	return bgp.NewBGPUpdateMessage(withdrawnRoutes, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	withdrawnRoutes := []bgp.PathNLRI{{NLRI: w1}}
+	return bgp.NewBGPUpdateMessage(withdrawnRoutes, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 }
 
 func TestRemovePrivateAS(t *testing.T) {
 	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{64512, 64513, 1, 2})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("30.30.30.0/24"))
-	path := NewPath(bgp.RF_IPv4_UC, nil, nlri, false, []bgp.PathAttributeInterface{aspath}, time.Now(), false)
+	path := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{aspath}, time.Now(), false)
 	path.RemovePrivateAS(10, oc.REMOVE_PRIVATE_AS_OPTION_ALL)
 	list := path.GetAsList()
 	assert.Equal(t, len(list), 2)
 	assert.Equal(t, list[0], uint32(1))
 	assert.Equal(t, list[1], uint32(2))
 
-	path = NewPath(bgp.RF_IPv4_UC, nil, nlri, false, []bgp.PathAttributeInterface{aspath}, time.Now(), false)
+	path = NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{aspath}, time.Now(), false)
 	path.RemovePrivateAS(10, oc.REMOVE_PRIVATE_AS_OPTION_REPLACE)
 	list = path.GetAsList()
 	assert.Equal(t, len(list), 4)
@@ -402,7 +402,7 @@ func TestReplaceAS(t *testing.T) {
 	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{64512, 64513, 1, 2})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("30.30.30.0/24"))
-	path := NewPath(bgp.RF_IPv4_UC, nil, nlri, false, []bgp.PathAttributeInterface{aspath}, time.Now(), false)
+	path := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{aspath}, time.Now(), false)
 	path = path.ReplaceAS(10, 1)
 	list := path.GetAsList()
 	assert.Equal(t, len(list), 4)

--- a/internal/pkg/table/policy_test.go
+++ b/internal/pkg/table/policy_test.go
@@ -61,7 +61,7 @@ func TestPrefixCalcurateNoRange(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.0/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// test
 	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: "10.10.0.0/24", MasklengthRange: ""})
@@ -85,7 +85,7 @@ func TestPrefixCalcurateAddress(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// test
 	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: "10.11.0.0/16", MasklengthRange: "21..24"})
@@ -106,7 +106,7 @@ func TestPrefixCalcurateLength(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// test
 	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: "10.10.64.0/24", MasklengthRange: "21..24"})
@@ -127,7 +127,7 @@ func TestPrefixCalcurateLengthRange(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// test
 	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: "10.10.0.0/16", MasklengthRange: "21..23"})
@@ -148,7 +148,7 @@ func TestPrefixCalcurateNoRangeIPv6(t *testing.T) {
 	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	mpnlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{mpnlri}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: mpnlri}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{mpreach, origin, aspath, med}
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, nil)
@@ -172,7 +172,7 @@ func TestPrefixCalcurateAddressIPv6(t *testing.T) {
 	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	mpnlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{mpnlri}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: mpnlri}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{mpreach, origin, aspath, med}
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, nil)
@@ -193,7 +193,7 @@ func TestPrefixCalcurateLengthIPv6(t *testing.T) {
 	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	mpnlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{mpnlri}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: mpnlri}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{mpreach, origin, aspath, med}
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, nil)
@@ -214,7 +214,7 @@ func TestPrefixCalcurateLengthRangeIPv6(t *testing.T) {
 	aspathParam := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 	mpnlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{mpnlri}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpreach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: mpnlri}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{mpreach, origin, aspath, med}
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, nil)
@@ -241,7 +241,7 @@ func TestPolicyNotMatch(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
 	// create policy
@@ -272,7 +272,7 @@ func TestPolicyMatchAndReject(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -303,7 +303,7 @@ func TestPolicyMatchAndAccept(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -335,7 +335,7 @@ func TestPolicyRejectOnlyPrefixSet(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.1.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path1 := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
 	peer = &PeerInfo{AS: 65002, Address: netip.MustParseAddr("10.0.2.2")}
@@ -346,7 +346,7 @@ func TestPolicyRejectOnlyPrefixSet(t *testing.T) {
 	med = bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes = []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.9.2.102/24"))
-	updateMsg = bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg = bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path2 := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
 	// create policy
@@ -382,7 +382,7 @@ func TestPolicyRejectOnlyNeighborSet(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.1.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path1 := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
 	peer = &PeerInfo{AS: 65002, Address: netip.MustParseAddr("10.0.2.2")}
@@ -393,7 +393,7 @@ func TestPolicyRejectOnlyNeighborSet(t *testing.T) {
 	med = bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes = []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.2.102/24"))
-	updateMsg = bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg = bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path2 := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
 	// create policy
@@ -428,7 +428,7 @@ func TestPolicyDifferentRoutefamilyOfPathAndPolicy(t *testing.T) {
 	medIPv4 := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributesIPv4 := []bgp.PathAttributeInterface{originIPv4, aspathIPv4, nexthopIPv4, medIPv4}
 	nlriIPv4, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsgIPv4 := bgp.NewBGPUpdateMessage(nil, pathAttributesIPv4, []*bgp.IPAddrPrefix{nlriIPv4})
+	updateMsgIPv4 := bgp.NewBGPUpdateMessage(nil, pathAttributesIPv4, []bgp.PathNLRI{{NLRI: nlriIPv4}})
 	pathIPv4 := ProcessMessage(updateMsgIPv4, peerIPv4, time.Now(), false)[0]
 	// create path ipv6
 	peerIPv6 := &PeerInfo{AS: 65001, Address: netip.MustParseAddr("2001::192:168:50:1")}
@@ -436,7 +436,7 @@ func TestPolicyDifferentRoutefamilyOfPathAndPolicy(t *testing.T) {
 	aspathParamIPv6 := []bgp.AsPathParamInterface{bgp.NewAsPathParam(2, []uint16{65001})}
 	aspathIPv6 := bgp.NewPathAttributeAsPath(aspathParamIPv6)
 	mpnlriIPv6, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpreachIPv6, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{mpnlriIPv6}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpreachIPv6, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: mpnlriIPv6}}, netip.MustParseAddr("2001::192:168:50:1"))
 	medIPv6 := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributesIPv6 := []bgp.PathAttributeInterface{mpreachIPv6, originIPv6, aspathIPv6, medIPv6}
 	updateMsgIPv6 := bgp.NewBGPUpdateMessage(nil, pathAttributesIPv6, nil)
@@ -486,7 +486,7 @@ func TestAsPathLengthConditionEvaluate(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
@@ -530,7 +530,7 @@ func TestLocalPrefEqConditionEvaluate(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, nexthop, med, localPref}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	t.Run("True", func(t *testing.T) {
 		// create match condition
@@ -560,7 +560,7 @@ func TestPolicyMatchAndAcceptLocalPrefEqCondition(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, nexthop, med, localPref}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
 	// create policy
@@ -598,7 +598,7 @@ func TestPolicyMatchAndRejectLocalPrefEqCondition(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(uint32(0))
 	pathAttributes := []bgp.PathAttributeInterface{origin, nexthop, med, localPref}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
 	// create policy
@@ -638,7 +638,7 @@ func TestMedEqConditionEvaluate(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(uint32(100))
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, localPref}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
 	t.Run("True", func(t *testing.T) {
@@ -671,7 +671,7 @@ func TestPolicyMatchAndAcceptMedEqCondition(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(uint32(100))
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, localPref}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
 	// create policy
@@ -711,7 +711,7 @@ func TestPolicyMatchAndRejectMedEqCondition(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(uint32(200))
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, localPref}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
 	// create policy
@@ -754,7 +754,7 @@ func TestOriginConditionEvaluate(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
@@ -821,7 +821,7 @@ func TestPolicyMatchAndAcceptNextHop(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
 	// create policy
@@ -853,7 +853,7 @@ func TestPolicyMatchAndRejectNextHop(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
 	// create policy
@@ -885,7 +885,7 @@ func TestSetNextHop(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
 	// create policy
@@ -970,7 +970,7 @@ func TestAsPathLengthConditionWithOtherCondition(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
@@ -1027,7 +1027,7 @@ func TestAs4PathLengthConditionEvaluate(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
@@ -1096,7 +1096,7 @@ func TestAs4PathLengthConditionWithOtherCondition(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
@@ -1143,7 +1143,7 @@ func TestAsPathConditionEvaluate(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg1.Body.(*bgp.BGPUpdate))
 	path1 := ProcessMessage(updateMsg1, peer, time.Now(), false)[0]
 
@@ -1152,7 +1152,7 @@ func TestAsPathConditionEvaluate(t *testing.T) {
 	}
 	aspath2 := bgp.NewPathAttributeAsPath(aspathParam2)
 	pathAttributes = []bgp.PathAttributeInterface{origin, aspath2, nexthop, med}
-	updateMsg2 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg2 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg2.Body.(*bgp.BGPUpdate))
 	path2 := ProcessMessage(updateMsg2, peer, time.Now(), false)[0]
 
@@ -1241,7 +1241,7 @@ func TestMultipleAsPathConditionEvaluate(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg1.Body.(*bgp.BGPUpdate))
 	path1 := ProcessMessage(updateMsg1, peer, time.Now(), false)[0]
 
@@ -1344,7 +1344,7 @@ func TestAsPathCondition(t *testing.T) {
 			bgp.NewAs4PathParam(asPathAttrType, ases),
 		}
 		pathAttributes := []bgp.PathAttributeInterface{bgp.NewPathAttributeAsPath(aspathParam)}
-		p := NewPath(bgp.RF_IPv4_UC, nil, nil, false, pathAttributes, time.Time{}, false)
+		p := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{}, false, pathAttributes, time.Time{}, false)
 		return astest{
 			path:   p,
 			result: result,
@@ -1428,7 +1428,7 @@ func TestAsPathConditionWithOtherCondition(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
@@ -1482,7 +1482,7 @@ func TestAs4PathConditionEvaluate(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg1.Body.(*bgp.BGPUpdate))
 	path1 := ProcessMessage(updateMsg1, peer, time.Now(), false)[0]
 
@@ -1493,7 +1493,7 @@ func TestAs4PathConditionEvaluate(t *testing.T) {
 	}
 	aspath2 := bgp.NewPathAttributeAsPath(aspathParam2)
 	pathAttributes = []bgp.PathAttributeInterface{origin, aspath2, nexthop, med}
-	updateMsg2 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg2 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg2.Body.(*bgp.BGPUpdate))
 	path2 := ProcessMessage(updateMsg2, peer, time.Now(), false)[0]
 
@@ -1600,7 +1600,7 @@ func TestMultipleAs4PathConditionEvaluate(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg1.Body.(*bgp.BGPUpdate))
 	path1 := ProcessMessage(updateMsg1, peer, time.Now(), false)[0]
 
@@ -1729,7 +1729,7 @@ func TestAs4PathConditionWithOtherCondition(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
@@ -1787,7 +1787,7 @@ func TestAs4PathConditionEvaluateMixedWith2byteAS(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg1.Body.(*bgp.BGPUpdate))
 	path1 := ProcessMessage(updateMsg1, peer, time.Now(), false)[0]
 
@@ -1890,7 +1890,7 @@ func TestCommunityConditionEvaluate(t *testing.T) {
 
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, communities}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg1.Body.(*bgp.BGPUpdate))
 	path1 := ProcessMessage(updateMsg1, peer, time.Now(), false)[0]
 
@@ -1902,7 +1902,7 @@ func TestCommunityConditionEvaluate(t *testing.T) {
 	})
 
 	pathAttributes2 := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, communities2}
-	updateMsg2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []*bgp.IPAddrPrefix{nlri})
+	updateMsg2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg2.Body.(*bgp.BGPUpdate))
 	path2 := ProcessMessage(updateMsg2, peer, time.Now(), false)[0]
 
@@ -2035,7 +2035,7 @@ func TestCommunityCountConditionEvaluate(t *testing.T) {
 		inPath: func() *Path {
 			pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 			nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-			updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+			updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 			UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 			return ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 		}(),
@@ -2053,7 +2053,7 @@ func TestCommunityCountConditionEvaluate(t *testing.T) {
 			extCommunities := bgp.NewPathAttributeExtendedCommunities(ec)
 			pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, extCommunities}
 			nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-			updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+			updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 			UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 			return ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 		}(),
@@ -2064,7 +2064,7 @@ func TestCommunityCountConditionEvaluate(t *testing.T) {
 			communities := bgp.NewPathAttributeCommunities([]uint32{stringToCommunityValue("65001:111")})
 			pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, communities}
 			nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-			updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+			updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 			UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 			return ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 		}(),
@@ -2087,7 +2087,7 @@ func TestCommunityCountConditionEvaluate(t *testing.T) {
 			})
 			pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, communities, extCommunities, largeCommunities}
 			nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-			updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+			updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 			UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 			return ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 		}(),
@@ -2109,7 +2109,7 @@ func TestCommunityCountConditionEvaluate(t *testing.T) {
 			extCommunities := bgp.NewPathAttributeExtendedCommunities(ec)
 			pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, communities, extCommunities}
 			nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-			updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+			updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 			UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 			return ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 		}(),
@@ -2143,7 +2143,7 @@ func TestCommunityCountConditionEvaluate(t *testing.T) {
 			})
 			pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, communities, extCommunities, largeCommunities}
 			nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-			updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+			updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 			UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 			return ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 		}(),
@@ -2231,7 +2231,7 @@ func TestCommunityConditionEvaluateWithOtherCondition(t *testing.T) {
 	})
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, communities}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
@@ -2311,7 +2311,7 @@ func TestPolicyMatchAndAddCommunities(t *testing.T) {
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -2354,7 +2354,7 @@ func TestPolicyMatchAndReplaceCommunities(t *testing.T) {
 	})
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, communities}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -2400,7 +2400,7 @@ func TestPolicyMatchAndRemoveCommunities(t *testing.T) {
 	})
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, communities}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -2445,7 +2445,7 @@ func TestPolicyMatchAndRemoveCommunitiesRegexp(t *testing.T) {
 	})
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, communities}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -2490,7 +2490,7 @@ func TestPolicyMatchAndRemoveCommunitiesRegexp2(t *testing.T) {
 	})
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, communities}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -2533,7 +2533,7 @@ func TestPolicyMatchAndClearCommunities(t *testing.T) {
 	})
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, communities}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -2637,7 +2637,7 @@ func TestExtCommunityConditionEvaluate(t *testing.T) {
 
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, extCommunities}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg1.Body.(*bgp.BGPUpdate))
 	path1 := ProcessMessage(updateMsg1, peer, time.Now(), false)[0]
 
@@ -2823,7 +2823,7 @@ func TestExtCommunityConditionEvaluateWithOtherCondition(t *testing.T) {
 
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med, extCommunities}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	UpdatePathAttrs4ByteAs(logger, updateMsg.Body.(*bgp.BGPUpdate))
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 
@@ -2888,7 +2888,7 @@ func TestPolicyMatchAndReplaceMed(t *testing.T) {
 
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -2931,7 +2931,7 @@ func TestPolicyMatchAndAddingMed(t *testing.T) {
 
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -2974,7 +2974,7 @@ func TestPolicyMatchAndAddingMedOverFlow(t *testing.T) {
 
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -3019,7 +3019,7 @@ func TestPolicyMatchAndSubtractMed(t *testing.T) {
 
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -3064,7 +3064,7 @@ func TestPolicyMatchAndSubtractMedUnderFlow(t *testing.T) {
 
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -3108,7 +3108,7 @@ func TestPolicyMatchWhenPathHaveNotMed(t *testing.T) {
 
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// create policy
 	ps := createPrefixSet("ps1", "10.10.0.0/16", "21..24")
@@ -3151,7 +3151,7 @@ func TestPolicyAsPathPrepend(t *testing.T) {
 
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 
 	body := updateMsg.Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(logger, body)
@@ -3195,7 +3195,7 @@ func TestPolicyAsPathPrependLastAs(t *testing.T) {
 
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 
 	body := updateMsg.Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(logger, body)
@@ -3245,7 +3245,7 @@ func TestPolicyAs4PathPrepend(t *testing.T) {
 
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 
 	body := updateMsg.Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(logger, body)
@@ -3302,7 +3302,7 @@ func TestPolicyAs4PathPrependLastAs(t *testing.T) {
 
 	pathAttributes := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.101/24"))
-	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 
 	body := updateMsg.Body.(*bgp.BGPUpdate)
 	UpdatePathAttrs4ByteAs(logger, body)
@@ -3397,7 +3397,7 @@ func TestLocalPrefAction(t *testing.T) {
 
 	attrs := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 
-	path := NewPath(bgp.RF_IPv4_UC, nil, nlri, false, attrs, time.Now(), false)
+	path := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
 	p, _ := action.Apply(path, nil)
 	assert.NotNil(t, p)
 
@@ -3427,7 +3427,7 @@ func TestOriginAction(t *testing.T) {
 
 	attrs := []bgp.PathAttributeInterface{origin, aspath, nexthop, med}
 
-	path := NewPath(bgp.RF_IPv4_UC, nil, nlri, false, attrs, time.Now(), false)
+	path := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
 	p, _ := action.Apply(path, nil)
 	assert.NotNil(t, p)
 
@@ -3595,20 +3595,20 @@ func TestPrefixSetMatch(t *testing.T) {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("0.0.0.0/6"))
-	path := NewPath(bgp.RF_IPv4_UC, nil, nlri, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.True(t, m.Evaluate(path, nil))
 
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("0.0.0.0/10"))
 
-	path = NewPath(bgp.RF_IPv4_UC, nil, nlri, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path = NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.False(t, m.Evaluate(path, nil))
 
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("0.0.0.0/25"))
-	path = NewPath(bgp.RF_IPv4_UC, nil, nlri, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path = NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.True(t, m.Evaluate(path, nil))
 
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("0.0.0.0/30"))
-	path = NewPath(bgp.RF_IPv4_UC, nil, nlri, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path = NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.True(t, m.Evaluate(path, nil))
 
 	p3 := oc.Prefix{
@@ -3624,7 +3624,7 @@ func TestPrefixSetMatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("0.0.0.0/10"))
-	path = NewPath(bgp.RF_IPv4_UC, nil, nlri, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path = NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.True(t, m.Evaluate(path, nil))
 
 	ps3, err := NewPrefixSet(oc.PrefixSet{
@@ -3636,7 +3636,7 @@ func TestPrefixSetMatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("0.0.0.0/6"))
-	path = NewPath(bgp.RF_IPv4_UC, nil, nlri, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path = NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.False(t, m.Evaluate(path, nil))
 }
 
@@ -3655,7 +3655,7 @@ func TestPrefixSetMatchV4withV6Prefix(t *testing.T) {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("192.0.0.0/6"))
-	path := NewPath(bgp.RF_IPv4_UC, nil, nlri, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.False(t, m.Evaluate(path, nil))
 }
 
@@ -3675,12 +3675,12 @@ func TestPrefixSetMatchV6LabeledwithV6Prefix(t *testing.T) {
 
 	labels := bgp.NewMPLSLabelStack(100, 200)
 	n1, _ := bgp.NewLabeledIPAddrPrefix(netip.MustParsePrefix("2806:106e:19::/48"), *labels)
-	path := NewPath(bgp.RF_IPv6_MPLS, nil, n1, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path := NewPath(bgp.RF_IPv6_MPLS, nil, bgp.PathNLRI{NLRI: n1}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.True(t, m.Evaluate(path, nil))
 
 	labels = bgp.NewMPLSLabelStack(100, 200)
 	n2, _ := bgp.NewLabeledIPAddrPrefix(netip.MustParsePrefix("1806:106e:19::/48"), *labels)
-	path = NewPath(bgp.RF_IPv6_MPLS, nil, n2, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path = NewPath(bgp.RF_IPv6_MPLS, nil, bgp.PathNLRI{NLRI: n2}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.False(t, m.Evaluate(path, nil))
 }
 
@@ -3702,15 +3702,15 @@ func TestPrefixSetMatchVPNV4Prefix(t *testing.T) {
 	rd, _ := bgp.ParseRouteDistinguisher("100:100")
 
 	n1, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("10.10.10.10/32"), *labels, rd)
-	path := NewPath(bgp.RF_IPv4_MPLS, nil, n1, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path := NewPath(bgp.RF_IPv4_MPLS, nil, bgp.PathNLRI{NLRI: n1}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.True(t, m.Evaluate(path, nil))
 
 	n2, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("10.20.20.20/32"), *labels, rd)
-	path = NewPath(bgp.RF_IPv4_MPLS, nil, n2, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path = NewPath(bgp.RF_IPv4_MPLS, nil, bgp.PathNLRI{NLRI: n2}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.False(t, m.Evaluate(path, nil))
 
 	n3, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("10.10.0.0/16"), *labels, rd)
-	path = NewPath(bgp.RF_IPv4_MPLS, nil, n3, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path = NewPath(bgp.RF_IPv4_MPLS, nil, bgp.PathNLRI{NLRI: n3}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.False(t, m.Evaluate(path, nil))
 }
 
@@ -3732,15 +3732,15 @@ func TestPrefixSetMatchVPNV6Prefix(t *testing.T) {
 	rd, _ := bgp.ParseRouteDistinguisher("100:100")
 
 	n1, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/128"), *labels, rd)
-	path := NewPath(bgp.RF_IPv6_VPN, nil, n1, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path := NewPath(bgp.RF_IPv6_VPN, nil, bgp.PathNLRI{NLRI: n1}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.True(t, m.Evaluate(path, nil))
 
 	n2, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("2001:124:123:1::/128"), *labels, rd)
-	path = NewPath(bgp.RF_IPv6_VPN, nil, n2, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path = NewPath(bgp.RF_IPv6_VPN, nil, bgp.PathNLRI{NLRI: n2}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.False(t, m.Evaluate(path, nil))
 
 	n3, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("2001:124:123::/48"), *labels, rd)
-	path = NewPath(bgp.RF_IPv6_VPN, nil, n3, false, []bgp.PathAttributeInterface{}, time.Now(), false)
+	path = NewPath(bgp.RF_IPv6_VPN, nil, bgp.PathNLRI{NLRI: n3}, false, []bgp.PathAttributeInterface{}, time.Now(), false)
 	assert.False(t, m.Evaluate(path, nil))
 }
 
@@ -3749,7 +3749,7 @@ func TestLargeCommunityMatchAction(t *testing.T) {
 		{ASN: 100, LocalData1: 100, LocalData2: 100},
 		{ASN: 100, LocalData1: 200, LocalData2: 200},
 	}
-	p := NewPath(bgp.RF_IPv4_UC, nil, nil, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeLargeCommunities(coms)}, time.Time{}, false)
+	p := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{}, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeLargeCommunities(coms)}, time.Time{}, false)
 
 	c := oc.LargeCommunitySet{
 		LargeCommunitySetName: "l0",
@@ -3830,7 +3830,7 @@ func TestLargeCommunitiesMatchClearAction(t *testing.T) {
 		{ASN: 100, LocalData1: 100, LocalData2: 100},
 		{ASN: 100, LocalData1: 200, LocalData2: 200},
 	}
-	p := NewPath(bgp.RF_FS_IPv4_UC, nil, nil, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeLargeCommunities(coms)}, time.Time{}, false)
+	p := NewPath(bgp.RF_FS_IPv4_UC, nil, bgp.PathNLRI{}, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeLargeCommunities(coms)}, time.Time{}, false)
 
 	a, err := NewLargeCommunityAction(oc.SetLargeCommunity{
 		SetLargeCommunityMethod: oc.SetLargeCommunityMethod{
@@ -3862,11 +3862,11 @@ func TestAfiSafiInMatchPath(t *testing.T) {
 	prefixv4, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("1.1.1.0/24"))
 	prefixv6, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:0db8:85a3:0000:0000:8a2e:0370:7334/0"))
 
-	pathVPNv4 := NewPath(bgp.RF_IPv4_VPN, nil, prefixVPNv4, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rtExtCom})}, time.Time{}, false)
-	pathVPNv6 := NewPath(bgp.RF_IPv6_VPN, nil, prefixVPNv6, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rtExtCom})}, time.Time{}, false)
-	pathv4 := NewPath(bgp.RF_IPv4_UC, nil, prefixv4, false, []bgp.PathAttributeInterface{}, time.Time{}, false)
-	pathv6 := NewPath(bgp.RF_IPv6_UC, nil, prefixv6, false, []bgp.PathAttributeInterface{}, time.Time{}, false)
-	pathRTC := NewPath(bgp.RF_RTC_UC, nil, prefixRTC, false, []bgp.PathAttributeInterface{}, time.Time{}, false)
+	pathVPNv4 := NewPath(bgp.RF_IPv4_VPN, nil, bgp.PathNLRI{NLRI: prefixVPNv4}, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rtExtCom})}, time.Time{}, false)
+	pathVPNv6 := NewPath(bgp.RF_IPv6_VPN, nil, bgp.PathNLRI{NLRI: prefixVPNv6}, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rtExtCom})}, time.Time{}, false)
+	pathv4 := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: prefixv4}, false, []bgp.PathAttributeInterface{}, time.Time{}, false)
+	pathv6 := NewPath(bgp.RF_IPv6_UC, nil, bgp.PathNLRI{NLRI: prefixv6}, false, []bgp.PathAttributeInterface{}, time.Time{}, false)
+	pathRTC := NewPath(bgp.RF_RTC_UC, nil, bgp.PathNLRI{NLRI: prefixRTC}, false, []bgp.PathAttributeInterface{}, time.Time{}, false)
 
 	type Entry struct {
 		path        *Path
@@ -3920,7 +3920,7 @@ func TestMultipleStatementPolicy(t *testing.T) {
 	nexthop, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("10.0.0.1"))
 	pattrs := []bgp.PathAttributeInterface{origin, aspath, nexthop}
 
-	path := NewPath(bgp.RF_IPv4_UC, nil, nlri, false, pattrs, time.Now(), false)
+	path := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, pattrs, time.Now(), false)
 
 	pType, newPath := r.policyMap["p1"].Apply(logger, path, nil)
 	assert.Equal(t, ROUTE_TYPE_NONE, pType)

--- a/internal/pkg/table/roa_test.go
+++ b/internal/pkg/table/roa_test.go
@@ -51,7 +51,7 @@ func validateOne(rt *ROATable, cidr, aspathStr string) oc.RpkiValidationResultTy
 		family = bgp.RF_IPv4_UC
 	}
 	attrs := []bgp.PathAttributeInterface{strToASParam(aspathStr)}
-	path := NewPath(family, &PeerInfo{LocalAS: 65500}, nlri, false, attrs, time.Now(), false)
+	path := NewPath(family, &PeerInfo{LocalAS: 65500}, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
 	ret := rt.Validate(path)
 	return ret.Status
 }

--- a/internal/pkg/table/table_manager_test.go
+++ b/internal/pkg/table/table_manager_test.go
@@ -78,7 +78,7 @@ func peerR3() *PeerInfo {
 func TestTreatAsWithdraw(t *testing.T) {
 	msg := update_fromR2_ipv6()
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("1.1.1.0/24"))
-	msg.Body.(*bgp.BGPUpdate).NLRI = append(msg.Body.(*bgp.BGPUpdate).NLRI, nlri)
+	msg.Body.(*bgp.BGPUpdate).NLRI = append(msg.Body.(*bgp.BGPUpdate).NLRI, bgp.PathNLRI{NLRI: nlri})
 
 	paths := ProcessMessage(msg, peerR2(), time.Now(), true)
 
@@ -198,7 +198,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv4(t *testing.T) {
 		origin1, aspath1, nexthop1, med1, localpref1,
 	}
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []*bgp.IPAddrPrefix{nlri1})
+	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []bgp.PathNLRI{{NLRI: nlri1}})
 
 	// high localpref message
 	origin2 := bgp.NewPathAttributeOrigin(0)
@@ -211,7 +211,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv4(t *testing.T) {
 		origin2, aspath2, nexthop2, med2, localpref2,
 	}
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []*bgp.IPAddrPrefix{nlri2})
+	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []bgp.PathNLRI{{NLRI: nlri2}})
 
 	peer1 := peerR1()
 	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
@@ -268,7 +268,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv6(t *testing.T) {
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri1}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri1}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(100)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -281,7 +281,7 @@ func TestProcessBGPUpdate_1_select_high_localpref_ipv6(t *testing.T) {
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
 	aspath2 := createAsPathAttribute([]uint32{65100, 65000})
-	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri2}, netip.MustParseAddr("2001::192:168:100:1"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri2}}, netip.MustParseAddr("2001::192:168:100:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(100)
 	localpref2 := bgp.NewPathAttributeLocalPref(200)
 
@@ -356,7 +356,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv4(t *testing.T) {
 		origin1, aspath1, nexthop1, med1, localpref1,
 	}
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []*bgp.IPAddrPrefix{nlri1})
+	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []bgp.PathNLRI{{NLRI: nlri1}})
 
 	// high localpref message
 	origin2 := bgp.NewPathAttributeOrigin(0)
@@ -369,7 +369,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv4(t *testing.T) {
 		origin2, aspath2, nexthop2, med2, localpref2,
 	}
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []*bgp.IPAddrPrefix{nlri2})
+	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []bgp.PathNLRI{{NLRI: nlri2}})
 
 	peer1 := peerR1()
 	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
@@ -428,7 +428,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv6(t *testing.T) {
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri1}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri1}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(100)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -441,7 +441,7 @@ func TestProcessBGPUpdate_2_select_local_origin_ipv6(t *testing.T) {
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{})
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri2}, netip.MustParseAddr("::"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri2}}, netip.MustParseAddr("::"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(100)
 	localpref2 := bgp.NewPathAttributeLocalPref(100)
 
@@ -627,7 +627,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv4(t *testing.T) {
 		origin1, aspath1, nexthop1, med1, localpref1,
 	}
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []*bgp.IPAddrPrefix{nlri1})
+	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []bgp.PathNLRI{{NLRI: nlri1}})
 
 	// high origin message
 	origin2 := bgp.NewPathAttributeOrigin(0)
@@ -640,7 +640,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv4(t *testing.T) {
 		origin2, aspath2, nexthop2, med2, localpref2,
 	}
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []*bgp.IPAddrPrefix{nlri2})
+	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []bgp.PathNLRI{{NLRI: nlri2}})
 
 	peer1 := peerR1()
 	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
@@ -697,7 +697,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv6(t *testing.T) {
 	origin1 := bgp.NewPathAttributeOrigin(1)
 	aspath1 := createAsPathAttribute([]uint32{65200, 65000})
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri1}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri1}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(100)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -710,7 +710,7 @@ func TestProcessBGPUpdate_4_select_low_origin_ipv6(t *testing.T) {
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{65100, 65000})
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri2}, netip.MustParseAddr("2001::192:168:100:1"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri2}}, netip.MustParseAddr("2001::192:168:100:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(100)
 	localpref2 := bgp.NewPathAttributeLocalPref(200)
 
@@ -785,7 +785,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv4(t *testing.T) {
 		origin1, aspath1, nexthop1, med1, localpref1,
 	}
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []*bgp.IPAddrPrefix{nlri1})
+	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []bgp.PathNLRI{{NLRI: nlri1}})
 
 	// high origin message
 	origin2 := bgp.NewPathAttributeOrigin(0)
@@ -798,7 +798,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv4(t *testing.T) {
 		origin2, aspath2, nexthop2, med2, localpref2,
 	}
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []*bgp.IPAddrPrefix{nlri2})
+	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []bgp.PathNLRI{{NLRI: nlri2}})
 
 	peer1 := peerR1()
 	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
@@ -855,7 +855,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv6(t *testing.T) {
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65200, 65000})
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri1}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri1}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(500)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -868,7 +868,7 @@ func TestProcessBGPUpdate_5_select_low_med_ipv6(t *testing.T) {
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{65100, 65000})
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri2}, netip.MustParseAddr("2001::192:168:100:1"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri2}}, netip.MustParseAddr("2001::192:168:100:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref2 := bgp.NewPathAttributeLocalPref(100)
 
@@ -943,7 +943,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv4(t *testing.T) {
 		origin1, aspath1, nexthop1, med1, localpref1,
 	}
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []*bgp.IPAddrPrefix{nlri1})
+	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []bgp.PathNLRI{{NLRI: nlri1}})
 
 	// high origin message
 	origin2 := bgp.NewPathAttributeOrigin(0)
@@ -956,7 +956,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv4(t *testing.T) {
 		origin2, aspath2, nexthop2, med2, localpref2,
 	}
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []*bgp.IPAddrPrefix{nlri2})
+	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []bgp.PathNLRI{{NLRI: nlri2}})
 
 	peer1 := peerR1()
 	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
@@ -1013,7 +1013,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000, 65200})
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri1}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri1}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -1026,7 +1026,7 @@ func TestProcessBGPUpdate_6_select_ebgp_path_ipv6(t *testing.T) {
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{65100, 65200})
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri2}, netip.MustParseAddr("2001::192:168:100:1"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri2}}, netip.MustParseAddr("2001::192:168:100:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref2 := bgp.NewPathAttributeLocalPref(100)
 
@@ -1104,7 +1104,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv4(t *testing.T) {
 		origin1, aspath1, nexthop1, med1, localpref1,
 	}
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []*bgp.IPAddrPrefix{nlri1})
+	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []bgp.PathNLRI{{NLRI: nlri1}})
 
 	// high origin message
 	origin2 := bgp.NewPathAttributeOrigin(0)
@@ -1117,7 +1117,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv4(t *testing.T) {
 		origin2, aspath2, nexthop2, med2, localpref2,
 	}
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []*bgp.IPAddrPrefix{nlri2})
+	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []bgp.PathNLRI{{NLRI: nlri2}})
 
 	peer1 := peerR1()
 	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
@@ -1174,7 +1174,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv6(t *testing.T) {
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000, 65200})
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri1}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri1}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -1187,7 +1187,7 @@ func TestProcessBGPUpdate_7_select_low_routerid_path_ipv6(t *testing.T) {
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{65100, 65200})
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri2}, netip.MustParseAddr("2001::192:168:100:1"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri2}}, netip.MustParseAddr("2001::192:168:100:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref2 := bgp.NewPathAttributeLocalPref(100)
 
@@ -1262,7 +1262,7 @@ func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 		origin1, aspath1, nexthop1, med1, localpref1,
 	}
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []*bgp.IPAddrPrefix{nlri1})
+	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []bgp.PathNLRI{{NLRI: nlri1}})
 
 	// path 2
 	origin2 := bgp.NewPathAttributeOrigin(0)
@@ -1275,7 +1275,7 @@ func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 		origin2, aspath2, nexthop2, med2, localpref2,
 	}
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []*bgp.IPAddrPrefix{nlri2})
+	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []bgp.PathNLRI{{NLRI: nlri2}})
 
 	peer1 := peerR1()
 	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
@@ -1329,7 +1329,7 @@ func TestProcessBGPUpdate_8_withdraw_path_ipv4(t *testing.T) {
 
 	// withdraw path
 	w1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	w := []*bgp.IPAddrPrefix{w1}
+	w := []bgp.PathNLRI{{NLRI: w1}}
 	bgpMessage3 := bgp.NewBGPUpdateMessage(w, nil, nil)
 
 	pList, err = tm.ProcessUpdate(peer2, bgpMessage3)
@@ -1356,7 +1356,7 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri1}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri1}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -1369,7 +1369,7 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{65100, 65000})
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri2}, netip.MustParseAddr("2001::192:168:100:1"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri2}}, netip.MustParseAddr("2001::192:168:100:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref2 := bgp.NewPathAttributeLocalPref(200)
 
@@ -1456,7 +1456,7 @@ func TestProcessBGPUpdate_8_mpunreach_path_ipv6(t *testing.T) {
 
 	// mpunreach path
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpUnreach, _ := bgp.NewPathAttributeMpUnreachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri})
+	mpUnreach, _ := bgp.NewPathAttributeMpUnreachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri}})
 	bgpMessage3 := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{mpUnreach}, nil)
 
 	pList, err = tm.ProcessUpdate(peer2, bgpMessage3)
@@ -1491,11 +1491,11 @@ func TestProcessBGPUpdate_bestpath_lost_ipv4(t *testing.T) {
 		origin1, aspath1, nexthop1, med1, localpref1,
 	}
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []*bgp.IPAddrPrefix{nlri1})
+	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []bgp.PathNLRI{{NLRI: nlri1}})
 
 	// path 1 withdraw
 	w1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	w := []*bgp.IPAddrPrefix{w1}
+	w := []bgp.PathNLRI{{NLRI: w1}}
 	bgpMessage1_w := bgp.NewBGPUpdateMessage(w, nil, nil)
 
 	peer1 := peerR1()
@@ -1552,7 +1552,7 @@ func TestProcessBGPUpdate_bestpath_lost_ipv6(t *testing.T) {
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000})
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri1}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri1}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref1 := bgp.NewPathAttributeLocalPref(100)
 
@@ -1570,7 +1570,7 @@ func TestProcessBGPUpdate_bestpath_lost_ipv6(t *testing.T) {
 
 	// path1 mpunreach
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpUnreach, _ := bgp.NewPathAttributeMpUnreachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri2})
+	mpUnreach, _ := bgp.NewPathAttributeMpUnreachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri2}})
 	bgpMessage1_w := bgp.NewBGPUpdateMessage(nil, []bgp.PathAttributeInterface{mpUnreach}, nil)
 
 	pList, err = tm.ProcessUpdate(peer1, bgpMessage1_w)
@@ -1631,7 +1631,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv4(t *testing.T) {
 		origin1, aspath1, nexthop1, med1, localpref1,
 	}
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []*bgp.IPAddrPrefix{nlri1})
+	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, []bgp.PathNLRI{{NLRI: nlri1}})
 
 	// path 1 from same peer but short AS_PATH
 	origin2 := bgp.NewPathAttributeOrigin(0)
@@ -1644,7 +1644,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv4(t *testing.T) {
 		origin2, aspath2, nexthop2, med2, localpref2,
 	}
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []*bgp.IPAddrPrefix{nlri2})
+	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []bgp.PathNLRI{{NLRI: nlri2}})
 
 	peer1 := peerR1()
 	pList, err := tm.ProcessUpdate(peer1, bgpMessage1)
@@ -1702,7 +1702,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv6(t *testing.T) {
 	origin1 := bgp.NewPathAttributeOrigin(0)
 	aspath1 := createAsPathAttribute([]uint32{65000, 65100, 65200})
 	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri1}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpReach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri1}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med1 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref1 := bgp.NewPathAttributeLocalPref(200)
 
@@ -1715,7 +1715,7 @@ func TestProcessBGPUpdate_implicit_withdrwal_ipv6(t *testing.T) {
 	origin2 := bgp.NewPathAttributeOrigin(0)
 	aspath2 := createAsPathAttribute([]uint32{65000, 65100})
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri2}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpReach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri2}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med2 := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref2 := bgp.NewPathAttributeLocalPref(200)
 
@@ -1859,7 +1859,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv4(t *testing.T) {
 	nlri3, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("30.30.30.0/24"))
 	nlri4, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("40.40.40.0/24"))
 	nlri5, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("50.50.50.0/24"))
-	nlri := []*bgp.IPAddrPrefix{nlri1, nlri2, nlri3, nlri4, nlri5}
+	nlri := []bgp.PathNLRI{{NLRI: nlri1}, {NLRI: nlri2}, {NLRI: nlri3}, {NLRI: nlri4}, {NLRI: nlri5}}
 	bgpMessage1 := bgp.NewBGPUpdateMessage(nil, pathAttributes1, nlri)
 
 	// path2
@@ -1869,20 +1869,20 @@ func TestProcessBGPUpdate_multiple_nlri_ipv4(t *testing.T) {
 	nlri3, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("33.33.33.0/24"))
 	nlri4, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("44.44.44.0/24"))
 	nlri5, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("55.55.55.0/24"))
-	nlri = []*bgp.IPAddrPrefix{nlri1, nlri2, nlri3, nlri4, nlri5}
+	nlri = []bgp.PathNLRI{{NLRI: nlri1}, {NLRI: nlri2}, {NLRI: nlri3}, {NLRI: nlri4}, {NLRI: nlri5}}
 	bgpMessage2 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, nlri)
 
 	// path3
 	pathAttributes3 := createPathAttr([]uint32{65000, 65100, 65400}, "192.168.50.1")
 	nlri1, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("77.77.77.0/24"))
 	nlri2, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("88.88.88.0/24"))
-	nlri = []*bgp.IPAddrPrefix{nlri1, nlri2}
+	nlri = []bgp.PathNLRI{{NLRI: nlri1}, {NLRI: nlri2}}
 	bgpMessage3 := bgp.NewBGPUpdateMessage(nil, pathAttributes3, nlri)
 
 	// path4
 	pathAttributes4 := createPathAttr([]uint32{65000, 65100, 65500}, "192.168.50.1")
 	nlri1, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("99.99.99.0/24"))
-	nlri = []*bgp.IPAddrPrefix{nlri1}
+	nlri = []bgp.PathNLRI{{NLRI: nlri1}}
 	bgpMessage4 := bgp.NewBGPUpdateMessage(nil, pathAttributes4, nlri)
 
 	peer1 := peerR1()
@@ -1950,7 +1950,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 		bgpUpdateNexthop := bgpPathAttributes[4]
 		nexthopStr := bgpUpdateNexthop.(*bgp.PathAttributeMpReachNLRI).Nexthop.String()
 		expectedNexthopAttr, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC,
-			[]bgp.AddrPrefixInterface{actual.GetNlri()},
+			[]bgp.PathNLRI{{NLRI: actual.GetNlri()}},
 			netip.MustParseAddr(nexthopStr))
 		attr := actual.getPathAttr(bgp.BGP_ATTR_TYPE_MP_REACH_NLRI)
 		pathNexthop := attr.(*bgp.PathAttributeMpReachNLRI)
@@ -1997,7 +1997,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 	nlri4, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:1240:11::/64"))
 	nlri5, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:1250:11::/64"))
 	mpreach1, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC,
-		[]bgp.AddrPrefixInterface{nlri1, nlri2, nlri3, nlri4, nlri5},
+		[]bgp.PathNLRI{{NLRI: nlri1}, {NLRI: nlri2}, {NLRI: nlri3}, {NLRI: nlri4}, {NLRI: nlri5}},
 		netip.MustParseAddr("2001::192:168:50:1"))
 
 	pathAttributes1 = append(pathAttributes1, mpreach1)
@@ -2011,7 +2011,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 	nlri4, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:1244:11::/64"))
 	nlri5, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:1255:11::/64"))
 	mpreach2, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC,
-		[]bgp.AddrPrefixInterface{nlri1, nlri2, nlri3, nlri4, nlri5},
+		[]bgp.PathNLRI{{NLRI: nlri1}, {NLRI: nlri2}, {NLRI: nlri3}, {NLRI: nlri4}, {NLRI: nlri5}},
 		netip.MustParseAddr("2001::192:168:50:1"))
 
 	pathAttributes2 = append(pathAttributes2, mpreach2)
@@ -2022,7 +2022,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 	nlri1, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:1277:11::/64"))
 	nlri2, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:1288:11::/64"))
 	mpreach3, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC,
-		[]bgp.AddrPrefixInterface{nlri1, nlri2},
+		[]bgp.PathNLRI{{NLRI: nlri1}, {NLRI: nlri2}},
 		netip.MustParseAddr("2001::192:168:50:1"))
 	pathAttributes3 = append(pathAttributes3, mpreach3)
 	bgpMessage3 := bgp.NewBGPUpdateMessage(nil, pathAttributes3, nil)
@@ -2030,7 +2030,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv6(t *testing.T) {
 	// path4
 	pathAttributes4 := createPathAttr([]uint32{65000, 65100, 65500})
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:1299:11::/64"))
-	mpreach4, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpreach4, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri}}, netip.MustParseAddr("2001::192:168:50:1"))
 	pathAttributes4 = append(pathAttributes4, mpreach4)
 	bgpMessage4 := bgp.NewBGPUpdateMessage(nil, pathAttributes4, nil)
 
@@ -2087,7 +2087,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv4_split(t *testing.T) {
 	n2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.0.0.2/32"))
 	n3, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.0.0.3/32"))
 	mpReach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv4_UC,
-		[]bgp.AddrPrefixInterface{n1, n2, n3},
+		[]bgp.PathNLRI{{NLRI: n1}, {NLRI: n2}, {NLRI: n3}},
 		netip.MustParseAddr("10.50.60.70"))
 	med := bgp.NewPathAttributeMultiExitDisc(200)
 	localpref := bgp.NewPathAttributeLocalPref(200)
@@ -2102,7 +2102,7 @@ func TestProcessBGPUpdate_multiple_nlri_ipv4_split(t *testing.T) {
 	for i, p := range pList {
 		attr := p.getPathAttr(bgp.BGP_ATTR_TYPE_MP_REACH_NLRI).(*bgp.PathAttributeMpReachNLRI)
 		assert.Equal(t, mpReach.Nexthop, attr.Nexthop)
-		assert.Equal(t, []bgp.AddrPrefixInterface{mpReach.Value[i]}, attr.Value)
+		assert.Equal(t, []bgp.PathNLRI{{NLRI: mpReach.Value[i].NLRI}}, attr.Value)
 	}
 	assert.NoError(t, err)
 }
@@ -2124,14 +2124,14 @@ func TestProcessBGPUpdate_Timestamp(t *testing.T) {
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
 
 	adjRib := NewAdjRib(logger, []bgp.Family{bgp.RF_IPv4_UC, bgp.RF_IPv6_UC})
-	m1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	m1 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	peer := peerR1()
 	pList1 := ProcessMessage(m1, peer, time.Now(), false)
 	path1 := pList1[0]
 	t1 := path1.GetTimestamp()
 	adjRib.Update(pList1)
 
-	m2 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	m2 := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	pList2 := ProcessMessage(m2, peer, time.Now(), false)
 	// path2 := pList2[0].(*IPv4Path)
 	// t2 = path2.timestamp
@@ -2149,7 +2149,7 @@ func TestProcessBGPUpdate_Timestamp(t *testing.T) {
 		med2,
 	}
 
-	m3 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []*bgp.IPAddrPrefix{nlri})
+	m3 := bgp.NewBGPUpdateMessage(nil, pathAttributes2, []bgp.PathNLRI{{NLRI: nlri}})
 	pList3 := ProcessMessage(m3, peer, time.Now(), false)
 	t3 := pList3[0].GetTimestamp()
 	adjRib.Update(pList3)
@@ -2175,7 +2175,7 @@ func update_fromR1() *bgp.BGPMessage {
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
 
-	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 }
 
 func update_fromR1_ipv6() *bgp.BGPMessage {
@@ -2184,7 +2184,7 @@ func update_fromR1_ipv6() *bgp.BGPMessage {
 	aspath := bgp.NewPathAttributeAsPath(aspathParam)
 
 	mp_nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:123:123:1::/64"))
-	mpReach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{mp_nlri}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpReach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: mp_nlri}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(0)
 
 	pathAttributes := []bgp.PathAttributeInterface{
@@ -2211,14 +2211,14 @@ func update_fromR2() *bgp.BGPMessage {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
-	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 }
 
 func update_fromR2_ipv6() *bgp.BGPMessage {
 	origin := bgp.NewPathAttributeOrigin(0)
 	aspath := createAsPathAttribute([]uint32{65100})
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2002:223:123:1::/64"))
-	mpReach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri}, netip.MustParseAddr("2001::192:168:100:1"))
+	mpReach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri}}, netip.MustParseAddr("2001::192:168:100:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(100)
 
 	pathAttributes := []bgp.PathAttributeInterface{
@@ -2249,14 +2249,14 @@ func update_fromR2viaR1() *bgp.BGPMessage {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
-	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 }
 
 func update_fromR2viaR1_ipv6() *bgp.BGPMessage {
 	origin := bgp.NewPathAttributeOrigin(0)
 	aspath := createAsPathAttribute([]uint32{65000, 65100})
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2002:223:123:1::/64"))
-	mpReach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.AddrPrefixInterface{nlri}, netip.MustParseAddr("2001::192:168:50:1"))
+	mpReach, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri}}, netip.MustParseAddr("2001::192:168:50:1"))
 	med := bgp.NewPathAttributeMultiExitDisc(100)
 
 	pathAttributes := []bgp.PathAttributeInterface{
@@ -2307,7 +2307,7 @@ func makeVpn4Path(t *testing.T, peerInfo *PeerInfo, address string, nh string, r
 	rd, _ := bgp.ParseRouteDistinguisher(rdStr)
 	labels := bgp.NewMPLSLabelStack(100, 200)
 	prefix, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix(address+"/24"), *labels, rd)
-	return NewPath(bgp.RF_IPv4_VPN, peerInfo, prefix, false, attrs, time.Now(), false)
+	return NewPath(bgp.RF_IPv4_VPN, peerInfo, bgp.PathNLRI{NLRI: prefix}, false, attrs, time.Now(), false)
 }
 
 func makeRtcPath(t *testing.T, peerInfo *PeerInfo, rtStr string, withdraw bool) *Path {
@@ -2324,7 +2324,7 @@ func makeRtcPath(t *testing.T, peerInfo *PeerInfo, rtStr string, withdraw bool) 
 
 	prefix := bgp.NewRouteTargetMembershipNLRI(peerInfo.AS, rt)
 
-	return NewPath(bgp.RF_RTC_UC, peerInfo, prefix, withdraw, attrs, time.Now(), false)
+	return NewPath(bgp.RF_RTC_UC, peerInfo, bgp.PathNLRI{NLRI: prefix}, withdraw, attrs, time.Now(), false)
 }
 
 func addVrf(t *testing.T, tm *TableManager, peerInfo *PeerInfo, vrfName, rdStr string, importRtsStr []string, exportRtsStr []string, id uint32) *Vrf {

--- a/internal/pkg/table/table_test.go
+++ b/internal/pkg/table/table_test.go
@@ -278,7 +278,7 @@ func TestTableSelectVPNv4(t *testing.T) {
 		rd, p, _ := bgp.ParseVPNPrefix(prefix)
 		nlri, _ := bgp.NewLabeledVPNIPAddrPrefix(p, *bgp.NewMPLSLabelStack(), rd)
 
-		destination := NewDestination(nlri, 0, NewPath(bgp.RF_IPv4_VPN, nil, nlri, false, nil, time.Now(), false))
+		destination := NewDestination(nlri, 0, NewPath(bgp.RF_IPv4_VPN, nil, bgp.PathNLRI{NLRI: nlri}, false, nil, time.Now(), false))
 		table.setDestination(destination)
 	}
 	assert.Equal(t, 9, len(table.GetDestinations()))
@@ -385,7 +385,7 @@ func TestTableSelectVPNv6(t *testing.T) {
 	for _, prefix := range prefixes {
 		rd, p, _ := bgp.ParseVPNPrefix(prefix)
 		nlri, _ := bgp.NewLabeledVPNIPAddrPrefix(p, *bgp.NewMPLSLabelStack(), rd)
-		destination := NewDestination(nlri, 0, NewPath(bgp.RF_IPv6_VPN, nil, nlri, false, nil, time.Now(), false))
+		destination := NewDestination(nlri, 0, NewPath(bgp.RF_IPv6_VPN, nil, bgp.PathNLRI{NLRI: nlri}, false, nil, time.Now(), false))
 		table.setDestination(destination)
 	}
 	assert.Equal(t, 9, len(table.GetDestinations()))
@@ -493,7 +493,7 @@ func TableCreatePath(peerT []*PeerInfo) []*Path {
 		nlriList := updateMsgT.NLRI
 		pathAttributes := updateMsgT.PathAttributes
 		nlri_info := nlriList[0]
-		pathT[i] = NewPath(bgp.RF_IPv4_UC, peerT[i], nlri_info, false, pathAttributes, time.Now(), false)
+		pathT[i] = NewPath(bgp.RF_IPv4_UC, peerT[i], bgp.PathNLRI{NLRI: nlri_info.NLRI}, false, pathAttributes, time.Now(), false)
 	}
 	return pathT
 }
@@ -513,7 +513,7 @@ func updateMsgT1() *bgp.BGPMessage {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 }
 
 func updateMsgT2() *bgp.BGPMessage {
@@ -531,7 +531,7 @@ func updateMsgT2() *bgp.BGPMessage {
 	}
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
-	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	return bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 }
 
 func updateMsgT3() *bgp.BGPMessage {
@@ -550,8 +550,8 @@ func updateMsgT3() *bgp.BGPMessage {
 
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("30.30.30.0/24"))
 	w1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("40.40.40.0/23"))
-	withdrawnRoutes := []*bgp.IPAddrPrefix{w1}
-	return bgp.NewBGPUpdateMessage(withdrawnRoutes, pathAttributes, []*bgp.IPAddrPrefix{nlri})
+	withdrawnRoutes := []bgp.PathNLRI{{NLRI: w1}}
+	return bgp.NewBGPUpdateMessage(withdrawnRoutes, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 }
 
 //nolint:errcheck

--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -100,7 +100,11 @@ func UnmarshalAttribute(attr *api.Attribute) (bgp.PathAttributeInterface, error)
 				return nil, fmt.Errorf("invalid nexthop: %s", nexthop)
 			}
 		}
-		attr, _ := bgp.NewPathAttributeMpReachNLRI(rf, nlris, nexthop)
+		l := make([]bgp.PathNLRI, 0, len(nlris))
+		for _, n := range nlris {
+			l = append(l, bgp.PathNLRI{NLRI: n})
+		}
+		attr, _ := bgp.NewPathAttributeMpReachNLRI(rf, l, nexthop)
 		attr.LinkLocalNexthop = linkLocalNexthop
 		return attr, nil
 	case *api.Attribute_MpUnreach:
@@ -109,7 +113,11 @@ func UnmarshalAttribute(attr *api.Attribute) (bgp.PathAttributeInterface, error)
 		if err != nil {
 			return nil, err
 		}
-		return bgp.NewPathAttributeMpUnreachNLRI(rf, nlris)
+		l := make([]bgp.PathNLRI, 0, len(nlris))
+		for _, n := range nlris {
+			l = append(l, bgp.PathNLRI{NLRI: n})
+		}
+		return bgp.NewPathAttributeMpUnreachNLRI(rf, l)
 	case *api.Attribute_ExtendedCommunities:
 		return unmarshalExComm(a.ExtendedCommunities)
 	case *api.Attribute_As4Path:
@@ -1898,7 +1906,11 @@ func NewMpReachNLRIAttributeFromNative(a *bgp.PathAttributeMpReachNLRI) (*api.Mp
 			nexthops = append(nexthops, a.LinkLocalNexthop.String())
 		}
 	}
-	n, err := MarshalNLRIs(a.Value)
+	l := make([]bgp.AddrPrefixInterface, 0, len(a.Value))
+	for _, v := range a.Value {
+		l = append(l, v.NLRI)
+	}
+	n, err := MarshalNLRIs(l)
 	if err != nil {
 		return nil, err
 	}
@@ -1910,7 +1922,11 @@ func NewMpReachNLRIAttributeFromNative(a *bgp.PathAttributeMpReachNLRI) (*api.Mp
 }
 
 func NewMpUnreachNLRIAttributeFromNative(a *bgp.PathAttributeMpUnreachNLRI) (*api.MpUnreachNLRIAttribute, error) {
-	n, err := MarshalNLRIs(a.Value)
+	l := make([]bgp.AddrPrefixInterface, 0, len(a.Value))
+	for _, v := range a.Value {
+		l = append(l, v.NLRI)
+	}
+	n, err := MarshalNLRIs(l)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apiutil/util.go
+++ b/pkg/apiutil/util.go
@@ -105,6 +105,8 @@ type Path struct {
 	SendMaxFiltered bool            `json:"send-max-filtered,omitempty"` // true if the path has been filtered out due to max path count reached
 	Filtered        bool            `json:"filtered,omitempty"`
 	Validation      *api.Validation `json:"validation,omitempty"`
+	RemoteID        uint32
+	LocalID         uint32
 }
 
 type PeerConf struct {
@@ -179,7 +181,6 @@ func NewPath(family bgp.Family, nlri bgp.AddrPrefixInterface, isWithdraw bool, a
 		Age:        tspb.New(age),
 		IsWithdraw: isWithdraw,
 		Family:     ToApiFamily(family.Afi(), family.Safi()),
-		Identifier: nlri.PathIdentifier(),
 	}, nil
 }
 

--- a/pkg/packet/bgp/bgp_race_test.go
+++ b/pkg/packet/bgp/bgp_race_test.go
@@ -31,13 +31,13 @@ func Test_RaceCondition(t *testing.T) {
 
 	go func(body *BGPUpdate) {
 		for _, v := range body.WithdrawnRoutes {
-			v.Serialize()
+			v.toSlice(true)
 		}
 		for _, v := range body.PathAttributes {
 			v.Serialize()
 		}
 		for _, v := range body.NLRI {
-			v.Serialize()
+			v.toSlice(true)
 		}
 	}(updateBody)
 

--- a/pkg/packet/bgp/helper.go
+++ b/pkg/packet/bgp/helper.go
@@ -40,7 +40,7 @@ func NewTestBGPOpenMessage() *BGPMessage {
 func NewTestBGPUpdateMessage() *BGPMessage {
 	w1, _ := NewIPAddrPrefix(netip.MustParsePrefix("121.1.3.2/23"))
 	w2, _ := NewIPAddrPrefix(netip.MustParsePrefix("100.33.3.0/17"))
-	w := []*IPAddrPrefix{w1, w2}
+	w := []AddrPrefixInterface{w1, w2}
 
 	aspath1 := []AsPathParamInterface{
 		NewAsPathParam(2, []uint16{1000}),
@@ -129,21 +129,28 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 		NewPathAttributeAs4Path(aspath3),
 		paag4,
 	}
+	toList := func(l []AddrPrefixInterface) []PathNLRI {
+		r := make([]PathNLRI, 0, len(l))
+		for _, p := range l {
+			r = append(r, PathNLRI{NLRI: p})
+		}
+		return r
+	}
 
 	// Create MP_REACH_NLRI attributes with error handling
-	mp1, _ := NewPathAttributeMpReachNLRI(RF_IPv4_VPN, prefixes1, netip.MustParseAddr("112.22.2.0"))
-	mp2, _ := NewPathAttributeMpReachNLRI(RF_IPv6_UC, prefixes2, netip.MustParseAddr("1023::"))
-	mp3, _ := NewPathAttributeMpReachNLRI(RF_IPv6_VPN, prefixes3, netip.MustParseAddr("fe80::"))
-	mp4, _ := NewPathAttributeMpReachNLRI(RF_IPv4_MPLS, prefixes4, netip.MustParseAddr("129.1.1.1"))
-	mp5, _ := NewPathAttributeMpReachNLRI(RF_EVPN, prefixes5, netip.MustParseAddr("129.1.1.1"))
-	mp6, _ := NewPathAttributeMpReachNLRI(RF_VPLS, prefixes6, netip.MustParseAddr("135.1.1.1"))
-	mpUnreach1, _ := NewPathAttributeMpUnreachNLRI(RF_IPv4_VPN, prefixes1)
+	mp1, _ := NewPathAttributeMpReachNLRI(RF_IPv4_VPN, toList(prefixes1), netip.MustParseAddr("112.22.2.0"))
+	mp2, _ := NewPathAttributeMpReachNLRI(RF_IPv6_UC, toList(prefixes2), netip.MustParseAddr("1023::"))
+	mp3, _ := NewPathAttributeMpReachNLRI(RF_IPv6_VPN, toList(prefixes3), netip.MustParseAddr("fe80::"))
+	mp4, _ := NewPathAttributeMpReachNLRI(RF_IPv4_MPLS, toList(prefixes4), netip.MustParseAddr("129.1.1.1"))
+	mp5, _ := NewPathAttributeMpReachNLRI(RF_EVPN, toList(prefixes5), netip.MustParseAddr("129.1.1.1"))
+	mp6, _ := NewPathAttributeMpReachNLRI(RF_VPLS, toList(prefixes6), netip.MustParseAddr("135.1.1.1"))
+	mpUnreach1, _ := NewPathAttributeMpUnreachNLRI(RF_IPv4_VPN, toList(prefixes1))
 	p = append(p, mp1, mp2, mp3, mp4, mp5, mp6, mpUnreach1,
 		// NewPathAttributeMpReachNLRI("112.22.2.0", []AddrPrefixInterface{}),
 		// NewPathAttributeMpUnreachNLRI([]AddrPrefixInterface{}),
 		NewPathAttributeUnknown(BGP_ATTR_FLAG_TRANSITIVE, 100, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
 	)
 	prefix, _ := NewIPAddrPrefix(netip.MustParsePrefix("13.2.3.1/24"))
-	n := []*IPAddrPrefix{prefix}
-	return NewBGPUpdateMessage(w, p, n)
+	n := []AddrPrefixInterface{prefix}
+	return NewBGPUpdateMessage(toList(w), p, toList(n))
 }

--- a/pkg/packet/bgp/mup.go
+++ b/pkg/packet/bgp/mup.go
@@ -121,7 +121,6 @@ func getMUPRouteType(at uint8, rt uint16) (MUPRouteTypeInterface, error) {
 }
 
 type MUPNLRI struct {
-	PrefixDefault
 	Afi              uint16
 	ArchitectureType uint8
 	RouteType        uint16

--- a/pkg/packet/bgp/sr_policy.go
+++ b/pkg/packet/bgp/sr_policy.go
@@ -9,7 +9,6 @@ import (
 )
 
 type SRPolicyNLRI struct {
-	PrefixDefault
 	rf            Family
 	Length        uint8
 	Distinguisher uint32
@@ -29,13 +28,6 @@ func (s *SRPolicyNLRI) Flat() map[string]string {
 }
 
 func (s *SRPolicyNLRI) decodeFromBytes(data []byte, options ...*MarshallingOption) error {
-	if IsAddPathEnabled(true, s.rf, options) {
-		var err error
-		data, err = s.decodePathIdentifier(data)
-		if err != nil {
-			return err
-		}
-	}
 	if len(data) < 1 {
 		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Malformed SR Policy NLRI")
 	}
@@ -73,13 +65,6 @@ func (s *SRPolicyNLRI) Serialize(options ...*MarshallingOption) ([]byte, error) 
 	binary.BigEndian.PutUint32(buf[p:p+4], s.Color)
 	p += 4
 	copy(buf[p:], s.Endpoint)
-	if IsAddPathEnabled(false, s.rf, options) {
-		id, err := s.serializeIdentifier()
-		if err != nil {
-			return nil, err
-		}
-		return append(id, buf...), nil
-	}
 	return buf, nil
 }
 

--- a/pkg/packet/bgp/validate.go
+++ b/pkg/packet/bgp/validate.go
@@ -92,7 +92,7 @@ func ValidateAttribute(a PathAttributeInterface, rfs map[Family]BGPAddPathMode, 
 	eSubCodeUnknown := uint8(BGP_ERROR_SUB_UNRECOGNIZED_WELL_KNOWN_ATTRIBUTE)
 	eSubCodeMalformedAspath := uint8(BGP_ERROR_SUB_MALFORMED_AS_PATH)
 
-	checkPrefix := func(family Family, l []AddrPrefixInterface) error {
+	checkPrefix := func(family Family, l []PathNLRI) error {
 		if _, ok := rfs[family]; !ok {
 			return NewMessageError(0, 0, nil, fmt.Sprintf("Address-family %s not available for this session", family))
 		}
@@ -101,7 +101,7 @@ func ValidateAttribute(a PathAttributeInterface, rfs map[Family]BGPAddPathMode, 
 			switch family {
 			case RF_FS_IPv4_UC, RF_FS_IPv6_UC, RF_FS_IPv4_VPN, RF_FS_IPv6_VPN, RF_FS_L2_VPN:
 				t := BGPFlowSpecType(0)
-				for _, v := range prefix.(*FlowSpecNLRI).Value {
+				for _, v := range prefix.NLRI.(*FlowSpecNLRI).Value {
 					if v.Type() <= t {
 						return NewMessageError(0, 0, nil, fmt.Sprintf("%s nlri violate strict type ordering", family))
 					}

--- a/pkg/packet/bgp/validate_test.go
+++ b/pkg/packet/bgp/validate_test.go
@@ -24,7 +24,7 @@ func bgpupdate() *BGPMessage {
 
 	prefix, _ := NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
 	n := []*IPAddrPrefix{prefix}
-	return NewBGPUpdateMessage(nil, p, n)
+	return NewBGPUpdateMessage(nil, p, []PathNLRI{{NLRI: n[0]}})
 }
 
 func bgpupdateV6() *BGPMessage {
@@ -39,7 +39,7 @@ func bgpupdateV6() *BGPMessage {
 		NewPathAttributeOrigin(1),
 		NewPathAttributeAsPath(aspath),
 	}
-	mpreach, _ := NewPathAttributeMpReachNLRI(RF_IPv6_UC, prefixes, netip.MustParseAddr("1023::"))
+	mpreach, _ := NewPathAttributeMpReachNLRI(RF_IPv6_UC, []PathNLRI{{NLRI: prefixes[0]}}, netip.MustParseAddr("1023::"))
 	p = append(p, mpreach)
 	return NewBGPUpdateMessage(nil, p, nil)
 }
@@ -417,7 +417,7 @@ func Test_Validate_flowspec(t *testing.T) {
 	item7 := NewFlowSpecComponentItem(BITMASK_FLAG_OP_MATCH, isFragment)
 	cmp = append(cmp, NewFlowSpecComponent(FLOW_SPEC_TYPE_FRAGMENT, []*FlowSpecComponentItem{item7}))
 	n1, _ := NewFlowSpecUnicast(RF_FS_IPv4_UC, cmp)
-	a, _ := NewPathAttributeMpReachNLRI(RF_FS_IPv4_UC, []AddrPrefixInterface{n1}, netip.IPv4Unspecified())
+	a, _ := NewPathAttributeMpReachNLRI(RF_FS_IPv4_UC, []PathNLRI{{NLRI: n1}}, netip.IPv4Unspecified())
 	m := map[Family]BGPAddPathMode{RF_FS_IPv4_UC: BGP_ADD_PATH_NONE}
 	_, err := ValidateAttribute(a, m, false, false, false)
 	assert.NoError(err)
@@ -428,7 +428,7 @@ func Test_Validate_flowspec(t *testing.T) {
 	destPrefix2, _ := NewIPAddrPrefix(netip.MustParsePrefix("10.0.0.0/24"))
 	cmp = append(cmp, NewFlowSpecDestinationPrefix(destPrefix2))
 	n1, _ = NewFlowSpecUnicast(RF_FS_IPv4_UC, cmp)
-	a, _ = NewPathAttributeMpReachNLRI(RF_FS_IPv4_UC, []AddrPrefixInterface{n1}, netip.IPv4Unspecified())
+	a, _ = NewPathAttributeMpReachNLRI(RF_FS_IPv4_UC, []PathNLRI{{NLRI: n1}}, netip.IPv4Unspecified())
 	// Swaps components order to reproduce the rules order violation.
 	n1.Value[0], n1.Value[1] = n1.Value[1], n1.Value[0]
 	_, err = ValidateAttribute(a, m, false, false, false)

--- a/pkg/packet/bgp/vpls.go
+++ b/pkg/packet/bgp/vpls.go
@@ -27,7 +27,6 @@ import (
 //
 // [RFC 4761, section 3.2.2]: https://www.rfc-editor.org/rfc/rfc4761.html#section-3.2.2.
 type VPLSNLRI struct {
-	PrefixDefault
 	VEID           uint16
 	VEBlockOffset  uint16
 	VEBlockSize    uint16

--- a/pkg/packet/bgp/vpls_test.go
+++ b/pkg/packet/bgp/vpls_test.go
@@ -71,7 +71,7 @@ func Test_VPLSNLRI_decoding(t *testing.T) {
 
 	rd := NewRouteDistinguisherTwoOctetAS(65017, 104)
 	nlri := NewVPLSNLRI(rd, 1, 1, 8, 800000)
-	m2, _ := NewPathAttributeMpReachNLRI(RF_VPLS, []AddrPrefixInterface{nlri}, netip.MustParseAddr("192.0.2.7"))
+	m2, _ := NewPathAttributeMpReachNLRI(RF_VPLS, []PathNLRI{{NLRI: nlri}}, netip.MustParseAddr("192.0.2.7"))
 	m2.Flags |= BGP_ATTR_FLAG_EXTENDED_LENGTH
 
 	assert.Equal(m1, m2)

--- a/pkg/packet/bmp/bmp_test.go
+++ b/pkg/packet/bmp/bmp_test.go
@@ -84,13 +84,12 @@ func Test_RouteMonitoringAddPath(t *testing.T) {
 		AddPath: map[bgp.Family]bgp.BGPAddPathMode{bgp.RF_IPv4_UC: bgp.BGP_ADD_PATH_BOTH},
 	}
 	p1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.10.0/24"))
-	p1.SetPathLocalIdentifier(10)
 	panh, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("129.1.1.2"))
 	p := []bgp.PathAttributeInterface{
 		bgp.NewPathAttributeOrigin(3),
 		panh,
 	}
-	m := bgp.NewBGPUpdateMessage([]*bgp.IPAddrPrefix{}, p, []*bgp.IPAddrPrefix{p1})
+	m := bgp.NewBGPUpdateMessage([]bgp.PathNLRI{}, p, []bgp.PathNLRI{{NLRI: p1, ID: 10}})
 	p0 := NewBMPPeerHeader(0, 0, 1000, netip.MustParseAddr("fe80::6e40:8ff:feab:2c2a"), 70000, netip.MustParseAddr("10.0.0.2"), 1)
 
 	m1 := NewBMPRouteMonitoring(*p0, m)
@@ -102,10 +101,7 @@ func Test_RouteMonitoringAddPath(t *testing.T) {
 
 	// We need to fix tha path identifier (local/remote)
 	u2 := m2.Body.(*BMPRouteMonitoring).BGPUpdate.Body.(*bgp.BGPUpdate).NLRI[0]
-	assert.Equal(t, u2.PathIdentifier(), uint32(10))
-	assert.Equal(t, u2.PathLocalIdentifier(), uint32(0))
-	u2.SetPathIdentifier(0)
-	u2.SetPathLocalIdentifier(10)
+	assert.Equal(t, u2.ID, uint32(10))
 
 	assert.Equal(t, m1, m2)
 }

--- a/pkg/packet/mrt/mrt.go
+++ b/pkg/packet/mrt/mrt.go
@@ -437,7 +437,7 @@ func parseRibEntry(data []byte, family bgp.Family, isAddPath bool, prefix ...bgp
 		} else if ok {
 			mp.AFI = family.Afi()
 			mp.SAFI = family.Safi()
-			mp.Value = []bgp.AddrPrefixInterface{prefix[0]}
+			mp.Value = []bgp.PathNLRI{{NLRI: prefix[0], ID: e.PathIdentifier}}
 		}
 
 		attrLen -= uint16(p.Len())

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -84,7 +84,7 @@ func TestToPathApi(t *testing.T) {
 					Address:      netip.MustParseAddr("10.12.12.12"),
 					LocalAddress: netip.MustParseAddr("10.13.13.13"),
 				},
-					n,
+					bgp.PathNLRI{NLRI: n},
 					false,
 					[]bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)},
 					time.Time{},

--- a/pkg/server/mrt.go
+++ b/pkg/server/mrt.go
@@ -151,7 +151,7 @@ func (m *mrtWriter) dumpTable() []*mrt.MRTMessage {
 					if !isAddPath {
 						entries = append(entries, mrt.NewRibEntry(idx(path), uint32(path.GetTimestamp().Unix()), 0, path.GetPathAttrs(), false))
 					} else {
-						entriesAddPath = append(entriesAddPath, mrt.NewRibEntry(idx(path), uint32(path.GetTimestamp().Unix()), path.GetNlri().PathIdentifier(), path.GetPathAttrs(), true))
+						entriesAddPath = append(entriesAddPath, mrt.NewRibEntry(idx(path), uint32(path.GetTimestamp().Unix()), path.RemoteID(), path.GetPathAttrs(), true))
 					}
 				}
 				if len(entries) > 0 {

--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -247,7 +247,7 @@ func (peer *peer) updateRoutes(paths ...*table.Path) {
 		destLocalKey := localKey.PathDestLocalKey
 		identifiers, destExists := peer.sentPaths[destLocalKey]
 		if path.IsWithdraw && destExists {
-			delete(identifiers, path.GetNlri().PathLocalIdentifier())
+			delete(identifiers, path.LocalID())
 		} else if !path.IsWithdraw {
 			if !destExists {
 				peer.sentPaths[destLocalKey] = make(map[uint32]struct{})
@@ -287,7 +287,7 @@ func (peer *peer) hasPathAlreadyBeenSent(path *table.Path) bool {
 	if _, dstExist := peer.sentPaths[destLocalKey]; !dstExist {
 		return false
 	}
-	_, pathExist := peer.sentPaths[destLocalKey][path.GetNlri().PathLocalIdentifier()]
+	_, pathExist := peer.sentPaths[destLocalKey][path.LocalID()]
 	return pathExist
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -813,7 +813,7 @@ func TestMonitor(test *testing.T) {
 	// Withdraws the previous route.
 	// NOTE: Withdraw should not require any path attribute.
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.0.0.0/24"))
-	if err := t.addPathList("", []*table.Path{table.NewPath(bgp.RF_IPv4_UC, nil, nlri, true, nil, time.Now(), false)}); err != nil {
+	if err := t.addPathList("", []*table.Path{table.NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, true, nil, time.Now(), false)}); err != nil {
 		test.Error(err)
 	}
 	ev = <-w.Event()
@@ -829,7 +829,7 @@ func TestMonitor(test *testing.T) {
 
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.1.0.0/24"))
 	// Prepares an initial route to test WatchUpdate with "current" flag.
-	if err := t.addPathList("", []*table.Path{table.NewPath(bgp.RF_IPv4_UC, nil, nlri, false, attrs, time.Now(), false)}); err != nil {
+	if err := t.addPathList("", []*table.Path{table.NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)}); err != nil {
 		test.Error(err)
 	}
 	for {
@@ -859,7 +859,7 @@ func TestMonitor(test *testing.T) {
 
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.2.0.0/24"))
 	// Advertises an additional route.
-	if err := t.addPathList("", []*table.Path{table.NewPath(bgp.RF_IPv4_UC, nil, nlri, false, attrs, time.Now(), false)}); err != nil {
+	if err := t.addPathList("", []*table.Path{table.NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)}); err != nil {
 		test.Error(err)
 	}
 	ev = <-w.Event()
@@ -871,7 +871,7 @@ func TestMonitor(test *testing.T) {
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.2.0.0/24"))
 	// Withdraws the previous route.
 	// NOTE: Withdraw should not require any path attribute.
-	if err := t.addPathList("", []*table.Path{table.NewPath(bgp.RF_IPv4_UC, nil, nlri, true, nil, time.Now(), false)}); err != nil {
+	if err := t.addPathList("", []*table.Path{table.NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, true, nil, time.Now(), false)}); err != nil {
 		test.Error(err)
 	}
 	ev = <-w.Event()
@@ -890,7 +890,7 @@ func TestMonitor(test *testing.T) {
 	}
 
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.0.0.0/24"))
-	if err := s.addPathList("vrf1", []*table.Path{table.NewPath(bgp.RF_IPv4_UC, nil, nlri, false, attrs, time.Now(), false)}); err != nil {
+	if err := s.addPathList("vrf1", []*table.Path{table.NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)}); err != nil {
 		test.Error(err)
 	}
 	ev = <-w.Event()
@@ -904,7 +904,7 @@ func TestMonitor(test *testing.T) {
 
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.0.0.0/24"))
 	// Withdraw the route
-	if err := s.addPathList("vrf1", []*table.Path{table.NewPath(bgp.RF_IPv4_UC, nil, nlri, true, attrs, time.Now(), false)}); err != nil {
+	if err := s.addPathList("vrf1", []*table.Path{table.NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, true, attrs, time.Now(), false)}); err != nil {
 		test.Error(err)
 	}
 	ev = <-w.Event()
@@ -1013,8 +1013,8 @@ func TestFilterpathWitheBGP(t *testing.T) {
 	pa1 := []bgp.PathAttributeInterface{bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{p1As})}), bgp.NewPathAttributeLocalPref(200)}
 	pa2 := []bgp.PathAttributeInterface{bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{p2As})})}
 
-	path1 := table.NewPath(bgp.RF_IPv4_UC, p1.peerInfo, nlri, false, pa1, time.Now(), false)
-	path2 := table.NewPath(bgp.RF_IPv4_UC, p2.peerInfo, nlri, false, pa2, time.Now(), false)
+	path1 := table.NewPath(bgp.RF_IPv4_UC, p1.peerInfo, bgp.PathNLRI{NLRI: nlri}, false, pa1, time.Now(), false)
+	path2 := table.NewPath(bgp.RF_IPv4_UC, p2.peerInfo, bgp.PathNLRI{NLRI: nlri}, false, pa2, time.Now(), false)
 	rib.Update(path2)
 	d := rib.Update(path1)
 	new, old, _ := d[0].GetChanges(table.GLOBAL_RIB_NAME, 0, false)
@@ -1055,8 +1055,8 @@ func TestFilterpathWithiBGP(t *testing.T) {
 	pa1 := []bgp.PathAttributeInterface{bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{as})}), bgp.NewPathAttributeLocalPref(200)}
 	// pa2 := []bgp.PathAttributeInterface{bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{as})})}
 
-	path1 := table.NewPath(bgp.RF_IPv4_UC, p1.peerInfo, nlri, false, pa1, time.Now(), false)
-	// path2 := table.NewPath(bgp.RF_IPv4_UC, pi2, nlri, false, pa2, time.Now(), false)
+	path1 := table.NewPath(bgp.RF_IPv4_UC, p1.peerInfo, bgp.PathNLRI{NLRI: nlri}, false, pa1, time.Now(), false)
+	// path2 := table.NewPath(bgp.RF_IPv4_UC, pi2, bgp.PathNLRI{NLRI: nlri}, false, pa2, time.Now(), false)
 
 	new, old := process(rib, []*table.Path{path1})
 	assert.Equal(t, new, path1)
@@ -1121,7 +1121,7 @@ func TestFilterpathWithRejectPolicy(t *testing.T) {
 		if addCommunity {
 			pa1 = append(pa1, bgp.NewPathAttributeCommunities([]uint32{100<<16 | 100}))
 		}
-		path1 := table.NewPath(bgp.RF_IPv4_UC, p1.peerInfo, nlri, false, pa1, time.Now(), false)
+		path1 := table.NewPath(bgp.RF_IPv4_UC, p1.peerInfo, bgp.PathNLRI{NLRI: nlri}, false, pa1, time.Now(), false)
 		new, old := process(rib2, []*table.Path{path1})
 		assert.Equal(t, new, path1)
 		s := NewBgpServer()
@@ -1767,7 +1767,7 @@ func TestDoNotReactToDuplicateRTCMemberships(t *testing.T) {
 		Address: netip.MustParseAddr("127.0.0.1"),
 		LocalID: netip.MustParseAddr("2.2.2.2"),
 		ID:      netip.MustParseAddr("1.1.1.1"),
-	}, rtcNLRI, false, []bgp.PathAttributeInterface{
+	}, bgp.PathNLRI{NLRI: rtcNLRI}, false, []bgp.PathAttributeInterface{
 		bgp.NewPathAttributeOrigin(0),
 		panh2,
 	}, time.Now(), false)

--- a/pkg/server/zclient.go
+++ b/pkg/server/zclient.go
@@ -291,7 +291,7 @@ func newPathFromIPRouteMessage(logger log.Logger, m *zebra.Message, version uint
 		if len(body.Nexthops) > 0 {
 			nexthop, err := netip.ParseAddr(body.Nexthops[0].Gate.String())
 			if err == nil {
-				attr, _ := bgp.NewPathAttributeMpReachNLRI(family, []bgp.AddrPrefixInterface{nlri}, nexthop)
+				attr, _ := bgp.NewPathAttributeMpReachNLRI(family, []bgp.PathNLRI{{NLRI: nlri}}, nexthop)
 				pattr = append(pattr, attr)
 			}
 		}
@@ -307,7 +307,7 @@ func newPathFromIPRouteMessage(logger log.Logger, m *zebra.Message, version uint
 	med := bgp.NewPathAttributeMultiExitDisc(body.Metric)
 	pattr = append(pattr, med)
 
-	path := table.NewPath(family, nil, nlri, isWithdraw, pattr, time.Now(), false)
+	path := table.NewPath(family, nil, bgp.PathNLRI{NLRI: nlri}, isWithdraw, pattr, time.Now(), false)
 	path.SetIsFromExternal(true)
 	return path
 }

--- a/pkg/server/zclient_test.go
+++ b/pkg/server/zclient_test.go
@@ -69,7 +69,7 @@ func Test_newPathFromIPRouteMessage(t *testing.T) {
 		logger := log.NewDefaultLogger()
 		zebra.BackwardIPv6RouteDelete.ToEach(v, software)
 		path := newPathFromIPRouteMessage(logger, m, v, software)
-		pp := table.NewPath(bgp.RF_IPv4_UC, nil, path.GetNlri(), path.IsWithdraw, path.GetPathAttrs(), time.Now(), false)
+		pp := table.NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: path.GetNlri()}, path.IsWithdraw, path.GetPathAttrs(), time.Now(), false)
 		pp.SetIsFromExternal(path.IsFromExternal())
 		assert.Equal("0.0.0.0", pp.GetNexthop().String())
 		assert.Equal("192.168.100.0/24", pp.GetNlri().String())
@@ -83,7 +83,7 @@ func Test_newPathFromIPRouteMessage(t *testing.T) {
 		m.Body = b
 
 		path = newPathFromIPRouteMessage(logger, m, v, software)
-		pp = table.NewPath(bgp.RF_IPv4_UC, nil, path.GetNlri(), path.IsWithdraw, path.GetPathAttrs(), time.Now(), false)
+		pp = table.NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: path.GetNlri()}, path.IsWithdraw, path.GetPathAttrs(), time.Now(), false)
 		pp.SetIsFromExternal(path.IsFromExternal())
 		assert.Equal("0.0.0.0", pp.GetNexthop().String())
 		assert.Equal("192.168.100.0/24", pp.GetNlri().String())
@@ -108,7 +108,7 @@ func Test_newPathFromIPRouteMessage(t *testing.T) {
 		m.Body = b
 
 		path = newPathFromIPRouteMessage(logger, m, v, software)
-		pp = table.NewPath(bgp.RF_IPv6_UC, nil, path.GetNlri(), path.IsWithdraw, path.GetPathAttrs(), time.Now(), false)
+		pp = table.NewPath(bgp.RF_IPv6_UC, nil, bgp.PathNLRI{NLRI: path.GetNlri()}, path.IsWithdraw, path.GetPathAttrs(), time.Now(), false)
 		pp.SetIsFromExternal(path.IsFromExternal())
 		assert.Equal("::", pp.GetNexthop().String())
 		assert.Equal("2001:db8:0:f101::/64", pp.GetNlri().String())
@@ -130,7 +130,7 @@ func Test_newPathFromIPRouteMessage(t *testing.T) {
 		m.Body = b
 
 		path = newPathFromIPRouteMessage(logger, m, v, software)
-		pp = table.NewPath(bgp.RF_IPv6_UC, nil, path.GetNlri(), path.IsWithdraw, path.GetPathAttrs(), time.Now(), false)
+		pp = table.NewPath(bgp.RF_IPv6_UC, nil, bgp.PathNLRI{NLRI: path.GetNlri()}, path.IsWithdraw, path.GetPathAttrs(), time.Now(), false)
 		pp.SetIsFromExternal(path.IsFromExternal())
 		assert.Equal("::", pp.GetNexthop().String())
 		assert.Equal("2001:db8:0:f101::/64", pp.GetNlri().String())


### PR DESCRIPTION
Remove the following AddPath methods in AddrPrefixInterface:

PathIdentifier() uint32
SetPathIdentifier(uint32)
PathLocalIdentifier() uint32
SetPathLocalIdentifier(uint32)

By separating AddPath handling from the various NLRI encoders and decoders, each encoder/decoder can focus solely on processing the NLRI format.

Since the packet library is not responsible for synchronization, using a mutex here is inappropriate.