### PR TITLE
Fix incorrect route policy operator parsing

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -1420,6 +1420,19 @@ func (s *server) DeleteDefinedSet(ctx context.Context, r *api.DeleteDefinedSetRe
 
 var _regexpMedActionType = regexp.MustCompile(`([+-]?)(\d+)`)
 
+func toOcAttributeComparison(a api.Comparison) oc.AttributeComparison {
+	switch a {
+	case api.Comparison_COMPARISON_EQ:
+		return oc.ATTRIBUTE_COMPARISON_EQ
+	case api.Comparison_COMPARISON_GE:
+		return oc.ATTRIBUTE_COMPARISON_GE
+	case api.Comparison_COMPARISON_LE:
+		return oc.ATTRIBUTE_COMPARISON_LE
+	default:
+		return oc.ATTRIBUTE_COMPARISON_EQ
+	}
+}
+
 func matchSetOptionsRestrictedTypeToAPI(t oc.MatchSetOptionsRestrictedType) api.MatchSet_Type {
 	t = t.DefaultAsNeeded()
 	switch t {
@@ -1726,7 +1739,7 @@ func newCommunityCountConditionFromApiStruct(a *api.CommunityCount) (*table.Comm
 		return nil, nil
 	}
 	return table.NewCommunityCountCondition(oc.CommunityCount{
-		Operator: oc.IntToAttributeComparisonMap[int(a.Type)],
+		Operator: toOcAttributeComparison(a.Type),
 		Value:    a.Count,
 	})
 }
@@ -1736,7 +1749,7 @@ func newAsPathLengthConditionFromApiStruct(a *api.AsPathLength) (*table.AsPathLe
 		return nil, nil
 	}
 	return table.NewAsPathLengthCondition(oc.AsPathLength{
-		Operator: oc.IntToAttributeComparisonMap[int(a.Type)],
+		Operator: toOcAttributeComparison(a.Type),
 		Value:    a.Length,
 	})
 }


### PR DESCRIPTION
This is a pull request solving problem in issue https://github.com/osrg/gobgp/issues/3204, where the policy operators (eq, ge, and le) are founded mapped to wrong actions. For convenience, the problem is reviewed below, and then the problem cause and solution are described. The base commit is https://github.com/osrg/gobgp/commit/cb60aef8ef9a66a9732de4a46ff3627dd690d2db.

## 1 Problem Description

I was defining the policies below:

```
policy-definitions:

   ...

  # Export: dont export providers/peers only provider+peer routes
  - name: outbound-policy
    statements:

      ...

      # Export self route
      - conditions:
          match-prefix-set:
            prefix-set: self_address
            match-set-options: any
          bgp-conditions:
            # route-type: local
            as-path-length:
              operator: eq
              value: 0
        actions:
          route-disposition: accept-route

      # Don't export routes directly connected to neighbors
      - conditions:
          match-prefix-set:
            prefix-set: connect_address
            match-set-options: any
          bgp-conditions:
            # route-type: local
            as-path-length:
              operator: ge
              value: 2
        actions:
          route-disposition: accept-route

      # Export self generated routes
      - conditions:
          match-prefix-set:
            prefix-set: connect_address
            match-set-options: invert
          bgp-conditions:
            # route-type: local
            as-path-length:
              operator: le
              value: 1
        actions:
          route-disposition: accept-route
```

However, `gobgp policy` shows:
```
    StatementName outbound-policy_stmt3:
      Conditions:
        PrefixSet: any self_address 
        AsPathLength: >=0
        RPKI result: UNSPECIFIED
      Actions:
         accept
    StatementName outbound-policy_stmt4:
      Conditions:
        PrefixSet: any connect_address 
        AsPathLength: <=2
        RPKI result: UNSPECIFIED
      Actions:
         accept
    StatementName outbound-policy_stmt5:
      Conditions:
        PrefixSet: invert connect_address 
        AsPathLength: =1
        RPKI result: UNSPECIFIED
      Actions:
```

The operators "eq", "ge", and "le" are wrongly mapped to ">=", "<=", and "=".

Also, with the policies above, route export behaviors are malfunctioning, showing that this is not just a error in printing, but also affecting actions being executed.

## 2 Problem Cause

### 2.1 Two data structures for policy maintaining
GoBGP maintains two types of data structure for route policies:
1. oc.BgpConfigSet (hereafter referred as ocStruct) defined at https://github.com/osrg/gobgp/blob/master/pkg/config/oc/serve.go#L11. This structure is used as Intermediate results parsed from input config file in OpenConfig (toml, json, yaml) format.
2. api.RoutingPolicy (hereafter referred as APIStruct) defined at https://github.com/osrg/gobgp/blob/master/api/gobgp.pb.go#L11473. This structure is used as request data to BGP server inside gobgpd.

### 2.2 Parsing and installing of policies defined in config file
The comparison policies (those with eq, ge, and le operators) defined in input config file will finally be installed into gobgpd's BGP server. The detailed steps are:

+ Step1: the config file is parsed into ocStruct;
+ Step2: the ocStruct is mapped to APIStruct;
+ Step3: the APIStruct is send to BGP server in gobgpd daemon;
+ Step4: the BGP server maps APIStruct into ocStruct again, and install reverse-mapped policies into daemon.

### 2.3 The problem cause
The problem is because of wrong mapping happened in Step4. The details are provided below:

The macros used to represent operators in ocStruct are defined in https://github.com/osrg/gobgp/blob/master/pkg/config/oc/bgp_configs.go#L254:

```go
const (
	ATTRIBUTE_COMPARISON_ATTRIBUTE_EQ AttributeComparison = "attribute-eq"
	ATTRIBUTE_COMPARISON_ATTRIBUTE_GE AttributeComparison = "attribute-ge"
	ATTRIBUTE_COMPARISON_ATTRIBUTE_LE AttributeComparison = "attribute-le"
	ATTRIBUTE_COMPARISON_EQ           AttributeComparison = "eq"
	ATTRIBUTE_COMPARISON_GE           AttributeComparison = "ge"
	ATTRIBUTE_COMPARISON_LE           AttributeComparison = "le"
)

var AttributeComparisonToIntMap = map[AttributeComparison]int{
	ATTRIBUTE_COMPARISON_ATTRIBUTE_EQ: 0,
	ATTRIBUTE_COMPARISON_ATTRIBUTE_GE: 1,
	ATTRIBUTE_COMPARISON_ATTRIBUTE_LE: 2,
	ATTRIBUTE_COMPARISON_EQ:           3,
	ATTRIBUTE_COMPARISON_GE:           4,
	ATTRIBUTE_COMPARISON_LE:           5,
}

var IntToAttributeComparisonMap = map[int]AttributeComparison{
	0: ATTRIBUTE_COMPARISON_ATTRIBUTE_EQ,
	1: ATTRIBUTE_COMPARISON_ATTRIBUTE_GE,
	2: ATTRIBUTE_COMPARISON_ATTRIBUTE_LE,
	3: ATTRIBUTE_COMPARISON_EQ,
	4: ATTRIBUTE_COMPARISON_GE,
	5: ATTRIBUTE_COMPARISON_LE,
}
```

The macros used to represent operators in APIStruct are defined in https://github.com/osrg/gobgp/blob/master/api/gobgp.pb.go#L326, where an additional Comparison_COMPARISON_UNSPECIFIED is added:
```go
const (
	Comparison_COMPARISON_UNSPECIFIED Comparison = 0
	Comparison_COMPARISON_EQ          Comparison = 1
	Comparison_COMPARISON_GE          Comparison = 2
	Comparison_COMPARISON_LE          Comparison = 3
)

// Enum value maps for Comparison.
var (
	Comparison_name = map[int32]string{
		0: "COMPARISON_UNSPECIFIED",
		1: "COMPARISON_EQ",
		2: "COMPARISON_GE",
		3: "COMPARISON_LE",
	}
	Comparison_value = map[string]int32{
		"COMPARISON_UNSPECIFIED": 0,
		"COMPARISON_EQ":          1,
		"COMPARISON_GE":          2,
		"COMPARISON_LE":          3,
	}
)
```

When mapping APIStruct to ocStruct, a direct access to oc.IntToAttributeComparisonMap is used (code at https://github.com/osrg/gobgp/blob/master/pkg/server/grpc_server.go#L1739):
```go
func newAsPathLengthConditionFromApiStruct(a *api.AsPathLength) (*table.AsPathLengthCondition, error) {
	if a == nil {
		return nil, nil
	}
	return table.NewAsPathLengthCondition(oc.AsPathLength{
		Operator: oc.IntToAttributeComparisonMap[int(a.Type)],
		Value:    a.Length,
	})
}
```

Nevertheless, **the enum defined for APIStruct has an additional COMPARISON_UNSPECIFIED compared to IntToAttributeComparisonMap, causing mis-alignment and wrong mapping from ocStruct to APIStruct**.

## 3 Code Fix
This pull request replaces mapping by direct-map-access above by defining a dedicated function for mapping operators from APIStruct to ocStruct:

```go
func toOcAttributeComparison(a api.Comparison) oc.AttributeComparison {
	switch a {
	case api.Comparison_COMPARISON_EQ:
		return oc.ATTRIBUTE_COMPARISON_EQ
	case api.Comparison_COMPARISON_GE:
		return oc.ATTRIBUTE_COMPARISON_GE
	case api.Comparison_COMPARISON_LE:
		return oc.ATTRIBUTE_COMPARISON_LE
	default:
		return oc.ATTRIBUTE_COMPARISON_EQ
	}
}
```

```go
func newAsPathLengthConditionFromApiStruct(a *api.AsPathLength) (*table.AsPathLengthCondition, error) {
	if a == nil {
		return nil, nil
	}
	return table.NewAsPathLengthCondition(oc.AsPathLength{
		Operator: toOcAttributeComparison(a.Type),
		Value:    a.Length,
	})
}
```

P.S. the mapping in the other direction (from APIStruct to ocStruct) is already implemented by a dedicated function `ToComparisonApi` (https://github.com/osrg/gobgp/blob/master/internal/pkg/table/policy.go#L4169), which is correct and need no fix.
