### PR TITLE
server: Complete nonblockSendChannel migration for notification sends

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -1447,7 +1447,7 @@ func (h *fsmHandler) recvMessageloop(ctx context.Context, conn net.Conn, holdtim
 		fmsg, err := h.recvMessageWithError(conn, stateReasonCh)
 		if fmsg != nil && ctx.Err() == nil {
 			if m, ok := fmsg.MsgData.(*bgp.MessageError); ok {
-				h.fsm.notification <- bgp.NewBGPNotificationMessage(m.TypeCode, m.SubTypeCode, m.Data)
+				nonblockSendChannel(h.fsm.notification, bgp.NewBGPNotificationMessage(m.TypeCode, m.SubTypeCode, m.Data))
 				// finish the loop
 				return
 			} else {
@@ -1478,7 +1478,7 @@ func (h *fsmHandler) recvMessageloop(ctx context.Context, conn net.Conn, holdtim
 							slog.String("Error", err.Error()))
 						fmsg.MsgData = err
 						m := err.(*bgp.MessageError)
-						h.fsm.notification <- bgp.NewBGPNotificationMessage(m.TypeCode, m.SubTypeCode, m.Data)
+						nonblockSendChannel(h.fsm.notification, bgp.NewBGPNotificationMessage(m.TypeCode, m.SubTypeCode, m.Data))
 						return
 					}
 
@@ -1497,7 +1497,7 @@ func (h *fsmHandler) recvMessageloop(ctx context.Context, conn net.Conn, holdtim
 
 					if err = table.UpdatePathAggregator4ByteAs(body); err != nil {
 						m := err.(*bgp.MessageError)
-						h.fsm.notification <- bgp.NewBGPNotificationMessage(m.TypeCode, m.SubTypeCode, m.Data)
+						nonblockSendChannel(h.fsm.notification, bgp.NewBGPNotificationMessage(m.TypeCode, m.SubTypeCode, m.Data))
 						return
 					}
 					fallthrough

--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -543,10 +543,7 @@ func (peer *peer) filterPathFromSourcePeer(path, old *table.Path) *table.Path {
 }
 
 func (peer *peer) sendNotification(msg *bgp.BGPMessage) {
-	select {
-	case peer.fsm.notification <- msg:
-	default:
-	}
+	nonblockSendChannel(peer.fsm.notification, msg)
 }
 
 func (peer *peer) isPrefixLimit(k bgp.Family, c *oc.PrefixLimitConfig) bool {


### PR DESCRIPTION
Replace the remaining inline non-blocking send patterns for the notification channel with the nonblockSendChannel() utility function because multiple goroutines could send to fsm.notification channel.