### PR TITLE
cmd: fix unix domain socket connection

### DIFF
--- a/cmd/gobgp/common.go
+++ b/cmd/gobgp/common.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
@@ -29,7 +28,6 @@ import (
 	"net/netip"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"google.golang.org/grpc"
@@ -310,12 +308,6 @@ func newConn() (*grpc.ClientConn, error) {
 	target := globalOpts.Target
 	if target == "" {
 		target = net.JoinHostPort(globalOpts.Host, strconv.Itoa(globalOpts.Port))
-	} else if strings.HasPrefix(target, "unix://") {
-		target = target[len("unix://"):]
-		dialer := func(ctx context.Context, addr string) (net.Conn, error) {
-			return net.Dial("unix", addr)
-		}
-		grpcOpts = append(grpcOpts, grpc.WithContextDialer(dialer))
 	}
 	return grpc.NewClient(target, grpcOpts...)
 }

--- a/cmd/gobgp/root.go
+++ b/cmd/gobgp/root.go
@@ -90,7 +90,7 @@ func newRootCmd() *cobra.Command {
 
 	rootCmd.PersistentFlags().StringVarP(&globalOpts.Host, "host", "u", "127.0.0.1", "host")
 	rootCmd.PersistentFlags().IntVarP(&globalOpts.Port, "port", "p", 50051, "port")
-	rootCmd.PersistentFlags().StringVarP(&globalOpts.Target, "target", "", "", "alternative to host/port when using UDS. Ex: unix:///var/run/go-bgp.sock if running gobgpd with a UDS socket.")
+	rootCmd.PersistentFlags().StringVarP(&globalOpts.Target, "target", "", "", "alternative to host/port when using UDS. Examples: unix:///var/run/go-bgp.sock (absolute path) or unix:tmp/go-bgp.sock (relative to current directory).")
 	rootCmd.PersistentFlags().BoolVarP(&globalOpts.Json, "json", "j", false, "use json format to output format")
 	rootCmd.PersistentFlags().BoolVarP(&globalOpts.Debug, "debug", "d", false, "use debug")
 	rootCmd.PersistentFlags().BoolVarP(&globalOpts.Quiet, "quiet", "q", false, "use quiet")


### PR DESCRIPTION
Use passthrough resolver for unix socket targets to avoid “produced zero addresses” error.