### PR TITLE
Speed up RTC in Adj-RIB tables

### DIFF
--- a/internal/pkg/table/adj.go
+++ b/internal/pkg/table/adj.go
@@ -22,6 +22,57 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
 
+// rtCounter keeps per-RT reference counts.
+type rtCounter struct {
+	rts map[uint64]int
+}
+
+func (rtc *rtCounter) add(path *Path) {
+	if rtc == nil {
+		return
+	}
+	if path.GetFamily() != bgp.RF_RTC_UC {
+		return
+	}
+	nlri, ok := path.GetNlri().(*bgp.RouteTargetMembershipNLRI)
+	if !ok {
+		return
+	}
+	rtHash, err := nlriRouteTargetKey(nlri)
+	if err != nil {
+		return
+	}
+	if _, found := rtc.rts[rtHash]; !found {
+		rtc.rts[rtHash] = 1
+		return
+	}
+	rtc.rts[rtHash]++
+}
+
+func (rtc *rtCounter) sub(path *Path) {
+	if rtc == nil {
+		return
+	}
+	if path.GetFamily() != bgp.RF_RTC_UC {
+		return
+	}
+	nlri, ok := path.GetNlri().(*bgp.RouteTargetMembershipNLRI)
+	if !ok {
+		return
+	}
+	rtHash, err := nlriRouteTargetKey(nlri)
+	if err != nil {
+		return
+	}
+	if val, found := rtc.rts[rtHash]; found {
+		if val <= 1 {
+			delete(rtc.rts, rtHash)
+			return
+		}
+		rtc.rts[rtHash]--
+	}
+}
+
 type AdjRib struct {
 	accepted map[bgp.Family]int
 	table    map[bgp.Family]*Table
@@ -31,13 +82,38 @@ type AdjRib struct {
 func NewAdjRib(logger *slog.Logger, rfList []bgp.Family) *AdjRib {
 	m := make(map[bgp.Family]*Table)
 	for _, f := range rfList {
-		m[f] = NewTable(logger, f)
+		m[f] = NewAdjTable(logger, f)
 	}
 	return &AdjRib{
 		table:    m,
 		accepted: make(map[bgp.Family]int),
 		logger:   logger,
 	}
+}
+
+func (adj *AdjRib) HasRTinRtcTable(routeTarget bgp.ExtendedCommunityInterface) bool {
+	table, found := adj.table[bgp.RF_RTC_UC]
+	if !found || table.adjRts == nil {
+		return false
+	}
+
+	key, err := extCommRouteTargetKey(routeTarget)
+	if err != nil {
+		return false
+	}
+
+	num, found := table.adjRts.rts[key]
+	return found && num > 0
+}
+
+func (adj *AdjRib) HasDefaultRT() bool {
+	table, found := adj.table[bgp.RF_RTC_UC]
+	if !found || table.adjRts == nil {
+		return false
+	}
+
+	num, found := table.adjRts.rts[DefaultRT]
+	return found && num > 0
 }
 
 func (adj *AdjRib) Update(pathList []*Path) {
@@ -68,6 +144,7 @@ func (adj *AdjRib) Update(pathList []*Path) {
 				}
 				if !old.IsRejected() {
 					adj.accepted[rf]--
+					t.adjRts.sub(old)
 				}
 			}
 			path.SetDropped(true)
@@ -75,8 +152,10 @@ func (adj *AdjRib) Update(pathList []*Path) {
 			if idx != -1 {
 				if old.IsRejected() && !path.IsRejected() {
 					adj.accepted[rf]++
+					t.adjRts.add(path)
 				} else if !old.IsRejected() && path.IsRejected() {
 					adj.accepted[rf]--
+					t.adjRts.sub(old)
 				}
 				if old.Equal(path) {
 					path.setTimestamp(old.GetTimestamp())
@@ -86,6 +165,7 @@ func (adj *AdjRib) Update(pathList []*Path) {
 				d.knownPathList = append(d.knownPathList, path)
 				if !path.IsRejected() {
 					adj.accepted[rf]++
+					t.adjRts.add(path)
 				}
 			}
 		}
@@ -107,6 +187,9 @@ func (adj *AdjRib) UpdateAdjRibOut(pathList []*Path) {
 		t := adj.table[path.GetFamily()]
 		d := t.getOrCreateDest(path.GetNlri(), 0)
 		d.knownPathList = append(d.knownPathList, path)
+		if !path.IsRejected() {
+			t.adjRts.add(path)
+		}
 	}
 }
 
@@ -166,7 +249,7 @@ func (adj *AdjRib) Drop(rfList []bgp.Family) []*Path {
 		return false
 	})
 	for _, rf := range rfList {
-		adj.table[rf] = NewTable(adj.logger, rf)
+		adj.table[rf] = NewAdjTable(adj.logger, rf)
 		adj.accepted[rf] = 0
 	}
 	return l
@@ -233,7 +316,7 @@ func (adj *AdjRib) MarkLLGRStaleOrDrop(rfList []bgp.Family) []*Path {
 func (adj *AdjRib) Select(family bgp.Family, accepted bool, option ...TableSelectOption) (*Table, error) {
 	t, ok := adj.table[family]
 	if !ok {
-		t = NewTable(adj.logger, family)
+		t = NewAdjTable(adj.logger, family)
 	}
 	option = append(option, TableSelectOption{adj: true})
 	return t.Select(option...)

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -191,18 +191,26 @@ type Table struct {
 	Family       bgp.Family
 	destinations Destinations
 	logger       *slog.Logger
+	// adjRts is an RT->count map (reference count of RTC paths per RT).
+	// It is used only for Adj-RIB tables with RF_RTC_UC.
+	adjRts *rtCounter
 	// index of evpn prefixes with paths to a specific MAC in a MAC-VRF
 	// this is a map[rt, MAC address]map[addrPrefixKey][]nlri
 	// this holds a map for a set of prefixes.
 	macIndex EVPNMacNLRIs
 }
 
-func NewTable(logger *slog.Logger, rf bgp.Family, dsts ...*destination) *Table {
+func newTablePartial(logger *slog.Logger, rf bgp.Family, isAdj bool, dsts ...*destination) *Table {
 	t := &Table{
 		Family:       rf,
 		destinations: make(Destinations),
 		logger:       logger,
 		macIndex:     make(EVPNMacNLRIs),
+	}
+	if isAdj && rf == bgp.RF_RTC_UC {
+		t.adjRts = &rtCounter{
+			rts: make(map[uint64]int),
+		}
 	}
 	for _, dst := range dsts {
 		t.setDestination(dst)
@@ -212,6 +220,14 @@ func NewTable(logger *slog.Logger, rf bgp.Family, dsts ...*destination) *Table {
 
 func (t *Table) GetFamily() bgp.Family {
 	return t.Family
+}
+
+func NewTable(logger *slog.Logger, rf bgp.Family, dsts ...*destination) *Table {
+	return newTablePartial(logger, rf, false, dsts...)
+}
+
+func NewAdjTable(logger *slog.Logger, rf bgp.Family, dsts ...*destination) *Table {
+	return newTablePartial(logger, rf, true, dsts...)
 }
 
 func (t *Table) deletePathsByVrf(vrf *Vrf) []*Path {
@@ -887,6 +903,11 @@ func (t *Table) Info(option ...TableInfoOptions) *TableInfo {
 	}
 }
 
+// DefaultRT is the uint64 encoding of the default (wildcard) Route Target used in RTC.
+// It indicates interest in all routes, regardless of their Route Targets.
+// In RouteTargetMembershipNLRI, this value is represented as a nil RouteTarget.
+const DefaultRT uint64 = 0
+
 var (
 	ErrInvalidRouteTarget error = errors.New("ExtendedCommunity is not RouteTarget")
 	ErrNilCommunity       error = errors.New("RouteTarget could not be nil")
@@ -906,6 +927,13 @@ func extCommRouteTargetKey(routeTarget bgp.ExtendedCommunityInterface) (uint64, 
 	default:
 		return 0, ErrInvalidRouteTarget
 	}
+}
+
+func nlriRouteTargetKey(nlri *bgp.RouteTargetMembershipNLRI) (uint64, error) {
+	if nlri.RouteTarget == nil {
+		return DefaultRT, nil
+	}
+	return extCommRouteTargetKey(nlri.RouteTarget)
 }
 
 type routeTargetMap map[uint64]bgp.ExtendedCommunityInterface

--- a/internal/pkg/table/table_test.go
+++ b/internal/pkg/table/table_test.go
@@ -734,7 +734,7 @@ func Test_RouteTargetKey(t *testing.T) {
 	binary.BigEndian.PutUint32(buf[9:], 0x15161718)
 	r, err := bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	key, err := extCommRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI).RouteTarget)
+	key, err := nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NoError(err)
 	assert.Equal(uint64(0x0002131415161718), key)
 
@@ -749,7 +749,7 @@ func Test_RouteTargetKey(t *testing.T) {
 	binary.BigEndian.PutUint16(buf[11:], 0x1314)
 	r, err = bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	key, err = extCommRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI).RouteTarget)
+	key, err = nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NoError(err)
 	assert.Equal(uint64(0x01020a0102031314), key)
 
@@ -763,7 +763,7 @@ func Test_RouteTargetKey(t *testing.T) {
 	binary.BigEndian.PutUint16(buf[11:], 0x1314)
 	r, err = bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	key, err = extCommRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI).RouteTarget)
+	key, err = nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NoError(err)
 	assert.Equal(uint64(0x0202151617181314), key)
 
@@ -775,8 +775,16 @@ func Test_RouteTargetKey(t *testing.T) {
 	binary.BigEndian.PutUint32(buf[9:], 1000000)
 	r, err = bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	_, err = extCommRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI).RouteTarget)
+	_, err = nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NotNil(err)
+
+	r = &bgp.RouteTargetMembershipNLRI{}
+	key, err = nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
+	assert.NoError(err)
+	assert.Equal(DefaultRT, key)
+
+	_, err = extCommRouteTargetKey(nil)
+	assert.Equal(ErrNilCommunity, err)
 }
 
 func TestContainsCIDR(t *testing.T) {

--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -481,13 +481,12 @@ func (peer *peer) stopPeerRestarting() {
 // Returns true if the peer is interested in this path according to BGP RTC
 // (i.e., has advertised the relevant RT).
 func (peer *peer) interestedIn(path *table.Path) bool {
+	if peer.adjRibIn.HasDefaultRT() {
+		return true
+	}
 	for _, ext := range path.GetExtCommunities() {
-		for _, p := range peer.adjRibIn.PathList([]bgp.Family{bgp.RF_RTC_UC}, true) {
-			rt := p.GetNlri().(*bgp.RouteTargetMembershipNLRI).RouteTarget
-			// Note: nil RT means the default route target
-			if rt == nil || ext.String() == rt.String() {
-				return true
-			}
+		if peer.adjRibIn.HasRTinRtcTable(ext) {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
Add an RT->count map for Adj-RIB tables and reduce filterpath function complexity.