### PR TITLE
feat: rework RTC handling with RouteTargetMembershipHandler

### DIFF
--- a/internal/pkg/table/adj.go
+++ b/internal/pkg/table/adj.go
@@ -31,33 +31,13 @@ type AdjRib struct {
 func NewAdjRib(logger *slog.Logger, rfList []bgp.Family) *AdjRib {
 	m := make(map[bgp.Family]*Table)
 	for _, f := range rfList {
-		m[f] = NewAdjTable(logger, f)
+		m[f] = NewTable(logger, f)
 	}
 	return &AdjRib{
 		table:    m,
 		accepted: make(map[bgp.Family]int),
 		logger:   logger,
 	}
-}
-
-func (adj *AdjRib) HasRTinRtcTable(routeTarget bgp.ExtendedCommunityInterface) bool {
-	table, found := adj.table[bgp.RF_RTC_UC]
-	if !found || table.adjRts == nil {
-		return false
-	}
-	key, err := extCommRouteTargetKey(routeTarget)
-	if err != nil {
-		return false
-	}
-	return table.adjRts.has(key)
-}
-
-func (adj *AdjRib) HasDefaultRT() bool {
-	table, found := adj.table[bgp.RF_RTC_UC]
-	if !found || table.adjRts == nil {
-		return false
-	}
-	return table.adjRts.has(DefaultRT)
 }
 
 func (adj *AdjRib) Update(pathList []*Path) {
@@ -91,7 +71,6 @@ func (adj *AdjRib) Update(pathList []*Path) {
 				d.knownPathList = append(d.knownPathList[:idx], d.knownPathList[idx+1:]...)
 				if !old.IsRejected() {
 					adj.accepted[rf]--
-					t.adjRts.sub(old)
 				}
 			}
 			if len(d.knownPathList) == 0 {
@@ -102,10 +81,8 @@ func (adj *AdjRib) Update(pathList []*Path) {
 			if idx != -1 {
 				if old.IsRejected() && !path.IsRejected() {
 					adj.accepted[rf]++
-					t.adjRts.add(path)
 				} else if !old.IsRejected() && path.IsRejected() {
 					adj.accepted[rf]--
-					t.adjRts.sub(old)
 				}
 				if old.Equal(path) {
 					path.setTimestamp(old.GetTimestamp())
@@ -115,7 +92,6 @@ func (adj *AdjRib) Update(pathList []*Path) {
 				d.knownPathList = append(d.knownPathList, path)
 				if !path.IsRejected() {
 					adj.accepted[rf]++
-					t.adjRts.add(path)
 				}
 			}
 		}
@@ -143,9 +119,6 @@ func (adj *AdjRib) UpdateAdjRibOut(pathList []*Path) {
 		shard.mu.Lock()
 		d := t.getOrCreateDest(shard, nlri, 0)
 		d.knownPathList = append(d.knownPathList, path)
-		if !path.IsRejected() {
-			t.adjRts.add(path)
-		}
 		shard.mu.Unlock()
 	}
 }
@@ -234,7 +207,7 @@ func (adj *AdjRib) Drop(rfList []bgp.Family) []*Path {
 		return false
 	})
 	for _, rf := range rfList {
-		adj.table[rf] = NewAdjTable(adj.logger, rf)
+		adj.table[rf] = NewTable(adj.logger, rf)
 		adj.accepted[rf] = 0
 	}
 	return l
@@ -301,7 +274,7 @@ func (adj *AdjRib) MarkLLGRStaleOrDrop(rfList []bgp.Family) []*Path {
 func (adj *AdjRib) Select(family bgp.Family, accepted bool, option ...TableSelectOption) (*Table, error) {
 	t, ok := adj.table[family]
 	if !ok {
-		t = NewAdjTable(adj.logger, family)
+		t = NewTable(adj.logger, family)
 	}
 	option = append(option, TableSelectOption{adj: true})
 	return t.Select(option...)

--- a/internal/pkg/table/adj_test.go
+++ b/internal/pkg/table/adj_test.go
@@ -28,11 +28,11 @@ import (
 )
 
 func TestCreateAdjTable(t *testing.T) {
-	table := NewAdjTable(logger, bgp.RF_RTC_UC)
-	assert.NotNil(t, table.adjRts)
+	table := NewTable(logger, bgp.RF_RTC_UC)
+	assert.Equal(t, bgp.RF_RTC_UC, table.GetFamily())
 
-	table = NewAdjTable(logger, bgp.RF_FS_IPv4_VPN)
-	assert.Nil(t, table.adjRts)
+	table = NewTable(logger, bgp.RF_FS_IPv4_VPN)
+	assert.Equal(t, bgp.RF_FS_IPv4_VPN, table.GetFamily())
 }
 
 func TestAddPath(t *testing.T) {
@@ -185,96 +185,6 @@ func TestLLGRStale(t *testing.T) {
 	}
 	require.NotNil(t, retainedRejected)
 	assert.Contains(t, retainedRejected.GetCommunities(), uint32(bgp.COMMUNITY_LLGR_STALE))
-}
-
-func TestAdjRTC(t *testing.T) {
-	pi := &PeerInfo{}
-	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
-
-	rt1, _ := bgp.ParseRouteTarget("65520:1000000")
-	_, err := extCommRouteTargetKey(rt1)
-	assert.NoError(t, err)
-	nlri1 := bgp.NewRouteTargetMembershipNLRI(65000, rt1)
-	p1 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1}, false, attrs, time.Now(), false)
-	p1.remoteID = 1
-
-	rt2, _ := bgp.ParseRouteTarget("65520:1000001")
-	nlri2 := bgp.NewRouteTargetMembershipNLRI(65000, rt2)
-	p2 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri2}, false, attrs, time.Now(), false)
-	p2.remoteID = 2
-
-	nlri3 := bgp.NewRouteTargetMembershipNLRI(0, nil)
-	p3 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri3}, false, attrs, time.Now(), false)
-	p3.remoteID = 3
-
-	family := p1.GetFamily()
-	assert.Equal(t, family, bgp.RF_RTC_UC)
-	families := []bgp.Family{family}
-	adj := NewAdjRib(logger, families)
-
-	adj.Update([]*Path{p1, p2, p3})
-	assert.Equal(t, adj.Count([]bgp.Family{family}), 3)
-
-	assert.True(t, adj.HasDefaultRT())
-	assert.True(t, adj.HasRTinRtcTable(rt1))
-	assert.True(t, adj.HasRTinRtcTable(rt2))
-
-	adj.Update([]*Path{p1.Clone(true)})
-	assert.Equal(t, adj.Count([]bgp.Family{family}), 2)
-	assert.True(t, adj.HasDefaultRT())
-	assert.True(t, !adj.HasRTinRtcTable(rt1))
-	assert.True(t, adj.HasRTinRtcTable(rt2))
-
-	adj.Update([]*Path{p3.Clone(true)})
-	assert.Equal(t, adj.Count([]bgp.Family{family}), 1)
-	assert.False(t, adj.HasDefaultRT())
-	assert.True(t, adj.HasRTinRtcTable(rt2))
-
-	adj.Update([]*Path{p2.Clone(true)})
-	assert.Equal(t, adj.Count([]bgp.Family{family}), 0)
-	assert.True(t, !adj.HasRTinRtcTable(rt2))
-}
-
-func TestAdjRTCSameRT(t *testing.T) {
-	pi := &PeerInfo{}
-	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
-
-	rt1, _ := bgp.ParseRouteTarget("65520:1000000")
-	nlri1a := bgp.NewRouteTargetMembershipNLRI(65000, rt1)
-	nlri1b := bgp.NewRouteTargetMembershipNLRI(65001, rt1) // same RT, different AS
-
-	// Two ADD-PATH paths for the same (AS=65000, RT=rt1) NLRI, different path IDs.
-	p1 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1a, ID: 1}, false, attrs, time.Now(), false)
-	p2 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1a, ID: 2}, false, attrs, time.Now(), false)
-	// Different AS, same RT.
-	p3 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1b, ID: 1}, false, attrs, time.Now(), false)
-
-	family := bgp.RF_RTC_UC
-	adj := NewAdjRib(logger, []bgp.Family{family})
-
-	adj.Update([]*Path{p1, p2, p3})
-	assert.Equal(t, 3, adj.Count([]bgp.Family{family}))
-	assert.True(t, adj.HasRTinRtcTable(rt1))
-
-	// Withdraw p1 — p2 and p3 still hold rt1 interest.
-	adj.Update([]*Path{p1.Clone(true)})
-	assert.Equal(t, 2, adj.Count([]bgp.Family{family}))
-	assert.True(t, adj.HasRTinRtcTable(rt1), "peer still has rt1 via p2 and p3")
-
-	// Withdraw p3 — p2 still holds rt1 interest.
-	adj.Update([]*Path{p3.Clone(true)})
-	assert.Equal(t, 1, adj.Count([]bgp.Family{family}))
-	assert.True(t, adj.HasRTinRtcTable(rt1), "peer still has rt1 via p2")
-
-	// Spurious withdraw: same NLRI as p2 but unknown pathID — must be a no-op.
-	pSpurious := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1a, ID: 99}, true, attrs, time.Now(), false)
-	adj.Update([]*Path{pSpurious})
-	assert.True(t, adj.HasRTinRtcTable(rt1), "spurious withdraw must not remove rt1 interest")
-
-	// Withdraw p2 — no more rt1 interest.
-	adj.Update([]*Path{p2.Clone(true)})
-	assert.Equal(t, 0, adj.Count([]bgp.Family{family}))
-	assert.False(t, adj.HasRTinRtcTable(rt1))
 }
 
 func TestWithdrawUnknownPath(t *testing.T) {

--- a/internal/pkg/table/rtc.go
+++ b/internal/pkg/table/rtc.go
@@ -88,3 +88,65 @@ func (s *rtmSet) has(rtHash uint64) bool {
 	defer s.mu.RUnlock()
 	return len(s.m[rtHash]) > 0
 }
+
+func (s *rtmSet) reset() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m = make(map[uint64]map[rtmKey]struct{})
+}
+
+// RouteTargetMembershipHandler tracks Route Target membership NLRI keys learned from a
+// peer that count for RTC constrained route distribution, after import policy.
+type RouteTargetMembershipHandler struct {
+	s *rtmSet
+}
+
+func NewRouteTargetMembershipHandler() *RouteTargetMembershipHandler {
+	return &RouteTargetMembershipHandler{s: newRtmSet()}
+}
+
+// SyncAfterImport updates the set from the RTC path as seen after import policy:
+// accepted advertisements add membership; withdrawals (including import rejects
+// represented as withdrawals) remove it.
+func (handler *RouteTargetMembershipHandler) SyncAfterImport(path *Path) {
+	if handler == nil || handler.s == nil {
+		return
+	}
+	if path == nil || path.IsEOR() || path.GetFamily() != bgp.RF_RTC_UC {
+		return
+	}
+	if path.IsWithdraw {
+		handler.s.sub(path)
+	} else {
+		handler.s.add(path)
+	}
+}
+
+func (handler *RouteTargetMembershipHandler) HasRouteTarget(routeTarget bgp.ExtendedCommunityInterface) bool {
+	if handler == nil || handler.s == nil {
+		return false
+	}
+	key, err := extCommRouteTargetKey(routeTarget)
+	if err != nil {
+		return false
+	}
+	return handler.s.has(key)
+}
+
+func (handler *RouteTargetMembershipHandler) HasDefaultRouteTarget() bool {
+	if handler == nil || handler.s == nil {
+		return false
+	}
+	return handler.s.has(DefaultRT)
+}
+
+// Reset clears all tracked memberships (e.g. when Adj-RIB-In for RTC is dropped).
+func (handler *RouteTargetMembershipHandler) Reset() {
+	if handler == nil || handler.s == nil {
+		return
+	}
+	handler.s.reset()
+}

