### PR TITLE
Properly handle local zone information

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -546,7 +546,7 @@ func (fsm *fsm) stateChange(nextState bgp.FSMState, reason *fsmStateReason) {
 
 		localTCP := fsm.conn.LocalAddr().(*net.TCPAddr)
 		localAddr, _ := netip.AddrFromSlice(localTCP.IP)
-		localAddr = localAddr.WithZone("")
+		localAddr = localAddr.WithZone(localTCP.Zone)
 
 		fsm.pConf.Transport.State.RemoteAddress = remoteAddr
 		fsm.pConf.Transport.State.RemotePort = uint16(remoteTCP.Port)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -619,7 +619,11 @@ func (s *BgpServer) prePolicyFilterpath(peer *peer, path, old *table.Path) (*tab
 		// OldNextHop option should be set to the local address.
 		// Otherwise, we advertise the unspecified nexthop as is when
 		// nexthop-unchanged is configured.
-		options.OldNextHop = net.ParseIP(peer.fsm.pConf.Transport.State.LocalAddress.String())
+		//
+		// When the local address contains zone, we need to strip it
+		// because BGP nexthop cannot contain zone information (AsSlice
+		// drops zone).
+		options.OldNextHop = net.IP(peer.fsm.pConf.Transport.State.LocalAddress.AsSlice())
 	} else {
 		options.OldNextHop = path.GetNexthop().AsSlice()
 	}


### PR DESCRIPTION
When we populate the fsm.pConf.Transport.State.LocalAddress, we drop the IPv6 zone information with .WithZone(""). As a result, the api.Peer.Transport.LocalAddress has wrong local address when the IPv6 link-local address is used (e.g. BGP Unnumbered).

```
$ gobgp neighbor -j | jq '.[0].transport'
{
  "local_address": "fe80::ac84:abff:fea4:2ed8" <= Missing zone
}
```

This commit fixes it.

```
$ gobgp neighbor -j | jq '.[0].transport'
{
  "local_address": "fe80::ac84:abff:fea4:2ed8%eth0" <= Contains zone
}
```