### PR TITLE
server: Add nonblockSendChannel utility for non-blocking channel sends

### DIFF
--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -21,6 +21,17 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
 
+func nonblockSendChannel[T any](ch chan<- T, item T) bool {
+	select {
+	case ch <- item:
+		// sent
+		return true
+	default:
+		// drop the item
+		return false
+	}
+}
+
 func drainChannel[T any](ch <-chan T) {
 	for {
 		select {


### PR DESCRIPTION
Extract repeated non-blocking channel send pattern into a reusable generic utility function. Replace 5 instances of inline select/case/ default with nonblockSendChannel() calls.