### PR TITLE
refactor: replace rtc handling logic to separate place.

### DIFF
--- a/internal/pkg/table/adj.go
+++ b/internal/pkg/table/adj.go
@@ -18,93 +18,9 @@ package table
 import (
 	"fmt"
 	"log/slog"
-	"sync"
 
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
-
-// adjRTKey uniquely identifies an RT membership entry within an RT hash bucket.
-// With ADD-PATH, the same (AS, RT) NLRI can appear with different path IDs;
-// both fields are required so a withdraw of one path-ID or different AS does not cancel others.
-type adjRTKey struct {
-	as     uint32
-	pathID uint32
-}
-
-// adjRTSet tracks which (AS, pathID) pairs are present per RT hash in an Adj-RIB.
-// Set semantics make ADD-PATH or different AS withdrawals safe: removing one path-ID does not
-// affect others sharing the same RT, and spurious removes are no-ops.
-// Thread-safe: add/sub are called under a shard write-lock, has is called from
-// interestedIn without any lock, so an internal RWMutex is required.
-type adjRTSet struct {
-	mu sync.RWMutex
-	m  map[uint64]map[adjRTKey]struct{}
-}
-
-func newAdjRTSet() *adjRTSet {
-	return &adjRTSet{m: make(map[uint64]map[adjRTKey]struct{})}
-}
-
-func (s *adjRTSet) add(path *Path) {
-	if s == nil {
-		return
-	}
-	if path.GetFamily() != bgp.RF_RTC_UC {
-		return
-	}
-	nlri, ok := path.GetNlri().(*bgp.RouteTargetMembershipNLRI)
-	if !ok {
-		return
-	}
-	rtHash, err := nlriRouteTargetKey(nlri)
-	if err != nil {
-		return
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	keys, ok := s.m[rtHash]
-	if !ok {
-		keys = make(map[adjRTKey]struct{})
-		s.m[rtHash] = keys
-	}
-	keys[adjRTKey{as: nlri.AS, pathID: path.remoteID}] = struct{}{}
-}
-
-func (s *adjRTSet) sub(path *Path) {
-	if s == nil {
-		return
-	}
-	if path.GetFamily() != bgp.RF_RTC_UC {
-		return
-	}
-	nlri, ok := path.GetNlri().(*bgp.RouteTargetMembershipNLRI)
-	if !ok {
-		return
-	}
-	rtHash, err := nlriRouteTargetKey(nlri)
-	if err != nil {
-		return
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	keys, ok := s.m[rtHash]
-	if !ok {
-		return
-	}
-	delete(keys, adjRTKey{as: nlri.AS, pathID: path.remoteID})
-	if len(keys) == 0 {
-		delete(s.m, rtHash)
-	}
-}
-
-func (s *adjRTSet) has(rtHash uint64) bool {
-	if s == nil {
-		return false
-	}
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return len(s.m[rtHash]) > 0
-}
 
 type AdjRib struct {
 	accepted map[bgp.Family]int

--- a/internal/pkg/table/adj_test.go
+++ b/internal/pkg/table/adj_test.go
@@ -18,7 +18,6 @@ package table
 import (
 	"log/slog"
 	"net/netip"
-	"sync"
 	"testing"
 	"time"
 
@@ -276,51 +275,6 @@ func TestAdjRTCSameRT(t *testing.T) {
 	adj.Update([]*Path{p2.Clone(true)})
 	assert.Equal(t, 0, adj.Count([]bgp.Family{family}))
 	assert.False(t, adj.HasRTinRtcTable(rt1))
-}
-
-func TestAdjRTSetConcurrent(t *testing.T) {
-	pi := &PeerInfo{}
-	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
-
-	rt, _ := bgp.ParseRouteTarget("65520:1000000")
-	nlri := bgp.NewRouteTargetMembershipNLRI(65000, rt)
-	rtHash, err := nlriRouteTargetKey(nlri)
-	assert.NoError(t, err)
-
-	s := newAdjRTSet()
-
-	const goroutines = 20
-	const iters = 500
-
-	var wg sync.WaitGroup
-
-	// Writers: concurrent add and sub.
-	for i := range goroutines {
-		wg.Add(1)
-		go func(id uint32) {
-			defer wg.Done()
-			path := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri, ID: id}, false, attrs, time.Now(), false)
-			withdraw := path.Clone(true)
-			for range iters {
-				s.add(path)
-				s.sub(withdraw)
-			}
-		}(uint32(i))
-	}
-
-	// Readers: concurrent has, running throughout the writes.
-	for range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for range iters {
-				_ = s.has(rtHash)
-				_ = s.has(DefaultRT)
-			}
-		}()
-	}
-
-	wg.Wait()
 }
 
 func TestWithdrawUnknownPath(t *testing.T) {

--- a/internal/pkg/table/rtc.go
+++ b/internal/pkg/table/rtc.go
@@ -1,0 +1,90 @@
+package table
+
+import (
+	"sync"
+
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+)
+
+// rtmKey uniquely identifies an RT membership entry within an RT hash bucket.
+// With ADD-PATH, the same (AS, RT) NLRI can appear with different path IDs;
+// both fields are required so a withdraw of one path-ID or different AS does not cancel others.
+type rtmKey struct {
+	as     uint32
+	pathID uint32
+}
+
+// rtmSet tracks which (AS, pathID) pairs are present per RT hash.
+// Set semantics make ADD-PATH or different AS withdrawals safe: removing one path-ID does not
+// affect others sharing the same RT, and spurious removes are no-ops.
+// Thread-safe: add/sub are called under a shard write-lock, has is called from
+// interestedIn without any lock, so an internal RWMutex is required.
+type rtmSet struct {
+	mu sync.RWMutex
+	m  map[uint64]map[rtmKey]struct{}
+}
+
+func newRtmSet() *rtmSet {
+	return &rtmSet{m: make(map[uint64]map[rtmKey]struct{})}
+}
+
+func (s *rtmSet) add(path *Path) {
+	if s == nil {
+		return
+	}
+	if path.GetFamily() != bgp.RF_RTC_UC {
+		return
+	}
+	nlri, ok := path.GetNlri().(*bgp.RouteTargetMembershipNLRI)
+	if !ok {
+		return
+	}
+	rtHash, err := nlriRouteTargetKey(nlri)
+	if err != nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	keys, ok := s.m[rtHash]
+	if !ok {
+		keys = make(map[rtmKey]struct{})
+		s.m[rtHash] = keys
+	}
+	keys[rtmKey{as: nlri.AS, pathID: path.remoteID}] = struct{}{}
+}
+
+func (s *rtmSet) sub(path *Path) {
+	if s == nil {
+		return
+	}
+	if path.GetFamily() != bgp.RF_RTC_UC {
+		return
+	}
+	nlri, ok := path.GetNlri().(*bgp.RouteTargetMembershipNLRI)
+	if !ok {
+		return
+	}
+	rtHash, err := nlriRouteTargetKey(nlri)
+	if err != nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	keys, ok := s.m[rtHash]
+	if !ok {
+		return
+	}
+	delete(keys, rtmKey{as: nlri.AS, pathID: path.remoteID})
+	if len(keys) == 0 {
+		delete(s.m, rtHash)
+	}
+}
+
+func (s *rtmSet) has(rtHash uint64) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.m[rtHash]) > 0
+}

