### PR TITLE
Revert "path attributes hash, fast compare"

### DIFF
--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -669,11 +669,12 @@ func compareByMED(path1, path2 *Path) *Path {
 		firstAS := func(path *Path) uint32 {
 			if asPath := path.GetAsPath(); asPath != nil {
 				for _, v := range asPath.Value {
+					segType := v.GetType()
 					asList := v.GetAS()
 					if len(asList) == 0 {
 						continue
 					}
-					switch v.GetType() {
+					switch segType {
 					case bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SET, bgp.BGP_ASPATH_ATTR_TYPE_CONFED_SEQ:
 						continue
 					}

--- a/internal/pkg/table/message.go
+++ b/internal/pkg/table/message.go
@@ -354,7 +354,7 @@ func newPackerMP(f bgp.Family) *packerMP {
 
 type packerV4 struct {
 	packer
-	hashmap     map[uint64][]*cage
+	hashmap     map[uint32][]*cage
 	mpPaths     []*Path
 	withdrawals []*Path
 }
@@ -491,7 +491,7 @@ func newPackerV4(f bgp.Family) *packerV4 {
 		packer: packer{
 			family: f,
 		},
-		hashmap:     make(map[uint64][]*cage),
+		hashmap:     make(map[uint32][]*cage),
 		withdrawals: make([]*Path, 0),
 		mpPaths:     make([]*Path, 0),
 	}

--- a/internal/pkg/table/path_test.go
+++ b/internal/pkg/table/path_test.go
@@ -255,49 +255,6 @@ func TestGetPathAttrs(t *testing.T) {
 	assert.NotNil(t, path2.getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP))
 }
 
-/*
-func TestGetTransversalPathAttrs(t *testing.T) {
-	checkTransversalPathAttrs := func(t *testing.T, path *Path, expectedAttr bgp.BGPAttrType, checkIsNotExist ...bool) {
-		for _, attr := range path.GetTransversalPathAttrs() {
-			assert.NotNil(t, attr)
-		}
-		if len(checkIsNotExist) > 0 && checkIsNotExist[0] {
-			assert.Nil(t, path.GetTransversalPathAttrs()[expectedAttr])
-		} else {
-			assert.NotNil(t, path.GetTransversalPathAttrs()[expectedAttr])
-		}
-	}
-	paths := PathCreatePath(PathCreatePeer())
-	path0 := paths[0]
-	checkTransversalPathAttrs(t, path0, bgp.BGP_ATTR_TYPE_ORIGIN)
-	nextHop := path0.getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
-	assert.NotNil(t, nextHop)
-	assert.Equal(t, nextHop.(*bgp.PathAttributeNextHop).Value.String(), "192.168.50.1")
-
-	path1 := path0.Clone(false)
-	path1.setPathAttr(bgp.NewPathAttributeNextHop("192.168.98.1"))
-	nextHop = path1.getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
-	assert.NotNil(t, nextHop)
-	assert.Equal(t, nextHop.(*bgp.PathAttributeNextHop).Value.String(), "192.168.98.1")
-	path1.delPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
-	assert.NotNil(t, path1.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGIN))
-	checkTransversalPathAttrs(t, path1, bgp.BGP_ATTR_TYPE_ORIGIN)
-	checkTransversalPathAttrs(t, path1, bgp.BGP_ATTR_TYPE_NEXT_HOP, true)
-
-	path2 := path1.Clone(false)
-	assert.NotNil(t, path2.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGIN))
-	path2.delPathAttr(bgp.BGP_ATTR_TYPE_ORIGIN)
-	// adding an attribute that has been deleted previously by underlayer, is not allowed
-	path2.setPathAttr(bgp.NewPathAttributeNextHop("192.168.99.1"))
-	checkTransversalPathAttrs(t, path2, bgp.BGP_ATTR_TYPE_ORIGIN, true)
-	checkTransversalPathAttrs(t, path2, bgp.BGP_ATTR_TYPE_NEXT_HOP, true)
-
-	nextHop = path2.getPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
-	assert.NotNil(t, nextHop)
-	assert.Equal(t, nextHop.(*bgp.PathAttributeNextHop).Value.String(), "192.168.99.1")
-}
-*/
-
 func PathCreatePeer() []*PeerInfo {
 	peerP1 := &PeerInfo{AS: 65000}
 	peerP2 := &PeerInfo{AS: 65001}
@@ -444,30 +401,4 @@ func TestNLRIToIPNet(t *testing.T) {
 	vpnv6, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("2001:db8:53::/64"), *labels, rd)
 	ipNet = nlriToIPNet(vpnv6)
 	assert.Equal(t, n6, ipNet)
-}
-
-func TestUnknownPathAttributes(t *testing.T) {
-	peerP := PathCreatePeer()
-	pathP := PathCreatePath(peerP)
-
-	type255 := bgp.BGPAttrType(255)
-	unknownAttr := bgp.NewPathAttributeUnknown(bgp.BGPAttrFlag(0), type255, []byte{0x01, 0x02, 0x03})
-	pathP[0].setPathAttr(unknownAttr)
-
-	// Check if the unknown attribute is present
-	assert.NotNil(t, pathP[0].getPathAttr(type255))
-
-	found255 := false
-	var last bgp.BGPAttrType
-	for _, attr := range pathP[0].GetPathAttrs() {
-		assert.NotNil(t, attr)
-		if last >= attr.GetType() {
-			t.Errorf("Path attributes are not sorted: %v >= %v", last, attr.GetType())
-		}
-		last = attr.GetType()
-		if attr.GetType() == type255 {
-			found255 = true
-		}
-	}
-	assert.True(t, found255, "Unknown attribute of type 255 should be present in the path attributes list")
 }

--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -59,14 +59,14 @@ func ProcessMessage(m *bgp.BGPMessage, peerInfo *PeerInfo, timestamp time.Time, 
 		attrs = []bgp.PathAttributeInterface{}
 	}
 
-	var hash uint64
+	var hash uint32
 	if len(attrs) != 0 {
 		total := bytes.NewBuffer(make([]byte, 0))
 		for _, a := range attrs {
 			b, _ := a.Serialize()
 			total.Write(b)
 		}
-		hash = farm.Hash64(total.Bytes())
+		hash = farm.Hash32(total.Bytes())
 	}
 
 	listLen := len(update.NLRI) + len(update.WithdrawnRoutes)
@@ -137,6 +137,7 @@ func makeAttributeList(
 	copy(reachAttrs, attrs)
 	// we sort attributes when creating a bgp message from paths
 	reachAttrs[len(reachAttrs)-1] = reach
+
 	return reachAttrs
 }
 

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -585,7 +585,7 @@ func api2Path(resource api.TableType, path *api.Path, isWithdraw bool) (*table.P
 			b, _ := a.Serialize()
 			total.Write(b)
 		}
-		newPath.SetHash(farm.Hash64(total.Bytes()))
+		newPath.SetHash(farm.Hash32(total.Bytes()))
 	}
 	newPath.SetIsFromExternal(path.IsFromExternal)
 	return newPath, nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2168,7 +2168,7 @@ func apiutil2Path(path *apiutil.Path, isVRFTable bool, isWithdraw ...bool) (*tab
 			b, _ := a.Serialize()
 			total.Write(b)
 		}
-		p.SetHash(farm.Hash64(total.Bytes()))
+		p.SetHash(farm.Hash32(total.Bytes()))
 	}
 	p.SetIsFromExternal(path.IsFromExternal)
 	return p, nil


### PR DESCRIPTION
As it break bgp packer and make benchmark slow and failed to sync all peers to connect and send routes.

This reverts commit 20f69ea2ea611d8b1f80cd4efffa5416ed644e4b.