### PR TITLE
server/fsm: Fix connection leak in connectLoop on context cancellation

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -862,6 +862,9 @@ func (h *fsmHandler) connectLoop(ctx context.Context) net.Conn {
 			select {
 			case <-ctx.Done():
 				fsm.logger.Debug("stop connect loop")
+				if conn != nil {
+					conn.Close()
+				}
 				return nil
 			default:
 			}


### PR DESCRIPTION
When context is cancelled immediately after DialContext succeeds, the established connection was not closed before returning nil, causing a file descriptor leak.

This fix checks if a connection was established and explicitly closes it before returning when the context is cancelled. This prevents resource leaks during FSM shutdown or peer restart scenarios where the connection establishment completes but the FSM is being torn down.