### PR TITLE
Migrate path.SetNexthop to netip types

### DIFF
--- a/internal/pkg/table/policy_test.go
+++ b/internal/pkg/table/policy_test.go
@@ -18,7 +18,6 @@ package table
 import (
 	"fmt"
 	"math"
-	"net"
 	"net/netip"
 	"strconv"
 	"strings"
@@ -909,7 +908,7 @@ func TestSetNextHop(t *testing.T) {
 		assert.NoError(t, err)
 		pType, newPath := r.policyMap["pd1"].Apply(logger, path, &PolicyOptions{Info: peer})
 		assert.Equal(t, ROUTE_TYPE_ACCEPT, pType)
-		path.SetNexthop(net.ParseIP("10.2.2.2"))
+		path.SetNexthop(netip.MustParseAddr("10.2.2.2"))
 		if diff := cmp.Diff(newPath, path); diff != "" {
 			t.Errorf("(-want, +got):\n%s", diff)
 		}
@@ -929,7 +928,7 @@ func TestSetNextHop(t *testing.T) {
 		assert.NoError(t, err)
 		pType, newPath := r.policyMap["pd1"].Apply(logger, path, &PolicyOptions{Info: peer})
 		assert.Equal(t, ROUTE_TYPE_ACCEPT, pType)
-		path.SetNexthop(net.ParseIP("20.0.0.1"))
+		path.SetNexthop(netip.MustParseAddr("20.0.0.1"))
 		if diff := cmp.Diff(newPath, path); diff != "" {
 			t.Errorf("(-want, +got):\n%s", diff)
 		}
@@ -949,7 +948,7 @@ func TestSetNextHop(t *testing.T) {
 		assert.NoError(t, err)
 		pType, newPath := r.policyMap["pd1"].Apply(logger, path, &PolicyOptions{Info: peer})
 		assert.Equal(t, ROUTE_TYPE_ACCEPT, pType)
-		path.SetNexthop(net.ParseIP("10.0.0.2"))
+		path.SetNexthop(netip.MustParseAddr("10.0.0.2"))
 		if diff := cmp.Diff(newPath, path); diff != "" {
 			t.Errorf("(-want, +got):\n%s", diff)
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -619,9 +619,9 @@ func (s *BgpServer) prePolicyFilterpath(peer *peer, path, old *table.Path) (*tab
 		// OldNextHop option should be set to the local address.
 		// Otherwise, we advertise the unspecified nexthop as is when
 		// nexthop-unchanged is configured.
-		options.OldNextHop = net.ParseIP(peer.fsm.pConf.Transport.State.LocalAddress.String())
+		options.OldNextHop = peer.fsm.pConf.Transport.State.LocalAddress
 	} else {
-		options.OldNextHop = path.GetNexthop().AsSlice()
+		options.OldNextHop = path.GetNexthop()
 	}
 	path = table.UpdatePathAttrs(peer.fsm.logger, peer.fsm.gConf, peer.fsm.pConf, peer.peerInfo, path)
 	peer.fsm.lock.Unlock()


### PR DESCRIPTION
The path.SetNexthop() still takes net.IP as an argument. Migrating it to netip.Addr simplifies good amount of code. Also migrating PolicyOptions.OldNextHop and NextHopSet.list to use netip types as some callsites pass them to path.SetNexthop().