### PR TITLE
packet/bgp: fix infinite loop when decoding srv6 unknown sub-TLV types

### DIFF
--- a/pkg/packet/bgp/prefix_sid.go
+++ b/pkg/packet/bgp/prefix_sid.go
@@ -228,10 +228,10 @@ func (s *SRv6L3ServiceAttribute) DecodeFromBytes(data []byte) error {
 				SubSubTLVs: make([]PrefixSIDTLVInterface, 0),
 			}
 		default:
-			if len(data) < t.Len() {
+			if len(stlvs) < t.Len() {
 				return malformedAttrListErr("SRv6L3ServiceAttribute/SubTLV malformed")
 			}
-			data = data[t.Len():]
+			stlvs = stlvs[t.Len():]
 			continue
 		}
 
@@ -674,10 +674,10 @@ func (s *SRv6ServiceTLV) DecodeFromBytes(data []byte) error {
 				SubSubTLVs: make([]PrefixSIDTLVInterface, 0),
 			}
 		default:
-			if len(data) < t.Len() {
+			if len(stlvs) < t.Len() {
 				return malformedAttrListErr("SRv6ServiceTLV malformed")
 			}
-			data = data[t.Len():]
+			stlvs = stlvs[t.Len():]
 			continue
 		}
 

--- a/pkg/packet/bgp/prefix_sid_test.go
+++ b/pkg/packet/bgp/prefix_sid_test.go
@@ -128,6 +128,39 @@ func TestNewPathAttributePrefixSID(t *testing.T) {
 	}
 }
 
+func TestSRv6L3ServiceUnknownSubTLV(t *testing.T) {
+	// SRv6L3ServiceAttribute with an unknown sub-TLV type (0xff).
+	// Previously, the default branch advanced the wrong variable (data
+	// instead of stlvs), causing an infinite loop.
+	input := []byte{
+		0x05,       // Type: TLVTypeSRv6L3Service
+		0x00, 0x07, // Length: 7 (1 reserved + 6 sub-TLV)
+		0x00, // Reserved
+		// Unknown sub-TLV: Type=0xff, Length=3, Value=0x01,0x02,0x03
+		0xff, 0x00, 0x03, 0x01, 0x02, 0x03,
+	}
+	s := &SRv6L3ServiceAttribute{}
+	err := s.DecodeFromBytes(input)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(s.SubTLVs))
+}
+
+func TestSRv6ServiceTLVUnknownSubTLV(t *testing.T) {
+	// SRv6ServiceTLV with an unknown sub-TLV type (0xff).
+	// Same bug as SRv6L3ServiceAttribute.
+	input := []byte{
+		0x05,       // Type: TLVTypeSRv6L3Service
+		0x00, 0x07, // Length: 7 (1 reserved + 6 sub-TLV)
+		0x00, // Reserved
+		// Unknown sub-TLV: Type=0xff, Length=3, Value=0x01,0x02,0x03
+		0xff, 0x00, 0x03, 0x01, 0x02, 0x03,
+	}
+	s := &SRv6ServiceTLV{}
+	err := s.DecodeFromBytes(input)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(s.SubTLVs))
+}
+
 // to make label with bottom of stack
 type prefixSidLabel struct {
 	Label uint32


### PR DESCRIPTION
SRv6L3ServiceAttribute.DecodeFromBytes and SRv6ServiceTLV.DecodeFromBytes advanced the wrong variable (data instead of stlvs) when skipping unknown sub-TLV types, leaving the loop iterator unchanged and causing an infinite loop that makes the BGP daemon unresponsive.