### PR TITLE
config: use netip for some OpenConfig types

### DIFF
--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -283,7 +283,7 @@
     [[policy-definitions.statements]]
         [policy-definitions.statements.conditions.bgp-conditions]
             next-hop-in-list = [
-               "10.0.100.1/32"
+               "10.0.100.1"
             ]
         [policy-definitions.statements.actions]
             route-disposition = "accept-route"

--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -122,7 +122,6 @@ func (i *PeerInfo) String() string {
 }
 
 func NewPeerInfo(g *oc.Global, p *oc.Neighbor, AS, localAS uint32, ID, localID netip.Addr, addr, localAddr netip.Addr) *PeerInfo {
-	clusterID, _ := netip.ParseAddr(string(p.RouteReflector.State.RouteReflectorClusterId))
 	return &PeerInfo{
 		AS:                      AS,
 		LocalAS:                 localAS,
@@ -130,7 +129,7 @@ func NewPeerInfo(g *oc.Global, p *oc.Neighbor, AS, localAS uint32, ID, localID n
 		LocalID:                 localID,
 		Address:                 addr,
 		LocalAddress:            localAddr,
-		RouteReflectorClusterID: clusterID,
+		RouteReflectorClusterID: p.RouteReflector.State.RouteReflectorClusterId,
 		RouteReflectorClient:    p.RouteReflector.Config.RouteReflectorClient,
 		MultihopTtl:             p.EbgpMultihop.Config.MultihopTtl,
 		Confederation:           p.IsConfederationMember(g),

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -309,7 +309,7 @@ func UpdatePathAttrs(logger log.Logger, global *oc.Global, peer *oc.Neighbor, in
 				path.setPathAttr(attr)
 			} else if path.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGINATOR_ID) == nil {
 				if path.IsLocal() {
-					attr, _ := bgp.NewPathAttributeOriginatorId(netip.MustParseAddr(global.Config.RouterId))
+					attr, _ := bgp.NewPathAttributeOriginatorId(global.Config.RouterId)
 					path.setPathAttr(attr)
 				} else {
 					attr, _ := bgp.NewPathAttributeOriginatorId(info.ID)
@@ -319,7 +319,7 @@ func UpdatePathAttrs(logger log.Logger, global *oc.Global, peer *oc.Neighbor, in
 			// When an RR reflects a route, it MUST prepend the local CLUSTER_ID to the CLUSTER_LIST.
 			// If the CLUSTER_LIST is empty, it MUST create a new one.
 			// TODO: needs to validated earlier.
-			clusterID := netip.MustParseAddr(string(peer.RouteReflector.State.RouteReflectorClusterId))
+			clusterID := peer.RouteReflector.State.RouteReflectorClusterId
 			if p := path.getPathAttr(bgp.BGP_ATTR_TYPE_CLUSTER_LIST); p == nil {
 				pa, _ := bgp.NewPathAttributeClusterList([]netip.Addr{clusterID})
 				path.setPathAttr(pa)

--- a/internal/pkg/table/policy_test.go
+++ b/internal/pkg/table/policy_test.go
@@ -64,13 +64,13 @@ func TestPrefixCalcurateNoRange(t *testing.T) {
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// test
-	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: "10.10.0.0/24", MasklengthRange: ""})
+	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("10.10.0.0/24"), MasklengthRange: ""})
 	match1 := pl1.Match(path)
 	assert.Equal(t, true, match1)
-	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: "10.10.0.0/23", MasklengthRange: ""})
+	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("10.10.0.0/23"), MasklengthRange: ""})
 	match2 := pl2.Match(path)
 	assert.Equal(t, false, match2)
-	pl3, _ := NewPrefix(oc.Prefix{IpPrefix: "10.10.0.0/16", MasklengthRange: "21..24"})
+	pl3, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("10.10.0.0/16"), MasklengthRange: "21..24"})
 	match3 := pl3.Match(path)
 	assert.Equal(t, true, match3)
 }
@@ -88,10 +88,10 @@ func TestPrefixCalcurateAddress(t *testing.T) {
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// test
-	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: "10.11.0.0/16", MasklengthRange: "21..24"})
+	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("10.11.0.0/16"), MasklengthRange: "21..24"})
 	match1 := pl1.Match(path)
 	assert.Equal(t, false, match1)
