### PR TITLE
table: Fix regexp for parsing large community

### DIFF
--- a/internal/pkg/table/policy.go
+++ b/internal/pkg/table/policy.go
@@ -1320,7 +1320,7 @@ func (s *LargeCommunitySet) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.ToConfig())
 }
 
-var _regexpCommunityLarge = regexp.MustCompile(`\d+:\d+:\d+`)
+var _regexpCommunityLarge = regexp.MustCompile(`^\d+:\d+:\d+$`)
 
 func ParseLargeCommunityRegexp(arg string) (*regexp.Regexp, error) {
 	if _regexpCommunityLarge.MatchString(arg) {


### PR DESCRIPTION
If the large community value is provided as a regexp including start/end of string anchors to `ParseLargeCommunityRegexp`, e.g. `"^1111:2222:3333$"`, the start/end anchors are duplicated in `ParseLargeCommunityRegexp`, e.g. to `"^^1111:2222:3333$$"`.

This fixes the `_regexpCommunityLarge` so that it matches only the large community values without any prefixes/suffixes, which avoids the problem.