### PR TITLE
table: disable CollisionAttack test

### DIFF
--- a/internal/pkg/table/table_test.go
+++ b/internal/pkg/table/table_test.go
@@ -613,6 +613,7 @@ func createAddrPrefixBaseIndex(index int) []bgp.NLRI {
 }
 
 func TestTableDestinationsCollisionAttack(t *testing.T) {
+	t.Skip()
 	if !strings.Contains(runtime.GOARCH, "64") {
 		t.Skip("This test is only for 64bit architecture")
 	}


### PR DESCRIPTION
This test takes too long on some environments. Also I suspect this test will ever finish in an environment with memory limitations for processes.

Maybe we had better to make this a benchmark test.