-	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: "10.10.0.0/16", MasklengthRange: "21..24"})
+	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("10.10.0.0/16"), MasklengthRange: "21..24"})
 	match2 := pl2.Match(path)
 	assert.Equal(t, true, match2)
 }
@@ -109,10 +109,10 @@ func TestPrefixCalcurateLength(t *testing.T) {
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// test
-	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: "10.10.64.0/24", MasklengthRange: "21..24"})
+	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("10.10.64.0/24"), MasklengthRange: "21..24"})
 	match1 := pl1.Match(path)
 	assert.Equal(t, false, match1)
-	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: "10.10.64.0/16", MasklengthRange: "21..24"})
+	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("10.10.64.0/16"), MasklengthRange: "21..24"})
 	match2 := pl2.Match(path)
 	assert.Equal(t, true, match2)
 }
@@ -130,13 +130,13 @@ func TestPrefixCalcurateLengthRange(t *testing.T) {
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// test
-	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: "10.10.0.0/16", MasklengthRange: "21..23"})
+	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("10.10.0.0/16"), MasklengthRange: "21..23"})
 	match1 := pl1.Match(path)
 	assert.Equal(t, false, match1)
-	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: "10.10.0.0/16", MasklengthRange: "25..26"})
+	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("10.10.0.0/16"), MasklengthRange: "25..26"})
 	match2 := pl2.Match(path)
 	assert.Equal(t, false, match2)
-	pl3, _ := NewPrefix(oc.Prefix{IpPrefix: "10.10.0.0/16", MasklengthRange: "21..24"})
+	pl3, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("10.10.0.0/16"), MasklengthRange: "21..24"})
 	match3 := pl3.Match(path)
 	assert.Equal(t, true, match3)
 }
@@ -154,13 +154,13 @@ func TestPrefixCalcurateNoRangeIPv6(t *testing.T) {
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, nil)
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// test
-	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: "2001:123:123::/48", MasklengthRange: ""})
+	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("2001:123:123::/48"), MasklengthRange: ""})
 	match1 := pl1.Match(path)
 	assert.Equal(t, false, match1)
-	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: "2001:123:123:1::/64", MasklengthRange: ""})
+	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("2001:123:123:1::/64"), MasklengthRange: ""})
 	match2 := pl2.Match(path)
 	assert.Equal(t, true, match2)
-	pl3, _ := NewPrefix(oc.Prefix{IpPrefix: "2001:123:123::/48", MasklengthRange: "64..80"})
+	pl3, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("2001:123:123::/48"), MasklengthRange: "64..80"})
 	match3 := pl3.Match(path)
 	assert.Equal(t, true, match3)
 }
@@ -178,10 +178,10 @@ func TestPrefixCalcurateAddressIPv6(t *testing.T) {
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, nil)
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// test
-	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: "2001:123:128::/48", MasklengthRange: "64..80"})
+	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("2001:123:128::/48"), MasklengthRange: "64..80"})
 	match1 := pl1.Match(path)
 	assert.Equal(t, false, match1)
-	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: "2001:123:123::/48", MasklengthRange: "64..80"})
+	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("2001:123:123::/48"), MasklengthRange: "64..80"})
 	match2 := pl2.Match(path)
 	assert.Equal(t, true, match2)
 }
@@ -199,10 +199,10 @@ func TestPrefixCalcurateLengthIPv6(t *testing.T) {
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, nil)
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// test
-	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: "2001:123:123:64::/64", MasklengthRange: "64..80"})
+	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("2001:123:123:64::/64"), MasklengthRange: "64..80"})
 	match1 := pl1.Match(path)
 	assert.Equal(t, false, match1)
-	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: "2001:123:123:64::/48", MasklengthRange: "64..80"})
+	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("2001:123:123:64::/48"), MasklengthRange: "64..80"})
 	match2 := pl2.Match(path)
 	assert.Equal(t, true, match2)
 }
