### PR TITLE
Replace rtCounter with adjRTSet

### DIFF
--- a/internal/pkg/table/adj.go
+++ b/internal/pkg/table/adj.go
@@ -18,17 +18,35 @@ package table
 import (
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
 
-// rtCounter keeps per-RT reference counts.
-type rtCounter struct {
-	rts map[uint64]int
+// adjRTKey uniquely identifies an RT membership entry within an RT hash bucket.
+// With ADD-PATH, the same (AS, RT) NLRI can appear with different path IDs;
+// both fields are required so a withdraw of one path-ID or different AS does not cancel others.
+type adjRTKey struct {
+	as     uint32
+	pathID uint32
 }
 
-func (rtc *rtCounter) add(path *Path) {
-	if rtc == nil {
+// adjRTSet tracks which (AS, pathID) pairs are present per RT hash in an Adj-RIB.
+// Set semantics make ADD-PATH or different AS withdrawals safe: removing one path-ID does not
+// affect others sharing the same RT, and spurious removes are no-ops.
+// Thread-safe: add/sub are called under a shard write-lock, has is called from
+// interestedIn without any lock, so an internal RWMutex is required.
+type adjRTSet struct {
+	mu sync.RWMutex
+	m  map[uint64]map[adjRTKey]struct{}
+}
+
+func newAdjRTSet() *adjRTSet {
+	return &adjRTSet{m: make(map[uint64]map[adjRTKey]struct{})}
+}
+
+func (s *adjRTSet) add(path *Path) {
+	if s == nil {
 		return
 	}
 	if path.GetFamily() != bgp.RF_RTC_UC {
@@ -42,15 +60,18 @@ func (rtc *rtCounter) add(path *Path) {
 	if err != nil {
 		return
 	}
-	if _, found := rtc.rts[rtHash]; !found {
-		rtc.rts[rtHash] = 1
-		return
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	keys, ok := s.m[rtHash]
+	if !ok {
+		keys = make(map[adjRTKey]struct{})
+		s.m[rtHash] = keys
 	}
-	rtc.rts[rtHash]++
+	keys[adjRTKey{as: nlri.AS, pathID: path.remoteID}] = struct{}{}
 }
 
-func (rtc *rtCounter) sub(path *Path) {
-	if rtc == nil {
+func (s *adjRTSet) sub(path *Path) {
+	if s == nil {
 		return
 	}
 	if path.GetFamily() != bgp.RF_RTC_UC {
@@ -64,13 +85,25 @@ func (rtc *rtCounter) sub(path *Path) {
 	if err != nil {
 		return
 	}
-	if val, found := rtc.rts[rtHash]; found {
-		if val <= 1 {
-			delete(rtc.rts, rtHash)
-			return
-		}
-		rtc.rts[rtHash]--
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	keys, ok := s.m[rtHash]
+	if !ok {
+		return
 	}
+	delete(keys, adjRTKey{as: nlri.AS, pathID: path.remoteID})
+	if len(keys) == 0 {
+		delete(s.m, rtHash)
+	}
+}
+
+func (s *adjRTSet) has(rtHash uint64) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.m[rtHash]) > 0
 }
 
 type AdjRib struct {
@@ -96,14 +129,11 @@ func (adj *AdjRib) HasRTinRtcTable(routeTarget bgp.ExtendedCommunityInterface) b
 	if !found || table.adjRts == nil {
 		return false
 	}
-
 	key, err := extCommRouteTargetKey(routeTarget)
 	if err != nil {
 		return false
 	}
-
-	num, found := table.adjRts.rts[key]
-	return found && num > 0
+	return table.adjRts.has(key)
 }
 
 func (adj *AdjRib) HasDefaultRT() bool {
@@ -111,9 +141,7 @@ func (adj *AdjRib) HasDefaultRT() bool {
 	if !found || table.adjRts == nil {
 		return false
 	}
-
-	num, found := table.adjRts.rts[DefaultRT]
-	return found && num > 0
+	return table.adjRts.has(DefaultRT)
 }
 
 func (adj *AdjRib) Update(pathList []*Path) {

--- a/internal/pkg/table/adj_test.go
+++ b/internal/pkg/table/adj_test.go
@@ -18,6 +18,7 @@ package table
 import (
 	"log/slog"
 	"net/netip"
+	"sync"
 	"testing"
 	"time"
 
@@ -233,6 +234,93 @@ func TestAdjRTC(t *testing.T) {
 	adj.Update([]*Path{p2.Clone(true)})
 	assert.Equal(t, adj.Count([]bgp.Family{family}), 0)
 	assert.True(t, !adj.HasRTinRtcTable(rt2))
+}
+
+func TestAdjRTCSameRT(t *testing.T) {
+	pi := &PeerInfo{}
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
+
+	rt1, _ := bgp.ParseRouteTarget("65520:1000000")
+	nlri1a := bgp.NewRouteTargetMembershipNLRI(65000, rt1)
+	nlri1b := bgp.NewRouteTargetMembershipNLRI(65001, rt1) // same RT, different AS
+
+	// Two ADD-PATH paths for the same (AS=65000, RT=rt1) NLRI, different path IDs.
+	p1 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1a, ID: 1}, false, attrs, time.Now(), false)
+	p2 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1a, ID: 2}, false, attrs, time.Now(), false)
+	// Different AS, same RT.
+	p3 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1b, ID: 1}, false, attrs, time.Now(), false)
+
+	family := bgp.RF_RTC_UC
+	adj := NewAdjRib(logger, []bgp.Family{family})
+
+	adj.Update([]*Path{p1, p2, p3})
+	assert.Equal(t, 3, adj.Count([]bgp.Family{family}))
+	assert.True(t, adj.HasRTinRtcTable(rt1))
+
+	// Withdraw p1 — p2 and p3 still hold rt1 interest.
+	adj.Update([]*Path{p1.Clone(true)})
+	assert.Equal(t, 2, adj.Count([]bgp.Family{family}))
+	assert.True(t, adj.HasRTinRtcTable(rt1), "peer still has rt1 via p2 and p3")
+
+	// Withdraw p3 — p2 still holds rt1 interest.
+	adj.Update([]*Path{p3.Clone(true)})
+	assert.Equal(t, 1, adj.Count([]bgp.Family{family}))
+	assert.True(t, adj.HasRTinRtcTable(rt1), "peer still has rt1 via p2")
+
+	// Spurious withdraw: same NLRI as p2 but unknown pathID — must be a no-op.
+	pSpurious := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1a, ID: 99}, true, attrs, time.Now(), false)
+	adj.Update([]*Path{pSpurious})
+	assert.True(t, adj.HasRTinRtcTable(rt1), "spurious withdraw must not remove rt1 interest")
+
+	// Withdraw p2 — no more rt1 interest.
+	adj.Update([]*Path{p2.Clone(true)})
+	assert.Equal(t, 0, adj.Count([]bgp.Family{family}))
+	assert.False(t, adj.HasRTinRtcTable(rt1))
+}
+
+func TestAdjRTSetConcurrent(t *testing.T) {
+	pi := &PeerInfo{}
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
+
+	rt, _ := bgp.ParseRouteTarget("65520:1000000")
+	nlri := bgp.NewRouteTargetMembershipNLRI(65000, rt)
+	rtHash, err := nlriRouteTargetKey(nlri)
+	assert.NoError(t, err)
+
+	s := newAdjRTSet()
+
+	const goroutines = 20
+	const iters = 500
+
+	var wg sync.WaitGroup
+
+	// Writers: concurrent add and sub.
+	for i := range goroutines {
+		wg.Add(1)
+		go func(id uint32) {
+			defer wg.Done()
+			path := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri, ID: id}, false, attrs, time.Now(), false)
+			withdraw := path.Clone(true)
+			for range iters {
+				s.add(path)
+				s.sub(withdraw)
+			}
+		}(uint32(i))
+	}
+
+	// Readers: concurrent has, running throughout the writes.
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iters {
+				_ = s.has(rtHash)
+				_ = s.has(DefaultRT)
+			}
+		}()
+	}
+
+	wg.Wait()
 }
 
 func TestWithdrawUnknownPath(t *testing.T) {

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -240,9 +240,9 @@ type Table struct {
 	Family       bgp.Family
 	destinations *Destinations
 	logger       *slog.Logger
-	// adjRts is an RT->count map (reference count of RTC paths per RT).
-	// It is used only for Adj-RIB tables with RF_RTC_UC.
-	adjRts *rtCounter
+	// adjRts tracks RT membership keys in Adj-RIB tables with RF_RTC_UC.
+	// nil for non-RTC and global tables.
+	adjRts *adjRTSet
 	// index of evpn prefixes with paths to a specific MAC in a MAC-VRF
 	// this is a map[rt, MAC address]map[addrPrefixKey][]nlri
 	// this holds a map for a set of prefixes.
@@ -257,9 +257,7 @@ func newTablePartial(logger *slog.Logger, rf bgp.Family, isAdj bool, dsts ...*de
 		macIndex:     NewEVPNMacNLRIs(),
 	}
 	if isAdj && rf == bgp.RF_RTC_UC {
-		t.adjRts = &rtCounter{
-			rts: make(map[uint64]int),
-		}
+		t.adjRts = newAdjRTSet()
 	}
 	for _, dst := range dsts {
 		t.setDestination(dst)


### PR DESCRIPTION
Counter semantics track only how many paths share an RT hash, not which
specific (AS, pathID) pairs are present. Set semantics make each entry
explicit: add is idempotent for the same key, and has() returning false
means every registered (AS, pathID) pair was explicitly removed.

Also make it more concurent safe

part of #3368