### PR TITLE
fix: drain channel

### DIFF
--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -35,7 +35,10 @@ func nonblockSendChannel[T any](ch chan<- T, item T) bool {
 func drainChannel[T any](ch <-chan T) {
 	for {
 		select {
-		case <-ch:
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
 			// drain the channel
 		default:
 			return


### PR DESCRIPTION
when a channel is closed, we can still receive indefinitely nil element from it. Check https://go.dev/play/p/VZ6rskaydvF
This is what make sometimes the unittest to fail.