@@ -220,13 +220,13 @@ func TestPrefixCalcurateLengthRangeIPv6(t *testing.T) {
 	updateMsg := bgp.NewBGPUpdateMessage(nil, pathAttributes, nil)
 	path := ProcessMessage(updateMsg, peer, time.Now(), false)[0]
 	// test
-	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: "2001:123:123::/48", MasklengthRange: "62..63"})
+	pl1, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("2001:123:123::/48"), MasklengthRange: "62..63"})
 	match1 := pl1.Match(path)
 	assert.Equal(t, false, match1)
-	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: "2001:123:123::/48", MasklengthRange: "65..66"})
+	pl2, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("2001:123:123::/48"), MasklengthRange: "65..66"})
 	match2 := pl2.Match(path)
 	assert.Equal(t, false, match2)
-	pl3, _ := NewPrefix(oc.Prefix{IpPrefix: "2001:123:123::/48", MasklengthRange: "63..65"})
+	pl3, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("2001:123:123::/48"), MasklengthRange: "63..65"})
 	match3 := pl3.Match(path)
 	assert.Equal(t, true, match3)
 }
@@ -831,7 +831,7 @@ func TestPolicyMatchAndAcceptNextHop(t *testing.T) {
 	ds.PrefixSets = []oc.PrefixSet{ps}
 	ds.NeighborSets = []oc.NeighborSet{ns}
 	s := createStatement("statement1", "ps1", "ns1", true)
-	s.Conditions.BgpConditions.NextHopInList = []string{"10.0.0.1/32"}
+	s.Conditions.BgpConditions.NextHopInList = []netip.Addr{netip.MustParseAddr("10.0.0.1")}
 	pd := createPolicyDefinition("pd1", s)
 	pl := createRoutingPolicy(ds, pd)
 
@@ -863,7 +863,7 @@ func TestPolicyMatchAndRejectNextHop(t *testing.T) {
 	ds.PrefixSets = []oc.PrefixSet{ps}
 	ds.NeighborSets = []oc.NeighborSet{ns}
 	s := createStatement("statement1", "ps1", "ns1", true)
-	s.Conditions.BgpConditions.NextHopInList = []string{"10.0.0.12"}
+	s.Conditions.BgpConditions.NextHopInList = []netip.Addr{netip.MustParseAddr("10.0.0.12")}
 	pd := createPolicyDefinition("pd1", s)
 	pl := createRoutingPolicy(ds, pd)
 
@@ -900,7 +900,7 @@ func TestSetNextHop(t *testing.T) {
 		s1.Actions.BgpActions.SetNextHop = oc.BgpNextHopType("10.2.2.2")
 		s1.Actions.RouteDisposition = oc.ROUTE_DISPOSITION_NONE
 		s2 := createStatement("statement2", "ps", "ns", true)
-		s2.Conditions.BgpConditions.NextHopInList = []string{"10.2.2.2"}
+		s2.Conditions.BgpConditions.NextHopInList = []netip.Addr{netip.MustParseAddr("10.2.2.2")}
 		pd := createPolicyDefinition("pd1", s1, s2)
 		pl := createRoutingPolicy(ds, pd)
 
@@ -920,7 +920,7 @@ func TestSetNextHop(t *testing.T) {
 		s1.Actions.BgpActions.SetNextHop = oc.BgpNextHopType("self")
 		s1.Actions.RouteDisposition = oc.ROUTE_DISPOSITION_NONE
 		s2 := createStatement("statement2", "ps", "ns", true)
-		s2.Conditions.BgpConditions.NextHopInList = []string{"20.0.0.1"}
+		s2.Conditions.BgpConditions.NextHopInList = []netip.Addr{netip.MustParseAddr("20.0.0.1")}
 		pd := createPolicyDefinition("pd1", s1, s2)
 		pl := createRoutingPolicy(ds, pd)
 
@@ -940,7 +940,7 @@ func TestSetNextHop(t *testing.T) {
 		s1.Actions.BgpActions.SetNextHop = oc.BgpNextHopType("peer-address")
 		s1.Actions.RouteDisposition = oc.ROUTE_DISPOSITION_NONE
 		s2 := createStatement("statement2", "ps", "ns", true)
-		s2.Conditions.BgpConditions.NextHopInList = []string{"10.0.0.2"}
+		s2.Conditions.BgpConditions.NextHopInList = []netip.Addr{netip.MustParseAddr("10.0.0.2")}
 		pd := createPolicyDefinition("pd1", s1, s2)
 		pl := createRoutingPolicy(ds, pd)
 
@@ -3521,7 +3521,7 @@ func createPrefixSet(name string, prefix string, maskLength string) oc.PrefixSet
 		PrefixSetName: name,
 		PrefixList: []oc.Prefix{
 			{
-				IpPrefix:        prefix,
+				IpPrefix:        netip.MustParsePrefix(prefix),
 				MasklengthRange: maskLength,
 			},
 		},
@@ -3547,11 +3547,11 @@ func createAs4Value(s string) uint32 {
 func TestPrefixSetOperation(t *testing.T) {
 	// tryp to create prefixset with multiple families
 	p1 := oc.Prefix{
-		IpPrefix:        "0.0.0.0/0",
+		IpPrefix:        netip.MustParsePrefix("0.0.0.0/0"),
 		MasklengthRange: "0..7",
 	}
 	p2 := oc.Prefix{
-		IpPrefix:        "0::/25",
+		IpPrefix:        netip.MustParsePrefix("0::/25"),
 		MasklengthRange: "25..128",
 	}
 	_, err := NewPrefixSet(oc.PrefixSet{
@@ -3570,19 +3570,19 @@ func TestPrefixSetOperation(t *testing.T) {
 	err = m2.Append(m1)
 	assert.NoError(t, err)
 	assert.Equal(t, bgp.RF_IPv4_UC, m2.family)
-	p3, _ := NewPrefix(oc.Prefix{IpPrefix: "10.10.0.0/24", MasklengthRange: ""})
-	p4, _ := NewPrefix(oc.Prefix{IpPrefix: "0::/25", MasklengthRange: ""})
+	p3, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("10.10.0.0/24"), MasklengthRange: ""})
+	p4, _ := NewPrefix(oc.Prefix{IpPrefix: netip.MustParsePrefix("0::/25"), MasklengthRange: ""})
 	_, err = NewPrefixSetFromApiStruct("ps3", []*Prefix{p3, p4})
 	assert.NotNil(t, err)
 }
 
 func TestPrefixSetMatch(t *testing.T) {
 	p1 := oc.Prefix{
-		IpPrefix:        "0.0.0.0/0",
+		IpPrefix:        netip.MustParsePrefix("0.0.0.0/0"),
 		MasklengthRange: "0..7",
 	}
 	p2 := oc.Prefix{
-		IpPrefix:        "0.0.0.0/0",
+		IpPrefix:        netip.MustParsePrefix("0.0.0.0/0"),
 		MasklengthRange: "25..32",
 	}
 	ps, err := NewPrefixSet(oc.PrefixSet{
@@ -3612,7 +3612,7 @@ func TestPrefixSetMatch(t *testing.T) {
 	assert.True(t, m.Evaluate(path, nil))
 
 	p3 := oc.Prefix{
-		IpPrefix:        "0.0.0.0/0",
+		IpPrefix:        netip.MustParsePrefix("0.0.0.0/0"),
 		MasklengthRange: "9..10",
 	}
 	ps2, err := NewPrefixSet(oc.PrefixSet{
@@ -3642,7 +3642,7 @@ func TestPrefixSetMatch(t *testing.T) {
 
 func TestPrefixSetMatchV4withV6Prefix(t *testing.T) {
 	p1 := oc.Prefix{
-		IpPrefix:        "c000::/3",
+		IpPrefix:        netip.MustParsePrefix("c000::/3"),
 		MasklengthRange: "3..128",
 	}
 	ps, err := NewPrefixSet(oc.PrefixSet{
@@ -3661,7 +3661,7 @@ func TestPrefixSetMatchV4withV6Prefix(t *testing.T) {
 
 func TestPrefixSetMatchV6LabeledwithV6Prefix(t *testing.T) {
 	p1 := oc.Prefix{
-		IpPrefix:        "2806:106e:19::/48",
+		IpPrefix:        netip.MustParsePrefix("2806:106e:19::/48"),
 		MasklengthRange: "48..48",
 	}
 	ps, err := NewPrefixSet(oc.PrefixSet{
@@ -3686,7 +3686,7 @@ func TestPrefixSetMatchV6LabeledwithV6Prefix(t *testing.T) {
 
 func TestPrefixSetMatchVPNV4Prefix(t *testing.T) {
 	p1 := oc.Prefix{
-		IpPrefix:        "10.10.10.0/24",
+		IpPrefix:        netip.MustParsePrefix("10.10.10.0/24"),
 		MasklengthRange: "24..32",
 	}
 	ps, err := NewPrefixSet(oc.PrefixSet{
@@ -3716,7 +3716,7 @@ func TestPrefixSetMatchVPNV4Prefix(t *testing.T) {
 
 func TestPrefixSetMatchVPNV6Prefix(t *testing.T) {
 	p1 := oc.Prefix{
-		IpPrefix:        "2001:123:123:1::/64",
+		IpPrefix:        netip.MustParsePrefix("2001:123:123:1::/64"),
 		MasklengthRange: "64..128",
 	}
 	ps, err := NewPrefixSet(oc.PrefixSet{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -182,7 +182,7 @@ func addDynamicNeighbors(ctx context.Context, bgpServer *server.BgpServer, dynam
 			})
 		if err := bgpServer.AddDynamicNeighbor(ctx, &api.AddDynamicNeighborRequest{
 			DynamicNeighbor: &api.DynamicNeighbor{
-				Prefix:    dn.Config.Prefix,
+				Prefix:    dn.Config.Prefix.String(),
 				PeerGroup: dn.Config.PeerGroup,
 			},
 		}); err != nil {
@@ -229,7 +229,7 @@ func deleteNeighbors(ctx context.Context, bgpServer *server.BgpServer, deleted [
 				"Key":   p.State.NeighborAddress,
 			})
 		if err := bgpServer.DeletePeer(ctx, &api.DeletePeerRequest{
-			Address: p.State.NeighborAddress,
+			Address: p.State.NeighborAddress.String(),
 		}); err != nil {
 			bgpServer.Log().Fatal("Failed to delete Peer",
 				log.Fields{
@@ -306,7 +306,7 @@ func InitialConfig(ctx context.Context, bgpServer *server.BgpServer, newConfig *
 
 	for _, c := range newConfig.RpkiServers {
 		if err := bgpServer.AddRpki(ctx, &api.AddRpkiRequest{
-			Address:  c.Config.Address,
+			Address:  c.Config.Address.String(),
 			Port:     c.Config.Port,
 			Lifetime: c.Config.RecordLifetime,
 		}); err != nil {
@@ -332,7 +332,7 @@ func InitialConfig(ctx context.Context, bgpServer *server.BgpServer, newConfig *
 
 	for _, c := range newConfig.BmpServers {
 		if err := bgpServer.AddBmp(ctx, &api.AddBmpRequest{
-			Address:           c.Config.Address,
+			Address:           c.Config.Address.String(),
 			Port:              c.Config.Port,
 			SysName:           c.Config.SysName,
 			SysDescr:          c.Config.SysDescr,

--- a/pkg/config/oc/serve.go
+++ b/pkg/config/oc/serve.go
@@ -2,6 +2,7 @@ package oc
 
 import (
 	"github.com/fsnotify/fsnotify"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/viper"
 
 	"github.com/osrg/gobgp/v4/pkg/log"
@@ -25,6 +26,7 @@ type BgpConfigSet struct {
 func ReadConfigfile(path, format string) (*BgpConfigSet, error) {
 	// Update config file type, if detectable
 	format = detectConfigFileType(path, format)
+	opts := viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(mapstructure.StringToNetIPAddrHookFunc(), mapstructure.StringToNetIPPrefixHookFunc()))
 
 	config := &BgpConfigSet{}
 	v := viper.New()
@@ -34,7 +36,7 @@ func ReadConfigfile(path, format string) (*BgpConfigSet, error) {
 	if err = v.ReadInConfig(); err != nil {
 		return nil, err
 	}
-	if err = v.UnmarshalExact(config); err != nil {
+	if err = v.UnmarshalExact(config, opts); err != nil {
 		return nil, err
 	}
 	if err = setDefaultConfigValuesWithViper(v, config); err != nil {

--- a/pkg/config/server_config_test.go
+++ b/pkg/config/server_config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"net/netip"
 	"testing"
 
 	"github.com/osrg/gobgp/v4/api"
@@ -31,7 +32,7 @@ func TestConfigErrors(t *testing.T) {
 	globalCfg := oc.Global{
 		Config: oc.GlobalConfig{
 			As:       1,
-			RouterId: "1.1.1.1",
+			RouterId: netip.MustParseAddr("1.1.1.1"),
 			Port:     11179,
 		},
 	}
@@ -49,7 +50,7 @@ func TestConfigErrors(t *testing.T) {
 					{
 						Config: oc.NeighborConfig{
 							PeerGroup:       "router",
-							NeighborAddress: "1.1.1.2",
+							NeighborAddress: netip.MustParseAddr("1.1.1.2"),
 						},
 					},
 				},
@@ -72,7 +73,7 @@ func TestConfigErrors(t *testing.T) {
 					{
 						Config: oc.NeighborConfig{
 							PeerGroup:       "not-exists",
-							NeighborAddress: "1.1.1.2",
+							NeighborAddress: netip.MustParseAddr("1.1.1.2"),
 						},
 					},
 				},

--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -218,7 +218,7 @@ func (b *bmpClient) loop() {
 						info := &table.PeerInfo{
 							Address: netip.MustParseAddr("0.0.0.0"),
 							AS:      b.s.bgpConfig.Global.Config.As,
-							ID:      netip.MustParseAddr(b.s.bgpConfig.Global.Config.RouterId),
+							ID:      b.s.bgpConfig.Global.Config.RouterId,
 						}
 						for _, p := range msg.PathList {
 							u := table.CreateUpdateMsgFromPaths([]*table.Path{p})[0]
@@ -371,7 +371,7 @@ func bmpPeerRouteMirroring(peerType uint8, peerDist uint64, peerInfo *table.Peer
 }
 
 func (b *bmpClientManager) addServer(c *oc.BmpServerConfig) error {
-	host := net.JoinHostPort(c.Address, strconv.Itoa(int(c.Port)))
+	host := net.JoinHostPort(c.Address.String(), strconv.Itoa(int(c.Port)))
 	if _, y := b.clientMap[host]; y {
 		return fmt.Errorf("bmp client %s is already configured", host)
 	}
@@ -387,7 +387,7 @@ func (b *bmpClientManager) addServer(c *oc.BmpServerConfig) error {
 }
 
 func (b *bmpClientManager) deleteServer(c *oc.BmpServerConfig) error {
-	host := net.JoinHostPort(c.Address, strconv.Itoa(int(c.Port)))
+	host := net.JoinHostPort(c.Address.String(), strconv.Itoa(int(c.Port)))
 	if c, y := b.clientMap[host]; !y {
 		return fmt.Errorf("bmp client %s isn't found", host)
 	} else {

--- a/pkg/server/fsm_test.go
+++ b/pkg/server/fsm_test.go
@@ -142,7 +142,7 @@ func TestFSMHandlerOpensent_HoldTimerExpired(t *testing.T) {
 
 	// set holdtime
 	p.fsm.opensentHoldTime = 2
-	p.fsm.gConf.Config.RouterId = "1.1.1.1"
+	p.fsm.gConf.Config.RouterId = netip.MustParseAddr("1.1.1.1")
 
 	state, reason := h.opensent(t.Context())
 

--- a/pkg/server/mrt.go
+++ b/pkg/server/mrt.go
@@ -61,10 +61,10 @@ func (m *mrtWriter) dumpTable() []*mrt.MRTMessage {
 	peers = append(peers, mrt.NewPeer(netip.MustParseAddr("0.0.0.0"), netip.MustParseAddr("0.0.0.0"), 0, true))
 	for _, peer := range m.s.neighborMap {
 		ocpeer := m.s.toConfig(peer, false)
-		peers = append(peers, mrt.NewPeer(netip.MustParseAddr(ocpeer.State.RemoteRouterId), netip.MustParseAddr(ocpeer.State.NeighborAddress), ocpeer.Config.PeerAs, true))
+		peers = append(peers, mrt.NewPeer(ocpeer.State.RemoteRouterId, ocpeer.State.NeighborAddress, ocpeer.Config.PeerAs, true))
 	}
 
-	if bm, err := mrt.NewMRTMessage(t, mrt.TABLE_DUMPv2, mrt.PEER_INDEX_TABLE, mrt.NewPeerIndexTable(netip.MustParseAddr(m.s.bgpConfig.Global.Config.RouterId), "", peers)); err != nil {
+	if bm, err := mrt.NewMRTMessage(t, mrt.TABLE_DUMPv2, mrt.PEER_INDEX_TABLE, mrt.NewPeerIndexTable(m.s.bgpConfig.Global.Config.RouterId, "", peers)); err != nil {
 		m.s.logger.Warn("Failed to create MRT TABLE_DUMPv2 message",
 			log.Fields{
 				"Topic":   "mrt",

--- a/pkg/server/rpki.go
+++ b/pkg/server/rpki.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"strconv"
 	"time"
 
@@ -339,7 +340,7 @@ func (m *roaManager) GetServers() []*oc.RpkiServer {
 		addr, port, _ := net.SplitHostPort(client.host)
 		l = append(l, &oc.RpkiServer{
 			Config: oc.RpkiServerConfig{
-				Address: addr,
+				Address: netip.MustParseAddr(addr),
 				// Note: RpkiServerConfig.Port is uint32 type, but the TCP/UDP
 				// port is 16-bit length.
 				Port: func() uint32 { p, _ := strconv.ParseUint(port, 10, 16); return uint32(p) }(),

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -965,7 +965,8 @@ func TestNumGoroutineWithAddDeleteNeighbor(t *testing.T) {
 }
 
 func newPeerandInfo(t *testing.T, myAs, as uint32, address string, rib *table.TableManager) *peer {
-	nConf := &oc.Neighbor{Config: oc.NeighborConfig{PeerAs: as, NeighborAddress: address}, State: oc.NeighborState{PeerAs: as, NeighborAddress: address, RemoteRouterId: address}}
+	addr := netip.MustParseAddr(address)
+	nConf := &oc.Neighbor{Config: oc.NeighborConfig{PeerAs: as, NeighborAddress: addr}, State: oc.NeighborState{PeerAs: as, NeighborAddress: netip.MustParseAddr(address), RemoteRouterId: addr}}
 	gConf := &oc.Global{Config: oc.GlobalConfig{As: myAs}}
 	err := oc.SetDefaultNeighborConfigValues(nConf, nil, gConf)
 	assert.NoError(t, err)
@@ -1160,7 +1161,7 @@ func TestPeerGroup(test *testing.T) {
 
 	n := &oc.Neighbor{
 		Config: oc.NeighborConfig{
-			NeighborAddress: "127.0.0.1",
+			NeighborAddress: netip.MustParseAddr("127.0.0.1"),
 			PeerGroup:       "g",
 		},
 		Transport: oc.Transport{
@@ -1198,7 +1199,7 @@ func TestPeerGroup(test *testing.T) {
 
 	m := &oc.Neighbor{
 		Config: oc.NeighborConfig{
-			NeighborAddress: "127.0.0.1",
+			NeighborAddress: netip.MustParseAddr("127.0.0.1"),
 			PeerAs:          1,
 		},
 		Transport: oc.Transport{
@@ -1269,7 +1270,7 @@ func TestDynamicNeighbor(t *testing.T) {
 
 	m := &oc.Neighbor{
 		Config: oc.NeighborConfig{
-			NeighborAddress: "127.0.0.1",
+			NeighborAddress: netip.MustParseAddr("127.0.0.1"),
 			PeerAs:          1,
 		},
 		Transport: oc.Transport{
@@ -1602,7 +1603,7 @@ func peerServers(t *testing.T, ctx context.Context, servers []*BgpServer, famili
 
 			neighborConfig := &oc.Neighbor{
 				Config: oc.NeighborConfig{
-					NeighborAddress: "127.0.0.1",
+					NeighborAddress: netip.MustParseAddr("127.0.0.1"),
 					PeerAs:          peer.bgpConfig.Global.Config.As,
 				},
 				AfiSafis: oc.AfiSafis{},
@@ -2538,7 +2539,7 @@ func TestListPathWithIdentifiers(t *testing.T) {
 func makeNeighborConfig(port int32) *oc.Neighbor {
 	return &oc.Neighbor{
 		Config: oc.NeighborConfig{
-			NeighborAddress: "127.0.0.1",
+			NeighborAddress: netip.MustParseAddr("127.0.0.1"),
 		},
 		Transport: oc.Transport{
 			Config: oc.TransportConfig{

--- a/tools/config/example_toml.go
+++ b/tools/config/example_toml.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"net/netip"
 
 	"github.com/BurntSushi/toml"
 	"github.com/osrg/gobgp/v4/pkg/config/oc"
@@ -13,7 +14,7 @@ func main() {
 		Global: oc.Global{
 			Config: oc.GlobalConfig{
 				As:       12332,
-				RouterId: "10.0.0.1",
+				RouterId: netip.MustParseAddr("10.0.0.1"),
 			},
 		},
 		Neighbors: []oc.Neighbor{
@@ -21,7 +22,7 @@ func main() {
 				Config: oc.NeighborConfig{
 					PeerAs:          12333,
 					AuthPassword:    "apple",
-					NeighborAddress: "192.168.177.33",
+					NeighborAddress: netip.MustParseAddr("192.168.177.33"),
 				},
 				AfiSafis: []oc.AfiSafi{
 					{
@@ -47,7 +48,7 @@ func main() {
 				Config: oc.NeighborConfig{
 					PeerAs:          12334,
 					AuthPassword:    "orange",
-					NeighborAddress: "192.168.177.32",
+					NeighborAddress: netip.MustParseAddr("192.168.177.32"),
 				},
 			},
 
@@ -55,7 +56,7 @@ func main() {
 				Config: oc.NeighborConfig{
 					PeerAs:          12335,
 					AuthPassword:    "grape",
-					NeighborAddress: "192.168.177.34",
+					NeighborAddress: netip.MustParseAddr("192.168.177.34"),
 				},
 			},
 		},
@@ -80,7 +81,7 @@ func policy() oc.RoutingPolicy {
 		PrefixSetName: "ps1",
 		PrefixList: []oc.Prefix{
 			{
-				IpPrefix:        "10.3.192.0/21",
+				IpPrefix:        netip.MustParsePrefix("10.3.192.0/21"),
 				MasklengthRange: "21..24",
 			},
 		},

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -938,7 +938,7 @@ module gobgp {
 
   augment "/bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:state" {
     leaf remote-router-id {
-        type string;
+        type inet:ipv4-address;
     }
   }
 
@@ -1081,7 +1081,7 @@ module gobgp {
     leaf-list neighbor-info {
       description
             "neighbor ip address or prefix";
-      type inet:ip-address;
+      type string;
     }
   }
 
@@ -1350,7 +1350,7 @@ module gobgp {
         type int32;
     }
     leaf-list local-address {
-        type string;
+        type inet:ip-address;
     }
   }
 
@@ -1390,7 +1390,7 @@ module gobgp {
      This configuration structure was taken from the latest openconfig.";
 
     leaf prefix {
-      type string;
+      type inet:ip-prefix;
     }
     leaf peer-group {
       type string;


### PR DESCRIPTION
- netip.Addr for inet:ip-address, inet:ipv4-address, and bgp-types:rr-cluster-id-type

- netip.Prefix for inet:ip-prefix

Add a workaround for union type for bgp:local-address to bgpyang2golang.py. Go doesn't support union type so pyang has to choose one type. But pyang doesn't know which is appropriate so bgpyang2golang needs to select an appropriate type for a member.

Also there are some changes for GoBGP specific types:

- netip.Addr for BGP remote ID instead of string
- netip.Addr for local addresses to listen instead of string
- netip.Prefix for Dynamic peer config instead of string