### PR TITLE
packet/bgp: fix panic in FlowSpec component parsing on invalid input

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -3466,6 +3466,9 @@ func parseFlowSpecNumericOperator(submatch []string) (operator uint8, err error)
 // e.g.) "&==100", ">=200" or "&<300"
 func parseFlowSpecNumericOpValues(typ BGPFlowSpecType, args []string, validationFunc func(uint64) error) (FlowSpecComponentInterface, error) {
 	argsLen := len(args)
+	if argsLen == 0 {
+		return nil, fmt.Errorf("invalid argument for %s: %q", typ.String(), args)
+	}
 	items := make([]*FlowSpecComponentItem, 0, argsLen)
 	for idx, arg := range args {
 		m := _regexpFlowSpecNumericType.FindStringSubmatch(arg)
@@ -3675,6 +3678,9 @@ func flowSpecTcpFlagParser(_ Family, typ BGPFlowSpecType, args []string) (FlowSp
 	// - Not FIN and not URG
 	//   args := []string{"!=F", "&!=U"}
 	args = normalizeFlowSpecOpValues(args)
+	if len(args) == 0 {
+		return nil, fmt.Errorf("invalid argument for %s: %q", typ.String(), args)
+	}
 
 	argsLen := len(args)
 	items := make([]*FlowSpecComponentItem, 0, argsLen)
@@ -3727,6 +3733,9 @@ func flowSpecFragmentParser(_ Family, typ BGPFlowSpecType, args []string) (FlowS
 	// - is-fragment and last-fragment (exact match)
 	//   args := []string{"==is-fragment+last-fragment"}
 	args = normalizeFlowSpecOpValues(args)
+	if len(args) == 0 {
+		return nil, fmt.Errorf("invalid argument for %s: %q", typ.String(), args)
+	}
 
 	argsLen := len(args)
 	items := make([]*FlowSpecComponentItem, 0, argsLen)

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -911,6 +911,31 @@ func Test_CompareFlowSpecNLRI(t *testing.T) {
 	assert.True(r < 0)
 }
 
+func Test_ParseFlowSpecComponents_DoesNotPanicOnInvalidInput(t *testing.T) {
+	// Regression: some inputs pass ParseFlowSpecComponents()'s len(args)>0 check
+	// but are discarded by normalizeFlowSpecOpValues(), leading to argsLen==0 and
+	// a panic when marking the end-of-list bit.
+	cases := []string{
+		"dscp foo",
+		"tcp-flags foo",
+		"fragment foo",
+	}
+
+	for _, c := range cases {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("ParseFlowSpecComponents must not panic for %q: %v", c, r)
+				}
+			}()
+			_, err := ParseFlowSpecComponents(RF_FS_IPv4_UC, c)
+			if err == nil {
+				t.Fatalf("expected error for %q", c)
+			}
+		}()
+	}
+}
+
 func TestMpReachDecodeDoesNotMutateInputWhenDeletingSecondRD(t *testing.T) {
 	// Triggers nexthoplen == 2*RD + (IPv6 global + link-local)
 	// and ensures DecodeFromBytes does not modify the input buffer.


### PR DESCRIPTION
normalizeFlowSpecOpValues can return an empty slice even when the original args are non-empty. This caused parseFlowSpecNumericOpValues (and related parsers) to index argsLen-1 and panic.

Add guards to return an error instead, and add a regression test to ensure ParseFlowSpecComponents never panics on malformed input.