### PR TITLE
Fix nil pointer panic in TestGRPCAddPathUpdatesUUIDMap

### DIFF
--- a/pkg/server/grpc_server_test.go
+++ b/pkg/server/grpc_server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/config/oc"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -501,7 +502,7 @@ func TestGRPCAddPathUpdatesUUIDMap(t *testing.T) {
 		TableType: api.TableType_TABLE_TYPE_GLOBAL,
 		Path:      path,
 	})
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	id, err := uuid.FromBytes(resp.Uuid)
 	assert.NoError(err)


### PR DESCRIPTION
This PR fixes a panic in `TestGRPCAddPathUpdatesUUIDMap`

Use `require.NoError` instead of `assert.NoError` for the AddPath gRPC call so the test stops immediately on connection failure rather than panicking on a `nil` response.