### PR TITLE
fix(StopBgp): if server is not serving, we cannot stop BGP server

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1848,6 +1848,9 @@ func (s *BgpServer) StopBgp(ctx context.Context, r *api.StopBgpRequest) error {
 	if r == nil {
 		return fmt.Errorf("nil request")
 	}
+	if !s.isServing.Load() {
+		return fmt.Errorf("BGP server is not running")
+	}
 	err := s.mgmtOperation(func() error {
 		defer s.runningCancel()
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -56,6 +56,9 @@ func TestStop(t *testing.T) {
 	assert.NoError(err)
 	err = s.StopBgp(context.Background(), &api.StopBgpRequest{})
 	assert.NoError(err)
+	// stop again to verify we not getting stuck and report an error
+	err = s.StopBgp(context.Background(), &api.StopBgpRequest{})
+	assert.Error(err)
 
 	s = NewBgpServer()
 	err = s.SetLogLevel(context.Background(), &api.SetLogLevelRequest{Level: api.SetLogLevelRequest_LEVEL_DEBUG})


### PR DESCRIPTION
If the server is not serving, we don't want the caller to be stuck as the managment chan will never be read.