### PR TITLE
Adj-Rib: fix leak memory on withdraw unknown path

### DIFF
--- a/internal/pkg/table/adj.go
+++ b/internal/pkg/table/adj.go
@@ -139,13 +139,13 @@ func (adj *AdjRib) Update(pathList []*Path) {
 		if path.IsWithdraw {
 			if idx != -1 {
 				d.knownPathList = append(d.knownPathList[:idx], d.knownPathList[idx+1:]...)
-				if len(d.knownPathList) == 0 {
-					t.deleteDest(d)
-				}
 				if !old.IsRejected() {
 					adj.accepted[rf]--
 					t.adjRts.sub(old)
 				}
+			}
+			if len(d.knownPathList) == 0 {
+				t.deleteDest(d)
 			}
 			path.SetDropped(true)
 		} else {

--- a/internal/pkg/table/adj_test.go
+++ b/internal/pkg/table/adj_test.go
@@ -221,3 +221,17 @@ func TestAdjRTC(t *testing.T) {
 	assert.Equal(t, adj.Count([]bgp.Family{family}), 0)
 	assert.True(t, !adj.HasRTinRtcTable(rt2))
 }
+
+func TestWithdrawUnknownPath(t *testing.T) {
+	pi := &PeerInfo{}
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
+
+	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
+	p1 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri1}, true, attrs, time.Now(), false)
+	family := p1.GetFamily()
+	families := []bgp.Family{family}
+
+	adj := NewAdjRib(logger, families)
+	adj.Update([]*Path{p1})
+	assert.Equal(t, len(adj.table[family].destinations), 0)
+}


### PR DESCRIPTION
If you try to delete an unknown path from adj-rib, a key with an empty slice will be created, which will live until you delete adj-rib.