### PR TITLE
cmd: remove "global" magic keyword

### DIFF
--- a/cmd/gobgp/common.go
+++ b/cmd/gobgp/common.go
@@ -40,8 +40,6 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
 
-const globalRIBName = "global"
-
 const (
 	cmdGlobal         = "global"
 	cmdNeighbor       = "neighbor"

--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -1162,9 +1162,6 @@ func showNeighborPolicy(remoteIP, policyType string, indent int) error {
 	default:
 		return fmt.Errorf("invalid policy type: choose from (import|export)")
 	}
-	if remoteIP == "" {
-		remoteIP = globalRIBName
-	}
 	stream, err := client.ListPolicyAssignment(ctx, &api.ListPolicyAssignmentRequest{
 		Name:      remoteIP,
 		Direction: dir,
@@ -1216,10 +1213,6 @@ func extractDefaultAction(args []string) ([]string, api.RouteAction, error) {
 }
 
 func modNeighborPolicy(remoteIP, policyType, cmdType string, args []string) error {
-	if remoteIP == "" {
-		remoteIP = globalRIBName
-	}
-
 	assign := &api.PolicyAssignment{
 		Name: remoteIP,
 	}


### PR DESCRIPTION
It's not a good idea to use the magic keyword, "global". The API handle an empty table name as the global rib. So no need to use "global".