### PR TITLE
fix BMP map issue

### DIFF
--- a/pkg/config/oc/bgp_configs.go
+++ b/pkg/config/oc/bgp_configs.go
@@ -875,6 +875,8 @@ var BmpRouteMonitoringPolicyTypeToIntMap = map[BmpRouteMonitoringPolicyType]int{
 	BMP_ROUTE_MONITORING_POLICY_TYPE_ALL:         4,
 }
 
+// IntToBmpRouteMonitoringPolicyTypeMap indexes policies 0..4 (no UNSPECIFIED).
+// It does not match api.AddBmpRequest_MonitoringPolicy numeric values (PRE=1..ALL=5, UNSPECIFIED=0).
 var IntToBmpRouteMonitoringPolicyTypeMap = map[int]BmpRouteMonitoringPolicyType{
 	0: BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY,
 	1: BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY,

--- a/pkg/config/oc/bgp_configs.go
+++ b/pkg/config/oc/bgp_configs.go
@@ -875,8 +875,6 @@ var BmpRouteMonitoringPolicyTypeToIntMap = map[BmpRouteMonitoringPolicyType]int{
 	BMP_ROUTE_MONITORING_POLICY_TYPE_ALL:         4,
 }
 
-// IntToBmpRouteMonitoringPolicyTypeMap indexes policies 0..4 (no UNSPECIFIED).
-// It does not match api.AddBmpRequest_MonitoringPolicy numeric values (PRE=1..ALL=5, UNSPECIFIED=0).
 var IntToBmpRouteMonitoringPolicyTypeMap = map[int]BmpRouteMonitoringPolicyType{
 	0: BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY,
 	1: BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1807,6 +1807,26 @@ func (s *BgpServer) EnableZebra(ctx context.Context, r *api.EnableZebraRequest) 
 	}, false)
 }
 
+// bmpMonitoringPolicyFromAPI maps gRPC enum values to OpenConfig string policies.
+// Do not use oc.IntToBmpRouteMonitoringPolicyTypeMap[int(policy)]: protobuf assigns
+// MONITORING_POLICY_PRE=1..ALL=5 with UNSPECIFIED=0, while the OC map uses 0..4 only.
+func bmpMonitoringPolicyFromAPI(p api.AddBmpRequest_MonitoringPolicy) oc.BmpRouteMonitoringPolicyType {
+	switch p {
+	case api.AddBmpRequest_MONITORING_POLICY_PRE:
+		return oc.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY
+	case api.AddBmpRequest_MONITORING_POLICY_POST:
+		return oc.BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY
+	case api.AddBmpRequest_MONITORING_POLICY_BOTH:
+		return oc.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH
+	case api.AddBmpRequest_MONITORING_POLICY_LOCAL:
+		return oc.BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB
+	case api.AddBmpRequest_MONITORING_POLICY_ALL:
+		return oc.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL
+	default:
+		return oc.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY
+	}
+}
+
 func (s *BgpServer) AddBmp(ctx context.Context, r *api.AddBmpRequest) error {
 	if r == nil {
 		return fmt.Errorf("nil request")
@@ -1839,7 +1859,7 @@ func (s *BgpServer) AddBmp(ctx context.Context, r *api.AddBmpRequest) error {
 			Port:                  port,
 			SysName:               sysname,
 			SysDescr:              sysDescr,
-			RouteMonitoringPolicy: oc.IntToBmpRouteMonitoringPolicyTypeMap[int(r.Policy)],
+			RouteMonitoringPolicy: bmpMonitoringPolicyFromAPI(r.Policy),
 			StatisticsTimeout:     uint16(r.StatisticsTimeout),
 		})
 	}, true)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -167,6 +167,56 @@ func TestModPolicyAssign(t *testing.T) {
 	assert.Equal(len(ps), 2)
 }
 
+func TestBMPMonitoringPolicyFromAPI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  api.AddBmpRequest_MonitoringPolicy
+		expect oc.BmpRouteMonitoringPolicyType
+	}{
+		{
+			name:   "unspecified defaults to pre-policy",
+			input:  api.AddBmpRequest_MONITORING_POLICY_UNSPECIFIED,
+			expect: oc.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY,
+		},
+		{
+			name:   "pre",
+			input:  api.AddBmpRequest_MONITORING_POLICY_PRE,
+			expect: oc.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY,
+		},
+		{
+			name:   "post",
+			input:  api.AddBmpRequest_MONITORING_POLICY_POST,
+			expect: oc.BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY,
+		},
+		{
+			name:   "both",
+			input:  api.AddBmpRequest_MONITORING_POLICY_BOTH,
+			expect: oc.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH,
+		},
+		{
+			name:   "local",
+			input:  api.AddBmpRequest_MONITORING_POLICY_LOCAL,
+			expect: oc.BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB,
+		},
+		{
+			name:   "all",
+			input:  api.AddBmpRequest_MONITORING_POLICY_ALL,
+			expect: oc.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := bmpMonitoringPolicyFromAPI(tt.input)
+			assert.Equal(t, tt.expect, got)
+		})
+	}
+}
+
 func TestListPolicyAssignment(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
The Protobuf values for api.AddBmpRequest_MonitoringPolicy range from 0 to 5 (including UNSPECIFIED = 0; policies are 1–5), while the keys in oc.IntToBmpRouteMonitoringPolicyTypeMap range from 0 to 4 (with no UNSPECIFIED). AddBmp directly looks up the table using int(r.Policy), causing the entire file to be misaligned (for example, selecting PRE results in POST).