### PR TITLE
config: use netip for mrt table-name OpenConfig

### DIFF
--- a/pkg/config/oc/bgp_configs.go
+++ b/pkg/config/oc/bgp_configs.go
@@ -1244,8 +1244,9 @@ type MrtConfig struct {
 	// Configures a file name to be written.
 	FileName string `mapstructure:"file-name" json:"file-name,omitempty"`
 	// original -> gobgp:table-name
+	// gobgp:table-name's original type is inet:ip-address.
 	// specify the table name with route server setup.
-	TableName string `mapstructure:"table-name" json:"table-name,omitempty"`
+	TableName netip.Addr `mapstructure:"table-name" json:"table-name,omitempty"`
 	// original -> gobgp:dump-interval
 	DumpInterval uint64 `mapstructure:"dump-interval" json:"dump-interval,omitempty"`
 	// original -> gobgp:rotation-interval

--- a/pkg/server/mrt.go
+++ b/pkg/server/mrt.go
@@ -120,8 +120,8 @@ func (m *mrtWriter) dumpTable() []*mrt.MRTMessage {
 	rib := m.s.globalRib
 	as := uint32(0)
 	id := table.GLOBAL_RIB_NAME
-	if len(m.c.TableName) > 0 {
-		peer, ok := m.s.neighborMap[m.c.TableName]
+	if m.c.TableName.IsValid() {
+		peer, ok := m.s.neighborMap[m.c.TableName.String()]
 		if !ok {
 			return []*mrt.MRTMessage{}
 		}
@@ -403,7 +403,7 @@ func (m *mrtManager) enable(c *oc.MrtConfig) error {
 	case oc.MRT_TYPE_UPDATES:
 		// ignore the dump interval
 		dInterval = 0
-		if len(c.TableName) > 0 {
+		if c.TableName.IsValid() {
 			return fmt.Errorf("can't specify the table name with the update dump type")
 		}
 		setRotationMin()

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -1230,7 +1230,7 @@ module gobgp {
           "Configures a file name to be written";
       }
       leaf table-name {
-        type string;
+        type inet:ip-address;
         description
           "specify the table name with route server setup";
       }


### PR DESCRIPTION
Use netip.Addr for MrtConfig.TableName instead of string.