### PR TITLE
server/fsm: Remove redundant notification in handleOpen

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -1319,7 +1319,6 @@ func (fsm *fsm) handleOpen(fmsg *fsmMsg) (bgp.FSMState, *fsmStateReason, *bgp.BG
 			if _, err := bgp.ValidateOpenMsg(body, fsmPeerAS, localAS, localID); err != nil {
 				err := err.(*bgp.MessageError)
 				notif := bgp.NewBGPNotificationMessage(err.TypeCode, err.SubTypeCode, err.Data)
-				_ = fsm.sendNotification(fsm.conn, m)
 				if err.TypeCode == bgp.BGP_ERROR_OPEN_MESSAGE_ERROR && err.SubTypeCode == bgp.BGP_ERROR_SUB_BAD_PEER_AS {
 					return bgp.BGP_FSM_IDLE, newfsmStateReason(fsmBadPeerAS, m, nil), notif
 				}


### PR DESCRIPTION
Remove duplicate sendNotification call that was sending the wrong message (original OPEN message 'm' instead of the notification 'notif').  The notification is sent by the callers (opensent and active) when handleOpen returns a non-nil notification message.