### PR TITLE
gobgpd: Fix printing of help message

### DIFF
--- a/cmd/gobgpd/main.go
+++ b/cmd/gobgpd/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -81,6 +82,13 @@ func main() {
 	}
 	_, err := flags.Parse(&opts)
 	if err != nil {
+		var flagsErr *flags.Error
+		if errors.As(err, &flagsErr) {
+			if flagsErr.Type == flags.ErrHelp {
+				os.Exit(0)
+			}
+		}
+
 		logger.Error("Error parsing flags", slog.String("Error", err.Error()))
 		os.Exit(1)
 	}


### PR DESCRIPTION
Currently, running `gobgpd --help` displays the nicely formatted help message, then also logs that string as a parser error and exits with an error. Instead, detect when the help message was printed and exit cleanly.