### PR TITLE
Fix prefix byte slice calculation in NewLsPrefixTLVs

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -5825,7 +5825,7 @@ func NewLsPrefixTLVs(pd *LsPrefixDescriptor) []LsTLVInterface {
 					Length: lenIpReach,
 				},
 				PrefixLength: uint8(prefixSize),
-				Prefix:       []byte(ip)[:((lenIpPrefix-1)/8 + 1)],
+				Prefix:       []byte(ip)[:lenIpPrefix],
 			}
 		} else if ipReach.IP.To16() != nil {
 			ip := ipReach.IP.To16()
@@ -5835,7 +5835,7 @@ func NewLsPrefixTLVs(pd *LsPrefixDescriptor) []LsTLVInterface {
 					Length: lenIpReach,
 				},
 				PrefixLength: uint8(prefixSize),
-				Prefix:       []byte(ip)[:((lenIpPrefix-1)/8 + 1)],
+				Prefix:       []byte(ip)[:lenIpPrefix],
 			}
 		}
 		lsTLVs = append(lsTLVs, tlv)


### PR DESCRIPTION
# Fix prefix byte slice calculation in NewLsPrefixTLVs

## Problem

The `NewLsPrefixTLVs` function in `pkg/packet/bgp/bgp.go` was incorrectly double-calculating the prefix length when creating the `Prefix` byte slice, causing it to be too short. This led to a panic when `ToIPNet` tried to access bytes beyond the slice length.

**Error:**
```
panic: runtime error: index out of range [1] with length 1
at github.com/osrg/gobgp/v4/pkg/packet/bgp.(*LsTLVIPReachability).ToIPNet
```

## Root Cause

The bug was in lines 5828 (IPv4) and 5838 (IPv6) of `pkg/packet/bgp/bgp.go`:

**Before (buggy):**
```go
lenIpPrefix := (prefixSize-1)/8 + 1  // Line 5816: calculates correctly
...
Prefix: []byte(ip)[:((lenIpPrefix-1)/8 + 1)],  // Line 5828: BUG - recalculates incorrectly
```

**Example for /24 prefix:**
- `prefixSize = 24`
- `lenIpPrefix = (24-1)/8 + 1 = 3` (correct calculation)
- But then: `[:((3-1)/8 + 1)] = [:(2/8 + 1)] = [:(0 + 1)] = [:1]` (WRONG!)
- Result: Only 1 byte instead of 3 bytes, causing panic when accessing `Prefix[1]`

## Solution

Changed the code to use `lenIpPrefix` directly, since it's already correctly calculated:

**After (fixed):**
```go
lenIpPrefix := (prefixSize-1)/8 + 1  // Line 5816: calculates correctly
...
Prefix: []byte(ip)[:lenIpPrefix],  // Line 5828: Uses already-calculated value
```

## Changes

- **Line 5828 (IPv4)**: Changed `[:((lenIpPrefix-1)/8 + 1)]` to `[:lenIpPrefix]`
- **Line 5838 (IPv6)**: Changed `[:((lenIpPrefix-1)/8 + 1)]` to `[:lenIpPrefix]`

## Testing

This fix resolves the panic when processing BGP-LS prefix (stub network) messages via gRPC `AddPath`. The prefix TLVs are now created with the correct number of bytes, allowing `ToIPNet` to correctly parse them.

## Impact

- Fixes panic when sending BGP-LS prefix NLRI messages via gRPC
- Affects both IPv4 and IPv6 prefix TLVs
- No breaking changes - this is a bug fix

