### PR TITLE
Fix fatal error in zclient

### DIFF
--- a/pkg/server/zclient.go
+++ b/pkg/server/zclient.go
@@ -382,7 +382,7 @@ func (z *zebraClient) loop() {
 			switch body := msg.Body.(type) {
 			case *zebra.IPRouteBody:
 				if path := newPathFromIPRouteMessage(z.server.logger, msg, z.client.Version, z.client.Software); path != nil {
-					if err := z.server.addPathList("", []*table.Path{path}); err != nil {
+					if err := z.server.addPathStream("", []*table.Path{path}); err != nil {
 						z.server.logger.Error("failed to add path from zebra",
 							slog.String("Topic", "Zebra"),
 							slog.Any("Path", path),


### PR DESCRIPTION
This pull request is solution of issue https://github.com/osrg/gobgp/issues/3198.

Only one line is modified. I just replace unsafe `addPathList` with contention-safe `addPathStream` in zclient.go.

The solution resembles that in issue https://github.com/osrg/gobgp/issues/2153 (commit https://github.com/osrg/gobgp/commit/07e70de118842609a8e1e4740fdb82179f4bdaca). Very simple but useful. Feel like it can be merged instantly.