### PR TITLE
packet/bgp: fix SRv6 End.X SID Sub-TLV length handling

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -8435,15 +8435,15 @@ func (l *LsTLVSrv6EndXSID) parseSubTLVs(data []byte) error {
 	for len(data) >= 4 {
 		tlvType := binary.BigEndian.Uint16(data[:2])
 		tlvLen := binary.BigEndian.Uint16(data[2:4])
-
-		if len(data) < int(4+tlvLen) {
-			return nil
+		need := 4 + int(tlvLen)
+		if len(data) < need {
+			return malformedAttrListErr("SRv6 End.X SID Sub-TLV is truncated")
 		}
 
 		switch tlvType {
 		case LS_TLV_SRV6_SID_STRUCTURE:
 			if tlvLen != 4 {
-				data = data[4+tlvLen:]
+				data = data[need:]
 				continue
 			}
 			l.Srv6SIDStructure.LocalBlock = data[4]
@@ -8454,7 +8454,7 @@ func (l *LsTLVSrv6EndXSID) parseSubTLVs(data []byte) error {
 			// TODO: handle unknown Sub-TLVs
 		}
 
-		data = data[4+tlvLen:]
+		data = data[need:]
 	}
 
 	return nil

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -4141,3 +4141,13 @@ func Test_LsTLVSrv6EndpointBehavior(t *testing.T) {
 		}
 	}
 }
+
+func TestParseSubTLVsOverflow(t *testing.T) {
+	l := &LsTLVSrv6EndXSID{}
+
+	// tlvLen = 65532 (0xFFFC) makes (uint16(4) + tlvLen) wrap to 0 in the buggy code.
+	data := []byte{0x00, 0x00, 0xFF, 0xFC}
+	if err := l.parseSubTLVs(data); err == nil {
+		t.Fatal("expected error for truncated Sub-TLV")
+	}
+}


### PR DESCRIPTION
Avoid uint16 overflow in Sub-TLV size calculation and return a malformed-attr error on truncated Sub-TLVs.

Also add a regression test to prevent hangs on crafted lengths.