### PR TITLE
server: make the FSM state lock-free

### DIFF
--- a/pkg/server/fsm_test.go
+++ b/pkg/server/fsm_test.go
@@ -322,7 +322,7 @@ func TestBadBGPIdentifier(t *testing.T) {
 }
 
 func makePeerAndHandler(m net.Conn) (*peer, *fsmHandler) {
-	fsm := newFSM(&oc.Global{}, &oc.Neighbor{}, slog.Default())
+	fsm := newFSM(&oc.Global{}, &oc.Neighbor{}, bgp.BGP_FSM_IDLE, slog.Default())
 	fsm.conn = m
 
 	p := &peer{fsm: fsm}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -978,6 +978,7 @@ func newPeerandInfo(t *testing.T, myAs, as uint32, address string, rib *table.Ta
 	p := newPeer(
 		&oc.Global{Config: oc.GlobalConfig{As: myAs}},
 		nConf,
+		bgp.BGP_FSM_IDLE,
 		rib,
 		policy,
 		logger)


### PR DESCRIPTION
Since the FSM state is read very frequently, using the FSM mutex isn't efficient. Use a lock-free structure.