--- a/internal/pkg/table/rtc_test.go
+++ b/internal/pkg/table/rtc_test.go
@@ -123,3 +123,83 @@ func TestAdjRTSetConcurrent(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestRouteTargetMembershipHandlerDefaultAndRTs(t *testing.T) {
+	pi := &PeerInfo{}
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
+
+	rt1, _ := bgp.ParseRouteTarget("65520:1000000")
+	_, err := extCommRouteTargetKey(rt1)
+	assert.NoError(t, err)
+	nlri1 := bgp.NewRouteTargetMembershipNLRI(65000, rt1)
+	p1 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1}, false, attrs, time.Now(), false)
+	p1.remoteID = 1
+
+	rt2, _ := bgp.ParseRouteTarget("65520:1000001")
+	nlri2 := bgp.NewRouteTargetMembershipNLRI(65000, rt2)
+	p2 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri2}, false, attrs, time.Now(), false)
+	p2.remoteID = 2
+
+	nlri3 := bgp.NewRouteTargetMembershipNLRI(0, nil)
+	p3 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri3}, false, attrs, time.Now(), false)
+	p3.remoteID = 3
+
+	rtc := NewRouteTargetMembershipHandler()
+	rtc.SyncAfterImport(p1)
+	rtc.SyncAfterImport(p2)
+	rtc.SyncAfterImport(p3)
+
+	assert.True(t, rtc.HasDefaultRouteTarget())
+	assert.True(t, rtc.HasRouteTarget(rt1))
+	assert.True(t, rtc.HasRouteTarget(rt2))
+
+	rtc.SyncAfterImport(p1.Clone(true))
+	assert.True(t, rtc.HasDefaultRouteTarget())
+	assert.False(t, rtc.HasRouteTarget(rt1))
+	assert.True(t, rtc.HasRouteTarget(rt2))
+
+	rtc.SyncAfterImport(p3.Clone(true))
+	assert.False(t, rtc.HasDefaultRouteTarget())
+	assert.True(t, rtc.HasRouteTarget(rt2))
+
+	rtc.SyncAfterImport(p2.Clone(true))
+	assert.False(t, rtc.HasRouteTarget(rt2))
+}
+
+func TestRouteTargetMembershipHandlerSameRTAddPath(t *testing.T) {
+	pi := &PeerInfo{}
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
+
+	rt1, _ := bgp.ParseRouteTarget("65520:1000000")
+	nlri1a := bgp.NewRouteTargetMembershipNLRI(65000, rt1)
+	nlri1b := bgp.NewRouteTargetMembershipNLRI(65001, rt1) // same RT, different AS
+
+	// Two ADD-PATH paths for the same (AS=65000, RT=rt1) NLRI, different path IDs.
+	p1 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1a, ID: 1}, false, attrs, time.Now(), false)
+	p2 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1a, ID: 2}, false, attrs, time.Now(), false)
+	// Different AS, same RT.
+	p3 := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1b, ID: 1}, false, attrs, time.Now(), false)
+
+	rtc := NewRouteTargetMembershipHandler()
+	rtc.SyncAfterImport(p1)
+	rtc.SyncAfterImport(p2)
+	rtc.SyncAfterImport(p3)
+	assert.True(t, rtc.HasRouteTarget(rt1))
+
+	// Withdraw p1 — p2 and p3 still hold rt1 interest.
+	rtc.SyncAfterImport(p1.Clone(true))
+	assert.True(t, rtc.HasRouteTarget(rt1), "still has rt1 via p2 and p3")
+
+	// Withdraw p3 — p2 still holds rt1 interest.
+	rtc.SyncAfterImport(p3.Clone(true))
+	assert.True(t, rtc.HasRouteTarget(rt1), "still has rt1 via p2")
+
+	// Spurious withdraw: same NLRI as p2 but unknown pathID — must be a no-op.
+	pSpurious := NewPath(bgp.RF_RTC_UC, pi, bgp.PathNLRI{NLRI: nlri1a, ID: 99}, true, attrs, time.Now(), false)
+	rtc.SyncAfterImport(pSpurious)
+	assert.True(t, rtc.HasRouteTarget(rt1), "spurious withdraw must not remove rt1 interest")
+
+	// Withdraw p2 — no more rt1 interest.
+	rtc.SyncAfterImport(p2.Clone(true))
+	assert.False(t, rtc.HasRouteTarget(rt1))
+}

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -240,24 +240,18 @@ type Table struct {
 	Family       bgp.Family
 	destinations *Destinations
 	logger       *slog.Logger
-	// adjRts tracks RT membership keys in Adj-RIB tables with RF_RTC_UC.
-	// nil for non-RTC and global tables.
-	adjRts *rtmSet
 	// index of evpn prefixes with paths to a specific MAC in a MAC-VRF
 	// this is a map[rt, MAC address]map[addrPrefixKey][]nlri
 	// this holds a map for a set of prefixes.
 	macIndex *EVPNMacNLRIs
 }
 
