### PR TITLE
ci: replace bufbuild/buf-setup-action with go install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: actions/setup-go@v6
         with:
-          version: latest
+          go-version: "stable"
+      - run: go install github.com/bufbuild/buf/cmd/buf@latest
 
       - name: buf lint
         run: buf lint proto/


### PR DESCRIPTION
buf-setup-action is deprecated and still depends on Node 20. Install buf via go install to avoid Node version dependencies.