### PR TITLE
packet/bgp: validate NEXT_HOP attribute length and value to prevent p…

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -11255,7 +11255,13 @@ func (p *PathAttributeNextHop) DecodeFromBytes(data []byte, options ...*Marshall
 		eSubCode := uint8(BGP_ERROR_SUB_ATTRIBUTE_LENGTH_ERROR)
 		return NewMessageError(eCode, eSubCode, nil, "nexthop length isn't correct")
 	}
-	p.Value, _ = netip.AddrFromSlice(value)
+	var ok bool
+	p.Value, ok = netip.AddrFromSlice(value)
+	if !ok {
+		eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
+		eSubCode := uint8(BGP_ERROR_SUB_INVALID_NEXT_HOP_ATTRIBUTE)
+		return NewMessageError(eCode, eSubCode, nil, "invalid nexthop address")
+	}
 	return nil
 }
 


### PR DESCRIPTION
…anic

Previously, PathAttributeNextHop.DecodeFromBytes checked only the attribute length field (p.Length) and ignored errors from netip.AddrFromSlice. This allowed malformed NEXT_HOP attributes to create invalid addresses, causing a panic when accessing ip[0] during validation in validate.go.

Now validate both the declared length (p.Length) and actual value length, ensuring they match and are valid (4 or 16 bytes). Also handle AddrFromSlice errors to reject malformed attributes early with proper error codes per RFC 4271 and RFC 7606.

Added comprehensive tests covering valid cases (IPv4, IPv6) and invalid cases (lengths 0-3, 5, and length mismatches).

Fixes #3305