### PR TITLE
Properly handle peer's zone information

### DIFF
--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -1091,7 +1091,7 @@ func (path *Path) MarshalJSON() ([]byte, error) {
 		Withdrawal bool                         `json:"withdrawal,omitempty"`
 		Validation string                       `json:"validation,omitempty"`
 		SourceID   net.IP                       `json:"source-id,omitempty"`
-		NeighborIP net.IP                       `json:"neighbor-ip,omitempty"`
+		NeighborIP netip.Addr                   `json:"neighbor-ip,omitempty"`
 		Stale      bool                         `json:"stale,omitempty"`
 		UUID       string                       `json:"uuid,omitempty"`
 		ID         uint32                       `json:"id,omitempty"`
@@ -1101,7 +1101,7 @@ func (path *Path) MarshalJSON() ([]byte, error) {
 		Age:        path.GetTimestamp().Unix(),
 		Withdrawal: path.IsWithdraw,
 		SourceID:   path.GetSource().ID.AsSlice(),
-		NeighborIP: path.GetSource().Address.AsSlice(),
+		NeighborIP: path.GetSource().Address,
 		Stale:      path.IsStale(),
 		ID:         path.remoteID,
 	})

--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -263,7 +263,7 @@ func (manager *TableManager) handleMacMobility(path *Path) []*Path {
 		return nil
 	}
 
-	f := func(p *Path) (bgp.EthernetSegmentIdentifier, uint32, net.HardwareAddr, int, net.IP) {
+	f := func(p *Path) (bgp.EthernetSegmentIdentifier, uint32, net.HardwareAddr, int, netip.Addr) {
 		nlri := p.GetNlri().(*bgp.EVPNNLRI)
 		d := nlri.RouteTypeData.(*bgp.EVPNMacIPAdvertisementRoute)
 		ecs := p.GetExtCommunities()
@@ -274,7 +274,7 @@ func (manager *TableManager) handleMacMobility(path *Path) []*Path {
 				break
 			}
 		}
-		return d.ESI, d.ETag, d.MacAddress, seq, p.GetSource().Address.AsSlice()
+		return d.ESI, d.ETag, d.MacAddress, seq, p.GetSource().Address
 	}
 	e1, et1, m1, s1, i1 := f(path)
 
@@ -294,7 +294,7 @@ func (manager *TableManager) handleMacMobility(path *Path) []*Path {
 		}
 		e2, et2, m2, s2, i2 := f(path2)
 		if et1 == et2 && bytes.Equal(m1, m2) && !bytes.Equal(e1.Value, e2.Value) {
-			if s1 > s2 || s1 == s2 && bytes.Compare(i1, i2) < 0 {
+			if s1 > s2 || s1 == s2 && i1.Compare(i2) < 0 {
 				pathList = append(pathList, path2.Clone(true))
 			}
 		}

--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -542,7 +542,7 @@ func (fsm *fsm) stateChange(nextState bgp.FSMState, reason *fsmStateReason) {
 	case bgp.BGP_FSM_ESTABLISHED:
 		remoteTCP := fsm.conn.RemoteAddr().(*net.TCPAddr)
 		remoteAddr, _ := netip.AddrFromSlice(remoteTCP.IP)
-		remoteAddr = remoteAddr.WithZone("")
+		remoteAddr = remoteAddr.WithZone(remoteTCP.Zone)
 
 		localTCP := fsm.conn.LocalAddr().(*net.TCPAddr)
 		localAddr, _ := netip.AddrFromSlice(localTCP.IP)


### PR DESCRIPTION
When we propagate the fsm.pConf.Transport.State.RemoteAddress => peer.peerInfo => path.info.source, we drop the IPv6 zone information with the operation like .WithZone("") or .AsSlice() in several places. As a result, some path-related API calls return wrong peer address when the IPv6 link-local address is used (e.g. BGP Unnumbered).

ListPath/WatchEvent for paths

```
{
  "2001:db8::/64": [
    {
      "Family": 0,
      "nlri": {
        "prefix": "2001:db8::/64"
      },
      ...
      "stale": false,
      "peer-id": "10.0.0.1",
      "peer-address": "fe80::ac84:abff:fea4:2ed8", <= Missing zone
      "RemoteID": 0,
      "LocalID": 0
    }
  ]
}
```

This commit fixes it to propagate zone information properly

```
{
  "2001:db8::/64": [
    {
      "Family": 0,
      "nlri": {
        "prefix": "2001:db8::/64"
      },
      ...
      "stale": false,
      "peer-id": "10.0.0.1",
      "peer-address": "fe80::ac84:abff:fea4:2ed8%eth0", <= Contains zone
      "RemoteID": 0,
      "LocalID": 0
    }
  ]
}
```