### PR TITLE
server: make fsm goroutin call fsm.StateChange

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -308,7 +308,7 @@ func newFSM(gConf *oc.Global, pConf *oc.Neighbor, state bgp.FSMState, logger *sl
 	return fsm
 }
 
-func (fsm *fsm) StateChange(nextState bgp.FSMState, reason *fsmStateReason) {
+func (fsm *fsm) stateChange(nextState bgp.FSMState, reason *fsmStateReason) {
 	fsm.lock.Lock()
 	defer fsm.lock.Unlock()
 
@@ -1805,6 +1805,8 @@ func (h *fsmHandler) loop(ctx context.Context, wg *sync.WaitGroup) {
 		if ctx.Err() != nil {
 			break
 		}
+
+		h.fsm.stateChange(nextState, reason)
 
 		msg := &fsmMsg{
 			MsgType:     fsmMsgStateChange,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1382,8 +1382,6 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 		peer.fsm.pConf.State.SessionState = oc.IntToSessionStateMap[int(nextState)]
 		peer.fsm.lock.Unlock()
 
-		peer.fsm.StateChange(nextState, e.StateReason)
-
 		peer.fsm.lock.RLock()
 		nextStateIdle := peer.fsm.pConf.GracefulRestart.State.PeerRestarting && nextState == bgp.BGP_FSM_IDLE
 		peer.fsm.lock.RUnlock()


### PR DESCRIPTION
In the past, the state change of fsm happens asynchronously via channel. Now it happens synchronously via the handler so make fsm loop goroutine call fsm.StateChange() for simplicity.