### PR TITLE
cmd/gobgp: fix p2p link show adj-in/out command

### DIFF
--- a/cmd/gobgp/common.go
+++ b/cmd/gobgp/common.go
@@ -322,13 +322,13 @@ func newConn() (*grpc.ClientConn, error) {
 	return grpc.NewClient(target, grpcOpts...)
 }
 
-func addr2AddressFamily(a net.IP) *api.Family {
-	if a.To4() != nil {
+func addr2AddressFamily(a netip.Addr) *api.Family {
+	if a.Is4() {
 		return &api.Family{
 			Afi:  api.Family_AFI_IP,
 			Safi: api.Family_SAFI_UNICAST,
 		}
-	} else if a.To16() != nil {
+	} else if a.Is6() {
 		return &api.Family{
 			Afi:  api.Family_AFI_IP6,
 			Safi: api.Family_SAFI_UNICAST,

--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"sort"
 	"strconv"
 	"strings"
@@ -795,7 +796,10 @@ func showValidationInfo(p *api.Path, shownAs map[uint32]struct{}) error {
 }
 
 func showRibInfo(r, name string) error {
-	def := addr2AddressFamily(net.ParseIP(name))
+	var def *api.Family
+	if addr, err := netip.ParseAddr(name); err == nil {
+		def = addr2AddressFamily(addr)
+	}
 	if r == cmdGlobal || r == cmdVRF {
 		def = ipv4UC
 	}
@@ -860,7 +864,11 @@ func showNeighborRib(r string, name string, args []string) error {
 	validationTarget := ""
 	rd := ""
 
-	def := addr2AddressFamily(net.ParseIP(name))
+	var def *api.Family
+	if addr, err := netip.ParseAddr(name); err == nil {
+		def = addr2AddressFamily(addr)
+	}
+
 	switch r {
 	case cmdGlobal:
 		def = ipv4UC


### PR DESCRIPTION
Fix the following panic:

root@da9787cd106c:/go# gobgp n fe80::2cf7:e0ff:fe37:6347%eth0 adj-in panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xaeca09]

goroutine 1 [running]:
github.com/osrg/gobgp/v4/pkg/apiutil.ToFamily(...)
	/home/fujita/git/gobgp/pkg/apiutil/util.go:218
main.showNeighborRib({0xd71b4d, 0x6}, {0xc00003eac0, 0x1e}, {0xc000043a30, 0x0, 0x1})
	/home/fujita/git/gobgp/cmd/gobgp/neighbor.go:881 +0x1a9
main.newNeighborCmd.func1(0xc0002ac308?, {0xc000043a30?, 0x1?, 0x1?})
	/home/fujita/git/gobgp/cmd/gobgp/neighbor.go:1481 +0x203
github.com/spf13/cobra.(*Command).execute(0xc0002ac308, {0xc0000439f0, 0x1, 0x1})
	/home/fujita/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1019 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0xc0002ab808)
	/home/fujita/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x46f
github.com/spf13/cobra.(*Command).Execute(...)
	/home/fujita/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
main.newNeighborCmd.func6(0xc00004f100?, {0xc0000cdf20?, 0x4?, 0xd704e4?})
	/home/fujita/git/gobgp/cmd/gobgp/neighbor.go:1569 +0xf5
github.com/spf13/cobra.(*Command).execute(0xc0002b0908, {0xc0000cdec0, 0x2, 0x2})
	/home/fujita/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1019 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0xc0002a6008)
	/home/fujita/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x46f
github.com/spf13/cobra.(*Command).Execute(...)
	/home/fujita/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
main.main()