-func newTablePartial(logger *slog.Logger, rf bgp.Family, isAdj bool, dsts ...*destination) *Table {
+func NewTable(logger *slog.Logger, rf bgp.Family, dsts ...*destination) *Table {
 	t := &Table{
 		Family:       rf,
 		destinations: NewDestinations(),
 		logger:       logger,
 		macIndex:     NewEVPNMacNLRIs(),
-	}
-	if isAdj && rf == bgp.RF_RTC_UC {
-		t.adjRts = newRtmSet()
 	}
 	for _, dst := range dsts {
 		t.setDestination(dst)
@@ -267,14 +261,6 @@ func newTablePartial(logger *slog.Logger, rf bgp.Family, isAdj bool, dsts ...*de
 
 func (t *Table) GetFamily() bgp.Family {
 	return t.Family
-}
-
-func NewTable(logger *slog.Logger, rf bgp.Family, dsts ...*destination) *Table {
-	return newTablePartial(logger, rf, false, dsts...)
-}
-
-func NewAdjTable(logger *slog.Logger, rf bgp.Family, dsts ...*destination) *Table {
-	return newTablePartial(logger, rf, true, dsts...)
 }
 
 func (t *Table) deletePathsByVrf(vrf *Vrf) []*Path {

--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -109,6 +109,8 @@ type peer struct {
 	sendMaxPathFiltered map[table.PathLocalKey]struct{}
 	llgrEndChs          []chan struct{} // protected by fsm.lock
 	longLivedRunning    atomic.Bool
+	// Route Target Membership handler after import policy (for constrained VPN distribution).
+	rtmHandler *table.RouteTargetMembershipHandler
 }
 
 func newPeer(g *oc.Global, conf *oc.Neighbor, state bgp.FSMState, loc *table.TableManager, policy *table.RoutingPolicy, logger *slog.Logger) *peer {
@@ -127,6 +129,7 @@ func newPeer(g *oc.Global, conf *oc.Neighbor, state bgp.FSMState, loc *table.Tab
 	}
 	rfs, _ := oc.AfiSafis(conf.AfiSafis).ToRfList()
 	peer.adjRibIn = table.NewAdjRib(logger, rfs)
+	peer.rtmHandler = table.NewRouteTargetMembershipHandler()
 	return peer
 }
 
@@ -472,11 +475,11 @@ func (peer *peer) stopPeerRestarting() {
 // Returns true if the peer is interested in this path according to BGP RTC
 // (i.e., has advertised the relevant RT).
 func (peer *peer) interestedIn(path *table.Path) bool {
-	if peer.adjRibIn.HasDefaultRT() {
+	if peer.rtmHandler.HasDefaultRouteTarget() {
 		return true
 	}
 	for _, ext := range path.GetExtCommunities() {
-		if peer.adjRibIn.HasRTinRtcTable(ext) {
+		if peer.rtmHandler.HasRouteTarget(ext) {
 			return true
 		}
 	}
@@ -694,5 +697,11 @@ func (peer *peer) PassConn(conn net.Conn) {
 }
 
 func (peer *peer) DropAll(rfList []bgp.Family) []*table.Path {
+	for _, rf := range rfList {
+		if rf == bgp.RF_RTC_UC {
+			peer.rtmHandler.Reset()
+			break
+		}
+	}
 	return peer.adjRibIn.Drop(rfList)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1163,6 +1163,7 @@ func (s *BgpServer) propagateUpdate(peer *peer, pathList []*table.Path) {
 			// between the previous and current state of the route distribution
 			// graph that is derived from Route Target membership information.
 			if peer != nil && path != nil && path.GetFamily() == bgp.RF_RTC_UC {
+				peer.rtmHandler.SyncAfterImport(path)
 				rt := path.GetNlri().(*bgp.RouteTargetMembershipNLRI).RouteTarget
 				fs := make([]bgp.Family, 0, len(peer.negotiatedRFList()))
 				for _, f := range peer.negotiatedRFList() {
@@ -1173,7 +1174,7 @@ func (s *BgpServer) propagateUpdate(peer *peer, pathList []*table.Path) {
 				var candidates []*table.Path
 				if path.IsWithdraw {
 					// Note: The paths to be withdrawn are filtered because the
-					// given RT on RTM NLRI is already removed from adj-RIB-in.
+					// given RT on RTM NLRI is already removed from the peer RTC index.
 					_, candidates = s.getBestFromLocal(peer, fs, true)
 				} else {
 					// https://github.com/osrg/gobgp/issues/1777

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -3862,3 +3862,187 @@ func TestStartBgp_RouterIdValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestRTCImplicitWithdrawForAcceptedPathWillWithdrawVPNPaths(t *testing.T) {
+	ctx := context.Background()
+
+	s1 := runNewServer(t, 1, "1.1.1.1", 22179)
+	defer s1.StopBgp(context.Background(), &api.StopBgpRequest{})
+	s2 := runNewServer(t, 1, "2.2.2.2", 33179)
+	defer s2.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	wgEstablished := newPeerStateWaiter(s1, api.PeerState_SESSION_STATE_ESTABLISHED)
+	if err := peerServers(t, ctx, []*BgpServer{s1, s2}, []oc.AfiSafiType{oc.AFI_SAFI_TYPE_L3VPN_IPV4_UNICAST, oc.AFI_SAFI_TYPE_RTC}); err != nil {
+		t.Fatal(err)
+	}
+	wgEstablished.Wait(t, 10*time.Second)
+	// Add import policy on s1: reject RTC routes with AS_PATH length >= 1.
+	stmt := &api.Statement{
+		Name: "reject_as_path",
+		Conditions: &api.Conditions{
+			AfiSafiIn: []*api.Family{
+				{Afi: api.Family_AFI_IP, Safi: api.Family_SAFI_ROUTE_TARGET_CONSTRAINTS},
+			},
+			AsPathLength: &api.AsPathLength{
+				Type:   api.Comparison_COMPARISON_GE,
+				Length: 1,
+			},
+		},
+		Actions: &api.Actions{RouteAction: api.RouteAction_ROUTE_ACTION_REJECT},
+	}
+	policy := &api.Policy{Name: "import_policy", Statements: []*api.Statement{stmt}}
+	require.NoError(t, s1.AddPolicy(ctx, &api.AddPolicyRequest{Policy: policy}))
+	require.NoError(t, s1.AddPolicyAssignment(ctx, &api.AddPolicyAssignmentRequest{
+		Assignment: &api.PolicyAssignment{
+			Name:          table.GLOBAL_RIB_NAME,
+			Direction:     api.PolicyDirection_POLICY_DIRECTION_IMPORT,
+			Policies:      []*api.Policy{policy},
+			DefaultAction: api.RouteAction_ROUTE_ACTION_ACCEPT,
+		},
+	}))
+
+	expectVpnRouteCountS2AdjIn := func(expected int) bool {
+		count := 0
+		_ = s2.ListPath(apiutil.ListPathRequest{
+			TableType: api.TableType_TABLE_TYPE_ADJ_IN,
+			Family:    bgp.RF_IPv4_VPN,
+			Name:      "127.0.0.1",
+		}, func(_ bgp.NLRI, _ []*apiutil.Path) { count++ })
+		return count == expected
+	}
+
+	rt100 := bgp.NewTwoOctetAsSpecificExtended(bgp.EC_SUBTYPE_ROUTE_TARGET, 100, 100, true)
+	panh, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("3.3.3.3"))
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		panh,
+		bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rt100}),
+	}
+	rd, _ := bgp.ParseRouteDistinguisher("100:100")
+	labels := bgp.NewMPLSLabelStack(100, 200)
+	prefix, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("10.30.2.0/24"), *labels, rd)
+	path, _ := apiutil.NewPath(bgp.RF_IPv4_VPN, prefix, false, attrs, time.Now())
+	if _, err := s1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(path)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// pathRtc1 — no AS_PATH, passes import policy on s1.
+	panh1, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("1.1.1.1"))
+	attrsRtc1 := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		panh1,
+	}
+	pathRtc1, _ := apiutil.NewPath(bgp.RF_RTC_UC, bgp.NewRouteTargetMembershipNLRI(1, rt100), false, attrsRtc1, time.Now())
+	if _, err := s2.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc1)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	require.Eventually(t, func() bool {
+		return expectVpnRouteCountS2AdjIn(1)
+	}, 10*time.Second, 100*time.Millisecond, "timeout waiting for VPN path at s2 adj-in from s1")
+
+	// pathRtc2 — has AS_PATH length 1, rejected by import policy on s1.
+	// This implicitly withdraws pathRtc1 for the same (AS=1, RT=100:100) NLRI.
+	attrsRtc2 := append(attrsRtc1, bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{
+		bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint16{2}),
+	}))
+	pathRtc2, _ := apiutil.NewPath(bgp.RF_RTC_UC, bgp.NewRouteTargetMembershipNLRI(1, rt100), false, attrsRtc2, time.Now())
+	if _, err := s2.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc2)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	require.Eventually(t, func() bool {
+		return expectVpnRouteCountS2AdjIn(0)
+	}, 10*time.Second, 100*time.Millisecond, "timeout waiting for VPN path to withdraw at s2 adj-in from s1")
+}
+
+func TestRTCShouldNotAdvertiseVPNRouteWhenRTCIsNotPassImportPolicies(t *testing.T) {
+	ctx := context.Background()
+
+	s1 := runNewServer(t, 1, "1.1.1.1", 44179)
+	defer s1.StopBgp(context.Background(), &api.StopBgpRequest{})
+	s2 := runNewServer(t, 1, "2.2.2.2", 55179)
+	defer s2.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	wgEstablished := newPeerStateWaiter(s1, api.PeerState_SESSION_STATE_ESTABLISHED)
+	if err := peerServers(t, ctx, []*BgpServer{s1, s2}, []oc.AfiSafiType{oc.AFI_SAFI_TYPE_L3VPN_IPV4_UNICAST, oc.AFI_SAFI_TYPE_RTC}); err != nil {
+		t.Fatal(err)
+	}
+	wgEstablished.Wait(t, 10*time.Second)
+	// Add import policy on s1: reject RTC routes with AS_PATH length >= 1.
+	stmt := &api.Statement{
+		Name: "reject_as_path",
+		Conditions: &api.Conditions{
+			AfiSafiIn: []*api.Family{
+				{Afi: api.Family_AFI_IP, Safi: api.Family_SAFI_ROUTE_TARGET_CONSTRAINTS},
+			},
+			AsPathLength: &api.AsPathLength{
+				Type:   api.Comparison_COMPARISON_GE,
+				Length: 1,
+			},
+		},
+		Actions: &api.Actions{RouteAction: api.RouteAction_ROUTE_ACTION_REJECT},
+	}
+	policy := &api.Policy{Name: "import_policy", Statements: []*api.Statement{stmt}}
+	require.NoError(t, s1.AddPolicy(ctx, &api.AddPolicyRequest{Policy: policy}))
+	require.NoError(t, s1.AddPolicyAssignment(ctx, &api.AddPolicyAssignmentRequest{
+		Assignment: &api.PolicyAssignment{
+			Name:          table.GLOBAL_RIB_NAME,
+			Direction:     api.PolicyDirection_POLICY_DIRECTION_IMPORT,
+			Policies:      []*api.Policy{policy},
+			DefaultAction: api.RouteAction_ROUTE_ACTION_ACCEPT,
+		},
+	}))
+
+	vpnPresentAtS2AdjIn := func() bool {
+		count := 0
+		_ = s2.ListPath(apiutil.ListPathRequest{
+			TableType: api.TableType_TABLE_TYPE_ADJ_IN,
+			Family:    bgp.RF_IPv4_VPN,
+			Name:      "127.0.0.1",
+		}, func(_ bgp.NLRI, _ []*apiutil.Path) { count++ })
+		return count > 0
+	}
+
+	rt100 := bgp.NewTwoOctetAsSpecificExtended(bgp.EC_SUBTYPE_ROUTE_TARGET, 100, 100, true)
+	panh, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("3.3.3.3"))
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		panh,
+		bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rt100}),
+	}
+	rd, _ := bgp.ParseRouteDistinguisher("100:100")
+	labels := bgp.NewMPLSLabelStack(100, 200)
+	prefix1, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("10.30.2.0/24"), *labels, rd)
+	prefix2, _ := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix("10.30.3.0/24"), *labels, rd)
+	path1, _ := apiutil.NewPath(bgp.RF_IPv4_VPN, prefix1, false, attrs, time.Now())
+	path2, _ := apiutil.NewPath(bgp.RF_IPv4_VPN, prefix2, false, attrs, time.Now())
+
+	panh2, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("1.1.1.1"))
+	attrsRtc := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		panh2,
+		bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{
+			bgp.NewAsPathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint16{2}),
+		}),
+	}
+
+	if _, err := s1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(path1)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	pathRtc, _ := apiutil.NewPath(bgp.RF_RTC_UC, bgp.NewRouteTargetMembershipNLRI(1, rt100), false, attrsRtc, time.Now())
+	if _, err := s2.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(pathRtc)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	require.Never(t, vpnPresentAtS2AdjIn, 10*time.Second, 100*time.Millisecond,
+		"VPN route should not appear at s2 adj-in from s1 while RTC fails import policy")
+
+	if _, err := s1.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(path2)}}); err != nil {
+		t.Fatal(err)
+	}
+
+	require.Never(t, vpnPresentAtS2AdjIn, 10*time.Second, 100*time.Millisecond,
+		"VPN route should not appear at s2 adj-in from s1 after second VPN prefix is added")
+}


### PR DESCRIPTION
Key changes:
 1. Replace rtm handling logic from adj-in to peer
 2. Add support for registering rtm with policy support
 3. Add unit tests for policy support
 
Part of #3368 