### PR TITLE
config: Fix RouteReflectorClusterId setting if configured

### DIFF
--- a/pkg/config/oc/default.go
+++ b/pkg/config/oc/default.go
@@ -253,6 +253,7 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, g *Glo
 			if !n.RouteReflector.Config.RouteReflectorClusterId.IsValid() || !n.RouteReflector.Config.RouteReflectorClusterId.Is4() {
 				return fmt.Errorf("route-reflector-cluster-id should be specified as IPv4 address")
 			}
+			n.RouteReflector.State.RouteReflectorClusterId = n.RouteReflector.Config.RouteReflectorClusterId
 		}
 	}
 	return nil


### PR DESCRIPTION
If RouteReflectorClusterId is configured for a Neighbor (.RouteReflector.Config.RouteReflectorClusterId is valid), it should be propagated into .RouteReflector.State.RouteReflectorClusterId, as that is the source of truth for the server / table operations. Before this fix, it was set only by the defaulting logic, when not explicitly configured.