### PR TITLE
fix: fix seting nil originator id for local rtc routes in route-reflector

### DIFF
--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -305,8 +305,13 @@ func UpdatePathAttrs(logger *slog.Logger, global *oc.Global, peer *oc.Neighbor, 
 			// address for that session.
 			if path.GetFamily() == bgp.RF_RTC_UC {
 				path.SetNexthop(localAddress)
-				attr, _ := bgp.NewPathAttributeOriginatorId(info.LocalID)
-				path.setPathAttr(attr)
+				if path.IsLocal() {
+					attr, _ := bgp.NewPathAttributeOriginatorId(global.Config.RouterId)
+					path.setPathAttr(attr)
+				} else {
+					attr, _ := bgp.NewPathAttributeOriginatorId(info.LocalID)
+					path.setPathAttr(attr)
+				}
 			} else if path.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGINATOR_ID) == nil {
 				if path.IsLocal() {
 					attr, _ := bgp.NewPathAttributeOriginatorId(global.Config.RouterId)

--- a/internal/pkg/table/path_test.go
+++ b/internal/pkg/table/path_test.go
@@ -412,6 +412,71 @@ func TestReplaceAS(t *testing.T) {
 	assert.Equal(t, list[3], uint32(2))
 }
 
+func TestUpdatePathAttrsRTCOriginatorIDWithLocalID(t *testing.T) {
+	global := &oc.Global{Config: oc.GlobalConfig{As: 65000, RouterId: netip.MustParseAddr("10.0.0.1")}}
+	clusterID := netip.MustParseAddr("10.0.0.100")
+	info := &PeerInfo{
+		AS:                      65000,
+		LocalAS:                 65000,
+		LocalAddress:            netip.MustParseAddr("192.168.0.1"),
+		RouteReflectorClient:    true,
+		RouteReflectorClusterID: clusterID,
+	}
+	peer := &oc.Neighbor{
+		State: oc.NeighborState{
+			PeerType: oc.PEER_TYPE_INTERNAL,
+		},
+		RouteReflector: oc.RouteReflector{
+			Config: oc.RouteReflectorConfig{
+				RouteReflectorClusterId: clusterID,
+				RouteReflectorClient:    true,
+			},
+			State: oc.RouteReflectorState{
+				RouteReflectorClusterId: clusterID,
+				RouteReflectorClient:    true,
+			},
+		},
+	}
+
+	// Case 1: Source with Address (not local) set - should use LocalID as Originator ID
+	sourceWithLocalID := &PeerInfo{
+		AS:      65000,
+		LocalAS: 65000,
+		ID:      netip.MustParseAddr("10.0.0.2"),
+		LocalID: netip.MustParseAddr("10.0.0.100"), // Different from global RouterId
+		Address: netip.MustParseAddr("10.0.0.2"),   // Not local path (IsLocal() == false)
+	}
+	nlri := bgp.PathNLRI{NLRI: bgp.NewRouteTargetMembershipNLRI(0, nil)}
+	nlriAttr, _ := bgp.NewPathAttributeMpReachNLRI(bgp.RF_RTC_UC, []bgp.PathNLRI{nlri})
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP),
+		nlriAttr,
+	}
+	pathWithLocalID := NewPath(bgp.RF_RTC_UC, sourceWithLocalID, nlri, false, attrs, time.Now(), false)
+	updatedPath1 := UpdatePathAttrs(logger, global, peer, info, pathWithLocalID)
+
+	attr1 := updatedPath1.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGINATOR_ID)
+	originatorID1 := attr1.(*bgp.PathAttributeOriginatorId).Value
+	assert.True(t, originatorID1.IsValid(), "Originator ID attribute should be set for RTC route")
+	assert.Equal(t, "10.0.0.100", originatorID1.String(),
+		"Originator ID should be src.LocalID when path is not local")
+
+	// Case 2: Source with LocalID nil - should fall back to global.Config.RouterId
+	sourceWithoutLocalID := &PeerInfo{
+		AS:      65000,
+		LocalAS: 65000,
+		ID:      netip.MustParseAddr("10.0.0.2"),
+	}
+	pathWithoutLocalID := NewPath(bgp.RF_RTC_UC, sourceWithoutLocalID, nlri, false, attrs, time.Now(), false)
+	updatedPath2 := UpdatePathAttrs(logger, global, peer, info, pathWithoutLocalID)
+
+	attr2 := updatedPath2.getPathAttr(bgp.BGP_ATTR_TYPE_ORIGINATOR_ID)
+	originatorID2 := attr2.(*bgp.PathAttributeOriginatorId).Value
+	assert.True(t, originatorID2.IsValid(), "Originator ID attribute should be set for RTC route")
+	assert.Equal(t, "10.0.0.1", originatorID2.String(),
+		"Originator ID should be global.Config.RouterId when path is local")
+}
+
 func TestNLRIToIPNet(t *testing.T) {
 	_, n1, _ := net.ParseCIDR("30.30.30.0/24")
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("30.30.30.0/24"))


