### PR TITLE
packet/bgp: fix IPAddrPrefixDefault.decodePrefix()

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -1418,11 +1418,6 @@ func (r *IPAddrPrefixDefault) decodePrefix(data []byte, bitlen uint8, addrlen in
 	if addrlen != 4 && addrlen != 16 {
 		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_INVALID_NETWORK_FIELD, nil, "invalid address length")
 	}
-	if len(data) < 1 {
-		eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
-		eSubCode := uint8(BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST)
-		return NewMessageError(eCode, eSubCode, nil, "prefix misses length field")
-	}
 
 	bytelen := (int(bitlen) + 7) / 8
 	if len(data) < bytelen {

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -90,6 +90,20 @@ func Test_IPAddrPrefixString(t *testing.T) {
 	assert.Equal(t, "::ffff:192.0.2.128/128", mapped_ipv6.String())
 }
 
+func Test_ZeroIPv4Prefix(t *testing.T) {
+	buf := []byte{0}
+	nlri, err := NLRIFromSlice(RF_IPv4_UC, buf)
+	assert.NoError(t, err)
+	assert.Equal(t, "0.0.0.0/0", nlri.String())
+	ipv4 := nlri.(*IPAddrPrefix)
+	assert.Equal(t, ipv4.Prefix.Bits(), 0)
+	assert.Equal(t, ipv4.Prefix.Addr(), netip.IPv4Unspecified())
+
+	buf, err = nlri.Serialize()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0}, buf)
+}
+
 func TestStringLabelAddrPrefix(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
fix IPAddrPrefixDefault.decodePrefix() to handle 0.0.0.0/0 prefix.