### PR TITLE
remove debug log as it's too noisy an on the hot path

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -501,7 +501,8 @@ func filterpath(peer *peer, path, old *table.Path) *table.Path {
 					return old.Clone(true)
 				}
 			}
-			peer.fsm.logger.Debug("From same AS, ignore", slog.Any("Path", path))
+			// this line is in comment because it's on the hot path
+			// peer.fsm.logger.Debug("From same AS, ignore", slog.Any("Path", path))
 			return nil
 		}
 	}


### PR DESCRIPTION
The issue here is on high load, previous pprof showed, that slog lock cost some time even if log level was set to info