### PR TITLE
Fix wrong multipath logic in the ListPath API

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2753,7 +2753,7 @@ func (s *BgpServer) ListPath(r apiutil.ListPathRequest, fn func(prefix bgp.NLRI,
 						case api.TableType_TABLE_TYPE_LOCAL, api.TableType_TABLE_TYPE_GLOBAL:
 							p.Best = true
 						}
-					} else if s.bgpConfig.Global.UseMultiplePaths.Config.Enabled && path.Equal(knownPathList[i-1]) {
+					} else if s.bgpConfig.Global.UseMultiplePaths.Config.Enabled && path.Compare(knownPathList[i-1]) == 0 {
 						p.Best = true
 					}
 				}


### PR DESCRIPTION
Fix the wrong multipath handling in the ListPath API. The current multipath selection uses Equal, but it should be Compare I believe. I added a new test case to test this behavior. Without the fix, the `with multipath` test case fails.

```
--- FAIL: TestListPathEnableMultipath (0.00s)
    --- FAIL: TestListPathEnableMultipath/with_multipath (0.00s)
        server_test.go:815:
            	Error Trace:	/home/yutaro.linux/WorkSpace/gobgp/pkg/server/server_test.go:815
            	            				/home/yutaro.linux/WorkSpace/gobgp/pkg/server/server.go:2771
            	            				/home/yutaro.linux/WorkSpace/gobgp/pkg/server/server.go:2774
            	            				/home/yutaro.linux/WorkSpace/gobgp/pkg/server/server_test.go:794
            	Error:      	Not equal:
            	            	expected: 2
            	            	actual  : 1
            	Test:       	TestListPathEnableMultipath/with_multipath
            	Messages:   	2 best path(s) expected
```