### PR TITLE
Use netip.Addr in watchEventMessage instead of net.IP

### DIFF
--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -234,12 +234,10 @@ func (b *bmpClient) loop() {
 							}
 						}
 					case *watchEventMessage:
-						addr, _ := netip.AddrFromSlice(msg.PeerAddress)
-						id, _ := netip.AddrFromSlice(msg.PeerID)
 						info := &table.PeerInfo{
-							Address: addr,
+							Address: msg.PeerAddress,
 							AS:      msg.PeerAS,
-							ID:      id,
+							ID:      msg.PeerID,
 						}
 						if err := write(bmpPeerRouteMirroring(bmp.BMP_PEER_TYPE_GLOBAL, 0, info, msg.Timestamp.Unix(), msg.Message)); err != nil {
 							return false

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -897,9 +897,9 @@ func (s *BgpServer) notifyMessageWatcher(peer *peer, timestamp time.Time, msg *b
 		Message:      msg,
 		PeerAS:       peer.fsm.pConf.State.PeerAs,
 		LocalAS:      peer.fsm.pConf.Config.LocalAs,
-		PeerAddress:  net.ParseIP(peer.fsm.pConf.State.NeighborAddress.String()),
-		LocalAddress: net.ParseIP(peer.fsm.pConf.Transport.State.LocalAddress.String()),
-		PeerID:       net.ParseIP(peer.fsm.pConf.State.RemoteRouterId.String()).To4(),
+		PeerAddress:  peer.fsm.pConf.State.NeighborAddress,
+		LocalAddress: peer.fsm.pConf.Transport.State.LocalAddress,
+		PeerID:       peer.fsm.pConf.State.RemoteRouterId,
 		FourBytesAs:  y,
 		Timestamp:    timestamp,
 		IsSent:       isSent,
@@ -4419,9 +4419,9 @@ type watchEventMessage struct {
 	Message      *bgp.BGPMessage
 	PeerAS       uint32
 	LocalAS      uint32
-	PeerAddress  net.IP
-	LocalAddress net.IP
-	PeerID       net.IP
+	PeerAddress  netip.Addr
+	LocalAddress netip.Addr
+	PeerID       netip.Addr
 	FourBytesAs  bool
 	Timestamp    time.Time
 	IsSent       bool


### PR DESCRIPTION
Update the watchEventMessage structure to use netip.Addr instead of net.IP.