### PR TITLE
server: Avoid overwriting log fields in adj table

### DIFF
--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -125,7 +125,7 @@ func newPeer(g *oc.Global, conf *oc.Neighbor, state bgp.FSMState, loc *table.Tab
 		peer.tableId = table.GLOBAL_RIB_NAME
 	}
 	rfs, _ := oc.AfiSafis(conf.AfiSafis).ToRfList()
-	peer.adjRibIn = table.NewAdjRib(peer.fsm.logger, rfs)
+	peer.adjRibIn = table.NewAdjRib(logger, rfs)
 	return peer
 }
 


### PR DESCRIPTION
Do not provide peer-specific logger when creating adj table, but use parent logger instead.
Peer-specific logger contains "Topic" and "Key" log fields, which are also set when logging table events, but with different values.
This is unnecessary and can be even deemed invalid in more strict logging setups.