### PR TITLE
markdownlint: Disable table-column-style rule

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -6,6 +6,7 @@
     "commands-show-output": false,
     "no-duplicate-header": false,
     "no-duplicate-heading": false,
+    "table-column-style": false,
     "no-inline-html": {
         "allowed_elements": [
             "br"


### PR DESCRIPTION
Allow flexible table formatting. Doesn't look like it makes sense much.