### PR TITLE
server: trigger session reset for TTL changes

### DIFF
--- a/pkg/config/oc/util.go
+++ b/pkg/config/oc/util.go
@@ -222,7 +222,9 @@ func (n *Neighbor) NeedsResendOpenMessage(new *Neighbor) bool {
 		!n.AddPaths.Config.Equal(&new.AddPaths.Config) ||
 		!n.AsPathOptions.Config.Equal(&new.AsPathOptions.Config) ||
 		!n.GracefulRestart.Config.Equal(&new.GracefulRestart.Config) ||
-		isAfiSafiChanged(n.AfiSafis, new.AfiSafis)
+		isAfiSafiChanged(n.AfiSafis, new.AfiSafis) ||
+		!n.EbgpMultihop.Config.Equal(&new.EbgpMultihop.Config) ||
+		!n.TtlSecurity.Config.Equal(&new.TtlSecurity.Config)
 }
 
 // TODO: these regexp are duplicated in api

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3458,28 +3458,6 @@ func (s *BgpServer) updateNeighbor(c *oc.Neighbor) (needsSoftResetIn bool, err e
 		return needsSoftResetIn, err
 	}
 
-	setTTL := false
-	if !original.EbgpMultihop.Config.Equal(&c.EbgpMultihop.Config) {
-		peer.fsm.pConf.EbgpMultihop.Config = c.EbgpMultihop.Config
-		setTTL = true
-	}
-	if !original.TtlSecurity.Config.Equal(&c.TtlSecurity.Config) {
-		peer.fsm.pConf.TtlSecurity.Config = c.TtlSecurity.Config
-		setTTL = true
-	}
-
-	if setTTL {
-		if err := setPeerConnTTL(peer.fsm); err != nil {
-			peer.fsm.logger.Error("failed to set peer connection TTL", slog.String("Err", err.Error()))
-			// rollback to original state
-			peer.fsm.pConf = original
-			if err := setPeerConnTTL(peer.fsm); err != nil {
-				peer.fsm.logger.Error("failed to rollback peer connection TTL", slog.String("Err", err.Error()))
-			}
-			return needsSoftResetIn, err
-		}
-	}
-
 	return needsSoftResetIn, err
 }
 


### PR DESCRIPTION
Move EbgpMultihop and TtlSecurity configuration changes to trigger full BGP session reset instead of runtime updates. TCP TTL settings must be applied during connection establishment and cannot be reliably changed on active connections.