### PR TITLE
zebra: fix panic in FuzzZapi test on short inputs

### DIFF
--- a/pkg/zebra/zapi_test.go
+++ b/pkg/zebra/zapi_test.go
@@ -1126,6 +1126,9 @@ func FuzzZapi(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		for v := MinZapiVer; v <= MaxZapiVer; v++ {
 			ZAPIHeaderSize := int(HeaderSize(v))
+			if len(data) < ZAPIHeaderSize {
+				continue
+			}
 
 			hd := &Header{}
 			err := hd.decodeFromBytes(data[:ZAPIHeaderSize])


### PR DESCRIPTION
FuzzZapi sliced data[:HeaderSize(v)] without checking length. Short inputs could trigger slice bounds out of range panics in the fuzz harness.

Add a length guard before decoding the header.