### PR TITLE
server: default to global RIB when policy name is empty

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3835,12 +3835,10 @@ func (s *BgpServer) DeletePolicy(ctx context.Context, r *api.DeletePolicyRequest
 
 func (s *BgpServer) toPolicyInfo(name string, dir api.PolicyDirection) (string, table.PolicyDirection, error) {
 	if name == "" {
-		return "", table.POLICY_DIRECTION_NONE, fmt.Errorf("empty table name")
+		name = table.GLOBAL_RIB_NAME
 	}
 
-	if name == table.GLOBAL_RIB_NAME {
-		name = table.GLOBAL_RIB_NAME
-	} else {
+	if name != table.GLOBAL_RIB_NAME {
 		remoteAddr, err := netip.ParseAddr(name)
 		if err != nil {
 			return "", table.POLICY_DIRECTION_NONE, fmt.Errorf("failed to parse address: %v", err)


### PR DESCRIPTION
When the name parameter is empty in toPolicyInfo(), use GLOBAL_RIB_NAME as the default instead of returning an error. This makes the behavior consistent with other APIs throughout the codebase where an empty string conventionally represents the global RIB.