### PR TITLE
packet/bgp: rename AddrPrefixInterface to NLRI

### DIFF
--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -448,7 +448,7 @@ func parseExtendedCommunities(args []string) ([]bgp.ExtendedCommunityInterface, 
 	return exts, nil
 }
 
-func parseFlowSpecArgs(rf bgp.Family, args []string) (bgp.AddrPrefixInterface, *bgp.PathAttributePrefixSID, []string, error) {
+func parseFlowSpecArgs(rf bgp.Family, args []string) (bgp.NLRI, *bgp.PathAttributePrefixSID, []string, error) {
 	// Format:
 	// match <rule>... [then <action>...] [rd <rd>] [rt <rt>...]
 	// or
@@ -504,7 +504,7 @@ func parseFlowSpecArgs(rf bgp.Family, args []string) (bgp.AddrPrefixInterface, *
 		return nil, nil, nil, err
 	}
 
-	var nlri bgp.AddrPrefixInterface
+	var nlri bgp.NLRI
 	switch rf {
 	case bgp.RF_FS_IPv4_UC, bgp.RF_FS_IPv6_UC:
 		nlri, _ = bgp.NewFlowSpecUnicast(rf, rules)
@@ -568,7 +568,7 @@ func parseFlowSpecArgs(rf bgp.Family, args []string) (bgp.AddrPrefixInterface, *
 	return nlri, psid, extcomms, nil
 }
 
-func parseEvpnEthernetAutoDiscoveryArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {
+func parseEvpnEthernetAutoDiscoveryArgs(args []string) (bgp.NLRI, []string, error) {
 	// Format:
 	// esi <esi> etag <etag> label <label> rd <rd> [rt <rt>...] [encap <encap type>] [esi-label <esi-label> [single-active | all-active]]
 	req := 8
@@ -637,7 +637,7 @@ func parseEvpnEthernetAutoDiscoveryArgs(args []string) (bgp.AddrPrefixInterface,
 	return bgp.NewEVPNNLRI(bgp.EVPN_ROUTE_TYPE_ETHERNET_AUTO_DISCOVERY, r), extcomms, nil
 }
 
-func parseEvpnMacAdvArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {
+func parseEvpnMacAdvArgs(args []string) (bgp.NLRI, []string, error) {
 	// Format:
 	// <mac address> <ip address> [esi <esi>] etag <etag> label <label> rd <rd> [rt <rt>...] [encap <encap type>] [router-mac <mac address>] [default-gateway]
 	// or
@@ -763,7 +763,7 @@ func parseEvpnMacAdvArgs(args []string) (bgp.AddrPrefixInterface, []string, erro
 	return bgp.NewEVPNNLRI(bgp.EVPN_ROUTE_TYPE_MAC_IP_ADVERTISEMENT, r), extcomms, nil
 }
 
-func parseEvpnMulticastArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {
+func parseEvpnMulticastArgs(args []string) (bgp.NLRI, []string, error) {
 	// Format:
 	// <ip address> etag <etag> rd <rd> [rt <rt>...] [encap <encap type>]
 	// or
@@ -836,7 +836,7 @@ func parseEvpnMulticastArgs(args []string) (bgp.AddrPrefixInterface, []string, e
 	return bgp.NewEVPNNLRI(bgp.EVPN_INCLUSIVE_MULTICAST_ETHERNET_TAG, r), extcomms, nil
 }
 
-func parseEvpnEthernetSegmentArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {
+func parseEvpnEthernetSegmentArgs(args []string) (bgp.NLRI, []string, error) {
 	// Format:
 	// <ip address> esi <esi> rd <rd> [rt <rt>...] [encap <encap type>]
 	req := 5
@@ -899,7 +899,7 @@ func parseEvpnEthernetSegmentArgs(args []string) (bgp.AddrPrefixInterface, []str
 	return bgp.NewEVPNNLRI(bgp.EVPN_ETHERNET_SEGMENT_ROUTE, r), extcomms, nil
 }
 
-func parseEvpnIPPrefixArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {
+func parseEvpnIPPrefixArgs(args []string) (bgp.NLRI, []string, error) {
 	// Format:
 	// <ip prefix> [gw <gateway>] [esi <esi>] etag <etag> [label <label>] rd <rd> [rt <rt>...] [encap <encap type>]
 	req := 5
@@ -988,7 +988,7 @@ func parseEvpnIPPrefixArgs(args []string) (bgp.AddrPrefixInterface, []string, er
 	return bgp.NewEVPNNLRI(bgp.EVPN_IP_PREFIX, r), extcomms, nil
 }
 
-func parseEvpnIPMSIArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {
+func parseEvpnIPMSIArgs(args []string) (bgp.NLRI, []string, error) {
 	// Format:
 	// etag <etag> rd <rd> [rt <rt>...] [encap <encap type>]
 	req := 4
@@ -1043,7 +1043,7 @@ func parseEvpnIPMSIArgs(args []string) (bgp.AddrPrefixInterface, []string, error
 	return bgp.NewEVPNNLRI(bgp.EVPN_I_PMSI, r), extcomms, nil
 }
 
-func parseEvpnArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {
+func parseEvpnArgs(args []string) (bgp.NLRI, []string, error) {
 	if len(args) < 1 {
 		return nil, nil, fmt.Errorf("lack of args. need 1 but %d", len(args))
 	}
@@ -1066,7 +1066,7 @@ func parseEvpnArgs(args []string) (bgp.AddrPrefixInterface, []string, error) {
 	return nil, nil, fmt.Errorf("invalid subtype. expect [macadv|multicast|prefix] but %s", subtype)
 }
 
-func parseMUPInterworkSegmentDiscoveryRouteArgs(args []string, afi uint16, nexthop string) (bgp.AddrPrefixInterface, *bgp.PathAttributePrefixSID, []string, error) {
+func parseMUPInterworkSegmentDiscoveryRouteArgs(args []string, afi uint16, nexthop string) (bgp.NLRI, *bgp.PathAttributePrefixSID, []string, error) {
 	// Format:
 	// <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...]
 	req := 13
@@ -1150,7 +1150,7 @@ func parseMUPInterworkSegmentDiscoveryRouteArgs(args []string, afi uint16, nexth
 	return bgp.NewMUPNLRI(afi, bgp.MUP_ARCH_TYPE_UNDEFINED, bgp.MUP_ROUTE_TYPE_INTERWORK_SEGMENT_DISCOVERY, r), psid, extcomms, nil
 }
 
-func parseMUPDirectSegmentDiscoveryRouteArgs(args []string, afi uint16, nexthop string) (bgp.AddrPrefixInterface, *bgp.PathAttributePrefixSID, []string, error) {
+func parseMUPDirectSegmentDiscoveryRouteArgs(args []string, afi uint16, nexthop string) (bgp.NLRI, *bgp.PathAttributePrefixSID, []string, error) {
 	// Format:
 	// <ip address> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup <segment identifier>]
 	req := 15
@@ -1264,7 +1264,7 @@ func parseTeid(s string) (teid netip.Addr, err error) {
 	return teid, nil
 }
 
-func parseMUPType1SessionTransformedRouteArgs(args []string, afi uint16) (bgp.AddrPrefixInterface, *bgp.PathAttributePrefixSID, []string, error) {
+func parseMUPType1SessionTransformedRouteArgs(args []string, afi uint16) (bgp.NLRI, *bgp.PathAttributePrefixSID, []string, error) {
 	// Format:
 	// <ip prefix> rd <rd> [rt <rt>...] teid <teid> qfi <qfi> endpoint <endpoint> [source <source>]
 	req := 5
@@ -1335,7 +1335,7 @@ func parseMUPType1SessionTransformedRouteArgs(args []string, afi uint16) (bgp.Ad
 	return bgp.NewMUPNLRI(afi, bgp.MUP_ARCH_TYPE_UNDEFINED, bgp.MUP_ROUTE_TYPE_TYPE_1_SESSION_TRANSFORMED, r), nil, extcomms, nil
 }
 
-func parseMUPType2SessionTransformedRouteArgs(args []string, afi uint16) (bgp.AddrPrefixInterface, *bgp.PathAttributePrefixSID, []string, error) {
+func parseMUPType2SessionTransformedRouteArgs(args []string, afi uint16) (bgp.NLRI, *bgp.PathAttributePrefixSID, []string, error) {
 	// Format:
 	// <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup <segment identifier>]
 	req := 6
@@ -1397,7 +1397,7 @@ func parseMUPType2SessionTransformedRouteArgs(args []string, afi uint16) (bgp.Ad
 	return bgp.NewMUPNLRI(afi, bgp.MUP_ARCH_TYPE_UNDEFINED, bgp.MUP_ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED, r), nil, extcomms, nil
 }
 
-func parseMUPArgs(args []string, afi uint16, nexthop string) (bgp.AddrPrefixInterface, *bgp.PathAttributePrefixSID, []string, error) {
+func parseMUPArgs(args []string, afi uint16, nexthop string) (bgp.NLRI, *bgp.PathAttributePrefixSID, []string, error) {
 	if len(args) < 1 {
 		return nil, nil, nil, fmt.Errorf("lack of args. need 1 but %d", len(args))
 	}
@@ -1416,7 +1416,7 @@ func parseMUPArgs(args []string, afi uint16, nexthop string) (bgp.AddrPrefixInte
 	return nil, nil, nil, fmt.Errorf("invalid subtype. expect [isd|dsd|t1st|t2st] but %s", subtype)
 }
 
-func parseLsLinkNLRIType(args []string) (bgp.AddrPrefixInterface, *bgp.PathAttributeLs, error) {
+func parseLsLinkNLRIType(args []string) (bgp.NLRI, *bgp.PathAttributeLs, error) {
 	// Format:
 	// <ip prefix> identifier <identifier> asn <asn> bgp-ls-id <bgp-ls-id> ospf
 	req := 26
@@ -1630,7 +1630,7 @@ func parseLsLinkNLRIType(args []string) (bgp.AddrPrefixInterface, *bgp.PathAttri
 	return nlri, pathAttributeLs, nil
 }
 
-func parseLsSRv6SIDNLRIType(args []string) (bgp.AddrPrefixInterface, *bgp.PathAttributeLs, error) {
+func parseLsSRv6SIDNLRIType(args []string) (bgp.NLRI, *bgp.PathAttributeLs, error) {
 	// Format:
 	// gobgp global rib add -a ls srv6sid bgp identifier <identifier> local-asn <local-asn> local-bgp-ls-id <local-bgp-ls-id> local-bgp-router-id <local-bgp-router-id> [local-bgp-confederation-member <confederation-member>] sids <sids>... [multi-topology-id <multi-topology-id>...]
 	req := 11
@@ -1746,7 +1746,7 @@ func lsTLVTypeSelect(s string) bgp.LsTLVType {
 	return bgp.LS_TLV_UNKNOWN
 }
 
-func parseLsArgs(args []string) (bgp.AddrPrefixInterface, *bgp.PathAttributeLs, error) {
+func parseLsArgs(args []string) (bgp.NLRI, *bgp.PathAttributeLs, error) {
 	if len(args) < 1 {
 		return nil, nil, fmt.Errorf("lack of nlriType")
 	}
@@ -1762,7 +1762,7 @@ func parseLsArgs(args []string) (bgp.AddrPrefixInterface, *bgp.PathAttributeLs, 
 	return nil, nil, fmt.Errorf("invalid nlriType. expect [link] but %s", nlriType)
 }
 
-func parseRtcArgs(args []string) (bgp.AddrPrefixInterface, error) {
+func parseRtcArgs(args []string) (bgp.NLRI, error) {
 	// Format:
 	// asn <asn> rt <rt> | default
 	m, err := extractReserved(args, map[string]int{
@@ -2038,7 +2038,7 @@ func extractAggregator(args []string) ([]string, bgp.PathAttributeInterface, err
 }
 
 func parsePath(rf bgp.Family, args []string) (*api.Path, error) {
-	var nlri bgp.AddrPrefixInterface
+	var nlri bgp.NLRI
 	var extcomms []string
 	var psid *bgp.PathAttributePrefixSID
 	var ls *bgp.PathAttributeLs

--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -561,7 +561,7 @@ func getPathSymbolString(p *api.Path, idx int, showBest bool) string {
 	return symbols
 }
 
-func getPathAttributeString(nlri bgp.AddrPrefixInterface, attrs []bgp.PathAttributeInterface) string {
+func getPathAttributeString(nlri bgp.NLRI, attrs []bgp.PathAttributeInterface) string {
 	s := make([]string, 0)
 	for _, a := range attrs {
 		switch a.GetType() {

--- a/docs/sources/lib.md
+++ b/docs/sources/lib.md
@@ -97,7 +97,7 @@ func main() {
 
 	s.ListPath(apiutil.ListPathRequest{
 		TableType: api.TableType_TABLE_TYPE_GLOBAL,
-	}, func(prefix bgp.AddrPrefixInterface, paths []*apiutil.Path) {
+	}, func(prefix bgp.NLRI, paths []*apiutil.Path) {
 		log.Info(prefix.String())
 		for _, p := range paths {
 			log.WithFields(logrus.Fields{

--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -138,12 +138,12 @@ func NewPeerInfo(g *oc.Global, p *oc.Neighbor, AS, localAS uint32, ID, localID n
 }
 
 type Destination struct {
-	nlri          bgp.AddrPrefixInterface
+	nlri          bgp.NLRI
 	knownPathList []*Path
 	localIdMap    *Bitmap
 }
 
-func NewDestination(nlri bgp.AddrPrefixInterface, mapSize int, known ...*Path) *Destination {
+func NewDestination(nlri bgp.NLRI, mapSize int, known ...*Path) *Destination {
 	d := &Destination{
 		nlri:          nlri,
 		knownPathList: known,
@@ -156,11 +156,11 @@ func NewDestination(nlri bgp.AddrPrefixInterface, mapSize int, known ...*Path) *
 	return d
 }
 
-func (dd *Destination) GetNlri() bgp.AddrPrefixInterface {
+func (dd *Destination) GetNlri() bgp.NLRI {
 	return dd.nlri
 }
 
-func (dd *Destination) setNlri(nlri bgp.AddrPrefixInterface) {
+func (dd *Destination) setNlri(nlri bgp.NLRI) {
 	dd.nlri = nlri
 }
 

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -86,7 +86,7 @@ func NewBitmap(size int) *Bitmap {
 }
 
 type originInfo struct {
-	nlri               bgp.AddrPrefixInterface
+	nlri               bgp.NLRI
 	source             *PeerInfo
 	timestamp          int64
 	noImplicitWithdraw bool
@@ -482,7 +482,7 @@ func (path *Path) SetNexthop(nexthop net.IP) {
 	}
 }
 
-func (path *Path) GetNlri() bgp.AddrPrefixInterface {
+func (path *Path) GetNlri() bgp.NLRI {
 	return path.OriginInfo().nlri
 }
 
@@ -1087,7 +1087,7 @@ func (lhs *Path) Equal(rhs *Path) bool {
 
 func (path *Path) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Nlri       bgp.AddrPrefixInterface      `json:"nlri"`
+		Nlri       bgp.NLRI                     `json:"nlri"`
 		PathAttrs  []bgp.PathAttributeInterface `json:"attrs"`
 		Age        int64                        `json:"age"`
 		Withdrawal bool                         `json:"withdrawal,omitempty"`
@@ -1356,7 +1356,7 @@ func (p *Path) RemoteID() uint32 {
 	return p.remoteID
 }
 
-func nlriToIPNet(nlri bgp.AddrPrefixInterface) *net.IPNet {
+func nlriToIPNet(nlri bgp.NLRI) *net.IPNet {
 	switch T := nlri.(type) {
 	case *bgp.IPAddrPrefix:
 		return &net.IPNet{

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -34,7 +34,7 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
 
-func addrPrefixOnlySerialize(nlri bgp.AddrPrefixInterface) []byte {
+func addrPrefixOnlySerialize(nlri bgp.NLRI) []byte {
 	switch T := nlri.(type) {
 	case *bgp.IPAddrPrefix:
 		byteLen := T.Prefix.Addr().BitLen() / 8
@@ -55,7 +55,7 @@ func addrPrefixOnlySerialize(nlri bgp.AddrPrefixInterface) []byte {
 	return []byte(nlri.String())
 }
 
-func AddrPrefixOnlyCompare(a, b bgp.AddrPrefixInterface) int {
+func AddrPrefixOnlyCompare(a, b bgp.NLRI) int {
 	return bytes.Compare(addrPrefixOnlySerialize(a), addrPrefixOnlySerialize(b))
 }
 
@@ -75,7 +75,7 @@ type TableSelectOption struct {
 	MultiPath      bool
 }
 
-func tableKey(nlri bgp.AddrPrefixInterface) addrPrefixKey {
+func tableKey(nlri bgp.NLRI) addrPrefixKey {
 	h := fnv1a.Init64
 	switch T := nlri.(type) {
 	case *bgp.IPAddrPrefix:
@@ -94,7 +94,7 @@ func tableKey(nlri bgp.AddrPrefixInterface) addrPrefixKey {
 
 type Destinations map[addrPrefixKey][]*Destination
 
-func (d Destinations) getDestinationList(nlri bgp.AddrPrefixInterface) []*Destination {
+func (d Destinations) getDestinationList(nlri bgp.NLRI) []*Destination {
 	dest, ok := d[tableKey(nlri)]
 	if !ok {
 		return nil
@@ -102,7 +102,7 @@ func (d Destinations) getDestinationList(nlri bgp.AddrPrefixInterface) []*Destin
 	return dest
 }
 
-func (d Destinations) Get(nlri bgp.AddrPrefixInterface) *Destination {
+func (d Destinations) Get(nlri bgp.NLRI) *Destination {
 	for _, d := range d.getDestinationList(nlri) {
 		if AddrPrefixOnlyCompare(d.nlri, nlri) == 0 {
 			return d
@@ -133,7 +133,7 @@ func (d Destinations) InsertUpdate(dest *Destination) (collision bool) {
 	return collision
 }
 
-func (d Destinations) Remove(nlri bgp.AddrPrefixInterface) {
+func (d Destinations) Remove(nlri bgp.NLRI) {
 	key := tableKey(nlri)
 	if _, ok := d[key]; !ok {
 		return
@@ -333,7 +333,7 @@ func (t *Table) validatePath(path *Path) {
 	}
 }
 
-func (t *Table) getOrCreateDest(nlri bgp.AddrPrefixInterface, size int) *Destination {
+func (t *Table) getOrCreateDest(nlri bgp.NLRI, size int) *Destination {
 	dest := t.GetDestination(nlri)
 	// If destination for given prefix does not exist we create it.
 	if dest == nil {
@@ -377,7 +377,7 @@ func (t *Table) GetDestinations() []*Destination {
 	return d
 }
 
-func (t *Table) GetDestination(nlri bgp.AddrPrefixInterface) *Destination {
+func (t *Table) GetDestination(nlri bgp.NLRI) *Destination {
 	return t.destinations.Get(nlri)
 }
 

--- a/internal/pkg/table/table_test.go
+++ b/internal/pkg/table/table_test.go
@@ -155,7 +155,7 @@ func BenchmarkTableKey(b *testing.B) {
 	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:db8::/64"))
 	nlri3, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("192.168.1.0/24"), *bgp.NewMPLSLabelStack(100, 200, 300), rd)
 	nlri4, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("2001:db8::/64"), *bgp.NewMPLSLabelStack(100, 200, 300), rd)
-	prefix := []bgp.AddrPrefixInterface{
+	prefix := []bgp.NLRI{
 		nlri1,
 		nlri2,
 		nlri3,
@@ -555,7 +555,7 @@ func updateMsgT3() *bgp.BGPMessage {
 }
 
 //nolint:errcheck
-func createRandomAddrPrefix() []bgp.AddrPrefixInterface {
+func createRandomAddrPrefix() []bgp.NLRI {
 	label := *bgp.NewMPLSLabelStack(1, 2, 3)
 	rd := bgp.NewRouteDistinguisherTwoOctetAS(256, 10000)
 
@@ -576,13 +576,13 @@ func createRandomAddrPrefix() []bgp.AddrPrefixInterface {
 	nlri4, _ := bgp.NewIPAddrPrefix(prefixv6)
 	nlri5, _ := bgp.NewLabeledVPNIPAddrPrefix(prefixv6, label, rd)
 	nlri6, _ := bgp.NewLabeledIPAddrPrefix(prefixv6, label)
-	prefixes := []bgp.AddrPrefixInterface{nlri1, nlri2, nlri3, nlri4, nlri5, nlri6}
+	prefixes := []bgp.NLRI{nlri1, nlri2, nlri3, nlri4, nlri5, nlri6}
 
 	return prefixes
 }
 
 //nolint:errcheck
-func createAddrPrefixBaseIndex(index int) []bgp.AddrPrefixInterface {
+func createAddrPrefixBaseIndex(index int) []bgp.NLRI {
 	label := *bgp.NewMPLSLabelStack(1, 2, 3)
 	rd := bgp.NewRouteDistinguisherTwoOctetAS(256, 10000)
 
@@ -607,7 +607,7 @@ func createAddrPrefixBaseIndex(index int) []bgp.AddrPrefixInterface {
 	nlri4, _ := bgp.NewIPAddrPrefix(prefixv6)
 	nlri5, _ := bgp.NewLabeledVPNIPAddrPrefix(prefixv6, label, rd)
 	nlri6, _ := bgp.NewLabeledIPAddrPrefix(prefixv6, label)
-	prefixes := []bgp.AddrPrefixInterface{nlri1, nlri2, nlri3, nlri4, nlri5, nlri6}
+	prefixes := []bgp.NLRI{nlri1, nlri2, nlri3, nlri4, nlri5, nlri6}
 
 	return prefixes
 }
@@ -651,7 +651,7 @@ func TestTableDestinationsCollisionAttack(t *testing.T) {
 	}
 }
 
-func buildPrefixesWithLabels() []bgp.AddrPrefixInterface {
+func buildPrefixesWithLabels() []bgp.NLRI {
 	label1 := *bgp.NewMPLSLabelStack(1, 2, 3)
 	label2 := *bgp.NewMPLSLabelStack(4, 5, 6)
 	label3 := *bgp.NewMPLSLabelStack(7, 8)
@@ -676,7 +676,7 @@ func buildPrefixesWithLabels() []bgp.AddrPrefixInterface {
 
 	nlri1, _ := bgp.NewIPAddrPrefix(prefixv4)
 	nlri2, _ := bgp.NewIPAddrPrefix(prefixv6)
-	prefixes := []bgp.AddrPrefixInterface{nlri1, nlri2}
+	prefixes := []bgp.NLRI{nlri1, nlri2}
 
 	for _, l := range []bgp.MPLSLabelStack{label1, label2, label3} {
 		for _, rd := range []bgp.RouteDistinguisherInterface{rd1, rd2} {

--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -1174,7 +1174,7 @@ func UnmarshalLsAttribute(a *api.LsAttribute) (*bgp.LsAttribute, error) {
 	return lsAttr, nil
 }
 
-func MarshalNLRI(value bgp.AddrPrefixInterface) (*api.NLRI, error) {
+func MarshalNLRI(value bgp.NLRI) (*api.NLRI, error) {
 	var nlri api.NLRI
 
 	switch v := value.(type) {
@@ -1471,7 +1471,7 @@ func MarshalNLRI(value bgp.AddrPrefixInterface) (*api.NLRI, error) {
 	return &nlri, nil
 }
 
-func MarshalNLRIs(values []bgp.AddrPrefixInterface) ([]*api.NLRI, error) {
+func MarshalNLRIs(values []bgp.NLRI) ([]*api.NLRI, error) {
 	nlris := make([]*api.NLRI, 0, len(values))
 	for _, value := range values {
 		nlri, err := MarshalNLRI(value)
@@ -1483,8 +1483,8 @@ func MarshalNLRIs(values []bgp.AddrPrefixInterface) ([]*api.NLRI, error) {
 	return nlris, nil
 }
 
-func UnmarshalNLRI(rf bgp.Family, an *api.NLRI) (bgp.AddrPrefixInterface, error) {
-	var nlri bgp.AddrPrefixInterface
+func UnmarshalNLRI(rf bgp.Family, an *api.NLRI) (bgp.NLRI, error) {
+	var nlri bgp.NLRI
 
 	switch n := an.GetNlri().(type) {
 	case *api.NLRI_Prefix:
@@ -1880,11 +1880,11 @@ func UnmarshalNLRI(rf bgp.Family, an *api.NLRI) (bgp.AddrPrefixInterface, error)
 	return nlri, nil
 }
 
-func UnmarshalNLRIs(rf bgp.Family, values []*api.NLRI) ([]bgp.AddrPrefixInterface, error) {
+func UnmarshalNLRIs(rf bgp.Family, values []*api.NLRI) ([]bgp.NLRI, error) {
 	if len(values) == 0 {
 		return nil, fmt.Errorf("no nlri values to unmarshal for %s family", rf.String())
 	}
-	nlris := make([]bgp.AddrPrefixInterface, 0, len(values))
+	nlris := make([]bgp.NLRI, 0, len(values))
 	for _, an := range values {
 		nlri, err := UnmarshalNLRI(rf, an)
 		if err != nil {
@@ -1906,7 +1906,7 @@ func NewMpReachNLRIAttributeFromNative(a *bgp.PathAttributeMpReachNLRI) (*api.Mp
 			nexthops = append(nexthops, a.LinkLocalNexthop.String())
 		}
 	}
-	l := make([]bgp.AddrPrefixInterface, 0, len(a.Value))
+	l := make([]bgp.NLRI, 0, len(a.Value))
 	for _, v := range a.Value {
 		l = append(l, v.NLRI)
 	}
@@ -1922,7 +1922,7 @@ func NewMpReachNLRIAttributeFromNative(a *bgp.PathAttributeMpReachNLRI) (*api.Mp
 }
 
 func NewMpUnreachNLRIAttributeFromNative(a *bgp.PathAttributeMpUnreachNLRI) (*api.MpUnreachNLRIAttribute, error) {
-	l := make([]bgp.AddrPrefixInterface, 0, len(a.Value))
+	l := make([]bgp.NLRI, 0, len(a.Value))
 	for _, v := range a.Value {
 		l = append(l, v.NLRI)
 	}

--- a/pkg/apiutil/util.go
+++ b/pkg/apiutil/util.go
@@ -89,7 +89,7 @@ type LookupPrefix struct {
 // used by server.WatchEventMessages API
 type Path struct {
 	Family             bgp.Family
-	Nlri               bgp.AddrPrefixInterface      `json:"nlri"`
+	Nlri               bgp.NLRI                     `json:"nlri"`
 	Age                int64                        `json:"age"`
 	Best               bool                         `json:"best"`
 	Attrs              []bgp.PathAttributeInterface `json:"attrs"`
@@ -166,7 +166,7 @@ func NewDestination(dst *api.Destination) *Destination {
 	return &Destination{Paths: l}
 }
 
-func NewPath(family bgp.Family, nlri bgp.AddrPrefixInterface, isWithdraw bool, attrs []bgp.PathAttributeInterface, age time.Time) (*api.Path, error) {
+func NewPath(family bgp.Family, nlri bgp.NLRI, isWithdraw bool, attrs []bgp.PathAttributeInterface, age time.Time) (*api.Path, error) {
 	n, err := MarshalNLRI(nlri)
 	if err != nil {
 		return nil, err
@@ -184,7 +184,7 @@ func NewPath(family bgp.Family, nlri bgp.AddrPrefixInterface, isWithdraw bool, a
 	}, nil
 }
 
-func GetNativeNlri(p *api.Path) (bgp.AddrPrefixInterface, error) {
+func GetNativeNlri(p *api.Path) (bgp.NLRI, error) {
 	if p.Family == nil {
 		return nil, fmt.Errorf("family cannot be nil")
 	}

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -1376,7 +1376,7 @@ func NewBGPOpenMessage(myas uint16, holdtime uint16, id netip.Addr, optparams []
 	}, nil
 }
 
-type AddrPrefixInterface interface {
+type NLRI interface {
 	Serialize(...*MarshallingOption) ([]byte, error)
 	Len(...*MarshallingOption) int
 	String() string
@@ -1386,7 +1386,7 @@ type AddrPrefixInterface interface {
 	Flat() map[string]string
 }
 
-func LabelString(nlri AddrPrefixInterface) string {
+func LabelString(nlri NLRI) string {
 	label := ""
 	switch n := nlri.(type) {
 	case *LabeledIPAddrPrefix:
@@ -9755,7 +9755,7 @@ func GetFamily(name string) (Family, error) {
 	return Family(0), fmt.Errorf("%s isn't a valid route family name", name)
 }
 
-func NLRIFromSlice(family Family, buf []byte, options ...*MarshallingOption) (nlri AddrPrefixInterface, err error) {
+func NLRIFromSlice(family Family, buf []byte, options ...*MarshallingOption) (nlri NLRI, err error) {
 	switch family {
 	case RF_IPv4_UC, RF_IPv4_MC, RF_IPv6_UC, RF_IPv6_MC:
 		if family.Afi() == AFI_IP6 {
@@ -14683,7 +14683,7 @@ func GetPathAttribute(data []byte) (PathAttributeInterface, error) {
 }
 
 type PathNLRI struct {
-	NLRI AddrPrefixInterface
+	NLRI NLRI
 	ID   uint32
 }
 

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -1186,7 +1186,7 @@ func Test_MpReachNLRIWithImplicitPrefix(t *testing.T) {
 	// assert.Equal(prefix.AFI(), p.AFI)
 	// assert.Equal(prefix.SAFI(), p.SAFI)
 	// prefix, _ := NewIPAddrPrefix(netip.MustParsePrefix("192.168.10.0/24"))
-	// value := []AddrPrefixInterface{prefix}
+	// value := []NLRI{prefix}
 	// assert.Equal(value, p.Value)
 	// Test Serialize()
 	bufout, err := p.Serialize(options)

--- a/pkg/packet/bgp/helper.go
+++ b/pkg/packet/bgp/helper.go
@@ -40,7 +40,7 @@ func NewTestBGPOpenMessage() *BGPMessage {
 func NewTestBGPUpdateMessage() *BGPMessage {
 	w1, _ := NewIPAddrPrefix(netip.MustParsePrefix("121.1.3.2/23"))
 	w2, _ := NewIPAddrPrefix(netip.MustParsePrefix("100.33.3.0/17"))
-	w := []AddrPrefixInterface{w1, w2}
+	w := []NLRI{w1, w2}
 
 	aspath1 := []AsPathParamInterface{
 		NewAsPathParam(2, []uint16{1000}),
@@ -79,22 +79,22 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 		NewRouteDistinguisherTwoOctetAS(256, 10000))
 	rd, _ := NewRouteDistinguisherIPAddressAS(netip.MustParseAddr("10.0.1.1"), 10001)
 	vpn2, _ := NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("192.10.8.0/24"), *NewMPLSLabelStack(5, 6, 7, 8), rd)
-	prefixes1 := []AddrPrefixInterface{vpn1, vpn2}
+	prefixes1 := []NLRI{vpn1, vpn2}
 
 	nlri, _ := NewIPAddrPrefix(netip.MustParsePrefix("fe80:1234:1234:5667:8967:af12:8912:1023/128"))
-	prefixes2 := []AddrPrefixInterface{nlri}
+	prefixes2 := []NLRI{nlri}
 
 	vpn3, _ := NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("fe80:1234:1234:5667:8967:af12:1203:33a1/128"), *NewMPLSLabelStack(5, 6), NewRouteDistinguisherFourOctetAS(5, 6))
-	prefixes3 := []AddrPrefixInterface{vpn3}
+	prefixes3 := []NLRI{vpn3}
 
 	mpls, _ := NewLabeledIPAddrPrefix(netip.MustParsePrefix("192.168.0.0/25"), *NewMPLSLabelStack(5, 6, 7))
-	prefixes4 := []AddrPrefixInterface{mpls}
+	prefixes4 := []NLRI{mpls}
 
 	r2, _ := NewEVPNMacIPAdvertisementRoute(NewRouteDistinguisherFourOctetAS(5, 6), EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, 3, "01:23:45:67:89:ab", netip.MustParseAddr("192.2.1.2"), []uint32{3, 4})
 	r3, _ := NewEVPNMulticastEthernetTagRoute(NewRouteDistinguisherFourOctetAS(5, 6), 3, netip.MustParseAddr("192.2.1.2"))
 	r4, _ := NewEVPNEthernetSegmentRoute(NewRouteDistinguisherFourOctetAS(5, 6), EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, netip.MustParseAddr("192.2.1.1"))
 	r5, _ := NewEVPNIPPrefixRoute(NewRouteDistinguisherFourOctetAS(5, 6), EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, 5, 24, netip.MustParseAddr("192.2.1.0"), netip.MustParseAddr("192.3.1.1"), 5)
-	prefixes5 := []AddrPrefixInterface{
+	prefixes5 := []NLRI{
 		NewEVPNEthernetAutoDiscoveryRoute(NewRouteDistinguisherFourOctetAS(5, 6), EthernetSegmentIdentifier{ESI_ARBITRARY, make([]byte, 9)}, 2, 2),
 		r2,
 		r3,
@@ -102,7 +102,7 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 		r5,
 	}
 
-	prefixes6 := []AddrPrefixInterface{NewVPLSNLRI(NewRouteDistinguisherFourOctetAS(5, 6), 101, 100, 10, 1000)}
+	prefixes6 := []NLRI{NewVPLSNLRI(NewRouteDistinguisherFourOctetAS(5, 6), 101, 100, 10, 1000)}
 
 	panh, _ := NewPathAttributeNextHop(netip.MustParseAddr("129.1.1.2"))
 	paag1, _ := NewPathAttributeAggregator(uint16(30002), netip.MustParseAddr("129.0.2.99"))
@@ -129,7 +129,7 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 		NewPathAttributeAs4Path(aspath3),
 		paag4,
 	}
-	toList := func(l []AddrPrefixInterface) []PathNLRI {
+	toList := func(l []NLRI) []PathNLRI {
 		r := make([]PathNLRI, 0, len(l))
 		for _, p := range l {
 			r = append(r, PathNLRI{NLRI: p})
@@ -146,11 +146,11 @@ func NewTestBGPUpdateMessage() *BGPMessage {
 	mp6, _ := NewPathAttributeMpReachNLRI(RF_VPLS, toList(prefixes6), netip.MustParseAddr("135.1.1.1"))
 	mpUnreach1, _ := NewPathAttributeMpUnreachNLRI(RF_IPv4_VPN, toList(prefixes1))
 	p = append(p, mp1, mp2, mp3, mp4, mp5, mp6, mpUnreach1,
-		// NewPathAttributeMpReachNLRI("112.22.2.0", []AddrPrefixInterface{}),
-		// NewPathAttributeMpUnreachNLRI([]AddrPrefixInterface{}),
+		// NewPathAttributeMpReachNLRI("112.22.2.0", []NLRI{}),
+		// NewPathAttributeMpUnreachNLRI([]NLRI{}),
 		NewPathAttributeUnknown(BGP_ATTR_FLAG_TRANSITIVE, 100, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
 	)
 	prefix, _ := NewIPAddrPrefix(netip.MustParsePrefix("13.2.3.1/24"))
-	n := []AddrPrefixInterface{prefix}
+	n := []NLRI{prefix}
 	return NewBGPUpdateMessage(toList(w), p, toList(n))
 }

--- a/pkg/packet/bgp/mup.go
+++ b/pkg/packet/bgp/mup.go
@@ -204,7 +204,7 @@ func NewMUPNLRI(afi uint16, at uint8, rt uint16, data MUPRouteTypeInterface) *MU
 	}
 }
 
-func TEIDString(nlri AddrPrefixInterface) string {
+func TEIDString(nlri NLRI) string {
 	s := ""
 	switch n := nlri.(type) {
 	case *MUPNLRI:
@@ -218,7 +218,7 @@ func TEIDString(nlri AddrPrefixInterface) string {
 	return s
 }
 
-func QFIString(nlri AddrPrefixInterface) string {
+func QFIString(nlri NLRI) string {
 	s := ""
 	switch n := nlri.(type) {
 	case *MUPNLRI:
@@ -232,7 +232,7 @@ func QFIString(nlri AddrPrefixInterface) string {
 	return s
 }
 
-func EndpointString(nlri AddrPrefixInterface) string {
+func EndpointString(nlri NLRI) string {
 	s := ""
 	switch n := nlri.(type) {
 	case *MUPNLRI:

--- a/pkg/packet/bgp/validate_test.go
+++ b/pkg/packet/bgp/validate_test.go
@@ -33,7 +33,7 @@ func bgpupdateV6() *BGPMessage {
 	}
 
 	nlri, _ := NewIPAddrPrefix(netip.MustParsePrefix("fe80:1234:1234:5667:8967:af12:8912:1023/100"))
-	prefixes := []AddrPrefixInterface{nlri}
+	prefixes := []NLRI{nlri}
 
 	p := []PathAttributeInterface{
 		NewPathAttributeOrigin(1),

--- a/pkg/packet/mrt/mrt.go
+++ b/pkg/packet/mrt/mrt.go
@@ -392,7 +392,7 @@ type RibEntry struct {
 
 var errNotAllRibEntryBytesAvailable = errors.New("not all RibEntry bytes are available")
 
-func parseRibEntry(data []byte, family bgp.Family, isAddPath bool, prefix ...bgp.AddrPrefixInterface) (*RibEntry, []byte, error) {
+func parseRibEntry(data []byte, family bgp.Family, isAddPath bool, prefix ...bgp.NLRI) (*RibEntry, []byte, error) {
 	if len(data) < 8 {
 		return nil, data, errNotAllRibEntryBytesAvailable
 	}
@@ -501,7 +501,7 @@ func (e *RibEntry) String() string {
 
 type Rib struct {
 	SequenceNumber uint32
-	Prefix         bgp.AddrPrefixInterface
+	Prefix         bgp.NLRI
 	Entries        []*RibEntry
 	Family         bgp.Family
 	isAddPath      bool
@@ -581,7 +581,7 @@ func (u *Rib) Serialize() ([]byte, error) {
 	return buf, nil
 }
 
-func NewRib(seq uint32, family bgp.Family, prefix bgp.AddrPrefixInterface, entries []*RibEntry) *Rib {
+func NewRib(seq uint32, family bgp.Family, prefix bgp.NLRI, entries []*RibEntry) *Rib {
 	return &Rib{
 		SequenceNumber: seq,
 		Family:         family,

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -294,7 +294,7 @@ func (s *server) listPath(ctx context.Context, r *api.ListPathRequest, fn func(*
 		}
 	}
 
-	err := s.bgpServer.ListPath(req, func(prefix bgp.AddrPrefixInterface, paths []*apiutil.Path) {
+	err := s.bgpServer.ListPath(req, func(prefix bgp.NLRI, paths []*apiutil.Path) {
 		select {
 		case <-ctx.Done():
 			return
@@ -509,7 +509,7 @@ func newRoutingPolicyFromApiStruct(arg *api.SetPoliciesRequest) (*oc.RoutingPoli
 
 func api2Path(resource api.TableType, path *api.Path, isWithdraw bool) (*table.Path, error) {
 	var pi *table.PeerInfo
-	var nlri bgp.AddrPrefixInterface
+	var nlri bgp.NLRI
 	var nexthop netip.Addr
 
 	if path.SourceAsn != 0 {

--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -159,7 +159,7 @@ func eor(f bgp.Family) *table.Path {
 	return p
 }
 
-func nlri(nlri bgp.AddrPrefixInterface) *api.NLRI {
+func nlri(nlri bgp.NLRI) *api.NLRI {
 	apiNlri, _ := apiutil.MarshalNLRI(nlri)
 	return apiNlri
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2872,7 +2872,7 @@ func (s *BgpServer) getAdjRib(addr string, family bgp.Family, in bool, enableFil
 	return
 }
 
-func (s *BgpServer) ListPath(r apiutil.ListPathRequest, fn func(prefix bgp.AddrPrefixInterface, paths []*apiutil.Path)) error {
+func (s *BgpServer) ListPath(r apiutil.ListPathRequest, fn func(prefix bgp.NLRI, paths []*apiutil.Path)) error {
 	in := false
 	family := r.Family
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -521,7 +521,7 @@ func TestListPathEnableFiltered(test *testing.T) {
 			Family:    bgpFamily, Name: "127.0.0.1",
 			// TODO(wenovus): This is confusing and we may want to change this.
 			EnableFiltered: true,
-		}, func(prefix bgp.AddrPrefixInterface, paths []*apiutil.Path) {
+		}, func(prefix bgp.NLRI, paths []*apiutil.Path) {
 			count++
 			for _, path := range paths {
 				comms := getCommunities(path)
@@ -543,7 +543,7 @@ func TestListPathEnableFiltered(test *testing.T) {
 			Family:    bgpFamily, Name: "127.0.0.1",
 			// TODO(wenovus): This is confusing and we may want to change this.
 			EnableFiltered: false,
-		}, func(prefix bgp.AddrPrefixInterface, paths []*apiutil.Path) {
+		}, func(prefix bgp.NLRI, paths []*apiutil.Path) {
 			count++
 			for _, path := range paths {
 				if path.Filtered {
@@ -568,7 +568,7 @@ func TestListPathEnableFiltered(test *testing.T) {
 			Family:         bgpFamily,
 			Name:           "127.0.0.1",
 			EnableFiltered: false,
-		}, func(prefix bgp.AddrPrefixInterface, paths []*apiutil.Path) {
+		}, func(prefix bgp.NLRI, paths []*apiutil.Path) {
 			count++
 			for _, path := range paths {
 				comms := getCommunities(path)
@@ -590,7 +590,7 @@ func TestListPathEnableFiltered(test *testing.T) {
 			Family:         bgpFamily,
 			Name:           "127.0.0.1",
 			EnableFiltered: true,
-		}, func(prefix bgp.AddrPrefixInterface, paths []*apiutil.Path) {
+		}, func(prefix bgp.NLRI, paths []*apiutil.Path) {
 			count++
 			for _, path := range paths {
 				if path.Filtered {
@@ -609,14 +609,14 @@ func TestListPathEnableFiltered(test *testing.T) {
 
 	// Check that 10.1.0.0/24 is filtered at the import side.
 	count := 0
-	err = server1.ListPath(apiutil.ListPathRequest{TableType: api.TableType_TABLE_TYPE_GLOBAL, Family: bgpFamily}, func(prefix bgp.AddrPrefixInterface, paths []*apiutil.Path) {
+	err = server1.ListPath(apiutil.ListPathRequest{TableType: api.TableType_TABLE_TYPE_GLOBAL, Family: bgpFamily}, func(prefix bgp.NLRI, paths []*apiutil.Path) {
 		count++
 	})
 	assert.NoError(err)
 	assert.Equal(1, count)
 
 	filtered := 0
-	err = server1.ListPath(apiutil.ListPathRequest{TableType: api.TableType_TABLE_TYPE_ADJ_IN, Family: bgpFamily, Name: "127.0.0.1", EnableFiltered: true}, func(prefix bgp.AddrPrefixInterface, paths []*apiutil.Path) {
+	err = server1.ListPath(apiutil.ListPathRequest{TableType: api.TableType_TABLE_TYPE_ADJ_IN, Family: bgpFamily, Name: "127.0.0.1", EnableFiltered: true}, func(prefix bgp.NLRI, paths []*apiutil.Path) {
 		if paths[0].Filtered {
 			filtered++
 		}
@@ -695,7 +695,7 @@ func TestListPathEnableFiltered(test *testing.T) {
 	assert.NoError(err)
 
 	count = 0
-	err = server1.ListPath(apiutil.ListPathRequest{TableType: api.TableType_TABLE_TYPE_GLOBAL, Family: bgpFamily}, func(prefix bgp.AddrPrefixInterface, paths []*apiutil.Path) {
+	err = server1.ListPath(apiutil.ListPathRequest{TableType: api.TableType_TABLE_TYPE_GLOBAL, Family: bgpFamily}, func(prefix bgp.NLRI, paths []*apiutil.Path) {
 		count++
 	})
 	assert.NoError(err)
@@ -703,7 +703,7 @@ func TestListPathEnableFiltered(test *testing.T) {
 
 	count = 0
 	filtered = 0
-	err = server1.ListPath(apiutil.ListPathRequest{TableType: api.TableType_TABLE_TYPE_ADJ_OUT, Family: bgpFamily, Name: "127.0.0.1", EnableFiltered: true}, func(prefix bgp.AddrPrefixInterface, paths []*apiutil.Path) {
+	err = server1.ListPath(apiutil.ListPathRequest{TableType: api.TableType_TABLE_TYPE_ADJ_OUT, Family: bgpFamily, Name: "127.0.0.1", EnableFiltered: true}, func(prefix bgp.NLRI, paths []*apiutil.Path) {
 		count++
 		if paths[0].Filtered {
 			filtered++
@@ -2181,7 +2181,7 @@ func TestAddDeletePath(t *testing.T) {
 
 	listRib := func(f bgp.Family) []*api.Destination {
 		l := make([]*api.Destination, 0)
-		err := s.ListPath(apiutil.ListPathRequest{TableType: api.TableType_TABLE_TYPE_GLOBAL, Family: f}, func(prefix bgp.AddrPrefixInterface, paths []*apiutil.Path) {
+		err := s.ListPath(apiutil.ListPathRequest{TableType: api.TableType_TABLE_TYPE_GLOBAL, Family: f}, func(prefix bgp.NLRI, paths []*apiutil.Path) {
 			d := api.Destination{
 				Prefix: prefix.String(),
 				Paths:  make([]*api.Path, len(paths)),
@@ -2492,7 +2492,7 @@ func TestListPathWithIdentifiers(t *testing.T) {
 			Name:      name,
 			TableType: tableType,
 			Family:    family,
-		}, func(prefix bgp.AddrPrefixInterface, paths []*apiutil.Path) {
+		}, func(prefix bgp.NLRI, paths []*apiutil.Path) {
 			d := api.Destination{
 				Prefix: prefix.String(),
 				Paths:  make([]*api.Path, len(paths)),

--- a/pkg/server/zclient.go
+++ b/pkg/server/zclient.go
@@ -259,7 +259,7 @@ func newPathFromIPRouteMessage(logger log.Logger, m *zebra.Message, version uint
 	family := body.Family(logger, version, software)
 	isWithdraw := body.IsWithdraw(version, software)
 
-	var nlri bgp.AddrPrefixInterface
+	var nlri bgp.NLRI
 	pattr := make([]bgp.PathAttributeInterface, 0)
 	origin := bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP)
 	pattr = append(pattr, origin)


### PR DESCRIPTION
Rename AddrPrefixInterface to NLRI because "AddrPrefix" doesn't make sense for some NLRIs that doesn't use "prefix".