### PR TITLE
server: use atomic.Value for fsm.rfMap

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -982,9 +982,11 @@ func newPeerandInfo(t *testing.T, myAs, as uint32, address string, rib *table.Ta
 		rib,
 		policy,
 		logger)
+	rfmap := make(map[bgp.Family]bgp.BGPAddPathMode)
 	for _, f := range rib.GetRFlist() {
-		p.fsm.rfMap[f] = bgp.BGP_ADD_PATH_NONE
+		rfmap[f] = bgp.BGP_ADD_PATH_NONE
 	}
+	p.fsm.familyMap.Store(rfmap)
 	remoteAddr := netip.MustParseAddr(address)
 	localAddr := netip.MustParseAddr("1.1.1.1")
 	info := table.NewPeerInfo(gConf, nConf, as, myAs, remoteAddr, localAddr, remoteAddr, localAddr)


### PR DESCRIPTION
Since `rfmap` is accessed for every received message, use `atomic.Value` to avoid locking. Also rfMap name, "RouteFamily", is odd so use familyMap.