### PR DESCRIPTION
Hi! I found a bug that when i want to inject route from CLI i have a core dump such as
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x1 pc=0x104c93310]

goroutine 45 [running]:
github.com/osrg/gobgp/v4/pkg/packet/bgp.(*PathAttributeOriginatorId).GetType(0x1400046b010?)
        <autogenerated>:1
github.com/osrg/gobgp/v4/internal/pkg/table.(*Path).setPathAttr(0x140003d4480, {0x10525ba08, 0x0})
        /Users/pokhabovivan/github/gobgp/internal/pkg/table/path.go:568 +0xe8
github.com/osrg/gobgp/v4/internal/pkg/table.UpdatePathAttrs(0x140003c8a40, 0x140003a6018, 0x14000491608, 0x14000388750, 0x140003d43c0)
        /Users/pokhabovivan/github/gobgp/internal/pkg/table/path.go:309 +0x728
github.com/osrg/gobgp/v4/pkg/server.(*BgpServer).prePolicyFilterpath(0x140003a6008?, 0x14000383c00, 0x1400046b318?, 0x0)
        /Users/pokhabovivan/github/gobgp/pkg/server/server.go:624 +0x364
github.com/osrg/gobgp/v4/pkg/server.(*BgpServer).filterpath(0x140003a6008, 0x14000383c00, 0x1400046b348?, 0x0)
        /Users/pokhabovivan/github/gobgp/pkg/server/server.go:656 +0x28
github.com/osrg/gobgp/v4/pkg/server.(*BgpServer).processOutgoingPaths(0x140003a6008, 0x14000383c00, {0x1400007e098, 0x1, 0x14000394228?}, {0x1400007e0a0, 0x1, 0x1400046b418?})
        /Users/pokhabovivan/github/gobgp/pkg/server/server.go:1054 +0x100
github.com/osrg/gobgp/v4/pkg/server.(*BgpServer).propagateUpdateToNeighbors(0x140003a6008, 0x140003f4d50, 0x0, 0x140003d43c0, {0x1400007e078, 0x1, 0x1}, 0x1)
        /Users/pokhabovivan/github/gobgp/pkg/server/server.go:1351 +0x538
github.com/osrg/gobgp/v4/pkg/server.(*BgpServer).propagateUpdate(0x140003a6008, 0x0, {0x1400046bd88, 0x1, 0x1?})
        /Users/pokhabovivan/github/gobgp/pkg/server/server.go:1199 +0x3e4
github.com/osrg/gobgp/v4/pkg/server.(*BgpServer).addPathList(0x140003a6008, {0x0?, 0x0?}, {0x14000091d88, 0x1, 0x1})
        /Users/pokhabovivan/github/gobgp/pkg/server/server.go:2113 +0x54
github.com/osrg/gobgp/v4/pkg/server.(*BgpServer).AddPath.func1()
        /Users/pokhabovivan/github/gobgp/pkg/server/server.go:2223 +0x128
github.com/osrg/gobgp/v4/pkg/server.(*BgpServer).handleMGMTOp(0xc264031c130bee48?, 0x140003a2990)
        /Users/pokhabovivan/github/gobgp/pkg/server/server.go:236 +0x8c
github.com/osrg/gobgp/v4/pkg/server.(*BgpServer).Serve(0x140003a6008)
        /Users/pokhabovivan/github/gobgp/pkg/server/server.go:378 +0x3cc
created by main.main in goroutine 1
        /Users/pokhabovivan/github/gobgp/cmd/gobgpd/main.go:230 +0x16b4
```

The root cause of this is command on route-reflector
```
gobgp global rib add -a rtc asn 64514 rt 65533:666 community 65535:65282
```
Here is fix and tests for regressions