### PR TITLE
Fix confederation peer classification for confed-ID non-member neighbors

### DIFF
--- a/pkg/config/oc/default.go
+++ b/pkg/config/oc/default.go
@@ -87,7 +87,7 @@ func setDefaultNeighborConfigValuesWithViper(v *viper.Viper, n *Neighbor, g *Glo
 	}
 	n.State.LocalAs = n.Config.LocalAs
 
-	if n.Config.PeerAs != n.Config.LocalAs {
+	if n.IsEBGPPeer(g) {
 		n.Config.PeerType = PEER_TYPE_EXTERNAL
 		n.State.PeerType = PEER_TYPE_EXTERNAL
 		n.State.RemovePrivateAs = n.Config.RemovePrivateAs

--- a/pkg/config/oc/util.go
+++ b/pkg/config/oc/util.go
@@ -125,6 +125,12 @@ func (n *Neighbor) IsConfederation(g *Global) bool {
 }
 
 func (n *Neighbor) IsEBGPPeer(g *Global) bool {
+	if g != nil && g.Confederation.Config.Enabled {
+		// In confederation mode, peers in the local member-AS are iBGP.
+		// All other peers (including confederation members and non-members)
+		// are handled as external sessions.
+		return n.Config.PeerAs != g.Config.As
+	}
 	return n.Config.PeerAs != n.Config.LocalAs
 }
 

--- a/pkg/config/oc/util_test.go
+++ b/pkg/config/oc/util_test.go
@@ -16,6 +16,7 @@
 package oc
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,4 +56,78 @@ func TestIsAfiSafiChanged(t *testing.T) {
 	v4ap.AddPaths.Config.Receive = true
 	new = []AfiSafi{v4ap}
 	assert.True(t, isAfiSafiChanged(old, new))
+}
+
+func TestIsEBGPPeerWithConfederation(t *testing.T) {
+	g := &Global{
+		Config: GlobalConfig{
+			As: 101,
+		},
+		Confederation: Confederation{
+			Config: ConfederationConfig{
+				Enabled:      true,
+				Identifier:   65000,
+				MemberAsList: []uint32{102},
+			},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		peerAs uint32
+		want   bool
+	}{
+		{
+			name:   "same member AS is internal",
+			peerAs: 101,
+			want:   false,
+		},
+		{
+			name:   "other confederation member is external",
+			peerAs: 102,
+			want:   true,
+		},
+		{
+			name:   "confederation identifier non-member is external",
+			peerAs: 65000,
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &Neighbor{
+				Config: NeighborConfig{
+					PeerAs:  tt.peerAs,
+					LocalAs: 65000,
+				},
+			}
+			assert.Equal(t, tt.want, n.IsEBGPPeer(g))
+		})
+	}
+}
+
+func TestSetDefaultNeighborConfigValuesConfedIdentifierPeerType(t *testing.T) {
+	g := &Global{
+		Config: GlobalConfig{
+			As: 101,
+		},
+		Confederation: Confederation{
+			Config: ConfederationConfig{
+				Enabled:      true,
+				Identifier:   65000,
+				MemberAsList: []uint32{102},
+			},
+		},
+	}
+	n := &Neighbor{
+		Config: NeighborConfig{
+			PeerAs:          65000,
+			NeighborAddress: netip.MustParseAddr("192.0.2.10"),
+		},
+	}
+
+	assert.NoError(t, SetDefaultNeighborConfigValues(n, nil, g))
+	assert.Equal(t, uint32(65000), n.Config.LocalAs)
+	assert.Equal(t, PEER_TYPE_EXTERNAL, n.State.PeerType)
 }


### PR DESCRIPTION
## Summary

This fixes incorrect peer/session classification when confederation is enabled and a neighbor uses the confederation identifier AS but is not a member-AS.

In that case, GoBGP could classify the session as internal due to `peer-as == local-as` after local-AS rewriting, which leads to incorrect confederation behavior.

## Root cause

Peer type defaulting and eBGP/iBGP detection relied on comparing `peer-as` with `local-as`.

In confederation mode, `local-as` may be rewritten to the confederation identifier for certain neighbors. That makes `peer-as == local-as` true even when the neighbor is not in the same member-AS, causing misclassification.

## Fix

- Make `IsEBGPPeer` confederation-aware:
  - When confederation is enabled, only neighbors in the same member-AS are treated as iBGP.
  - All others are treated as external sessions.
- Update default peer type assignment to use `IsEBGPPeer(g)` instead of raw `peer-as != local-as`.

## Tests

Added regression coverage in `pkg/config/oc/util_test.go`:

- `TestIsEBGPPeerWithConfederation`
  - same member-AS => internal
  - other confed member-AS => external
  - confed-ID non-member => external
- `TestSetDefaultNeighborConfigValuesConfedIdentifierPeerType`
  - validates default peer type is external for confed-ID non-member peer

## Verification

Ran:

- `go test ./pkg/config/oc`
- `go test ./pkg/config/oc -run 'TestIsEBGPPeerWithConfederation|TestSetDefaultNeighborConfigValuesConfedIdentifierPeerType' -count=1 -v`
- `go test ./pkg/server -run 'TestCheckOwnASLoop|TestFSMHandlerEstablished_.*' -count=1`

All passed.

Note: `go test ./...` in this environment fails in existing `pkg/server` tests due to bind-address availability (`127.0.0.100` / `127.0.0.201`), unrelated to this change.
