### PR TITLE
server: use netip.Addr for neighborMap

### DIFF
--- a/pkg/server/mrt.go
+++ b/pkg/server/mrt.go
@@ -121,7 +121,7 @@ func (m *mrtWriter) dumpTable() []*mrt.MRTMessage {
 	as := uint32(0)
 	id := table.GLOBAL_RIB_NAME
 	if m.c.TableName.IsValid() {
-		peer, ok := m.s.neighborMap[m.c.TableName.String()]
+		peer, ok := m.s.neighborMap[m.c.TableName]
 		if !ok {
 			return []*mrt.MRTMessage{}
 		}
@@ -142,7 +142,7 @@ func (m *mrtWriter) dumpTable() []*mrt.MRTMessage {
 					isAddPath := false
 					if path.IsLocal() {
 						isAddPath = true
-					} else if neighbor, ok := m.s.neighborMap[path.GetSource().Address.String()]; ok {
+					} else if neighbor, ok := m.s.neighborMap[path.GetSource().Address]; ok {
 						isAddPath = neighbor.isAddPathReceiveEnabled(family)
 					}
 					if !isAddPath {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1481,7 +1481,7 @@ func TestTcpConnectionClosedAfterPeerDel(t *testing.T) {
 
 	// We delete the peer incoming channel from the server list so that we can
 	// intercept the transition from ACTIVE state to OPENSENT state.
-	neighbor1 := s1.neighborMap[p1.Conf.NeighborAddress]
+	neighbor1 := s1.neighborMap[netip.MustParseAddr(p1.Conf.NeighborAddress)]
 	// incoming := neighbor1.fsm.h.msgCh
 	// err = s1.mgmtOperation(func() error {
 	// 	s1.delIncoming(incoming)
@@ -1797,7 +1797,7 @@ func TestDoNotReactToDuplicateRTCMemberships(t *testing.T) {
 		panh2,
 	}, time.Now(), false)
 
-	s1Peer := s2.neighborMap["127.0.0.1"]
+	s1Peer := s2.neighborMap[netip.MustParseAddr("127.0.0.1")]
 	s2.propagateUpdate(s1Peer, []*table.Path{rtcPath})
 
 	t2 := time.NewTimer(2 * time.Second)


### PR DESCRIPTION
use netip.Addr for neighborMap in BgpServer instead of string. netip.Addr should be more efficient as a key for the map type.