### PR TITLE
feat: rework RTC handling with per-peer RT membership index

### DIFF
--- a/internal/pkg/table/adj.go
+++ b/internal/pkg/table/adj.go
@@ -22,57 +22,6 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
 
-// rtCounter keeps per-RT reference counts.
-type rtCounter struct {
-	rts map[uint64]int
-}
-
-func (rtc *rtCounter) add(path *Path) {
-	if rtc == nil {
-		return
-	}
-	if path.GetFamily() != bgp.RF_RTC_UC {
-		return
-	}
-	nlri, ok := path.GetNlri().(*bgp.RouteTargetMembershipNLRI)
-	if !ok {
-		return
-	}
-	rtHash, err := nlriRouteTargetKey(nlri)
-	if err != nil {
-		return
-	}
-	if _, found := rtc.rts[rtHash]; !found {
-		rtc.rts[rtHash] = 1
-		return
-	}
-	rtc.rts[rtHash]++
-}
-
-func (rtc *rtCounter) sub(path *Path) {
-	if rtc == nil {
-		return
-	}
-	if path.GetFamily() != bgp.RF_RTC_UC {
-		return
-	}
-	nlri, ok := path.GetNlri().(*bgp.RouteTargetMembershipNLRI)
-	if !ok {
-		return
-	}
-	rtHash, err := nlriRouteTargetKey(nlri)
-	if err != nil {
-		return
-	}
-	if val, found := rtc.rts[rtHash]; found {
-		if val <= 1 {
-			delete(rtc.rts, rtHash)
-			return
-		}
-		rtc.rts[rtHash]--
-	}
-}
-
 type AdjRib struct {
 	accepted map[bgp.Family]int
 	table    map[bgp.Family]*Table
@@ -89,31 +38,6 @@ func NewAdjRib(logger *slog.Logger, rfList []bgp.Family) *AdjRib {
 		accepted: make(map[bgp.Family]int),
 		logger:   logger,
 	}
-}
-
-func (adj *AdjRib) HasRTinRtcTable(routeTarget bgp.ExtendedCommunityInterface) bool {
-	table, found := adj.table[bgp.RF_RTC_UC]
-	if !found || table.adjRts == nil {
-		return false
-	}
-
-	key, err := extCommRouteTargetKey(routeTarget)
-	if err != nil {
-		return false
-	}
-
-	num, found := table.adjRts.rts[key]
-	return found && num > 0
-}
-
-func (adj *AdjRib) HasDefaultRT() bool {
-	table, found := adj.table[bgp.RF_RTC_UC]
-	if !found || table.adjRts == nil {
-		return false
-	}
-
-	num, found := table.adjRts.rts[DefaultRT]
-	return found && num > 0
 }
 
 func (adj *AdjRib) Update(pathList []*Path) {
@@ -147,7 +71,6 @@ func (adj *AdjRib) Update(pathList []*Path) {
 				d.knownPathList = append(d.knownPathList[:idx], d.knownPathList[idx+1:]...)
 				if !old.IsRejected() {
 					adj.accepted[rf]--
-					t.adjRts.sub(old)
 				}
 			}
 			if len(d.knownPathList) == 0 {
@@ -158,10 +81,8 @@ func (adj *AdjRib) Update(pathList []*Path) {
 			if idx != -1 {
 				if old.IsRejected() && !path.IsRejected() {
 					adj.accepted[rf]++
-					t.adjRts.add(path)
 				} else if !old.IsRejected() && path.IsRejected() {
 					adj.accepted[rf]--
-					t.adjRts.sub(old)
 				}
 				if old.Equal(path) {
 					path.setTimestamp(old.GetTimestamp())
@@ -171,7 +92,6 @@ func (adj *AdjRib) Update(pathList []*Path) {
 				d.knownPathList = append(d.knownPathList, path)
 				if !path.IsRejected() {
 					adj.accepted[rf]++
-					t.adjRts.add(path)
 				}
 			}
 		}
@@ -199,9 +119,6 @@ func (adj *AdjRib) UpdateAdjRibOut(pathList []*Path) {
 		shard.mu.Lock()
 		d := t.getOrCreateDest(shard, nlri, 0)
 		d.knownPathList = append(d.knownPathList, path)
-		if !path.IsRejected() {
-			t.adjRts.add(path)
-		}
 		shard.mu.Unlock()
 	}
 }

--- a/internal/pkg/table/adj_test.go
+++ b/internal/pkg/table/adj_test.go
@@ -27,14 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateAdjTable(t *testing.T) {
-	table := NewAdjTable(logger, bgp.RF_RTC_UC)
-	assert.NotNil(t, table.adjRts)
-
-	table = NewAdjTable(logger, bgp.RF_FS_IPv4_VPN)
-	assert.Nil(t, table.adjRts)
-}
-
 func TestAddPath(t *testing.T) {
 	pi := &PeerInfo{}
 	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
@@ -185,54 +177,6 @@ func TestLLGRStale(t *testing.T) {
 	}
 	require.NotNil(t, retainedRejected)
 	assert.Contains(t, retainedRejected.GetCommunities(), uint32(bgp.COMMUNITY_LLGR_STALE))
-}
-
-func TestAdjRTC(t *testing.T) {
-	pi := &PeerInfo{}
-	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
-
-	rt1, _ := bgp.ParseRouteTarget("65520:1000000")
-	_, err := extCommRouteTargetKey(rt1)
-	assert.NoError(t, err)
-	nlri1 := bgp.NewRouteTargetMembershipNLRI(65000, rt1)
-	p1 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1}, false, attrs, time.Now(), false)
-	p1.remoteID = 1
-
-	rt2, _ := bgp.ParseRouteTarget("65520:1000001")
-	nlri2 := bgp.NewRouteTargetMembershipNLRI(65000, rt2)
-	p2 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri2}, false, attrs, time.Now(), false)
-	p2.remoteID = 2
-
-	nlri3 := bgp.NewRouteTargetMembershipNLRI(0, nil)
-	p3 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri3}, false, attrs, time.Now(), false)
-	p3.remoteID = 3
-
-	family := p1.GetFamily()
-	assert.Equal(t, family, bgp.RF_RTC_UC)
-	families := []bgp.Family{family}
-	adj := NewAdjRib(logger, families)
-
-	adj.Update([]*Path{p1, p2, p3})
-	assert.Equal(t, adj.Count([]bgp.Family{family}), 3)
-
-	assert.True(t, adj.HasDefaultRT())
-	assert.True(t, adj.HasRTinRtcTable(rt1))
-	assert.True(t, adj.HasRTinRtcTable(rt2))
-
-	adj.Update([]*Path{p1.Clone(true)})
-	assert.Equal(t, adj.Count([]bgp.Family{family}), 2)
-	assert.True(t, adj.HasDefaultRT())
-	assert.True(t, !adj.HasRTinRtcTable(rt1))
-	assert.True(t, adj.HasRTinRtcTable(rt2))
-
-	adj.Update([]*Path{p3.Clone(true)})
-	assert.Equal(t, adj.Count([]bgp.Family{family}), 1)
-	assert.False(t, adj.HasDefaultRT())
-	assert.True(t, adj.HasRTinRtcTable(rt2))
-
-	adj.Update([]*Path{p2.Clone(true)})
-	assert.Equal(t, adj.Count([]bgp.Family{family}), 0)
-	assert.True(t, !adj.HasRTinRtcTable(rt2))
 }
 
 func TestWithdrawUnknownPath(t *testing.T) {

--- a/internal/pkg/table/policy.go
+++ b/internal/pkg/table/policy.go
@@ -4098,7 +4098,7 @@ func CanImportToVrf(v *Vrf, path *Path) bool {
 		if !isTransitiveType(x) {
 			continue
 		}
-		key, err := extCommRouteTargetKey(x)
+		key, err := ExtCommRouteTargetKey(x)
 		if err != nil {
 			continue
 		}

--- a/internal/pkg/table/rtc.go
+++ b/internal/pkg/table/rtc.go
@@ -1,0 +1,186 @@
+package table
+
+import (
+	"sync"
+
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+)
+
+type vpnFamilyRT map[*Path]struct{}
+
+func (el vpnFamilyRT) empty() bool {
+	return len(el) == 0
+}
+
+// rtmKey uniquely identifies an RT membership NLRI within a given RT hash bucket.
+// The RT value itself is already the outer map key (rtHash), so here we only need to
+// distinguish NLRIs that share the same RT. With ADD-PATH, the same (AS, RT) can appear
+// multiple times with different path identifiers, so both fields are required.
+// pathID comes from Path.RemoteID() (the ADD-PATH path identifier stored on the Path,
+// not on the NLRI, in this version of the bgp package).
+type rtmKey struct {
+	pathID uint32
+	as     uint32
+}
+
+func newRTMKey(nlri *bgp.RouteTargetMembershipNLRI, pathID uint32) rtmKey {
+	return rtmKey{pathID: pathID, as: nlri.AS}
+}
+
+func newRTCPart(rf bgp.Family, isAdj bool) *rtcHandler {
+	if !isAdj && rf != bgp.RF_RTC_UC {
+		return newRTCHandler()
+	}
+	return nil
+}
+
+// rtcHandler tracks VPN paths per RT in global tables.
+// It must register all VPN paths that are added to the Table (currently the only place is
+// 'func (t *Table) update(newPath *Path)'). It must unregister all VPN paths that are removed from
+// the Table (same place). In other words, it must maintain the same set of paths as the Table does.
+// Thread-safe: all methods are protected by the embedded RWMutex.
+type rtcHandler struct {
+	mu sync.RWMutex
+	m  map[uint64]vpnFamilyRT
+}
+
+func newRTCHandler() *rtcHandler {
+	return &rtcHandler{m: make(map[uint64]vpnFamilyRT)}
+}
+
+func (rtc *rtcHandler) register(path *Path) {
+	if path == nil {
+		return
+	}
+	rtc.mu.Lock()
+	defer rtc.mu.Unlock()
+	for _, ext := range path.GetExtCommunities() {
+		key, err := ExtCommRouteTargetKey(ext)
+		if err != nil {
+			// ext is not route target, skip it.
+			continue
+		}
+		rtTable, found := rtc.m[key]
+		if !found {
+			rtTable = make(vpnFamilyRT)
+			rtc.m[key] = rtTable
+		}
+		rtTable[path] = struct{}{}
+	}
+}
+
+func (rtc *rtcHandler) unregister(path *Path, deleteEmpty bool) {
+	if path == nil {
+		return
+	}
+	rtc.mu.Lock()
+	defer rtc.mu.Unlock()
+	for _, ext := range path.GetExtCommunities() {
+		key, err := ExtCommRouteTargetKey(ext)
+		if err != nil {
+			// ext is not route target, skip it.
+			continue
+		}
+		rtTable, found := rtc.m[key]
+		if !found {
+			// ext hasn't been registered, skip it.
+			continue
+		}
+		delete(rtTable, path)
+		if deleteEmpty && rtTable.empty() {
+			delete(rtc.m, key)
+		}
+	}
+}
+
+// maxLen returns the number of VPN paths registered for the given RT hash.
+func (rtc *rtcHandler) maxLen(rt uint64) int {
+	rtc.mu.RLock()
+	defer rtc.mu.RUnlock()
+	if vpnPaths, ok := rtc.m[rt]; ok {
+		return len(vpnPaths)
+	}
+	return 0
+}
+
+// appendBests appends the best VPN paths for the given RT hash to paths.
+// isWithdraw=true clones each path as a withdrawal.
+// The RLock is held for the entire iteration to prevent concurrent modification.
+func (rtc *rtcHandler) appendBests(paths []*Path, rt uint64, tableId string, as uint32, isWithdraw bool) []*Path {
+	rtc.mu.RLock()
+	defer rtc.mu.RUnlock()
+	rtTable, ok := rtc.m[rt]
+	if !ok {
+		return paths
+	}
+	return appendBestPathListForRT(paths, tableId, as, isWithdraw, rtTable)
+}
+
+// peerRTMIndex tracks RT membership interest per peer at the TableManager level.
+// Layout: rtHash → peerID → {rtmKey set}.
+// Set semantics (vs a counter) are required for correctness with ADD-PATH:
+// the same (AS, RT) can arrive with multiple path identifiers and each must be
+// tracked independently so that a withdraw of one does not cancel the others.
+type peerRTMIndex map[uint64]map[string]map[rtmKey]struct{}
+
+func newPeerRTMIndex() peerRTMIndex {
+	return make(peerRTMIndex)
+}
+
+// addRTM registers (nlri, pathID) for peerID under rtHash.
+// Returns true if this is the first RTM for this peer+RT (paths should be sent).
+func (idx peerRTMIndex) addRTM(rtHash uint64, peerID string, nlri *bgp.RouteTargetMembershipNLRI, pathID uint32) bool {
+	peers, ok := idx[rtHash]
+	if !ok {
+		peers = make(map[string]map[rtmKey]struct{})
+		idx[rtHash] = peers
+	}
+	keys, ok := peers[peerID]
+	if !ok {
+		keys = make(map[rtmKey]struct{}, 1)
+		peers[peerID] = keys
+	}
+	key := newRTMKey(nlri, pathID)
+	if _, exists := keys[key]; exists {
+		return false
+	}
+	isFirst := len(keys) == 0
+	keys[key] = struct{}{}
+	return isFirst
+}
+
+// deleteRTM unregisters (nlri, pathID) for peerID under rtHash.
+// Returns true if this was the last RTM for this peer+RT (paths should be withdrawn).
+func (idx peerRTMIndex) deleteRTM(rtHash uint64, peerID string, nlri *bgp.RouteTargetMembershipNLRI, pathID uint32) bool {
+	peers, ok := idx[rtHash]
+	if !ok {
+		return false
+	}
+	keys, ok := peers[peerID]
+	if !ok {
+		return false
+	}
+	key := newRTMKey(nlri, pathID)
+	if _, exists := keys[key]; !exists {
+		return false
+	}
+	delete(keys, key)
+	isLast := len(keys) == 0
+	if isLast {
+		delete(peers, peerID)
+		if len(peers) == 0 {
+			delete(idx, rtHash)
+		}
+	}
+	return isLast
+}
+
+// hasPeer reports whether peerID has any active RT membership for rtHash.
+func (idx peerRTMIndex) hasPeer(rtHash uint64, peerID string) bool {
+	peers, ok := idx[rtHash]
+	if !ok {
+		return false
+	}
+	_, ok = peers[peerID]
+	return ok
+}

--- a/internal/pkg/table/rtc_test.go
+++ b/internal/pkg/table/rtc_test.go
@@ -1,0 +1,139 @@
+package table
+
+import (
+	"testing"
+	"time"
+
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPeerRTMIndex(t *testing.T) {
+	rt, _ := bgp.ParseRouteTarget("100:100")
+	const rtHash = uint64(12345) // arbitrary, normally from NlriRouteTargetKey()
+
+	// Same RT, different AS → different rtmKeys (ADD-PATH semantics)
+	nlri1 := bgp.NewRouteTargetMembershipNLRI(64512, rt)
+	nlri2 := bgp.NewRouteTargetMembershipNLRI(64513, rt)
+
+	idx := newPeerRTMIndex()
+
+	// Add first RTM for peer1 — should be "first".
+	assert.True(t, idx.addRTM(rtHash, "peer1", nlri1, 0))
+	assert.True(t, idx.hasPeer(rtHash, "peer1"))
+
+	// Add same RTM again — duplicate, not first.
+	assert.False(t, idx.addRTM(rtHash, "peer1", nlri1, 0))
+	assert.True(t, idx.hasPeer(rtHash, "peer1"))
+
+	// Add second RTM (different AS) for peer1 — not first (peer already has one).
+	assert.False(t, idx.addRTM(rtHash, "peer1", nlri2, 0))
+	assert.True(t, idx.hasPeer(rtHash, "peer1"))
+
+	// Add RTM for peer2 — first for peer2.
+	assert.True(t, idx.addRTM(rtHash, "peer2", nlri1, 0))
+	assert.True(t, idx.hasPeer(rtHash, "peer2"))
+
+	// Remove nlri1 from peer1 — peer1 still has nlri2, not last.
+	assert.False(t, idx.deleteRTM(rtHash, "peer1", nlri1, 0))
+	assert.True(t, idx.hasPeer(rtHash, "peer1"))
+
+	// Remove nlri1 again — already gone, no-op.
+	assert.False(t, idx.deleteRTM(rtHash, "peer1", nlri1, 0))
+
+	// Remove nlri2 from peer1 — last for peer1.
+	assert.True(t, idx.deleteRTM(rtHash, "peer1", nlri2, 0))
+	assert.False(t, idx.hasPeer(rtHash, "peer1"))
+
+	// peer2 still present.
+	assert.True(t, idx.hasPeer(rtHash, "peer2"))
+
+	// Remove nlri1 from peer2 — last for peer2, index entry for rtHash deleted.
+	assert.True(t, idx.deleteRTM(rtHash, "peer2", nlri1, 0))
+	assert.False(t, idx.hasPeer(rtHash, "peer2"))
+	assert.Equal(t, 0, len(idx))
+
+	// Remove again — no-op.
+	assert.False(t, idx.deleteRTM(rtHash, "peer2", nlri1, 0))
+
+	// Withdraw an RTM with an AS that was never registered — must be a safe no-op.
+	nlriUnknownAS := bgp.NewRouteTargetMembershipNLRI(999, rt)
+	assert.False(t, idx.deleteRTM(rtHash, "peer1", nlriUnknownAS, 0))
+	assert.Equal(t, 0, len(idx))
+}
+
+func TestVpnFamilyRTEmpty(t *testing.T) {
+	rt := make(vpnFamilyRT)
+	assert.True(t, rt.empty())
+}
+
+// TestRTCPeerTracking tests that UpdateRTC + PeerHasRT correctly track per-peer RT interest.
+// Path IDs are set via PathNLRI.ID (the ADD-PATH path identifier stored on the Path).
+func TestRTCPeerTracking(t *testing.T) {
+	pi := &PeerInfo{}
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
+
+	rt1, _ := bgp.ParseRouteTarget("65520:1000000")
+	nlri1 := bgp.NewRouteTargetMembershipNLRI(65000, rt1)
+	hash1, err := NlriRouteTargetKey(nlri1)
+	assert.NoError(t, err)
+
+	rt2, _ := bgp.ParseRouteTarget("65520:1000001")
+	nlri2 := bgp.NewRouteTargetMembershipNLRI(65000, rt2)
+	hash2, err := NlriRouteTargetKey(nlri2)
+	assert.NoError(t, err)
+
+	// pathID is set via PathNLRI.ID; it becomes Path.remoteID used by UpdateRTC.
+	p1 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1, ID: 1}, false, attrs, time.Now(), false)
+	p2 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri2, ID: 2}, false, attrs, time.Now(), false)
+	// p22 simulates the same RT with a different path identifier (ADD-PATH).
+	nlri2b := bgp.NewRouteTargetMembershipNLRI(65000, rt2)
+	p22 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri2b, ID: 3}, false, attrs, time.Now(), false)
+	p2Withdraw := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri2, ID: 2}, true, attrs, time.Now(), false)
+	p22Withdraw := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri2b, ID: 3}, true, attrs, time.Now(), false)
+
+	tm := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_VPN})
+	const peer1 = "192.0.2.1"
+	const tableID = "global"
+	rfList := []bgp.Family{bgp.RF_IPv4_VPN}
+
+	assert.False(t, tm.PeerHasRT(peer1, hash1))
+	assert.False(t, tm.PeerHasRT(peer1, hash2))
+
+	// Register p1 (RT1) for peer1.
+	tm.UpdateRTC(peer1, tableID, p1, rfList)
+	assert.True(t, tm.PeerHasRT(peer1, hash1))
+	assert.False(t, tm.PeerHasRT(peer1, hash2))
+
+	// Register p2 (RT2, pathID=2) for peer1.
+	tm.UpdateRTC(peer1, tableID, p2, rfList)
+	assert.True(t, tm.PeerHasRT(peer1, hash1))
+	assert.True(t, tm.PeerHasRT(peer1, hash2))
+
+	// Withdraw p1 — peer1 no longer has RT1.
+	tm.UpdateRTC(peer1, tableID, p1.Clone(true), rfList)
+	assert.False(t, tm.PeerHasRT(peer1, hash1))
+	assert.True(t, tm.PeerHasRT(peer1, hash2))
+
+	// Withdraw with an ASN that was never registered for RT2 — must not affect filtering.
+	nlri2UnknownAS := bgp.NewRouteTargetMembershipNLRI(99999, rt2)
+	p2UnknownAS := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri2UnknownAS, ID: 2}, true, attrs, time.Now(), false)
+	tm.UpdateRTC(peer1, tableID, p2UnknownAS, rfList)
+	assert.True(t, tm.PeerHasRT(peer1, hash2), "spurious withdraw must not remove peer interest")
+
+	// Withdraw p2 (pathID=2, correct ASN) — peer1 no longer has RT2.
+	tm.UpdateRTC(peer1, tableID, p2Withdraw, rfList)
+	assert.False(t, tm.PeerHasRT(peer1, hash2))
+
+	// Idempotent: withdrawing again should not panic.
+	tm.UpdateRTC(peer1, tableID, p2Withdraw, rfList)
+	assert.False(t, tm.PeerHasRT(peer1, hash2))
+
+	// Register p22 (same RT2, different pathID) — ADD-PATH case.
+	tm.UpdateRTC(peer1, tableID, p22, rfList)
+	assert.True(t, tm.PeerHasRT(peer1, hash2))
+
+	// Withdraw p22 — peer1 loses RT2 again.
+	tm.UpdateRTC(peer1, tableID, p22Withdraw, rfList)
+	assert.False(t, tm.PeerHasRT(peer1, hash2))
+}

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -240,9 +240,9 @@ type Table struct {
 	Family       bgp.Family
 	destinations *Destinations
 	logger       *slog.Logger
-	// adjRts is an RT->count map (reference count of RTC paths per RT).
-	// It is used only for Adj-RIB tables with RF_RTC_UC.
-	adjRts *rtCounter
+	// rtc tracks VPN paths per RT for global VPN tables, enabling O(1) lookup.
+	// nil for Adj-RIB and non-VPN tables.
+	rtc *rtcHandler
 	// index of evpn prefixes with paths to a specific MAC in a MAC-VRF
 	// this is a map[rt, MAC address]map[addrPrefixKey][]nlri
 	// this holds a map for a set of prefixes.
@@ -254,12 +254,8 @@ func newTablePartial(logger *slog.Logger, rf bgp.Family, isAdj bool, dsts ...*de
 		Family:       rf,
 		destinations: NewDestinations(),
 		logger:       logger,
+		rtc:          newRTCPart(rf, isAdj),
 		macIndex:     NewEVPNMacNLRIs(),
-	}
-	if isAdj && rf == bgp.RF_RTC_UC {
-		t.adjRts = &rtCounter{
-			rts: make(map[uint64]int),
-		}
 	}
 	for _, dst := range dsts {
 		t.setDestination(dst)
@@ -322,7 +318,11 @@ func (t *Table) deleteRTCPathsByVrf(vrf *Vrf, vrfs map[string]*Vrf) []*Path {
 	for lhs := range vrf.ImportRt {
 		t.destinations.iterateAllDestinations(func(dest *destination) {
 			nlri := dest.GetNlri().(*bgp.RouteTargetMembershipNLRI)
-			rhs, _ := extCommRouteTargetKey(nlri.RouteTarget)
+			// default can not be in vrf imports.
+			if nlri.RouteTarget == nil {
+				return
+			}
+			rhs, _ := ExtCommRouteTargetKey(nlri.RouteTarget)
 			if lhs == rhs && isLastTargetUser(vrfs, lhs) {
 				for _, p := range dest.knownPathList {
 					if p.IsLocal() {
@@ -452,6 +452,21 @@ func (t *Table) update(newPath *Path) *Update {
 	dst := t.getOrCreateDest(shard, nlri, 64)
 	u := dst.Calculate(t.logger, newPath)
 
+	if t.rtc != nil {
+		var oldBest *Path
+		if len(u.OldKnownPathList) > 0 {
+			oldBest = u.OldKnownPathList[0]
+		}
+		var newBest *Path
+		if len(dst.knownPathList) > 0 {
+			newBest = dst.knownPathList[0]
+		}
+		if oldBest != newBest {
+			t.rtc.unregister(oldBest, newBest == nil)
+			t.rtc.register(newBest)
+		}
+	}
+
 	if len(dst.knownPathList) == 0 {
 		t.deleteDest(shard, dst)
 		return u
@@ -466,6 +481,37 @@ func (t *Table) update(newPath *Path) *Update {
 	}
 
 	return u
+}
+
+func appendBestPathListForRT(outPaths []*Path, id string, as uint32, withdraw bool, inPaths map[*Path]struct{}) []*Path {
+	for p := range inPaths {
+		if p.IsNexthopInvalid || rsFilter(id, as, p) {
+			continue
+		}
+		if !p.IsWithdraw && withdraw {
+			p = p.Clone(true)
+		}
+		outPaths = append(outPaths, p)
+	}
+	return outPaths
+}
+
+func (t *Table) bestPathListForRTMaxLen(rt uint64) int {
+	if t.rtc == nil || rt == DefaultRT {
+		return 0
+	}
+	return t.rtc.maxLen(rt)
+}
+
+// appendBestsForRT appends paths for the given RT from this table.
+// isWithdraw=true clones each path as a withdrawal.
+// Peer membership tracking (idempotency) is handled by TableManager.peerRTM.
+// DefaultRT (rt==0) is not supported: caller handles path distribution for that case.
+func (t *Table) appendBestsForRT(paths []*Path, rt uint64, tableId string, as uint32, isWithdraw bool) []*Path {
+	if t.rtc == nil || rt == DefaultRT {
+		return paths
+	}
+	return t.rtc.appendBests(paths, rt, tableId, as, isWithdraw)
 }
 
 // GetDestinations returns snapshots of all destinations in the table.
@@ -1045,7 +1091,10 @@ var (
 	ErrNilCommunity       error = errors.New("RouteTarget could not be nil")
 )
 
-func extCommRouteTargetKey(routeTarget bgp.ExtendedCommunityInterface) (uint64, error) {
+// ExtCommRouteTargetKey computes a uint64 hash key for the given Route Target
+// extended community, used to index VPN paths by RT.
+// Returns ErrNilCommunity if routeTarget is nil, ErrInvalidRouteTarget for unsupported types.
+func ExtCommRouteTargetKey(routeTarget bgp.ExtendedCommunityInterface) (uint64, error) {
 	if routeTarget == nil {
 		return 0, ErrNilCommunity
 	}
@@ -1061,11 +1110,13 @@ func extCommRouteTargetKey(routeTarget bgp.ExtendedCommunityInterface) (uint64, 
 	}
 }
 
-func nlriRouteTargetKey(nlri *bgp.RouteTargetMembershipNLRI) (uint64, error) {
+// NlriRouteTargetKey computes a uint64 hash key for a RouteTargetMembershipNLRI.
+// A nil RouteTarget (wildcard / default) maps to DefaultRT (0).
+func NlriRouteTargetKey(nlri *bgp.RouteTargetMembershipNLRI) (uint64, error) {
 	if nlri.RouteTarget == nil {
 		return DefaultRT, nil
 	}
-	return extCommRouteTargetKey(nlri.RouteTarget)
+	return ExtCommRouteTargetKey(nlri.RouteTarget)
 }
 
 type routeTargetMap map[uint64]bgp.ExtendedCommunityInterface
@@ -1089,7 +1140,7 @@ func (rtm routeTargetMap) Clone() routeTargetMap {
 func newRouteTargetMap(s []bgp.ExtendedCommunityInterface) (routeTargetMap, error) {
 	m := make(routeTargetMap, len(s))
 	for _, rt := range s {
-		key, err := extCommRouteTargetKey(rt)
+		key, err := ExtCommRouteTargetKey(rt)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -146,6 +146,7 @@ type TableManager struct {
 	mu             sync.RWMutex // protects tables and vrfs maps
 	tables         map[bgp.Family]*Table
 	vrfs           map[string]*Vrf
+	peerRTM        peerRTMIndex // RT membership per peer; replaces per-table peersRTMMap
 	rfList         []bgp.Family
 	maxPathCounted atomic.Uint64
 	logger         *slog.Logger
@@ -153,11 +154,12 @@ type TableManager struct {
 
 func NewTableManager(logger *slog.Logger, rfList []bgp.Family) *TableManager {
 	t := &TableManager{
-		mu:     sync.RWMutex{},
-		tables: make(map[bgp.Family]*Table),
-		vrfs:   make(map[string]*Vrf),
-		rfList: rfList,
-		logger: logger,
+		mu:      sync.RWMutex{},
+		tables:  make(map[bgp.Family]*Table),
+		vrfs:    make(map[string]*Vrf),
+		peerRTM: newPeerRTMIndex(),
+		rfList:  rfList,
+		logger:  logger,
 	}
 	for _, rf := range rfList {
 		t.tables[rf] = NewTable(logger, rf)
@@ -369,6 +371,63 @@ func (manager *TableManager) GetBestPathList(id string, as uint32, rfList []bgp.
 	}
 	manager.updateMaxPathCounted(len(paths))
 	return paths
+}
+
+// UpdateRTC registers or unregisters a peer's RT membership interest and returns the VPN paths
+// that need to be advertised or withdrawn as a result. It replaces the combination of
+// adjRibIn.UpdateRTC + GetBestPathListForAdded/WithdrawnRT that was previously spread across
+// server.go. For DefaultRT (rtHash==0) the returned path slices are always empty — the caller
+// is responsible for sending all VPN routes in that case.
+func (manager *TableManager) UpdateRTC(peerID, tableID string, path *Path, rfList []bgp.Family) ([]*Path, []*Path) {
+	nlri, ok := path.GetNlri().(*bgp.RouteTargetMembershipNLRI)
+	if !ok {
+		return nil, nil
+	}
+	rtHash, err := NlriRouteTargetKey(nlri)
+	if err != nil {
+		return nil, nil
+	}
+
+	manager.mu.RLock()
+	defer manager.mu.RUnlock()
+
+	tables := manager.getTables(rfList...)
+
+	if path.IsWithdraw {
+		if !manager.peerRTM.deleteRTM(rtHash, peerID, nlri, path.RemoteID()) {
+			// Not the last RTM for this peer+RT: peer still interested, nothing to withdraw.
+			return nil, nil
+		}
+		maxLen := 0
+		for _, t := range tables {
+			maxLen += t.bestPathListForRTMaxLen(rtHash)
+		}
+		withdrawals := make([]*Path, 0, maxLen)
+		for _, t := range tables {
+			withdrawals = t.appendBestsForRT(withdrawals, rtHash, tableID, nlri.AS, true)
+		}
+		return nil, withdrawals
+	}
+
+	if !manager.peerRTM.addRTM(rtHash, peerID, nlri, path.RemoteID()) {
+		// Not the first RTM for this peer+RT: paths already sent, nothing new.
+		return nil, nil
+	}
+	maxLen := 0
+	for _, t := range tables {
+		maxLen += t.bestPathListForRTMaxLen(rtHash)
+	}
+	newPaths := make([]*Path, 0, maxLen)
+	for _, t := range tables {
+		newPaths = t.appendBestsForRT(newPaths, rtHash, tableID, nlri.AS, false)
+	}
+	return newPaths, nil
+}
+
+// PeerHasRT reports whether the given peer has advertised RT membership interest for rtHash.
+// O(1) lookup via the TableManager-level peerRTMIndex.
+func (manager *TableManager) PeerHasRT(peerID string, rtHash uint64) bool {
+	return manager.peerRTM.hasPeer(rtHash, peerID)
 }
 
 func (manager *TableManager) GetBestMultiPathList(id string, rfList []bgp.Family) [][]*Path {

--- a/internal/pkg/table/table_test.go
+++ b/internal/pkg/table/table_test.go
@@ -765,7 +765,7 @@ func Test_RouteTargetKey(t *testing.T) {
 	binary.BigEndian.PutUint32(buf[9:], 0x15161718)
 	r, err := bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	key, err := nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
+	key, err := NlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NoError(err)
 	assert.Equal(uint64(0x0002131415161718), key)
 
@@ -780,7 +780,7 @@ func Test_RouteTargetKey(t *testing.T) {
 	binary.BigEndian.PutUint16(buf[11:], 0x1314)
 	r, err = bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	key, err = nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
+	key, err = NlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NoError(err)
 	assert.Equal(uint64(0x01020a0102031314), key)
 
@@ -794,7 +794,7 @@ func Test_RouteTargetKey(t *testing.T) {
 	binary.BigEndian.PutUint16(buf[11:], 0x1314)
 	r, err = bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	key, err = nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
+	key, err = NlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NoError(err)
 	assert.Equal(uint64(0x0202151617181314), key)
 
@@ -806,15 +806,15 @@ func Test_RouteTargetKey(t *testing.T) {
 	binary.BigEndian.PutUint32(buf[9:], 1000000)
 	r, err = bgp.NLRIFromSlice(bgp.RF_RTC_UC, buf)
 	assert.NoError(err)
-	_, err = nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
+	_, err = NlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NotNil(err)
 
 	r = &bgp.RouteTargetMembershipNLRI{}
-	key, err = nlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
+	key, err = NlriRouteTargetKey(r.(*bgp.RouteTargetMembershipNLRI))
 	assert.NoError(err)
 	assert.Equal(DefaultRT, key)
 
-	_, err = extCommRouteTargetKey(nil)
+	_, err = ExtCommRouteTargetKey(nil)
 	assert.Equal(ErrNilCommunity, err)
 }
 
@@ -884,4 +884,150 @@ func TestContainsCIDR(t *testing.T) {
 			assert.Equal(t, tt.result, result)
 		})
 	}
+}
+
+type testPathWithRTs struct {
+	prefix string // VPN prefix string, e.g. "100:100:10.10.10.10/32"
+	rts    []bgp.ExtendedCommunityInterface
+}
+
+func makeTableWithRT(t *testing.T, tbl *Table, declarations []testPathWithRTs, rf bgp.Family) (*Table, []*Path) {
+	t.Helper()
+	if tbl == nil {
+		tbl = NewTable(logger, rf)
+	}
+	paths := make([]*Path, 0, len(declarations))
+	for _, item := range declarations {
+		rd, prefix, err := bgp.ParseVPNPrefix(item.prefix)
+		if err != nil {
+			t.Fatalf("ParseVPNPrefix(%q): %v", item.prefix, err)
+		}
+		label := *bgp.NewMPLSLabelStack()
+		nlri, err := bgp.NewLabeledVPNIPAddrPrefix(prefix, label, rd)
+		if err != nil {
+			t.Fatalf("NewLabeledVPNIPAddrPrefix: %v", err)
+		}
+		var pattr *bgp.PathAttributeExtendedCommunities
+		if len(item.rts) > 0 {
+			pattr = bgp.NewPathAttributeExtendedCommunities(item.rts)
+		}
+		path := NewPath(rf, nil, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{pattr}, time.Now(), false)
+
+		update := tbl.update(path)
+		assert.Equal(t, 1, len(update.KnownPathList))
+		assert.Equal(t, 0, len(update.OldKnownPathList))
+		assert.True(t, update.KnownPathList[0].Equal(path))
+		paths = append(paths, path)
+	}
+	return tbl, paths
+}
+
+func equalPaths(paths1, paths2 []*Path) bool {
+	if len(paths1) != len(paths2) {
+		return false
+	}
+	cp2 := make([]*Path, len(paths2))
+	copy(cp2, paths2)
+	for _, p1 := range paths1 {
+		found := false
+		for i2, p2 := range cp2 {
+			if p1.Equal(p2) {
+				found = true
+				cp2 = append(cp2[:i2], cp2[i2+1:]...)
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return len(cp2) == 0
+}
+
+func TestTableRTC(t *testing.T) {
+	rtStrings := []string{"100:100", "100:200", "100:300"}
+	rts := make([]bgp.ExtendedCommunityInterface, 0, len(rtStrings))
+	for _, strRT := range rtStrings {
+		rt, err := bgp.ParseRouteTarget(strRT)
+		assert.NoError(t, err)
+		rts = append(rts, rt)
+	}
+	assert.Equal(t, 3, len(rts))
+	nlris := make([]*bgp.RouteTargetMembershipNLRI, 0, len(rts))
+	for _, rt := range rts {
+		nlris = append(nlris, bgp.NewRouteTargetMembershipNLRI(0, rt))
+	}
+	declarations := []testPathWithRTs{
+		{
+			prefix: "100:100:10.10.10.10/32",
+			rts:    []bgp.ExtendedCommunityInterface{rts[0]},
+		},
+		{
+			prefix: "101:100:10.10.10.11/32",
+			rts:    []bgp.ExtendedCommunityInterface{rts[0], rts[1]},
+		},
+		{
+			prefix: "100:200:10.10.10.12/32",
+			rts:    []bgp.ExtendedCommunityInterface{rts[1]},
+		},
+		{
+			prefix: "100:300:10.10.10.13/32",
+			rts:    []bgp.ExtendedCommunityInterface{rts[2]},
+		},
+	}
+	tbl, paths := makeTableWithRT(t, nil, declarations, bgp.RF_IPv4_VPN)
+	assert.Equal(t, 4, len(tbl.GetDestinations()))
+
+	hash0, err := ExtCommRouteTargetKey(rts[0])
+	assert.NoError(t, err)
+	// appendBestsForRT returns paths for an RT from the table.
+	// Idempotency (per-peer deduplication) is handled by TableManager.peerRTM, not here.
+	pathsRT := tbl.appendBestsForRT(nil, hash0, "global", nlris[0].AS, false)
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[0], paths[1]}))
+
+	hash1, err := ExtCommRouteTargetKey(rts[1])
+	assert.NoError(t, err)
+
+	pathsRT = tbl.appendBestsForRT(nil, hash1, "global", nlris[1].AS, false)
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[1], paths[2]}))
+
+	hash2, err := ExtCommRouteTargetKey(rts[2])
+	assert.NoError(t, err)
+
+	// Accumulate paths from multiple RTs.
+	pathsRT = tbl.appendBestsForRT(pathsRT, hash2, "global", nlris[2].AS, false)
+	assert.Equal(t, 3, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[1], paths[2], paths[3]}))
+
+	// appendBestsForRT is not idempotent at the table level — always returns paths.
+	pathsRT = tbl.appendBestsForRT(nil, hash1, "global", nlris[1].AS, false)
+	assert.Equal(t, 2, len(pathsRT))
+
+	update := tbl.update(paths[2].Clone(true))
+	assert.Equal(t, 0, len(update.KnownPathList))
+	assert.Equal(t, 1, len(update.OldKnownPathList))
+	assert.True(t, update.OldKnownPathList[0].Equal(paths[2]))
+
+	update = tbl.update(paths[1].Clone(false))
+	assert.Equal(t, 1, len(update.KnownPathList))
+	assert.Equal(t, 1, len(update.OldKnownPathList))
+	assert.True(t, update.KnownPathList[0].Equal(paths[1]))
+	assert.True(t, update.OldKnownPathList[0].Equal(paths[1]))
+
+	// After removing paths[2] (withdrawn) and refreshing paths[1], only paths[1] remains for RT1.
+	pathsRT = tbl.appendBestsForRT(nil, hash1, "global", nlris[1].AS, false)
+	assert.Equal(t, 1, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[1]}))
+
+	// Withdrawal: isWithdraw=true clones paths as withdrawals.
+	pathsRT = tbl.appendBestsForRT(nil, hash0, "global", nlris[0].AS, true)
+	assert.Equal(t, 2, len(pathsRT))
+	assert.True(t, pathsRT[0].IsWithdraw)
+	assert.True(t, pathsRT[1].IsWithdraw)
+
+	pathsRT = tbl.appendBestsForRT(pathsRT, hash2, "global", nlris[2].AS, true)
+	assert.Equal(t, 3, len(pathsRT))
+	assert.True(t, equalPaths(pathsRT, []*Path{paths[0], paths[1], paths[3]}))
 }

--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -469,14 +469,22 @@ func (peer *peer) stopPeerRestarting() {
 	peer.longLivedRunning.Store(false)
 }
 
+func (peer *peer) HasRT(rtHash uint64) bool {
+	return peer.localRib.PeerHasRT(peer.ID(), rtHash)
+}
+
 // Returns true if the peer is interested in this path according to BGP RTC
-// (i.e., has advertised the relevant RT).
+// (i.e., has advertised the relevant RT via UpdateRTC).
 func (peer *peer) interestedIn(path *table.Path) bool {
-	if peer.adjRibIn.HasDefaultRT() {
+	if peer.HasRT(table.DefaultRT) {
 		return true
 	}
 	for _, ext := range path.GetExtCommunities() {
-		if peer.adjRibIn.HasRTinRtcTable(ext) {
+		key, err := table.ExtCommRouteTargetKey(ext)
+		if err != nil {
+			continue
+		}
+		if peer.HasRT(key) {
 			return true
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1156,61 +1156,64 @@ func (s *BgpServer) propagateUpdate(peer *peer, pathList []*table.Path) {
 			// between the previous and current state of the route distribution
 			// graph that is derived from Route Target membership information.
 			if peer != nil && path != nil && path.GetFamily() == bgp.RF_RTC_UC {
-				rt := path.GetNlri().(*bgp.RouteTargetMembershipNLRI).RouteTarget
+				nlri, ok := path.GetNlri().(*bgp.RouteTargetMembershipNLRI)
+				if !ok {
+					peer.fsm.logger.Warn("Route Target Constraint wrong format, ignore",
+						slog.String("Key", peer.ID()),
+						slog.Any("Data", path))
+					continue
+				}
+				rtHash, err := table.NlriRouteTargetKey(nlri)
+				if err != nil {
+					peer.fsm.logger.Warn("Route Target Constraint wrong format, ignore",
+						slog.String("Key", peer.ID()),
+						slog.Any("Data", path))
+					continue
+				}
 				fs := make([]bgp.Family, 0, len(peer.negotiatedRFList()))
 				for _, f := range peer.negotiatedRFList() {
 					if f != bgp.RF_RTC_UC {
 						fs = append(fs, f)
 					}
 				}
-				var candidates []*table.Path
+				// UpdateRTC registers/unregisters the peer's RT interest in the global RIB
+				// and returns VPN paths affected by the change. For DefaultRT the returned
+				// slices are empty — path distribution is handled below by the caller.
+				newPaths, withdrawals := rib.UpdateRTC(peer.ID(), peer.TableID(), path, fs)
 				if path.IsWithdraw {
-					// Note: The paths to be withdrawn are filtered because the
-					// given RT on RTM NLRI is already removed from adj-RIB-in.
-					_, candidates = s.getBestFromLocal(peer, fs, true)
-				} else {
-					// https://github.com/osrg/gobgp/issues/1777
-					// Ignore duplicate Membership announcements
-					membershipsForSource := s.globalRib.GetPathListWithSource(table.GLOBAL_RIB_NAME, []bgp.Family{bgp.RF_RTC_UC}, path.GetSource())
-					found := false
-					equalRT := func(a, b bgp.ExtendedCommunityInterface) bool {
-						if a == nil && b == nil {
-							return true
+					if rtHash == table.DefaultRT {
+						// Note: The paths to be withdrawn are filtered because the
+						// given RT on RTM NLRI is already removed from adj-RIB-in.
+						_, withdrawals = s.getBestFromLocal(peer, fs, false)
+						withdrawnPaths := make([]*table.Path, 0, len(withdrawals))
+						for _, p := range withdrawals {
+							withdrawnPaths = append(withdrawnPaths, p.Clone(true))
 						}
-						return a != nil && b != nil && a.String() == b.String()
-					}
-					for _, membership := range membershipsForSource {
-						mrt := membership.GetNlri().(*bgp.RouteTargetMembershipNLRI).RouteTarget
-						if equalRT(mrt, rt) {
-							found = true
-							break
-						}
-					}
-					if !found {
-						candidates = s.globalRib.GetBestPathList(peer.TableID(), 0, fs)
-					}
-				}
-				paths := make([]*table.Path, 0, len(candidates))
-				for _, p := range candidates {
-					for _, ext := range p.GetExtCommunities() {
-						if rt == nil || ext.String() == rt.String() {
-							if path.IsWithdraw {
-								p = p.Clone(true)
+						withdrawals = withdrawnPaths
+					} else {
+						// Filter: now that peer no longer has this RTM, paths that
+						// were previously sent must be withdrawn.
+						filtered := make([]*table.Path, 0, len(withdrawals))
+						for _, p := range withdrawals {
+							if s.filterpath(peer, p, nil) == nil {
+								filtered = append(filtered, p)
 							}
-							paths = append(paths, p)
-							break
 						}
+						withdrawals = filtered
 					}
-				}
-				if path.IsWithdraw {
 					// Skips filtering because the paths are already filtered
 					// and the withdrawal does not need the path attributes.
-					sendfsmOutgoingMsg(peer, paths)
-				} else if !peer.getRtcEORWait() {
-					paths = s.processOutgoingPaths(peer, paths, nil)
-					sendfsmOutgoingMsg(peer, paths)
+					sendfsmOutgoingMsg(peer, withdrawals)
 				} else {
-					peer.fsm.logger.Debug("Nothing sent in response to RT received. Waiting for RTC EOR.", slog.Any("Path", path))
+					if rtHash == table.DefaultRT {
+						newPaths = rib.GetBestPathList(peer.TableID(), 0, fs)
+					}
+					if !peer.getRtcEORWait() {
+						newPaths = s.processOutgoingPaths(peer, newPaths, nil)
+						sendfsmOutgoingMsg(peer, newPaths)
+					} else {
+						peer.fsm.logger.Debug("Nothing sent in response to RT received. Waiting for RTC EOR.", slog.Any("Path", path))
+					}
 				}
 			}
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -3813,3 +3813,285 @@ func TestStartBgp_RouterIdValidation(t *testing.T) {
 		})
 	}
 }
+
+// TestRTCWithdrawSameRTFromPeer tests that withdrawing one of two RTC paths for the same RT
+// does not cause VPN paths to be withdrawn while the peer still has the other RTC path.
+// Only after withdrawing both does the peer lose interest and VPN paths get withdrawn.
+func TestRTCWithdrawSameRTFromPeer(t *testing.T) {
+	ctx := context.Background()
+
+	s1 := runNewServer(t, 1, "1.1.1.1", 14179)
+	defer s1.StopBgp(context.Background(), &api.StopBgpRequest{})
+	s2 := runNewServer(t, 1, "2.2.2.2", 24179)
+	defer s2.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	if err := peerServers(t, ctx, []*BgpServer{s1, s2}, []oc.AfiSafiType{oc.AFI_SAFI_TYPE_L3VPN_IPV4_UNICAST, oc.AFI_SAFI_TYPE_RTC}); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := bgp.NewTwoOctetAsSpecificExtended(bgp.EC_SUBTYPE_ROUTE_TARGET, 100, 100, true)
+
+	panh, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("2.2.2.2"))
+	vpnAttrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		panh,
+		bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rt}),
+	}
+	rd, _ := bgp.ParseRouteDistinguisher("100:100")
+	labels := bgp.NewMPLSLabelStack(100, 200)
+	prefix, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("10.30.2.0/24"), *labels, rd)
+	vpnPath, _ := apiutil.NewPath(bgp.RF_IPv4_VPN, prefix, false, vpnAttrs, time.Now())
+	if _, err := s2.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(vpnPath)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// s1 adds two RTC paths with the same RT=100:100 but different ASNs,
+	// simulating s1 having learned RT membership from two upstream peers.
+	rtcNH, _ := bgp.NewPathAttributeNextHop(netip.IPv4Unspecified())
+	rtcAttrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP), rtcNH}
+	pathRtc1, _ := apiutil.NewPath(bgp.RF_RTC_UC, bgp.NewRouteTargetMembershipNLRI(64512, rt), false, rtcAttrs, time.Now())
+	pathRtc2, _ := apiutil.NewPath(bgp.RF_RTC_UC, bgp.NewRouteTargetMembershipNLRI(64513, rt), false, rtcAttrs, time.Now())
+	if _, err := s1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc1)}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc2)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	expectVpnRouteCount := func(expected int) bool {
+		count := 0
+		_ = s1.ListPath(apiutil.ListPathRequest{
+			TableType: api.TableType_TABLE_TYPE_ADJ_IN,
+			Family:    bgp.RF_IPv4_VPN,
+			Name:      "127.0.0.1",
+		}, func(_ bgp.NLRI, _ []*apiutil.Path) { count++ })
+		return count == expected
+	}
+
+	expectRTCRouteCount := func(expected int) bool {
+		count := 0
+		_ = s2.ListPath(apiutil.ListPathRequest{
+			TableType: api.TableType_TABLE_TYPE_ADJ_IN,
+			Family:    bgp.RF_RTC_UC,
+			Name:      "127.0.0.1",
+		}, func(_ bgp.NLRI, paths []*apiutil.Path) {
+			count += len(paths)
+		})
+		return count == expected
+	}
+
+	require.Eventually(t, func() bool {
+		return expectRTCRouteCount(2)
+	}, 10*time.Second, 100*time.Millisecond, "timeout waiting for RTC paths to arrive at s2 adj-in")
+
+	require.Eventually(t, func() bool {
+		return expectVpnRouteCount(1)
+	}, 10*time.Second, 100*time.Millisecond, "timeout waiting for VPN path to arrive at s1 adj-in")
+
+	require.NoError(t, s1.DeletePath(apiutil.DeletePathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc1)}}))
+
+	require.Eventually(t, func() bool {
+		return expectRTCRouteCount(1)
+	}, 10*time.Second, 100*time.Millisecond, "timeout waiting for first RTC path to withdraw at s2 adj-in")
+
+	time.Sleep(5 * time.Second)
+	assert.True(t, expectVpnRouteCount(1), "VPN path should remain after withdrawing first RTC (peer still has 64513:100:100)")
+
+	require.NoError(t, s1.DeletePath(apiutil.DeletePathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc2)}}))
+
+	require.Eventually(t, func() bool {
+		return expectRTCRouteCount(0)
+	}, 10*time.Second, 100*time.Millisecond, "timeout waiting for second RTC path to withdraw at s2 adj-in")
+
+	// After withdrawing both RTCs, peer has no RT 100:100 membership, VPN path should be withdrawn.
+	require.Eventually(t, func() bool {
+		return expectVpnRouteCount(0)
+	}, 10*time.Second, 100*time.Millisecond, "timeout waiting for VPN path to be withdrawn at s1 adj-in")
+}
+
+// TestRTCImplicitWithdrawForAcceptedPathWillWithdrawVPNPaths tests that if a new RTC path
+// implicitly withdraws (replaces) an existing accepted one and the new path is rejected by
+// import policy, the peer loses RT interest and the VPN paths are withdrawn.
+func TestRTCImplicitWithdrawForAcceptedPathWillWithdrawVPNPaths(t *testing.T) {
+	ctx := context.Background()
+
+	s1 := runNewServer(t, 1, "1.1.1.1", 22179)
+	defer s1.StopBgp(context.Background(), &api.StopBgpRequest{})
+	s2 := runNewServer(t, 1, "2.2.2.2", 33179)
+	defer s2.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	if err := peerServers(t, ctx, []*BgpServer{s1, s2}, []oc.AfiSafiType{oc.AFI_SAFI_TYPE_L3VPN_IPV4_UNICAST, oc.AFI_SAFI_TYPE_RTC}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add import policy on s1: reject RTC routes with AS_PATH length >= 1.
+	stmt := &api.Statement{
+		Name: "reject_as_path",
+		Conditions: &api.Conditions{
+			AfiSafiIn: []*api.Family{
+				{Afi: api.Family_AFI_IP, Safi: api.Family_SAFI_ROUTE_TARGET_CONSTRAINTS},
+			},
+			AsPathLength: &api.AsPathLength{
+				Type:   api.Comparison_COMPARISON_GE,
+				Length: 1,
+			},
+		},
+		Actions: &api.Actions{RouteAction: api.RouteAction_ROUTE_ACTION_REJECT},
+	}
+	policy := &api.Policy{Name: "import_policy", Statements: []*api.Statement{stmt}}
+	require.NoError(t, s1.AddPolicy(ctx, &api.AddPolicyRequest{Policy: policy}))
+	require.NoError(t, s1.AddPolicyAssignment(ctx, &api.AddPolicyAssignmentRequest{
+		Assignment: &api.PolicyAssignment{
+			Name:          table.GLOBAL_RIB_NAME,
+			Direction:     api.PolicyDirection_POLICY_DIRECTION_IMPORT,
+			Policies:      []*api.Policy{policy},
+			DefaultAction: api.RouteAction_ROUTE_ACTION_ACCEPT,
+		},
+	}))
+
+	expectVpnRouteCountS2AdjIn := func(expected int) bool {
+		count := 0
+		_ = s2.ListPath(apiutil.ListPathRequest{
+			TableType: api.TableType_TABLE_TYPE_ADJ_IN,
+			Family:    bgp.RF_IPv4_VPN,
+			Name:      "127.0.0.1",
+		}, func(_ bgp.NLRI, _ []*apiutil.Path) { count++ })
+		return count == expected
+	}
+
+	rt100 := bgp.NewTwoOctetAsSpecificExtended(bgp.EC_SUBTYPE_ROUTE_TARGET, 100, 100, true)
+	panh, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("3.3.3.3"))
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		panh,
+		bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rt100}),
+	}
+	rd, _ := bgp.ParseRouteDistinguisher("100:100")
+	labels := bgp.NewMPLSLabelStack(100, 200)
+	prefix, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("10.30.2.0/24"), *labels, rd)
+	path, _ := apiutil.NewPath(bgp.RF_IPv4_VPN, prefix, false, attrs, time.Now())
+	if _, err := s1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(path)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// pathRtc1 — no AS_PATH, passes import policy on s1.
+	panh1, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("1.1.1.1"))
+	attrsRtc1 := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		panh1,
+	}
+	pathRtc1, _ := apiutil.NewPath(bgp.RF_RTC_UC, bgp.NewRouteTargetMembershipNLRI(1, rt100), false, attrsRtc1, time.Now())
+	if _, err := s2.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc1)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	require.Eventually(t, func() bool {
+		return expectVpnRouteCountS2AdjIn(1)
+	}, 10*time.Second, 100*time.Millisecond, "timeout waiting for VPN path at s2 adj-in from s1")
+
+	// pathRtc2 — has AS_PATH length 1, rejected by import policy on s1.
+	// This implicitly withdraws pathRtc1 for the same (AS=1, RT=100:100) NLRI.
+	attrsRtc2 := append(attrsRtc1, bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint16{2}),
+	}))
+	pathRtc2, _ := apiutil.NewPath(bgp.RF_RTC_UC, bgp.NewRouteTargetMembershipNLRI(1, rt100), false, attrsRtc2, time.Now())
+	if _, err := s2.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc2)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	require.Eventually(t, func() bool {
+		return expectVpnRouteCountS2AdjIn(0)
+	}, 10*time.Second, 100*time.Millisecond, "timeout waiting for VPN path to withdraw at s2 adj-in from s1")
+}
+
+// TestRTCShouldNotAdvertiseVPNRouteWhenRTCIsNotPassImportPolicies tests that VPN routes are
+// not advertised to a peer whose RTC announcements fail the local import policy.
+func TestRTCShouldNotAdvertiseVPNRouteWhenRTCIsNotPassImportPolicies(t *testing.T) {
+	ctx := context.Background()
+
+	s1 := runNewServer(t, 1, "1.1.1.1", 44179)
+	defer s1.StopBgp(context.Background(), &api.StopBgpRequest{})
+	s2 := runNewServer(t, 1, "2.2.2.2", 55179)
+	defer s2.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	if err := peerServers(t, ctx, []*BgpServer{s1, s2}, []oc.AfiSafiType{oc.AFI_SAFI_TYPE_L3VPN_IPV4_UNICAST, oc.AFI_SAFI_TYPE_RTC}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add import policy on s1: reject RTC routes with AS_PATH length >= 1.
+	stmt := &api.Statement{
+		Name: "reject_as_path",
+		Conditions: &api.Conditions{
+			AfiSafiIn: []*api.Family{
+				{Afi: api.Family_AFI_IP, Safi: api.Family_SAFI_ROUTE_TARGET_CONSTRAINTS},
+			},
+			AsPathLength: &api.AsPathLength{
+				Type:   api.Comparison_COMPARISON_GE,
+				Length: 1,
+			},
+		},
+		Actions: &api.Actions{RouteAction: api.RouteAction_ROUTE_ACTION_REJECT},
+	}
+	policy := &api.Policy{Name: "import_policy", Statements: []*api.Statement{stmt}}
+	require.NoError(t, s1.AddPolicy(ctx, &api.AddPolicyRequest{Policy: policy}))
+	require.NoError(t, s1.AddPolicyAssignment(ctx, &api.AddPolicyAssignmentRequest{
+		Assignment: &api.PolicyAssignment{
+			Name:          table.GLOBAL_RIB_NAME,
+			Direction:     api.PolicyDirection_POLICY_DIRECTION_IMPORT,
+			Policies:      []*api.Policy{policy},
+			DefaultAction: api.RouteAction_ROUTE_ACTION_ACCEPT,
+		},
+	}))
+
+	vpnPresentAtS2AdjIn := func() bool {
+		count := 0
+		_ = s2.ListPath(apiutil.ListPathRequest{
+			TableType: api.TableType_TABLE_TYPE_ADJ_IN,
+			Family:    bgp.RF_IPv4_VPN,
+			Name:      "127.0.0.1",
+		}, func(_ bgp.NLRI, _ []*apiutil.Path) { count++ })
+		return count > 0
+	}
+
+	rt100 := bgp.NewTwoOctetAsSpecificExtended(bgp.EC_SUBTYPE_ROUTE_TARGET, 100, 100, true)
+	panh, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("3.3.3.3"))
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		panh,
+		bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rt100}),
+	}
+	rd, _ := bgp.ParseRouteDistinguisher("100:100")
+	labels := bgp.NewMPLSLabelStack(100, 200)
+	prefix1, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("10.30.2.0/24"), *labels, rd)
+	prefix2, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("10.30.3.0/24"), *labels, rd)
+	path1, _ := apiutil.NewPath(bgp.RF_IPv4_VPN, prefix1, false, attrs, time.Now())
+	path2, _ := apiutil.NewPath(bgp.RF_IPv4_VPN, prefix2, false, attrs, time.Now())
+
+	panh2, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("1.1.1.1"))
+	attrsRtc := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		panh2,
+		bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{
+			bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint16{2}),
+		}),
+	}
+
+	if _, err := s1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(path1)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	pathRtc, _ := apiutil.NewPath(bgp.RF_RTC_UC, bgp.NewRouteTargetMembershipNLRI(1, rt100), false, attrsRtc, time.Now())
+	if _, err := s2.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	require.Never(t, vpnPresentAtS2AdjIn, 10*time.Second, 100*time.Millisecond,
+		"VPN route should not appear at s2 adj-in from s1 while RTC fails import policy")
+
+	if _, err := s1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(path2)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	require.Never(t, vpnPresentAtS2AdjIn, 10*time.Second, 100*time.Millisecond,
+		"VPN route should not appear at s2 adj-in from s1 after second VPN prefix is added")
+}


### PR DESCRIPTION
  Replace the O(n) RT-scan logic in propagateUpdate with a structured
  peerRTMIndex (rtHash → peerID → {rtmKey set}) that enables O(1)
  lookup of per-peer RT interest.

  Add support for RTC import policy filtering, making route-target
  membership filtering more flexible by allowing default import policies
  to apply to RTC routes.

  Key changes:
  - Add peerRTMIndex to TableManager; expose UpdateRTC() and PeerHasRT()
  - Convert rtcHandler to a sync.RWMutex-protected struct for safe concurrent
  - Fix rtcHandler not being updated on destination delete
  - Export ExtCommRouteTargetKey / NlriRouteTargetKey
  - Remove adjRts / rtCounter / HasRTinRtcTable — superseded by peerRTMIndex
  - Add tests for ADD-PATH tracking, multi-RT withdrawal, and policy-based RTC filtering