### PR TITLE
Scaling up gobgp, handleFSMMessage re-entrant

### DIFF
--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -96,6 +96,11 @@ func newDynamicPeer(g *oc.Global, neighborAddress string, pg *oc.PeerGroup, loc 
 	return newPeer(g, &conf, bgp.BGP_FSM_ACTIVE, loc, policy, logger)
 }
 
+// pathIDSet is the set of add-path local identifiers advertised for a destination.
+// Values of this type are stored in peer.sentPaths and MUST only be accessed
+// under the propagation bucket lock for the corresponding prefix.
+type pathIDSet map[uint32]struct{}
+
 type peer struct {
 	tableId           string
 	fsm               *fsm
@@ -104,9 +109,14 @@ type peer struct {
 	localRib          *table.TableManager
 	peerInfo          atomic.Pointer[table.PeerInfo]
 	prefixLimitWarned map[bgp.Family]bool // protected by fsm.lock
-	// map of path local identifiers sent for that prefix
-	sentPaths           map[table.PathDestLocalKey]map[uint32]struct{}
-	sendMaxPathFiltered map[table.PathLocalKey]struct{}
+	// map[table.PathDestLocalKey]pathIDSet, with inner pathIDSets protected
+	// by the matching server propagation bucket for the route prefix.
+	// All methods that read or mutate a pathIDSet value (updateRoutes,
+	// getRoutesCount, hasPathAlreadyBeenSent) MUST be called under the
+	// bucket lock for that prefix (sharedData.propagateBucket).
+	sentPaths sync.Map
+	// map[table.PathLocalKey]struct{}
+	sendMaxPathFiltered sync.Map
 	llgrEndChs          []chan struct{} // protected by fsm.lock
 	longLivedRunning    atomic.Bool
 	// Route Target Membership handler after import policy (for constrained VPN distribution).
@@ -117,12 +127,10 @@ type peer struct {
 
 func newPeer(g *oc.Global, conf *oc.Neighbor, state bgp.FSMState, loc *table.TableManager, policy *table.RoutingPolicy, logger *slog.Logger) *peer {
 	peer := &peer{
-		localRib:            loc,
-		policy:              policy,
-		fsm:                 newFSM(g, conf, state, logger.With(slog.String("Topic", "Peer"), slog.String("Key", conf.State.NeighborAddress.String()))),
-		prefixLimitWarned:   make(map[bgp.Family]bool),
-		sentPaths:           make(map[table.PathDestLocalKey]map[uint32]struct{}),
-		sendMaxPathFiltered: make(map[table.PathLocalKey]struct{}),
+		localRib:          loc,
+		policy:            policy,
+		fsm:               newFSM(g, conf, state, logger.With(slog.String("Topic", "Peer"), slog.String("Key", conf.State.NeighborAddress.String()))),
+		prefixLimitWarned: make(map[bgp.Family]bool),
 	}
 	if peer.isRouteServerClient() {
 		peer.tableId = conf.State.NeighborAddress.String()
@@ -229,8 +237,8 @@ func (peer *peer) getAddPathSendMax(family bgp.Family) uint8 {
 
 func (peer *peer) getRoutesCount(family bgp.Family, dstPrefix string) uint8 {
 	destLocalKey := table.NewPathDestLocalKey(family, dstPrefix)
-	if identifiers, ok := peer.sentPaths[*destLocalKey]; ok {
-		count := len(identifiers)
+	if identifiers, ok := peer.sentPaths.Load(*destLocalKey); ok {
+		count := len(identifiers.(pathIDSet))
 		// the send-max config is uint8, so we need to check for overflow
 		if count > int(^uint8(0)) {
 			return ^uint8(0)
@@ -247,16 +255,26 @@ func (peer *peer) updateRoutes(paths ...*table.Path) {
 	for _, path := range paths {
 		localKey := path.GetLocalKey()
 		destLocalKey := localKey.PathDestLocalKey
-		identifiers, destExists := peer.sentPaths[destLocalKey]
+		identifiersValue, destExists := peer.sentPaths.Load(destLocalKey)
 		if path.IsWithdraw && destExists {
+			identifiers := identifiersValue.(pathIDSet)
 			delete(identifiers, path.LocalID())
-		} else if !path.IsWithdraw {
-			if !destExists {
-				peer.sentPaths[destLocalKey] = make(map[uint32]struct{})
+			if len(identifiers) == 0 {
+				peer.sentPaths.Delete(destLocalKey)
 			}
-			identifiers := peer.sentPaths[destLocalKey]
+		} else if !path.IsWithdraw {
+			var identifiers pathIDSet
+			if destExists {
+				identifiers = identifiersValue.(pathIDSet)
+			} else {
+				identifiers = make(pathIDSet)
+			}
 			if len(identifiers) < int(peer.getAddPathSendMax(destLocalKey.Family)) {
 				identifiers[localKey.Id] = struct{}{}
+				if !destExists {
+					// store only the first insert, mutations are inplace
+					peer.sentPaths.Store(destLocalKey, identifiers)
+				}
 			}
 		}
 	}
@@ -266,18 +284,25 @@ func (peer *peer) isPathSendMaxFiltered(path *table.Path) bool {
 	if path == nil {
 		return false
 	}
-	_, found := peer.sendMaxPathFiltered[path.GetLocalKey()]
+	_, found := peer.sendMaxPathFiltered.Load(path.GetLocalKey())
 	return found
+}
+
+func (peer *peer) setPathSendMaxFiltered(path *table.Path) {
+	if path == nil {
+		return
+	}
+	peer.sendMaxPathFiltered.Store(path.GetLocalKey(), struct{}{})
 }
 
 func (peer *peer) unsetPathSendMaxFiltered(path *table.Path) bool {
 	if path == nil {
 		return false
 	}
-	if _, ok := peer.sendMaxPathFiltered[path.GetLocalKey()]; !ok {
+	if _, ok := peer.sendMaxPathFiltered.Load(path.GetLocalKey()); !ok {
 		return false
 	}
-	delete(peer.sendMaxPathFiltered, path.GetLocalKey())
+	peer.sendMaxPathFiltered.Delete(path.GetLocalKey())
 	return true
 }
 
@@ -286,10 +311,11 @@ func (peer *peer) hasPathAlreadyBeenSent(path *table.Path) bool {
 		return false
 	}
 	destLocalKey := path.GetDestLocalKey()
-	if _, dstExist := peer.sentPaths[destLocalKey]; !dstExist {
+	identifiers, dstExist := peer.sentPaths.Load(destLocalKey)
+	if !dstExist {
 		return false
 	}
-	_, pathExist := peer.sentPaths[destLocalKey][path.LocalID()]
+	_, pathExist := identifiers.(pathIDSet)[path.LocalID()]
 	return pathExist
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -102,14 +102,27 @@ func TimingHookOption(hook FSMTimingHook) ServerOption {
 	}
 }
 
+const propagateBucketCount = 2048
+
 type sharedData struct {
-	mu sync.RWMutex
+	mu               sync.RWMutex
+	propagateBuckets [propagateBucketCount]sync.Mutex
 }
 
 func newSharedData() *sharedData {
 	return &sharedData{
 		mu: sync.RWMutex{},
 	}
+}
+
+func (d *sharedData) propagateBucket(path *table.Path) *sync.Mutex {
+	if path == nil {
+		return &d.propagateBuckets[0]
+	}
+	// note: we can't use path.GetNlri().Serialize() here as peer.sentPaths is indexed by destLocalKey
+	destLocalKey := path.GetDestLocalKey()
+	idx := farm.Hash64([]byte(destLocalKey.Family.String()+destLocalKey.Prefix)) % uint64(len(d.propagateBuckets))
+	return &d.propagateBuckets[idx]
 }
 
 type BgpServer struct {
@@ -1150,48 +1163,54 @@ func (s *BgpServer) propagateUpdate(peer *peer, pathList []*table.Path) {
 			}
 		}
 
-		// Strip LOCAL_PREF from eBGP peers on ingress.
-		// RFC 4271: LOCAL_PREF is only used in iBGP.
-		if peer != nil && !peer.isIBGPPeer() && !peer.isRouteServerClient() {
-			path.RemoveLocalPref()
-		}
+		func(path *table.Path) {
+			bucket := s.shared.propagateBucket(path)
+			bucket.Lock()
+			defer bucket.Unlock()
 
-		policyOptions := &table.PolicyOptions{
-			Validate: s.roaTable.Validate,
-		}
-
-		if !rs && peer != nil {
-			policyOptions.Info = peer.peerInfo.Load()
-		}
-
-		if p := s.policy.ApplyPolicy(tableId, table.POLICY_DIRECTION_IMPORT, path, policyOptions); p != nil {
-			path = p
-		} else {
-			path = path.Clone(true)
-		}
-
-		if !rs {
-			s.notifyPostPolicyUpdateWatcher(peer, []*table.Path{path})
-
-			// RFC4684 Constrained Route Distribution 6. Operation
-			//
-			// When a BGP speaker receives a BGP UPDATE that advertises or withdraws
-			// a given Route Target membership NLRI, it should examine the RIB-OUTs
-			// of VPN NLRIs and re-evaluate the advertisement status of routes that
-			// match the Route Target in question.
-			//
-			// A BGP speaker should generate the minimum set of BGP VPN route
-			// updates (advertisements and/or withdraws) necessary to transition
-			// between the previous and current state of the route distribution
-			// graph that is derived from Route Target membership information.
-			if peer != nil && path != nil && path.GetFamily() == bgp.RF_RTC_UC {
-				s.processRTCMembership(peer, path)
+			// Strip LOCAL_PREF from eBGP peers on ingress.
+			// RFC 4271: LOCAL_PREF is only used in iBGP.
+			if peer != nil && !peer.isIBGPPeer() && !peer.isRouteServerClient() {
+				path.RemoveLocalPref()
 			}
-		}
 
-		if dsts := rib.Update(path); len(dsts) > 0 {
-			s.propagateUpdateToNeighbors(rib, peer, path, dsts, true)
-		}
+			policyOptions := &table.PolicyOptions{
+				Validate: s.roaTable.Validate,
+			}
+
+			if !rs && peer != nil {
+				policyOptions.Info = peer.peerInfo.Load()
+			}
+
+			if p := s.policy.ApplyPolicy(tableId, table.POLICY_DIRECTION_IMPORT, path, policyOptions); p != nil {
+				path = p
+			} else {
+				path = path.Clone(true)
+			}
+
+			if !rs {
+				s.notifyPostPolicyUpdateWatcher(peer, []*table.Path{path})
+
+				// RFC4684 Constrained Route Distribution 6. Operation
+				//
+				// When a BGP speaker receives a BGP UPDATE that advertises or withdraws
+				// a given Route Target membership NLRI, it should examine the RIB-OUTs
+				// of VPN NLRIs and re-evaluate the advertisement status of routes that
+				// match the Route Target in question.
+				//
+				// A BGP speaker should generate the minimum set of BGP VPN route
+				// updates (advertisements and/or withdraws) necessary to transition
+				// between the previous and current state of the route distribution
+				// graph that is derived from Route Target membership information.
+				if peer != nil && path != nil && path.GetFamily() == bgp.RF_RTC_UC {
+					s.processRTCMembership(peer, path)
+				}
+			}
+
+			if dsts := rib.Update(path); len(dsts) > 0 {
+				s.propagateUpdateToNeighbors(rib, peer, path, dsts, true)
+			}
+		}(path)
 	}
 }
 
@@ -1409,7 +1428,7 @@ func (s *BgpServer) propagateUpdateToNeighbors(rib *table.TableManager, source *
 						}
 					} else {
 						bestList = []*table.Path{}
-						targetPeer.sendMaxPathFiltered[newPath.GetLocalKey()] = struct{}{}
+						targetPeer.setPathSendMaxFiltered(newPath)
 						targetPeer.fsm.logger.Warn("exceeding max routes for prefix", slog.String("Prefix", newPath.GetPrefix()))
 					}
 				}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1144,7 +1144,9 @@ func (s *BgpServer) propagateUpdate(peer *peer, pathList []*table.Path) {
 			}
 			path = path.ToGlobal(vrfObj)
 			if s.zclient != nil {
+				s.zclient.pathVrfMu.Lock()
 				s.zclient.pathVrfMap[path] = vrfObj.Id
+				s.zclient.pathVrfMu.Unlock()
 			}
 		}
 
@@ -2233,7 +2235,9 @@ func (s *BgpServer) addPathList(vrfId string, pathList []*table.Path) error {
 	err := s.fixupApiPath(vrfId, pathList)
 	if err == nil {
 		if s.zclient != nil {
+			s.zclient.cacheLock.Lock()
 			s.zclient.nexthopCache.applyToNewPathList(pathList)
+			s.zclient.cacheLock.Unlock()
 		}
 		s.propagateUpdate(nil, pathList)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1440,21 +1440,35 @@ func (s *BgpServer) propagateUpdateToNeighbors(rib *table.TableManager, source *
 
 func (s *BgpServer) stopNeighbor(peer *peer, oldState bgp.FSMState, e *fsmMsg) {
 	peer.stopPeerRestarting()
-	delete(s.neighborMap, netip.MustParseAddr(peer.ID()))
+	// Guard against the TOCTOU window between the RUnlock and write-Lock in
+	// handleFSMMessage: only delete if the map still holds this exact peer
+	key := netip.MustParseAddr(peer.ID())
+	if s.neighborMap[key] == peer {
+		delete(s.neighborMap, key)
+	}
 	peer.stopFSM()
 	s.broadcastPeerState(peer, bgp.BGP_FSM_IDLE, oldState, e)
 }
 
 func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
+	needStopNeighbor := false
+	var oldState bgp.FSMState
 	s.shared.mu.RLock()
-	defer s.shared.mu.RUnlock()
+	defer func() {
+		s.shared.mu.RUnlock()
+		if needStopNeighbor {
+			s.shared.mu.Lock()
+			s.stopNeighbor(peer, oldState, e)
+			s.shared.mu.Unlock()
+		}
+	}()
 
 	switch e.MsgType {
 	case fsmMsgStateChange:
 		nextState := e.MsgData.(bgp.FSMState)
 		peer.fsm.lock.Lock()
 		conf := peer.fsm.pConf.ReadCopy()
-		oldState := bgp.FSMState(conf.State.SessionState.ToInt())
+		oldState = bgp.FSMState(conf.State.SessionState.ToInt())
 		conf.State.SessionState = oc.IntToSessionStateMap[int(nextState)]
 		peer.fsm.pConf.Update(&conf)
 
@@ -1509,7 +1523,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 			}
 
 			if !graceful && peer.isDynamicNeighbor() {
-				s.stopNeighbor(peer, oldState, e)
+				needStopNeighbor = true
 				return
 			}
 		} else if nextStateIdle {
@@ -1591,7 +1605,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 				s.propagateUpdate(peer, peer.DropAll(peer.configuredRFlist()))
 
 				if peer.isDynamicNeighbor() {
-					s.stopNeighbor(peer, oldState, e)
+					needStopNeighbor = true
 					return
 				}
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -103,12 +103,12 @@ func TimingHookOption(hook FSMTimingHook) ServerOption {
 }
 
 type sharedData struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 }
 
 func newSharedData() *sharedData {
 	return &sharedData{
-		mu: sync.Mutex{},
+		mu: sync.RWMutex{},
 	}
 }
 
@@ -1446,8 +1446,8 @@ func (s *BgpServer) stopNeighbor(peer *peer, oldState bgp.FSMState, e *fsmMsg) {
 }
 
 func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
-	s.shared.mu.Lock()
-	defer s.shared.mu.Unlock()
+	s.shared.mu.RLock()
+	defer s.shared.mu.RUnlock()
 
 	switch e.MsgType {
 	case fsmMsgStateChange:

--- a/pkg/server/server_handlefsmmessage_test.go
+++ b/pkg/server/server_handlefsmmessage_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/osrg/gobgp/v4/api"
@@ -393,4 +394,945 @@ func TestHandleFSMMessage_LLGREndChsRace(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+// TestHandleFSMMessage_Parallel_StateChanges tests various state change scenarios in parallel
+func TestHandleFSMMessage_Parallel_StateChanges(t *testing.T) {
+	numPeers := 80
+
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	// Create multiple peers
+	peers := make([]*peer, numPeers)
+	for i := range numPeers {
+		peerAddr := netip.AddrFrom4([4]byte{10, 0, 0, byte(i + 1)})
+		err = s.AddPeer(context.Background(), &api.AddPeerRequest{
+			Peer: &api.Peer{
+				Conf: &api.PeerConf{
+					NeighborAddress: peerAddr.String(),
+					PeerAsn:         uint32(65002 + i),
+					AdminDown:       true, // Keep peer admin down to prevent actual connections
+				},
+				AfiSafis: []*api.AfiSafi{
+					{
+						Config: &api.AfiSafiConfig{
+							Family: &api.Family{
+								Afi:  api.Family_AFI_IP,
+								Safi: api.Family_SAFI_UNICAST,
+							},
+							Enabled: true,
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		err = s.mgmtOperation(func() error {
+			peers[i] = s.neighborMap[peerAddr]
+			return nil
+		}, true)
+		require.NoError(t, err)
+		require.NotNil(t, peers[i])
+	}
+
+	// Run handleFSMMessage for all peers concurrently with state changes
+	var wg sync.WaitGroup
+	for i := range numPeers {
+		wg.Add(1)
+		go func(peerIdx int) {
+			defer wg.Done()
+			p := peers[peerIdx]
+
+			// Test state change from IDLE to ACTIVE
+			msg1 := &fsmMsg{
+				MsgType:     fsmMsgStateChange,
+				MsgData:     bgp.BGP_FSM_ACTIVE,
+				StateReason: newfsmStateReason(fsmIdleTimerExpired, nil, nil),
+				timestamp:   time.Now(),
+			}
+			s.handleFSMMessage(p, msg1)
+
+			// Small delay
+			time.Sleep(10 * time.Millisecond)
+
+			// Test state change from ACTIVE to IDLE
+			msg2 := &fsmMsg{
+				MsgType:     fsmMsgStateChange,
+				MsgData:     bgp.BGP_FSM_IDLE,
+				StateReason: newfsmStateReason(fsmAdminDown, nil, nil),
+				timestamp:   time.Now(),
+			}
+			s.handleFSMMessage(p, msg2)
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	wg.Wait()
+
+	// Verify all peers are still in the neighbor map
+	err = s.mgmtOperation(func() error {
+		assert.Equal(t, numPeers, len(s.neighborMap))
+		return nil
+	}, true)
+	require.NoError(t, err)
+}
+
+// TestHandleFSMMessage_StateChange_AdminDown tests admin down state changes
+func TestHandleFSMMessage_StateChange_AdminDown(t *testing.T) {
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	peerAddr := "2.2.2.2"
+	err = s.AddPeer(context.Background(), &api.AddPeerRequest{
+		Peer: &api.Peer{
+			Conf: &api.PeerConf{
+				NeighborAddress: peerAddr,
+				PeerAsn:         65002,
+				AdminDown:       true,
+			},
+			AfiSafis: []*api.AfiSafi{
+				{
+					Config: &api.AfiSafiConfig{
+						Family: &api.Family{
+							Afi:  api.Family_AFI_IP,
+							Safi: api.Family_SAFI_UNICAST,
+						},
+						Enabled: true,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var p *peer
+	err = s.mgmtOperation(func() error {
+		p = s.neighborMap[netip.MustParseAddr(peerAddr)]
+		return nil
+	}, true)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	// Set peer admin down state
+	p.fsm.adminState.Store(adminStateDown)
+
+	// Send state change to IDLE with admin down
+	msg := &fsmMsg{
+		MsgType:     fsmMsgStateChange,
+		MsgData:     bgp.BGP_FSM_IDLE,
+		StateReason: newfsmStateReason(fsmAdminDown, nil, nil),
+		timestamp:   time.Now(),
+	}
+
+	s.handleFSMMessage(p, msg)
+
+	// Verify counters were cleared (admin down clears counters)
+	conf := *p.fsm.pConf.ReadOnly()
+	assert.Equal(t, int64(0), conf.Timers.State.Uptime)
+	assert.Equal(t, int64(0), conf.Timers.State.Downtime)
+}
+
+// TestHandleFSMMessage_StateChange_IdleToActive tests state transition from IDLE to ACTIVE
+func TestHandleFSMMessage_StateChange_IdleToActive(t *testing.T) {
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	peerAddr := "2.2.2.2"
+	err = s.AddPeer(context.Background(), &api.AddPeerRequest{
+		Peer: &api.Peer{
+			Conf: &api.PeerConf{
+				NeighborAddress: peerAddr,
+				PeerAsn:         65002,
+				AdminDown:       true,
+			},
+			AfiSafis: []*api.AfiSafi{
+				{
+					Config: &api.AfiSafiConfig{
+						Family: &api.Family{
+							Afi:  api.Family_AFI_IP,
+							Safi: api.Family_SAFI_UNICAST,
+						},
+						Enabled: true,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var p *peer
+	err = s.mgmtOperation(func() error {
+		p = s.neighborMap[netip.MustParseAddr(peerAddr)]
+		return nil
+	}, true)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	// Send state change from IDLE to ACTIVE
+	msg := &fsmMsg{
+		MsgType:     fsmMsgStateChange,
+		MsgData:     bgp.BGP_FSM_ACTIVE,
+		StateReason: newfsmStateReason(fsmIdleTimerExpired, nil, nil),
+		timestamp:   time.Now(),
+	}
+
+	initialState := p.State()
+	s.handleFSMMessage(p, msg)
+
+	// Verify state change was processed (state changed from initial)
+	conf := *p.fsm.pConf.ReadOnly()
+	assert.NotEqual(t, int(initialState), conf.State.SessionState.ToInt())
+}
+
+// TestHandleFSMMessage_ConcurrentAccess tests concurrent access to handleFSMMessage
+func TestHandleFSMMessage_ConcurrentAccess(t *testing.T) {
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	// Create three peers
+	numPeers := 80
+	peers := make([]*peer, numPeers)
+
+	for i := range numPeers {
+		peerAddr := netip.AddrFrom4([4]byte{10, 0, 0, byte(i + 1)})
+		err = s.AddPeer(context.Background(), &api.AddPeerRequest{
+			Peer: &api.Peer{
+				Conf: &api.PeerConf{
+					NeighborAddress: peerAddr.String(),
+					PeerAsn:         uint32(65002 + i),
+					AdminDown:       true,
+				},
+				AfiSafis: []*api.AfiSafi{
+					{
+						Config: &api.AfiSafiConfig{
+							Family: &api.Family{
+								Afi:  api.Family_AFI_IP,
+								Safi: api.Family_SAFI_UNICAST,
+							},
+							Enabled: true,
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		err = s.mgmtOperation(func() error {
+			peers[i] = s.neighborMap[peerAddr]
+			return nil
+		}, true)
+		require.NoError(t, err)
+		require.NotNil(t, peers[i])
+	}
+
+	// Send multiple state change messages concurrently to all peers
+	var wg sync.WaitGroup
+	iterations := 300
+
+	for i := range numPeers {
+		for j := range iterations {
+			wg.Add(1)
+			go func(peerIdx, iter int) {
+				defer wg.Done()
+				p := peers[peerIdx]
+
+				// Alternate between IDLE and ACTIVE
+				var targetState bgp.FSMState
+				var reason fsmStateReasonType
+				if iter%2 == 0 {
+					targetState = bgp.BGP_FSM_ACTIVE
+					reason = fsmIdleTimerExpired
+				} else {
+					targetState = bgp.BGP_FSM_IDLE
+					reason = fsmAdminDown
+				}
+
+				msg := &fsmMsg{
+					MsgType:     fsmMsgStateChange,
+					MsgData:     targetState,
+					StateReason: newfsmStateReason(reason, nil, nil),
+					timestamp:   time.Now(),
+				}
+
+				s.handleFSMMessage(p, msg)
+			}(i, j)
+		}
+	}
+
+	wg.Wait()
+
+	// Verify all peers are still in the neighbor map
+	err = s.mgmtOperation(func() error {
+		assert.Equal(t, numPeers, len(s.neighborMap))
+		for _, p := range peers {
+			assert.NotNil(t, p)
+		}
+		return nil
+	}, true)
+	require.NoError(t, err)
+}
+
+// TestHandleFSMMessage_WithGracefulRestart tests graceful restart scenarios
+func TestHandleFSMMessage_WithGracefulRestart(t *testing.T) {
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	peerAddr := "2.2.2.2"
+	err = s.AddPeer(context.Background(), &api.AddPeerRequest{
+		Peer: &api.Peer{
+			Conf: &api.PeerConf{
+				NeighborAddress: peerAddr,
+				PeerAsn:         65002,
+				AdminDown:       true,
+			},
+			GracefulRestart: &api.GracefulRestart{
+				Enabled:     true,
+				RestartTime: 120,
+			},
+			AfiSafis: []*api.AfiSafi{
+				{
+					Config: &api.AfiSafiConfig{
+						Family: &api.Family{
+							Afi:  api.Family_AFI_IP,
+							Safi: api.Family_SAFI_UNICAST,
+						},
+						Enabled: true,
+					},
+					MpGracefulRestart: &api.MpGracefulRestart{
+						Config: &api.MpGracefulRestartConfig{
+							Enabled: true,
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var p *peer
+	err = s.mgmtOperation(func() error {
+		p = s.neighborMap[netip.MustParseAddr(peerAddr)]
+		return nil
+	}, true)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	// Verify graceful restart config is set
+	conf := *p.fsm.pConf.ReadOnly()
+	assert.True(t, conf.GracefulRestart.Config.Enabled, "GR should be enabled in config")
+
+	// Send state change message
+	msg := &fsmMsg{
+		MsgType:     fsmMsgStateChange,
+		MsgData:     bgp.BGP_FSM_IDLE,
+		StateReason: newfsmStateReason(fsmGracefulRestart, nil, nil),
+		timestamp:   time.Now(),
+	}
+
+	s.handleFSMMessage(p, msg)
+
+	// Wait a bit for processing
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify message was processed without panic
+	assert.NotNil(t, p)
+}
+
+// TestHandleFSMMessage_DynamicNeighborRace tests the race condition in stopNeighbor with dynamic neighbors
+func TestHandleFSMMessage_DynamicNeighborRace(t *testing.T) {
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	// Add a peer group for dynamic neighbors
+	err = s.AddPeerGroup(context.Background(), &api.AddPeerGroupRequest{
+		PeerGroup: &api.PeerGroup{
+			Conf: &api.PeerGroupConf{
+				PeerGroupName: "dynamic-group",
+				PeerAsn:       65002,
+			},
+			AfiSafis: []*api.AfiSafi{
+				{
+					Config: &api.AfiSafiConfig{
+						Family: &api.Family{
+							Afi:  api.Family_AFI_IP,
+							Safi: api.Family_SAFI_UNICAST,
+						},
+						Enabled: true,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Add dynamic neighbor configuration
+	err = s.AddDynamicNeighbor(context.Background(), &api.AddDynamicNeighborRequest{
+		DynamicNeighbor: &api.DynamicNeighbor{
+			Prefix:    "10.0.0.0/24",
+			PeerGroup: "dynamic-group",
+		},
+	})
+	require.NoError(t, err)
+
+	numPeers := 80
+	peers := make([]*peer, numPeers)
+
+	// Manually create dynamic peers by adding them directly
+	// Dynamic peers have invalid NeighborAddress
+	for i := range numPeers {
+		peerAddr := netip.AddrFrom4([4]byte{10, 0, 0, byte(i + 1)})
+
+		err = s.mgmtOperation(func() error {
+			// Get peer group
+			pg, ok := s.peerGroupMap["dynamic-group"]
+			if !ok {
+				return nil
+			}
+
+			// Create a dynamic peer using the internal function
+			peer := newDynamicPeer(&s.bgpConfig.Global, peerAddr.String(), pg.Conf, s.globalRib, s.policy, s.logger)
+			if peer != nil {
+				s.neighborMap[peerAddr] = peer
+				peers[i] = peer
+
+				// Start the peer's FSM
+				peer.fsm.start(s.shutdownWG, func(msg *fsmMsg) {
+					s.handleFSMMessage(peer, msg)
+				})
+			}
+			return nil
+		}, true)
+		require.NoError(t, err)
+	}
+
+	// Wait a bit for FSMs to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Now trigger ESTABLISHED -> IDLE transitions in parallel for dynamic peers
+	// This should trigger stopNeighbor which modifies s.neighborMap
+	var wg sync.WaitGroup
+	for i := range numPeers {
+		if peers[i] == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(peerIdx int) {
+			defer wg.Done()
+			p := peers[peerIdx]
+
+			// Verify it's a dynamic neighbor
+			if !p.isDynamicNeighbor() {
+				t.Errorf("Peer %d is not dynamic - cannot trigger stopNeighbor race", peerIdx)
+				return
+			}
+
+			t.Logf("Peer %d is dynamic, triggering stopNeighbor", peerIdx)
+
+			// Set peer to ESTABLISHED first
+			p.fsm.lock.Lock()
+			conf := p.fsm.pConf.ReadCopy()
+			conf.State.SessionState = "established"
+			conf.Timers.State.Uptime = time.Now().Add(-1 * time.Minute).Unix()
+			p.fsm.pConf.Update(&conf)
+			p.fsm.lock.Unlock()
+
+			// Send state change from ESTABLISHED to IDLE (non-graceful)
+			// This should trigger stopNeighbor which deletes from s.neighborMap
+			msg := &fsmMsg{
+				MsgType:     fsmMsgStateChange,
+				MsgData:     bgp.BGP_FSM_IDLE,
+				StateReason: newfsmStateReason(fsmAdminDown, nil, nil), // non-graceful
+				timestamp:   time.Now(),
+			}
+
+			s.handleFSMMessage(p, msg)
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// TestHandleFSMMessage_NeighborMapIterationRace tests race when iterating neighborMap during EOR processing
+func TestHandleFSMMessage_NeighborMapIterationRace(t *testing.T) {
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	numPeers := 80
+	peers := make([]*peer, numPeers)
+
+	// Create peers with graceful restart enabled
+	for i := range numPeers {
+		peerAddr := netip.AddrFrom4([4]byte{10, 0, 0, byte(i + 1)})
+		err = s.AddPeer(context.Background(), &api.AddPeerRequest{
+			Peer: &api.Peer{
+				Conf: &api.PeerConf{
+					NeighborAddress: peerAddr.String(),
+					PeerAsn:         uint32(65002 + i),
+					AdminDown:       true,
+				},
+				GracefulRestart: &api.GracefulRestart{
+					Enabled:     true,
+					RestartTime: 120,
+				},
+				AfiSafis: []*api.AfiSafi{
+					{
+						Config: &api.AfiSafiConfig{
+							Family: &api.Family{
+								Afi:  api.Family_AFI_IP,
+								Safi: api.Family_SAFI_UNICAST,
+							},
+							Enabled: true,
+						},
+						MpGracefulRestart: &api.MpGracefulRestart{
+							Config: &api.MpGracefulRestartConfig{
+								Enabled: true,
+							},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		err = s.mgmtOperation(func() error {
+			peers[i] = s.neighborMap[peerAddr]
+			return nil
+		}, true)
+		require.NoError(t, err)
+		require.NotNil(t, peers[i])
+	}
+
+	// Run parallel operations that trigger neighborMap iteration
+	var wg sync.WaitGroup
+
+	// Goroutine 1: Trigger state transitions that cause EOR processing
+	// This will iterate over s.neighborMap at lines 1568, 1576, 1684, 1692
+	for i := range numPeers / 2 {
+		wg.Add(1)
+		go func(peerIdx int) {
+			defer wg.Done()
+			p := peers[peerIdx]
+
+			// Set to ESTABLISHED to enable EOR processing path
+			p.fsm.lock.Lock()
+			conf := p.fsm.pConf.ReadCopy()
+			conf.State.SessionState = "established"
+			conf.Timers.State.Uptime = time.Now().Add(-1 * time.Minute).Unix()
+			conf.GracefulRestart.State.LocalRestarting = true
+			p.fsm.pConf.Update(&conf)
+			p.fsm.lock.Unlock()
+
+			// Send BGP UPDATE with EOR to trigger the neighborMap iteration
+			eorMsg := bgp.NewBGPUpdateMessage(nil, nil, nil)
+			msg := &fsmMsg{
+				MsgType:     fsmMsgBGPMessage,
+				MsgData:     eorMsg,
+				StateReason: nil,
+				timestamp:   time.Now(),
+			}
+
+			s.handleFSMMessage(p, msg)
+		}(i)
+	}
+
+	// Goroutine 2: Add/remove dynamic neighbors to cause concurrent map modifications
+	// This simulates the race between iteration and modification
+	for i := numPeers / 2; i < numPeers; i++ {
+		wg.Add(1)
+		go func(peerIdx int) {
+			defer wg.Done()
+			p := peers[peerIdx]
+
+			// Rapidly change states to stress the system
+			for range 300 {
+				msg := &fsmMsg{
+					MsgType:     fsmMsgStateChange,
+					MsgData:     bgp.BGP_FSM_ACTIVE,
+					StateReason: newfsmStateReason(fsmIdleTimerExpired, nil, nil),
+					timestamp:   time.Now(),
+				}
+				s.handleFSMMessage(p, msg)
+				time.Sleep(5 * time.Millisecond)
+
+				msg = &fsmMsg{
+					MsgType:     fsmMsgStateChange,
+					MsgData:     bgp.BGP_FSM_IDLE,
+					StateReason: newfsmStateReason(fsmAdminDown, nil, nil),
+					timestamp:   time.Now(),
+				}
+				s.handleFSMMessage(p, msg)
+				time.Sleep(5 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// TestHandleFSMMessage_PropagateUpdateRace tests race in propagateUpdate's neighborMap iteration
+func TestHandleFSMMessage_PropagateUpdateRace(t *testing.T) {
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	// Add peer group for dynamic neighbors
+	err = s.AddPeerGroup(context.Background(), &api.AddPeerGroupRequest{
+		PeerGroup: &api.PeerGroup{
+			Conf: &api.PeerGroupConf{
+				PeerGroupName: "test-group",
+				PeerAsn:       65002,
+			},
+			AfiSafis: []*api.AfiSafi{
+				{
+					Config: &api.AfiSafiConfig{
+						Family: &api.Family{
+							Afi:  api.Family_AFI_IP,
+							Safi: api.Family_SAFI_UNICAST,
+						},
+						Enabled: true,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	err = s.AddDynamicNeighbor(context.Background(), &api.AddDynamicNeighborRequest{
+		DynamicNeighbor: &api.DynamicNeighbor{
+			Prefix:    "10.0.0.0/24",
+			PeerGroup: "test-group",
+		},
+	})
+	require.NoError(t, err)
+
+	numPeers := 80
+	peers := make([]*peer, numPeers)
+	dynamicPeers := make([]bool, numPeers)
+
+	// Create mix of regular and dynamic peers
+	for i := range numPeers {
+		peerAddr := netip.AddrFrom4([4]byte{10, 0, 0, byte(i + 1)})
+		isDynamic := i < numPeers/2 // half of the peers are dynamic
+
+		if isDynamic {
+			// Create dynamic peer
+			err = s.mgmtOperation(func() error {
+				pg, ok := s.peerGroupMap["test-group"]
+				if !ok {
+					return nil
+				}
+				peer := newDynamicPeer(&s.bgpConfig.Global, peerAddr.String(), pg.Conf, s.globalRib, s.policy, s.logger)
+				if peer != nil {
+					s.neighborMap[peerAddr] = peer
+					peers[i] = peer
+					dynamicPeers[i] = true
+					peer.fsm.start(s.shutdownWG, func(msg *fsmMsg) {
+						s.handleFSMMessage(peer, msg)
+					})
+				}
+				return nil
+			}, true)
+		} else {
+			// Create regular peer
+			err = s.AddPeer(context.Background(), &api.AddPeerRequest{
+				Peer: &api.Peer{
+					Conf: &api.PeerConf{
+						NeighborAddress: peerAddr.String(),
+						PeerAsn:         uint32(65002 + i),
+						AdminDown:       true,
+					},
+					AfiSafis: []*api.AfiSafi{
+						{
+							Config: &api.AfiSafiConfig{
+								Family: &api.Family{
+									Afi:  api.Family_AFI_IP,
+									Safi: api.Family_SAFI_UNICAST,
+								},
+								Enabled: true,
+							},
+						},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			err = s.mgmtOperation(func() error {
+				peers[i] = s.neighborMap[peerAddr]
+				return nil
+			}, true)
+		}
+		require.NoError(t, err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	var wg sync.WaitGroup
+
+	// Goroutines that trigger propagateUpdate (which iterates neighborMap at line 1209)
+	for i := numPeers / 2; i < numPeers; i++ {
+		if peers[i] == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(peerIdx int) {
+			defer wg.Done()
+			p := peers[peerIdx]
+
+			// Set to ESTABLISHED
+			p.fsm.lock.Lock()
+			conf := p.fsm.pConf.ReadCopy()
+			conf.State.SessionState = "established"
+			conf.Timers.State.Uptime = time.Now().Add(-1 * time.Minute).Unix()
+			p.fsm.pConf.Update(&conf)
+			p.fsm.lock.Unlock()
+
+			// Trigger state change that calls propagateUpdate
+			msg := &fsmMsg{
+				MsgType:     fsmMsgStateChange,
+				MsgData:     bgp.BGP_FSM_IDLE,
+				StateReason: newfsmStateReason(fsmHoldTimerExpired, nil, nil),
+				timestamp:   time.Now(),
+			}
+
+			s.handleFSMMessage(p, msg)
+		}(i)
+	}
+
+	// Concurrently delete dynamic neighbors (triggers stopNeighbor)
+	for i := range numPeers / 2 {
+		if peers[i] == nil || !dynamicPeers[i] {
+			continue
+		}
+		wg.Add(1)
+		go func(peerIdx int) {
+			defer wg.Done()
+			p := peers[peerIdx]
+
+			if !p.isDynamicNeighbor() {
+				return
+			}
+
+			// Set to ESTABLISHED then trigger peer down (non-graceful)
+			p.fsm.lock.Lock()
+			conf := p.fsm.pConf.ReadCopy()
+			conf.State.SessionState = "established"
+			conf.Timers.State.Uptime = time.Now().Add(-1 * time.Minute).Unix()
+			p.fsm.pConf.Update(&conf)
+			p.fsm.lock.Unlock()
+
+			// This will call stopNeighbor which deletes from neighborMap
+			// While other goroutines are iterating over it
+			msg := &fsmMsg{
+				MsgType:     fsmMsgStateChange,
+				MsgData:     bgp.BGP_FSM_IDLE,
+				StateReason: newfsmStateReason(fsmAdminDown, nil, nil), // non-graceful
+				timestamp:   time.Now(),
+			}
+
+			s.handleFSMMessage(p, msg)
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// TestHandleFSMMessage_ParallelDifferentPeers tests handleFSMMessage with different peers in parallel
+func TestHandleFSMMessage_ParallelDifferentPeers(t *testing.T) {
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	numPeers := 80
+	peers := make([]*peer, numPeers)
+
+	// Create peers with different configurations
+	for i := range numPeers {
+		peerAddr := netip.AddrFrom4([4]byte{10, 0, 0, byte(i + 1)})
+		enableGR := i%2 == 0 // Enable GR for even numbered peers
+
+		peerConfig := &api.Peer{
+			Conf: &api.PeerConf{
+				NeighborAddress: peerAddr.String(),
+				PeerAsn:         uint32(65002 + i),
+				AdminDown:       true,
+			},
+			AfiSafis: []*api.AfiSafi{
+				{
+					Config: &api.AfiSafiConfig{
+						Family: &api.Family{
+							Afi:  api.Family_AFI_IP,
+							Safi: api.Family_SAFI_UNICAST,
+						},
+						Enabled: true,
+					},
+				},
+			},
+		}
+
+		if enableGR {
+			peerConfig.GracefulRestart = &api.GracefulRestart{
+				Enabled:     true,
+				RestartTime: 120,
+			}
+			peerConfig.AfiSafis[0].MpGracefulRestart = &api.MpGracefulRestart{
+				Config: &api.MpGracefulRestartConfig{
+					Enabled: true,
+				},
+			}
+		}
+
+		err = s.AddPeer(context.Background(), &api.AddPeerRequest{Peer: peerConfig})
+		require.NoError(t, err)
+
+		err = s.mgmtOperation(func() error {
+			peers[i] = s.neighborMap[peerAddr]
+			return nil
+		}, true)
+		require.NoError(t, err)
+		require.NotNil(t, peers[i])
+	}
+
+	// Process messages for all peers in parallel
+	var wg sync.WaitGroup
+	for i := range numPeers {
+		wg.Add(1)
+		go func(peerIdx int) {
+			defer wg.Done()
+			p := peers[peerIdx]
+
+			// Send multiple state changes
+			states := []bgp.FSMState{
+				bgp.BGP_FSM_ACTIVE,
+				bgp.BGP_FSM_IDLE,
+				bgp.BGP_FSM_ACTIVE,
+				bgp.BGP_FSM_IDLE,
+			}
+
+			for _, state := range states {
+				reason := fsmIdleTimerExpired
+				if state == bgp.BGP_FSM_IDLE {
+					reason = fsmAdminDown
+				}
+
+				msg := &fsmMsg{
+					MsgType:     fsmMsgStateChange,
+					MsgData:     state,
+					StateReason: newfsmStateReason(reason, nil, nil),
+					timestamp:   time.Now(),
+				}
+
+				s.handleFSMMessage(p, msg)
+				time.Sleep(5 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all peers are still present and functional
+	err = s.mgmtOperation(func() error {
+		assert.Equal(t, numPeers, len(s.neighborMap))
+		for i, p := range peers {
+			assert.NotNil(t, p, "peer %d should not be nil", i)
+			// Verify GR config settings are still correct
+			conf := *p.fsm.pConf.ReadOnly()
+			if i%2 == 0 {
+				assert.True(t, conf.GracefulRestart.Config.Enabled, "peer %d should have GR enabled in config", i)
+			} else {
+				assert.False(t, conf.GracefulRestart.Config.Enabled, "peer %d should not have GR enabled in config", i)
+			}
+		}
+		return nil
+	}, true)
+	require.NoError(t, err)
 }

--- a/pkg/server/server_handlefsmmessage_test.go
+++ b/pkg/server/server_handlefsmmessage_test.go
@@ -278,6 +278,149 @@ func TestRTCMembershipSerializesTriggeredVPNUpdates(t *testing.T) {
 	}
 }
 
+func TestPropagateUpdateUsesPrefixBuckets(t *testing.T) {
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	blockedPath := makePath(t, "192.0.2.0/32", "192.0.2.254", 0)
+	blockedBucket := s.shared.propagateBucket(blockedPath)
+	var differentBucketPath *table.Path
+	for i := 1; i < 255; i++ {
+		prefix := netip.PrefixFrom(netip.AddrFrom4([4]byte{198, 51, 100, byte(i)}), 32).String()
+		path := makePath(t, prefix, "192.0.2.254", 0)
+		if s.shared.propagateBucket(path) != blockedBucket {
+			differentBucketPath = path
+			break
+		}
+	}
+	require.NotNil(t, differentBucketPath)
+
+	blockedBucket.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			blockedBucket.Unlock()
+		}
+	}()
+
+	samePrefixDone := make(chan struct{})
+	go func() {
+		s.propagateUpdate(nil, []*table.Path{blockedPath})
+		close(samePrefixDone)
+	}()
+
+	select {
+	case <-samePrefixDone:
+		t.Fatal("same-prefix propagation completed while its bucket was held")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	differentPrefixDone := make(chan struct{})
+	go func() {
+		s.propagateUpdate(nil, []*table.Path{differentBucketPath})
+		close(differentPrefixDone)
+	}()
+
+	select {
+	case <-differentPrefixDone:
+	case <-time.After(time.Second):
+		t.Fatal("different-prefix propagation did not complete while another bucket was held")
+	}
+
+	blockedBucket.Unlock()
+	locked = false
+
+	select {
+	case <-samePrefixDone:
+	case <-time.After(time.Second):
+		t.Fatal("same-prefix propagation did not complete after its bucket was released")
+	}
+}
+
+func TestPropagateUpdateSerializesConcurrentLiveDeltas(t *testing.T) {
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+
+	peerAddr := netip.MustParseAddr("10.0.0.1")
+	target := newPeerandInfo(t, 65001, 65002, peerAddr.String(), s.globalRib)
+	target.fsm.state.Store(bgp.BGP_FSM_ESTABLISHED)
+	target.fsm.familyMap.Store(map[bgp.Family]bgp.BGPAddPathMode{
+		bgp.RF_IPv4_UC: bgp.BGP_ADD_PATH_SEND,
+	})
+
+	const pathCount = 64
+	target.fsm.lock.Lock()
+	conf := target.fsm.pConf.ReadCopy()
+	foundFamily := false
+	for i := range conf.AfiSafis {
+		if conf.AfiSafis[i].State.Family != bgp.RF_IPv4_UC {
+			continue
+		}
+		conf.AfiSafis[i].AddPaths.Config.SendMax = pathCount
+		conf.AfiSafis[i].AddPaths.State.SendMax = pathCount
+		foundFamily = true
+	}
+	target.fsm.pConf.Update(&conf)
+	target.fsm.lock.Unlock()
+	require.True(t, foundFamily)
+
+	err = s.mgmtOperation(func() error {
+		s.neighborMap[peerAddr] = target
+		return nil
+	}, true)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := s.mgmtOperation(func() error {
+			delete(s.neighborMap, peerAddr)
+			return nil
+		}, false)
+		require.NoError(t, err)
+		cleanInfiniteChannel(target.fsm.outgoingCh)
+		require.NoError(t, s.StopBgp(context.Background(), &api.StopBgpRequest{}))
+	})
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range pathCount {
+		prefix := netip.PrefixFrom(netip.AddrFrom4([4]byte{192, 0, 2, byte(i)}), 32).String()
+		path := makePath(t, prefix, "192.0.2.254", 0)
+		wg.Add(1)
+		go func(path *table.Path) {
+			defer wg.Done()
+			<-start
+			s.propagateUpdate(nil, []*table.Path{path})
+		}(path)
+	}
+	close(start)
+	wg.Wait()
+
+	sentPathCount := 0
+	target.sentPaths.Range(func(_, _ any) bool {
+		sentPathCount++
+		return true
+	})
+	require.Equal(t, pathCount, sentPathCount)
+}
+
 // TestHandleFSMMessage_LLGREndChsRace tests concurrent append and reset of llgrEndChs slice
 func TestHandleFSMMessage_LLGREndChsRace(t *testing.T) {
 	s := NewBgpServer()

--- a/pkg/server/zclient.go
+++ b/pkg/server/zclient.go
@@ -23,6 +23,7 @@ import (
 	"net/netip"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -183,14 +184,18 @@ func newIPRouteBody(dst []*table.Path, vrfID uint32, z *zebraClient) (body *zebr
 		return nil, false
 	}
 	nhVrfID := uint32(zebra.DefaultVrf)
-	for vrfPath, pathVrfID := range z.pathVrfMap {
-		if path.Equal(vrfPath) {
-			nhVrfID = pathVrfID
-			break
-		} else {
-			continue
+	func() {
+		z.pathVrfMu.RLock()
+		defer z.pathVrfMu.RUnlock()
+		for vrfPath, pathVrfID := range z.pathVrfMap {
+			if path.Equal(vrfPath) {
+				nhVrfID = pathVrfID
+				break
+			} else {
+				continue
+			}
 		}
-	}
+	}()
 	for _, p := range paths {
 		nexthop.Gate = p.GetNexthop()
 		nexthop.VrfID = nhVrfID
@@ -340,7 +345,9 @@ type zebraClient struct {
 	client       *zebra.Client
 	server       *BgpServer
 	nexthopCache nexthopStateCache
+	cacheLock    sync.Mutex
 	pathVrfMap   map[*table.Path]uint32 // vpn paths and nexthop vpn id
+	pathVrfMu    sync.RWMutex
 	mplsLabel    mplsLabelParameter
 	dead         chan struct{}
 }
@@ -373,7 +380,9 @@ func (z *zebraClient) getPathListWithNexthopUpdate(body *zebra.NexthopUpdateBody
 }
 
 func (z *zebraClient) updatePathByNexthopCache(paths []*table.Path) {
+	z.cacheLock.Lock()
 	paths = z.nexthopCache.applyToPathList(paths)
+	z.cacheLock.Unlock()
 	if len(paths) > 0 {
 		if err := z.server.updatePath("", paths); err != nil {
 			z.server.logger.Error("failed to update nexthop reachability",
@@ -412,13 +421,19 @@ func (z *zebraClient) loop() {
 					}
 				}
 			case *zebra.NexthopUpdateBody:
-				if updated := z.nexthopCache.updateByNexthopUpdate(body); !updated {
+				z.cacheLock.Lock()
+				updated := z.nexthopCache.updateByNexthopUpdate(body)
+				z.cacheLock.Unlock()
+				if !updated {
 					continue
 				}
 				paths := z.getPathListWithNexthopUpdate(body)
 				if len(paths) == 0 {
 					// If there is no path bound for the given nexthop, send
 					// NEXTHOP_UNREGISTER message.
+					z.cacheLock.Lock()
+					delete(z.nexthopCache, body.Prefix.Prefix)
+					z.cacheLock.Unlock()
 					err := z.client.SendNexthopRegister(msg.Header.VrfID, newNexthopUnregisterBody(uint16(body.Prefix.Family), body.Prefix.Prefix), true)
 					if err != nil {
 						z.server.logger.Error("failed to send nexthop unregister",
@@ -426,7 +441,7 @@ func (z *zebraClient) loop() {
 							slog.String("Error", err.Error()),
 						)
 					}
-					delete(z.nexthopCache, body.Prefix.Prefix)
+					continue
 				}
 				z.updatePathByNexthopCache(paths)
 			case *zebra.GetLabelChunkBody:
@@ -464,7 +479,10 @@ func (z *zebraClient) loop() {
 									continue
 								}
 							}
-							if body := newNexthopRegisterBody(paths, z.nexthopCache); body != nil {
+							z.cacheLock.Lock()
+							body := newNexthopRegisterBody(paths, z.nexthopCache)
+							z.cacheLock.Unlock()
+							if body != nil {
 								err := z.client.SendNexthopRegister(i, body, false)
 								if err != nil {
 									z.server.logger.Error("failed to send nexthop register",
@@ -490,7 +508,10 @@ func (z *zebraClient) loop() {
 									continue
 								}
 							}
-							if body := newNexthopRegisterBody([]*table.Path{path}, z.nexthopCache); body != nil {
+							z.cacheLock.Lock()
+							body := newNexthopRegisterBody([]*table.Path{path}, z.nexthopCache)
+							z.cacheLock.Unlock()
+							if body != nil {
 								err := z.client.SendNexthopRegister(i, body, false)
 								if err != nil {
 									z.server.logger.Error("failed to send nexthop register",
@@ -504,7 +525,10 @@ func (z *zebraClient) loop() {
 					}
 				}
 			case *watchEventUpdate:
-				if body := newNexthopRegisterBody(msg.PathList, z.nexthopCache); body != nil {
+				z.cacheLock.Lock()
+				body := newNexthopRegisterBody(msg.PathList, z.nexthopCache)
+				z.cacheLock.Unlock()
+				if body != nil {
 					vrfID := uint32(0)
 					err := z.server.ListVrf(context.Background(), &api.ListVrfRequest{Name: msg.Neighbor.Config.Vrf}, func(v *api.Vrf) {
 						vrfID = v.Id


### PR DESCRIPTION
This PR will enable `handleFSMMessage` function to be re-entrant, this will allow peers to run in parallel
Notes:
 o adj tables are accessed under s.shared.Lock()
 o I ran some benchmark and fuzzing adding/delete peers and path dynamically under `-race`
 o ran on staging for a week with 2500 peers / 28 routes per peer

Depend on https://github.com/osrg/gobgp/pull/3332
Depend on https://github.com/osrg/gobgp/pull/3349

<img width="5964" height="3593" alt="image" src="https://github.com/user-attachments/assets/89325c47-364f-4b65-be02-531dac48f846" />

<img width="4764" height="2996" alt="image" src="https://github.com/user-attachments/assets/1dcab506-05c0-4fe1-80dd-03a98f692641" />

