### PR TITLE
fix: remove logging on connection closing

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -1997,10 +1997,7 @@ func (h *fsmHandler) loop(ctx context.Context, wg *sync.WaitGroup) {
 	default:
 	}
 	if fsm.conn != nil {
-		err := fsm.conn.Close()
-		if err != nil {
-			fsm.logger.Error("failed to close existing tcp connection", slog.String("State", oldState.String()))
-		}
+		fsm.conn.Close()
 	}
 	close(fsm.connCh)
 	cleanInfiniteChannel(fsm.outgoingCh)


### PR DESCRIPTION
The FSM handling of a TCP connection is pretty messy, and a connection can be closed mutliple times, examples:
- in established state, if the fsm context is done, sendNotification will close the connection, then from the fsm loop, logging an error
- in any state, if a reason is received on the reasonCh, we close the connection, which get closed in the fsm loop
- in the established state, if the hold time expires, sendNotification closes the connection, then push to the reasonCh which closes the connection, and then the fsm loop closes the connection...