### PR TITLE
server/fsm: Replace shared stateReasonCh with local channels per FSM …

### DIFF
--- a/pkg/server/fsm_test.go
+++ b/pkg/server/fsm_test.go
@@ -328,10 +328,9 @@ func makePeerAndHandler(m net.Conn) (*peer, *fsmHandler) {
 	p := &peer{fsm: fsm}
 
 	h := &fsmHandler{
-		fsm:           fsm,
-		stateReasonCh: make(chan fsmStateReason, 2),
-		outgoing:      channels.NewInfiniteChannel(),
-		callback:      func(*fsmMsg) {},
+		fsm:      fsm,
+		outgoing: channels.NewInfiniteChannel(),
+		callback: func(*fsmMsg) {},
 	}
 
 	fsm.h = h


### PR DESCRIPTION
…state

Move stateReasonCh from fsmHandler to local variables in each state function (opensent, openconfirm, established). This prevents stale state transitions from leaking between FSM states and makes channel ownership clearer.