### PR TITLE
fix: remove logging on connection closing

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -1997,10 +1997,7 @@ func (h *fsmHandler) loop(ctx context.Context, wg *sync.WaitGroup) {
 	default:
 	}
 	if fsm.conn != nil {
-		err := fsm.conn.Close()
-		if err != nil {
-			fsm.logger.Error("failed to close existing tcp connection", slog.String("State", oldState.String()))
-		}
+		fsm.conn.Close()
 	}
 	close(fsm.connCh)
 	cleanInfiniteChannel(fsm.outgoingCh)


### PR DESCRIPTION
The FSM handling of a TCP connection is pretty messy, and we always close multiple times the same TCP connection. Hence, there is always an error returned at the end of the fsm loop.