### PR TITLE
server: Fix gRPC AddPath uuidMap handling

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -644,7 +644,6 @@ func (s *server) AddPath(ctx context.Context, r *api.AddPathRequest) (*api.AddPa
 	}
 
 	id := path[0].UUID
-	s.bgpServer.uuidMap[apiutilPathTokey(p)] = id
 	uuidBytes, err = id.MarshalBinary()
 	return &api.AddPathResponse{Uuid: uuidBytes}, err
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2096,10 +2096,6 @@ func pathTokey(path *table.Path) string {
 	return fmt.Sprintf("%d:%s", path.RemoteID(), path.GetPrefix())
 }
 
-func apiutilPathTokey(path *apiutil.Path) string {
-	return fmt.Sprintf("%d:%s", path.RemoteID, path.Nlri.String())
-}
-
 func (s *BgpServer) addPathList(vrfId string, pathList []*table.Path) error {
 	err := s.fixupApiPath(vrfId, pathList)
 	if err == nil {


### PR DESCRIPTION
Drop the redundant grpc AddPath uuidMap write to avoid races, and add a gRPC test that verifies uuidMap is updated via BgpServer.AddPath.