--- a/internal/pkg/table/rtc_test.go
+++ b/internal/pkg/table/rtc_test.go
@@ -1,0 +1,125 @@
+package table
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+)
+
+func TestAdjRTSetAddSubHas(t *testing.T) {
+	pi := &PeerInfo{}
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
+
+	rt, err := bgp.ParseRouteTarget("65520:1000000")
+	assert.NoError(t, err)
+	nlri := bgp.NewRouteTargetMembershipNLRI(65000, rt)
+	rtHash, err := nlriRouteTargetKey(nlri)
+	assert.NoError(t, err)
+
+	var nilSet *rtmSet
+	nilSet.add(nil)
+	nilSet.sub(nil)
+	assert.False(t, nilSet.has(rtHash))
+	assert.False(t, nilSet.has(DefaultRT))
+
+	s := newRtmSet()
+	assert.False(t, s.has(rtHash))
+	assert.False(t, s.has(DefaultRT))
+
+	// Non-RTC paths are ignored.
+	v4 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: &bgp.IPAddrPrefix{}}, false, attrs, time.Now(), false)
+	s.add(v4)
+	s.sub(v4)
+	assert.False(t, s.has(rtHash))
+
+	// Single path: add then withdraw clears the bucket.
+	p := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri, ID: 7}, false, attrs, time.Now(), false)
+	s.add(p)
+	assert.True(t, s.has(rtHash))
+	s.sub(p.Clone(true))
+	assert.False(t, s.has(rtHash))
+
+	// ADD-PATH: two path IDs for the same (AS, RT); withdrawing one leaves the other.
+	p1 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri, ID: 1}, false, attrs, time.Now(), false)
+	p2 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri, ID: 2}, false, attrs, time.Now(), false)
+	s.add(p1)
+	s.add(p2)
+	assert.True(t, s.has(rtHash))
+	s.sub(p1.Clone(true))
+	assert.True(t, s.has(rtHash), "second path-ID must still advertise the RT")
+	s.sub(p2.Clone(true))
+	assert.False(t, s.has(rtHash))
+
+	// Same RT, different originating AS: independent keys.
+	nlriOtherAS := bgp.NewRouteTargetMembershipNLRI(65001, rt)
+	pA := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri, ID: 1}, false, attrs, time.Now(), false)
+	pB := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlriOtherAS, ID: 1}, false, attrs, time.Now(), false)
+	s.add(pA)
+	s.add(pB)
+	assert.True(t, s.has(rtHash))
+	s.sub(pA.Clone(true))
+	assert.True(t, s.has(rtHash), "other AS must still hold this RT")
+	s.sub(pB.Clone(true))
+	assert.False(t, s.has(rtHash))
+
+	// Default (wildcard) RT uses key DefaultRT.
+	nlriDef := bgp.NewRouteTargetMembershipNLRI(0, nil)
+	pDef := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlriDef, ID: 1}, false, attrs, time.Now(), false)
+	s.add(pDef)
+	assert.True(t, s.has(DefaultRT))
+	s.sub(pDef.Clone(true))
+	assert.False(t, s.has(DefaultRT))
+
+	// Spurious withdraw is a no-op on an empty set.
+	s.sub(p.Clone(true))
+	assert.False(t, s.has(rtHash))
+}
+
+func TestAdjRTSetConcurrent(t *testing.T) {
+	pi := &PeerInfo{}
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
+
+	rt, _ := bgp.ParseRouteTarget("65520:1000000")
+	nlri := bgp.NewRouteTargetMembershipNLRI(65000, rt)
+	rtHash, err := nlriRouteTargetKey(nlri)
+	assert.NoError(t, err)
+
+	s := newRtmSet()
+
+	const goroutines = 20
+	const iters = 500
+
+	var wg sync.WaitGroup
+
+	// Writers: concurrent add and sub.
+	for i := range goroutines {
+		wg.Add(1)
+		go func(id uint32) {
+			defer wg.Done()
+			path := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri, ID: id}, false, attrs, time.Now(), false)
+			withdraw := path.Clone(true)
+			for range iters {
+				s.add(path)
+				s.sub(withdraw)
+			}
+		}(uint32(i))
+	}
+
+	// Readers: concurrent has, running throughout the writes.
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iters {
+				_ = s.has(rtHash)
+				_ = s.has(DefaultRT)
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -242,7 +242,7 @@ type Table struct {
 	logger       *slog.Logger
 	// adjRts tracks RT membership keys in Adj-RIB tables with RF_RTC_UC.
 	// nil for non-RTC and global tables.
-	adjRts *adjRTSet
+	adjRts *rtmSet
 	// index of evpn prefixes with paths to a specific MAC in a MAC-VRF
 	// this is a map[rt, MAC address]map[addrPrefixKey][]nlri
 	// this holds a map for a set of prefixes.
@@ -257,7 +257,7 @@ func newTablePartial(logger *slog.Logger, rf bgp.Family, isAdj bool, dsts ...*de
 		macIndex:     NewEVPNMacNLRIs(),
 	}
 	if isAdj && rf == bgp.RF_RTC_UC {
-		t.adjRts = newAdjRTSet()
+		t.adjRts = newRtmSet()
 	}
 	for _, dst := range dsts {
 		t.setDestination(dst)


### PR DESCRIPTION
Key changes:
 1. Move rtc registering logic to separate file
 2. A little name and comments refactoring
 3. Unit tests for rtc registering logic
 
 Part of #3368 