### PR TITLE
WIP: fix(#3214): tablemanager use link-local nexthop if global is unspecified

### DIFF
--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -90,6 +90,10 @@ func ProcessMessage(m *bgp.BGPMessage, peerInfo *PeerInfo, timestamp time.Time, 
 		nexthop := reach.Nexthop
 		family := bgp.NewFamily(reach.AFI, reach.SAFI)
 
+		if nexthop.IsUnspecified() && reach.LinkLocalNexthop.IsValid() && !reach.LinkLocalNexthop.IsUnspecified() {
+			nexthop = reach.LinkLocalNexthop
+		}
+
 		for _, nlri := range reach.Value {
 			// when build path from reach
 			// reachAttrs might not contain next_hop if `attrs` does not have one


### PR DESCRIPTION
Work In Progress. Showcasing a quick fix for #3214.

When BIRD peers using only a link-local address it supplies this in a 32byte next-hop as `:: LL` (i.e. `::   fe80::ade0`). FRR supports this format as well ([see this issue](https://github.com/FRRouting/frr/issues/6259)).

Though not entirely related, there's a draft RFC about this [here](https://www.ietf.org/archive/id/draft-ietf-idr-linklocal-capability-02.html).

This PR adds logic to the table manager that: if the nexthop is unspecified and the LinkLocalNexthop is valid and actually a local-link, then uses the LinkLocalNextHop for the path.


Some questions and statements floating in my mind while working on this:

A new [RFC Draft](https://www.ietf.org/archive/id/draft-ietf-idr-linklocal-capability-02.html) for LinkLocal only capable peers state that a peer that advertises ONLY a LinkLocal Nexthop MUST encode this in 16 bytes nexthop. 
This would mean that while decoding the nexthop in [bgp.go](https://github.com/TimVosch/gobgp/blob/fix-3214-ll-only/pkg/packet/bgp/bgp.go) the `BGP_ATTR_NHLEN_IPV6_GLOBAL` actually means `BGP_ATTR_NHLEN_IPV6_GLOBAL_OR_LINKLOCAL`.

This might also - at least for me - require a concrete definition for `PathAttributeMpReachNLRI.NextHop` In [bgp.go](https://github.com/TimVosch/gobgp/blob/4c62dacd66a8e81c5d149d85f6eb0eedd1ab3017/pkg/packet/bgp/bgp.go#L11809-L11810). Is the field NextHop only Global or can it also be the LinkLocal? What is the LinkLocalNextHop field in that case.
**2025-10-31**: [path.go](https://github.com/osrg/gobgp/blob/master/internal/pkg/table/path.go) derives whether its local from the fact it uses a LocalAddress vs Address of a peer. This would argue in favor of NextHop being global address only.



