### PR TITLE
server: Use State instead of Config to determine GR-enabled peers in StopBgp

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1902,8 +1902,7 @@ func (s *BgpServer) StopBgp(ctx context.Context, r *api.StopBgpRequest) error {
 			c := &oc.Neighbor{Config: oc.NeighborConfig{
 				NeighborAddress: address,
 			}}
-			nconf := neighbor.fsm.pConf.ReadOnly()
-			sendNotification := !r.AllowGracefulRestart || !nconf.GracefulRestart.Config.Enabled
+			sendNotification := !r.AllowGracefulRestart || !neighbor.isGracefulRestartEnabled()
 			if err := s.deleteNeighbor(c, bgp.BGP_ERROR_CEASE, bgp.BGP_ERROR_SUB_PEER_DECONFIGURED, sendNotification); err != nil {
 				return err
 			}


### PR DESCRIPTION
As we aim to skip sending the NOTIFICATION messages to GR-enabled peers if the `allow_graceful_restart` flag is set to true in `StopBgpRequest`, we should not rely on peer's config, but the actual state (that's where `isGracefulRestartEnabled` looks it up) - as the graceful restart may be configured, but not enabled if the remote side is not supporting it.