### PR TITLE
docs: Update repository clone URL in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,8 @@
 
 ## Building the development environment
 
-You need a working [Go environment](https://golang.org/doc/install) (1.16 or newer).
-
 ```bash
-$ git clone git://github.com/osrg/gobgp
+$ git clone https://github.com/osrg/gobgp.git
 $ cd gobgp && go mod download
 ```
 


### PR DESCRIPTION
Change the git protocol URL to HTTPS for better compatibility and security.

Also remove the redundant Go version requirement sentence as the specific version constraint is already documented in go.mod and enforced by the Go toolchain.