### PR TITLE
feat: (table/server) add VPN path RT index for O(1) RTC candidate lookup

### DIFF
--- a/internal/pkg/table/rtc.go
+++ b/internal/pkg/table/rtc.go
@@ -98,6 +98,109 @@ func (s *rtmSet) reset() {
 	s.m = make(map[uint64]map[rtmKey]struct{})
 }
 
+// vpnPathKey identifies a VPN path without relying on *Path pointer identity.
+// info points to the root originInfo shared by a path and all its clones, so
+// Register/Unregister match even when the path was cloned in the pipeline.
+type vpnPathKey struct {
+	info   *originInfo
+	pathID uint32
+}
+
+func makeVPNPathKey(path *Path) vpnPathKey {
+	return vpnPathKey{info: path.OriginInfo(), pathID: path.remoteID}
+}
+
+// vpnRTEntry holds the set of paths indexed under a single RT hash.
+type vpnRTEntry struct {
+	paths map[vpnPathKey]*Path
+}
+
+func newVPNRTEntry() *vpnRTEntry {
+	return &vpnRTEntry{paths: make(map[vpnPathKey]*Path)}
+}
+
+// VPNPathIndex is a standalone thread-safe index of VPN (and similar) paths by Route Target.
+// It lives inside each VPN-family Table and is maintained as paths enter or leave the table,
+// enabling O(1) RT-based candidate lookup during RTC processing instead of a linear scan.
+//
+// Thread-safe: all operations are protected by an internal RWMutex.
+type VPNPathIndex struct {
+	mu  sync.RWMutex
+	rts map[uint64]*vpnRTEntry // rtHash → entry
+}
+
+func NewVPNPathIndex() *VPNPathIndex {
+	return &VPNPathIndex{rts: make(map[uint64]*vpnRTEntry)}
+}
+
+// RegisterPath indexes path under each of its RT extended communities.
+// No-op for nil, EOR, or withdraw paths and for paths with no RT ext comms.
+func (idx *VPNPathIndex) RegisterPath(path *Path) {
+	if idx == nil || path == nil || path.IsEOR() || path.IsWithdraw {
+		return
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	for _, ext := range path.GetExtCommunities() {
+		rtHash, err := extCommRouteTargetKey(ext)
+		if err != nil {
+			continue
+		}
+		entry, ok := idx.rts[rtHash]
+		if !ok {
+			entry = newVPNRTEntry()
+			idx.rts[rtHash] = entry
+		}
+		entry.paths[makeVPNPathKey(path)] = path
+	}
+}
+
+// UnregisterPath removes path from the index. Spurious removes are no-ops.
+func (idx *VPNPathIndex) UnregisterPath(path *Path) {
+	if idx == nil || path == nil || path.IsEOR() {
+		return
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	for _, ext := range path.GetExtCommunities() {
+		rtHash, err := extCommRouteTargetKey(ext)
+		if err != nil {
+			continue
+		}
+		entry, ok := idx.rts[rtHash]
+		if !ok {
+			continue
+		}
+		delete(entry.paths, makeVPNPathKey(path))
+		if len(entry.paths) == 0 {
+			delete(idx.rts, rtHash)
+		}
+	}
+}
+
+// GetPathsByRT returns all indexed paths whose extended communities include rt.
+// If rt is nil (wildcard), returns nil.
+func (idx *VPNPathIndex) GetPathsByRT(rt bgp.ExtendedCommunityInterface) []*Path {
+	if idx == nil || rt == nil {
+		return nil
+	}
+	rtHash, err := extCommRouteTargetKey(rt)
+	if err != nil {
+		return nil
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	entry, ok := idx.rts[rtHash]
+	if !ok {
+		return nil
+	}
+	paths := make([]*Path, 0, len(entry.paths))
+	for _, p := range entry.paths {
+		paths = append(paths, p)
+	}
+	return paths
+}
+
 // RouteTargetMembershipHandler tracks Route Target membership NLRI keys learned from a
 // peer that count for RTC constrained route distribution, after import policy.
 type RouteTargetMembershipHandler struct {

--- a/internal/pkg/table/rtc.go
+++ b/internal/pkg/table/rtc.go
@@ -98,6 +98,97 @@ func (s *rtmSet) reset() {
 	s.m = make(map[uint64]map[rtmKey]struct{})
 }
 
+// vpnRTEntry holds the set of paths indexed under a single RT hash.
+type vpnRTEntry struct {
+	paths map[*Path]struct{}
+}
+
+func newVPNRTEntry() *vpnRTEntry {
+	return &vpnRTEntry{paths: make(map[*Path]struct{})}
+}
+
+// VPNPathIndex is a standalone thread-safe index of VPN (and similar) paths by Route Target.
+// It lives inside each VPN-family Table and is maintained as paths enter or leave the table,
+// enabling O(1) RT-based candidate lookup during RTC processing instead of a linear scan.
+//
+// Thread-safe: all operations are protected by an internal RWMutex.
+type VPNPathIndex struct {
+	mu  sync.RWMutex
+	rts map[uint64]*vpnRTEntry // rtHash → entry
+}
+
+func NewVPNPathIndex() *VPNPathIndex {
+	return &VPNPathIndex{rts: make(map[uint64]*vpnRTEntry)}
+}
+
+// RegisterPath indexes path under each of its RT extended communities.
+// No-op for nil, EOR, or withdraw paths and for paths with no RT ext comms.
+func (idx *VPNPathIndex) RegisterPath(path *Path) {
+	if idx == nil || path == nil || path.IsEOR() || path.IsWithdraw {
+		return
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	for _, ext := range path.GetExtCommunities() {
+		rtHash, err := extCommRouteTargetKey(ext)
+		if err != nil {
+			continue
+		}
+		entry, ok := idx.rts[rtHash]
+		if !ok {
+			entry = newVPNRTEntry()
+			idx.rts[rtHash] = entry
+		}
+		entry.paths[path] = struct{}{}
+	}
+}
+
+// UnregisterPath removes path from the index. Spurious removes are no-ops.
+func (idx *VPNPathIndex) UnregisterPath(path *Path) {
+	if idx == nil || path == nil || path.IsEOR() {
+		return
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	for _, ext := range path.GetExtCommunities() {
+		rtHash, err := extCommRouteTargetKey(ext)
+		if err != nil {
+			continue
+		}
+		entry, ok := idx.rts[rtHash]
+		if !ok {
+			continue
+		}
+		delete(entry.paths, path)
+		if len(entry.paths) == 0 {
+			delete(idx.rts, rtHash)
+		}
+	}
+}
+
+// GetPathsByRT returns all indexed paths whose extended communities include rt.
+// If rt is nil (wildcard), returns nil.
+func (idx *VPNPathIndex) GetPathsByRT(rt bgp.ExtendedCommunityInterface) []*Path {
+	if idx == nil || rt == nil {
+		return nil
+	}
+	rtHash, err := extCommRouteTargetKey(rt)
+	if err != nil {
+		return nil
+	}
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	entry, ok := idx.rts[rtHash]
+	if !ok {
+		return nil
+	}
+	paths := make([]*Path, 0, len(entry.paths))
+	for p := range entry.paths {
+		paths = append(paths, p)
+	}
+	return paths
+}
+
 // RouteTargetMembershipHandler tracks Route Target membership NLRI keys learned from a
 // peer that count for RTC constrained route distribution, after import policy.
 type RouteTargetMembershipHandler struct {

--- a/internal/pkg/table/rtc_test.go
+++ b/internal/pkg/table/rtc_test.go
@@ -1,6 +1,8 @@
 package table
 
 import (
+	"net/netip"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -10,7 +12,7 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
 
-func TestAdjRTSetAddSubHas(t *testing.T) {
+func TestRTMSetAddSubHas(t *testing.T) {
 	pi := &PeerInfo{}
 	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
 
@@ -79,7 +81,7 @@ func TestAdjRTSetAddSubHas(t *testing.T) {
 	assert.False(t, s.has(rtHash))
 }
 
-func TestAdjRTSetConcurrent(t *testing.T) {
+func TestRTMSetConcurrent(t *testing.T) {
 	pi := &PeerInfo{}
 	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
 
@@ -202,4 +204,173 @@ func TestRouteTargetMembershipHandlerSameRTAddPath(t *testing.T) {
 	// Withdraw p2 — no more rt1 interest.
 	rtc.SyncAfterImport(p2.Clone(true))
 	assert.False(t, rtc.HasRouteTarget(rt1))
+}
+
+func makeVPNNLRI(t *testing.T, prefix string, rdAS, rdVal uint16) bgp.PathNLRI {
+	t.Helper()
+	rd := bgp.NewRouteDistinguisherTwoOctetAS(rdAS, uint32(rdVal))
+	nlri, err := bgp.NewLabeledVPNIPAddrPrefix(
+		netip.MustParsePrefix(prefix),
+		*bgp.NewMPLSLabelStack(100),
+		rd,
+	)
+	if err != nil {
+		t.Fatalf("NewLabeledVPNIPAddrPrefix: %v", err)
+	}
+	return bgp.PathNLRI{NLRI: nlri}
+}
+
+func makeVPNPath(t *testing.T, pi *PeerInfo, rts []bgp.ExtendedCommunityInterface, prefix string) *Path {
+	t.Helper()
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		bgp.NewPathAttributeExtendedCommunities(rts),
+	}
+	return NewPath(bgp.RF_IPv4_VPN, pi, makeVPNNLRI(t, prefix, 65000, 1), false, attrs, time.Now(), false)
+}
+
+func TestVPNPathIndexRegisterUnregister(t *testing.T) {
+	pi := &PeerInfo{}
+	rt1, _ := bgp.ParseRouteTarget("65000:1")
+	rt2, _ := bgp.ParseRouteTarget("65000:2")
+
+	p1 := makeVPNPath(t, pi, []bgp.ExtendedCommunityInterface{rt1}, "10.1.0.0/24")
+	p2 := makeVPNPath(t, pi, []bgp.ExtendedCommunityInterface{rt2}, "10.2.0.0/24")
+
+	idx := NewVPNPathIndex()
+
+	// Empty index returns nothing.
+	assert.Empty(t, idx.GetPathsByRT(rt1))
+	assert.Empty(t, idx.GetPathsByRT(nil))
+
+	// Register p1 under rt1.
+	idx.RegisterPath(p1)
+	assert.Equal(t, []*Path{p1}, idx.GetPathsByRT(rt1))
+	assert.Empty(t, idx.GetPathsByRT(rt2))
+
+	// Register p2 under rt2.
+	idx.RegisterPath(p2)
+	assert.Equal(t, []*Path{p2}, idx.GetPathsByRT(rt2))
+
+	// Nil rt is not a wildcard here: RTC wildcard handling uses a full RIB scan
+	// (see TableManager.GetPathsByRT, rtcVPNCandidates), not the per-table index.
+	assert.Nil(t, idx.GetPathsByRT(nil))
+
+	// Unregister p1; rt1 bucket should disappear.
+	idx.UnregisterPath(p1)
+	assert.Empty(t, idx.GetPathsByRT(rt1))
+	assert.Equal(t, []*Path{p2}, idx.GetPathsByRT(rt2))
+
+	// Spurious unregister is a no-op.
+	idx.UnregisterPath(p1)
+	assert.Equal(t, []*Path{p2}, idx.GetPathsByRT(rt2))
+
+	// Withdraw-flagged path is ignored by RegisterPath.
+	idx.RegisterPath(p1.Clone(true))
+	assert.Empty(t, idx.GetPathsByRT(rt1))
+}
+
+func TestVPNPathIndexMultipleRTsPerPath(t *testing.T) {
+	pi := &PeerInfo{}
+	rt1, _ := bgp.ParseRouteTarget("65000:1")
+	rt2, _ := bgp.ParseRouteTarget("65000:2")
+
+	// Single path carrying both RTs.
+	p := makeVPNPath(t, pi, []bgp.ExtendedCommunityInterface{rt1, rt2}, "10.3.0.0/24")
+
+	idx := NewVPNPathIndex()
+	idx.RegisterPath(p)
+
+	assert.Equal(t, []*Path{p}, idx.GetPathsByRT(rt1))
+	assert.Equal(t, []*Path{p}, idx.GetPathsByRT(rt2))
+
+	// Unregistering removes p from both RT buckets.
+	idx.UnregisterPath(p)
+	assert.Empty(t, idx.GetPathsByRT(rt1))
+	assert.Empty(t, idx.GetPathsByRT(rt2))
+}
+
+func TestVPNPathIndexNilInputs(t *testing.T) {
+	var nilIdx *VPNPathIndex
+	// All methods must be no-ops on a nil receiver.
+	nilIdx.RegisterPath(nil)
+	nilIdx.UnregisterPath(nil)
+	assert.Nil(t, nilIdx.GetPathsByRT(nil))
+
+	// Non-nil index, nil / withdraw paths must not be indexed.
+	idx := NewVPNPathIndex()
+	idx.RegisterPath(nil)
+
+	pi := &PeerInfo{}
+	rt1, _ := bgp.ParseRouteTarget("65000:1")
+	withdraw := makeVPNPath(t, pi, []bgp.ExtendedCommunityInterface{rt1}, "10.4.0.0/24").Clone(true)
+	idx.RegisterPath(withdraw)
+	assert.Empty(t, idx.GetPathsByRT(nil))
+}
+
+// TestVPNPathIndexCloneUnregister verifies that unregistering a clone of a registered
+// path correctly removes it. With pointer-based keys this would be a silent no-op,
+// leaving a dangling entry. With vpnPathKey it must succeed.
+func TestVPNPathIndexCloneUnregister(t *testing.T) {
+	pi := &PeerInfo{}
+	rt1, _ := bgp.ParseRouteTarget("65000:1")
+
+	original := makeVPNPath(t, pi, []bgp.ExtendedCommunityInterface{rt1}, "10.5.0.0/24")
+
+	idx := NewVPNPathIndex()
+	idx.RegisterPath(original)
+	assert.Len(t, idx.GetPathsByRT(rt1), 1)
+
+	// Clone(false) produces a new *Path with the same NLRI and pathID but a different address.
+	clone := original.Clone(false)
+	assert.NotSame(t, original, clone, "clone must be a distinct pointer")
+
+	idx.UnregisterPath(clone)
+	assert.Empty(t, idx.GetPathsByRT(rt1), "unregistering a clone must remove the original entry")
+}
+
+func TestVPNPathIndexConcurrent(t *testing.T) {
+	pi := &PeerInfo{}
+	rt1, _ := bgp.ParseRouteTarget("65000:1")
+	rt2, _ := bgp.ParseRouteTarget("65000:2")
+
+	idx := NewVPNPathIndex()
+
+	const goroutines = 20
+	const iters = 200
+
+	var wg sync.WaitGroup
+
+	// Concurrent writers: each goroutine registers then unregisters its own paths.
+	for i := range goroutines {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Unique prefixes per goroutine to avoid pointer aliasing between goroutines.
+			p1 := makeVPNPath(t, pi, []bgp.ExtendedCommunityInterface{rt1},
+				"10."+strconv.Itoa(i)+".1.0/24")
+			p2 := makeVPNPath(t, pi, []bgp.ExtendedCommunityInterface{rt2},
+				"10."+strconv.Itoa(i)+".2.0/24")
+			for range iters {
+				idx.RegisterPath(p1)
+				idx.RegisterPath(p2)
+				idx.UnregisterPath(p1)
+				idx.UnregisterPath(p2)
+			}
+		}(i)
+	}
+
+	// Concurrent readers running throughout the writes.
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iters {
+				_ = idx.GetPathsByRT(rt1)
+				_ = idx.GetPathsByRT(nil)
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/internal/pkg/table/rtc_test.go
+++ b/internal/pkg/table/rtc_test.go
@@ -1,6 +1,8 @@
 package table
 
 import (
+	"net/netip"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -10,7 +12,7 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
 
-func TestAdjRTSetAddSubHas(t *testing.T) {
+func TestRTMSetAddSubHas(t *testing.T) {
 	pi := &PeerInfo{}
 	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
 
@@ -79,7 +81,7 @@ func TestAdjRTSetAddSubHas(t *testing.T) {
 	assert.False(t, s.has(rtHash))
 }
 
-func TestAdjRTSetConcurrent(t *testing.T) {
+func TestRTMSetConcurrent(t *testing.T) {
 	pi := &PeerInfo{}
 	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
 
@@ -202,4 +204,152 @@ func TestRouteTargetMembershipHandlerSameRTAddPath(t *testing.T) {
 	// Withdraw p2 — no more rt1 interest.
 	rtc.SyncAfterImport(p2.Clone(true))
 	assert.False(t, rtc.HasRouteTarget(rt1))
+}
+
+func makeVPNNLRI(t *testing.T, prefix string, rdAS, rdVal uint16) bgp.PathNLRI {
+	t.Helper()
+	rd := bgp.NewRouteDistinguisherTwoOctetAS(rdAS, uint32(rdVal))
+	nlri, err := bgp.NewLabeledVPNIPAddrPrefix(
+		netip.MustParsePrefix(prefix),
+		*bgp.NewMPLSLabelStack(100),
+		rd,
+	)
+	if err != nil {
+		t.Fatalf("NewLabeledVPNIPAddrPrefix: %v", err)
+	}
+	return bgp.PathNLRI{NLRI: nlri}
+}
+
+func makeVPNPath(t *testing.T, pi *PeerInfo, rts []bgp.ExtendedCommunityInterface, prefix string) *Path {
+	t.Helper()
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		bgp.NewPathAttributeExtendedCommunities(rts),
+	}
+	return NewPath(bgp.RF_IPv4_VPN, pi, makeVPNNLRI(t, prefix, 65000, 1), false, attrs, time.Now(), false)
+}
+
+func TestVPNPathIndexRegisterUnregister(t *testing.T) {
+	pi := &PeerInfo{}
+	rt1, _ := bgp.ParseRouteTarget("65000:1")
+	rt2, _ := bgp.ParseRouteTarget("65000:2")
+
+	p1 := makeVPNPath(t, pi, []bgp.ExtendedCommunityInterface{rt1}, "10.1.0.0/24")
+	p2 := makeVPNPath(t, pi, []bgp.ExtendedCommunityInterface{rt2}, "10.2.0.0/24")
+
+	idx := NewVPNPathIndex()
+
+	// Empty index returns nothing.
+	assert.Empty(t, idx.GetPathsByRT(rt1))
+	assert.Empty(t, idx.GetPathsByRT(nil))
+
+	// Register p1 under rt1.
+	idx.RegisterPath(p1)
+	assert.Equal(t, []*Path{p1}, idx.GetPathsByRT(rt1))
+	assert.Empty(t, idx.GetPathsByRT(rt2))
+
+	// Register p2 under rt2.
+	idx.RegisterPath(p2)
+	assert.Equal(t, []*Path{p2}, idx.GetPathsByRT(rt2))
+
+	// Nil rt is not a wildcard here: RTC wildcard handling uses a full RIB scan
+	// (see TableManager.GetPathsByRT, rtcVPNCandidates), not the per-table index.
+	assert.Nil(t, idx.GetPathsByRT(nil))
+
+	// Unregister p1; rt1 bucket should disappear.
+	idx.UnregisterPath(p1)
+	assert.Empty(t, idx.GetPathsByRT(rt1))
+	assert.Equal(t, []*Path{p2}, idx.GetPathsByRT(rt2))
+
+	// Spurious unregister is a no-op.
+	idx.UnregisterPath(p1)
+	assert.Equal(t, []*Path{p2}, idx.GetPathsByRT(rt2))
+
+	// Withdraw-flagged path is ignored by RegisterPath.
+	idx.RegisterPath(p1.Clone(true))
+	assert.Empty(t, idx.GetPathsByRT(rt1))
+}
+
+func TestVPNPathIndexMultipleRTsPerPath(t *testing.T) {
+	pi := &PeerInfo{}
+	rt1, _ := bgp.ParseRouteTarget("65000:1")
+	rt2, _ := bgp.ParseRouteTarget("65000:2")
+
+	// Single path carrying both RTs.
+	p := makeVPNPath(t, pi, []bgp.ExtendedCommunityInterface{rt1, rt2}, "10.3.0.0/24")
+
+	idx := NewVPNPathIndex()
+	idx.RegisterPath(p)
+
+	assert.Equal(t, []*Path{p}, idx.GetPathsByRT(rt1))
+	assert.Equal(t, []*Path{p}, idx.GetPathsByRT(rt2))
+
+	// Unregistering removes p from both RT buckets.
+	idx.UnregisterPath(p)
+	assert.Empty(t, idx.GetPathsByRT(rt1))
+	assert.Empty(t, idx.GetPathsByRT(rt2))
+}
+
+func TestVPNPathIndexNilInputs(t *testing.T) {
+	var nilIdx *VPNPathIndex
+	// All methods must be no-ops on a nil receiver.
+	nilIdx.RegisterPath(nil)
+	nilIdx.UnregisterPath(nil)
+	assert.Nil(t, nilIdx.GetPathsByRT(nil))
+
+	// Non-nil index, nil / withdraw paths must not be indexed.
+	idx := NewVPNPathIndex()
+	idx.RegisterPath(nil)
+
+	pi := &PeerInfo{}
+	rt1, _ := bgp.ParseRouteTarget("65000:1")
+	withdraw := makeVPNPath(t, pi, []bgp.ExtendedCommunityInterface{rt1}, "10.4.0.0/24").Clone(true)
+	idx.RegisterPath(withdraw)
+	assert.Empty(t, idx.GetPathsByRT(nil))
+}
+
+func TestVPNPathIndexConcurrent(t *testing.T) {
+	pi := &PeerInfo{}
+	rt1, _ := bgp.ParseRouteTarget("65000:1")
+	rt2, _ := bgp.ParseRouteTarget("65000:2")
+
+	idx := NewVPNPathIndex()
+
+	const goroutines = 20
+	const iters = 200
+
+	var wg sync.WaitGroup
+
+	// Concurrent writers: each goroutine registers then unregisters its own paths.
+	for i := range goroutines {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Unique prefixes per goroutine to avoid pointer aliasing between goroutines.
+			p1 := makeVPNPath(t, pi, []bgp.ExtendedCommunityInterface{rt1},
+				"10."+strconv.Itoa(i)+".1.0/24")
+			p2 := makeVPNPath(t, pi, []bgp.ExtendedCommunityInterface{rt2},
+				"10."+strconv.Itoa(i)+".2.0/24")
+			for range iters {
+				idx.RegisterPath(p1)
+				idx.RegisterPath(p2)
+				idx.UnregisterPath(p1)
+				idx.UnregisterPath(p2)
+			}
+		}(i)
+	}
+
+	// Concurrent readers running throughout the writes.
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iters {
+				_ = idx.GetPathsByRT(rt1)
+				_ = idx.GetPathsByRT(nil)
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -24,6 +24,7 @@ import (
 	"math/bits"
 	"net"
 	"net/netip"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -244,19 +245,47 @@ type Table struct {
 	// this is a map[rt, MAC address]map[addrPrefixKey][]nlri
 	// this holds a map for a set of prefixes.
 	macIndex *EVPNMacNLRIs
+	// vpnIdx indexes all known paths by Route Target for O(1) RT-based lookup.
+	// Non-nil only for families that carry RT extended communities (VPNV4-6, EVPN, …).
+	vpnIdx *VPNPathIndex
+}
+
+// vpnFamilies lists the route families whose paths carry RT extended communities
+// and should therefore be indexed in VPNPathIndex.
+func isVPNFamily(rf bgp.Family) bool {
+	switch rf {
+	case bgp.RF_IPv4_VPN, bgp.RF_IPv6_VPN,
+		bgp.RF_IPv4_VPN_MC, bgp.RF_IPv6_VPN_MC,
+		bgp.RF_EVPN,
+		bgp.RF_FS_IPv4_VPN, bgp.RF_FS_IPv6_VPN,
+		bgp.RF_MUP_IPv4, bgp.RF_MUP_IPv6:
+		return true
+	}
+	return false
 }
 
 func NewTable(logger *slog.Logger, rf bgp.Family, dsts ...*destination) *Table {
+	var vpnIdx *VPNPathIndex
+	if isVPNFamily(rf) {
+		vpnIdx = NewVPNPathIndex()
+	}
 	t := &Table{
 		Family:       rf,
 		destinations: NewDestinations(),
 		logger:       logger,
 		macIndex:     NewEVPNMacNLRIs(),
+		vpnIdx:       vpnIdx,
 	}
 	for _, dst := range dsts {
 		t.setDestination(dst)
 	}
 	return t
+}
+
+// GetVPNIndex returns the RT-keyed path index for this table, or nil if the
+// table's family does not carry RT extended communities.
+func (t *Table) GetVPNIndex() *VPNPathIndex {
+	return t.vpnIdx
 }
 
 func (t *Table) GetFamily() bgp.Family {
@@ -438,7 +467,6 @@ func (t *Table) update(newPath *Path) *Update {
 
 	if len(dst.knownPathList) == 0 {
 		t.deleteDest(shard, dst)
-		return u
 	}
 
 	if evpnNlri, ok := nlri.(*bgp.EVPNNLRI); ok {
@@ -449,7 +477,27 @@ func (t *Table) update(newPath *Path) *Update {
 		}
 	}
 
+	if t.vpnIdx != nil {
+		syncVPNIndex(t.vpnIdx, u.KnownPathList, u.OldKnownPathList)
+	}
+
 	return u
+}
+
+// syncVPNIndex unregisters paths removed from the known list and registers paths added.
+// Both lists are small (typically ≤ a handful of paths per destination), so the O(n²)
+// pointer scan is negligible in practice.
+func syncVPNIndex(idx *VPNPathIndex, after, before []*Path) {
+	for _, old := range before {
+		if !slices.Contains(after, old) {
+			idx.UnregisterPath(old)
+		}
+	}
+	for _, p := range after {
+		if !slices.Contains(before, p) {
+			idx.RegisterPath(p)
+		}
+	}
 }
 
 // GetDestinations returns snapshots of all destinations in the table.

--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -354,6 +354,25 @@ func (manager *TableManager) updateMaxPathCounted(pathCount int) {
 	}
 }
 
+// GetPathsByRT returns all paths indexed under rt across all tables in rfList.
+// If rt is nil, returns nil.
+// Only tables with a VPNPathIndex (VPN, EVPN, …) contribute results.
+func (manager *TableManager) GetPathsByRT(rt bgp.ExtendedCommunityInterface, rfList []bgp.Family) []*Path {
+	if rt == nil {
+		return nil
+	}
+	manager.mu.RLock()
+	defer manager.mu.RUnlock()
+
+	var paths []*Path
+	for _, t := range manager.getTables(rfList...) {
+		if idx := t.GetVPNIndex(); idx != nil {
+			paths = append(paths, idx.GetPathsByRT(rt)...)
+		}
+	}
+	return paths
+}
+
 func (manager *TableManager) GetBestPathList(id string, as uint32, rfList []bgp.Family) []*Path {
 	if SelectionOptions.DisableBestPathSelection {
 		// Note: If best path selection disabled, there is no best path.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1163,63 +1163,7 @@ func (s *BgpServer) propagateUpdate(peer *peer, pathList []*table.Path) {
 			// between the previous and current state of the route distribution
 			// graph that is derived from Route Target membership information.
 			if peer != nil && path != nil && path.GetFamily() == bgp.RF_RTC_UC {
-				peer.rtmHandler.SyncAfterImport(path)
-				rt := path.GetNlri().(*bgp.RouteTargetMembershipNLRI).RouteTarget
-				fs := make([]bgp.Family, 0, len(peer.negotiatedRFList()))
-				for _, f := range peer.negotiatedRFList() {
-					if f != bgp.RF_RTC_UC {
-						fs = append(fs, f)
-					}
-				}
-				var candidates []*table.Path
-				if path.IsWithdraw {
-					// Note: The paths to be withdrawn are filtered because the
-					// given RT on RTM NLRI is already removed from the peer RTC index.
-					_, candidates = s.getBestFromLocal(peer, fs, true)
-				} else {
-					// https://github.com/osrg/gobgp/issues/1777
-					// Ignore duplicate Membership announcements
-					membershipsForSource := s.globalRib.GetPathListWithSource(table.GLOBAL_RIB_NAME, []bgp.Family{bgp.RF_RTC_UC}, path.GetSource())
-					found := false
-					equalRT := func(a, b bgp.ExtendedCommunityInterface) bool {
-						if a == nil && b == nil {
-							return true
-						}
-						return a != nil && b != nil && a.String() == b.String()
-					}
-					for _, membership := range membershipsForSource {
-						mrt := membership.GetNlri().(*bgp.RouteTargetMembershipNLRI).RouteTarget
-						if equalRT(mrt, rt) {
-							found = true
-							break
-						}
-					}
-					if !found {
-						candidates = s.globalRib.GetBestPathList(peer.TableID(), 0, fs)
-					}
-				}
-				paths := make([]*table.Path, 0, len(candidates))
-				for _, p := range candidates {
-					for _, ext := range p.GetExtCommunities() {
-						if rt == nil || ext.String() == rt.String() {
-							if path.IsWithdraw {
-								p = p.Clone(true)
-							}
-							paths = append(paths, p)
-							break
-						}
-					}
-				}
-				if path.IsWithdraw {
-					// Skips filtering because the paths are already filtered
-					// and the withdrawal does not need the path attributes.
-					sendfsmOutgoingMsg(peer, paths)
-				} else if !peer.getRtcEORWait() {
-					paths = s.processOutgoingPaths(peer, paths, nil)
-					sendfsmOutgoingMsg(peer, paths)
-				} else {
-					peer.fsm.logger.Debug("Nothing sent in response to RT received. Waiting for RTC EOR.", slog.Any("Path", path))
-				}
+				s.processRTCMembership(peer, path)
 			}
 		}
 
@@ -1227,6 +1171,86 @@ func (s *BgpServer) propagateUpdate(peer *peer, pathList []*table.Path) {
 			s.propagateUpdateToNeighbors(rib, peer, path, dsts, true)
 		}
 	}
+}
+
+// processRTCMembership handles a single RTC NLRI path (announce or withdraw) received
+// from peer, updating the membership index and sending the minimum necessary VPN route
+// updates to the peer.
+//
+// RFC4684 §6: re-evaluate RIB-OUTs for VPN NLRIs matching the Route Target.
+func (s *BgpServer) processRTCMembership(peer *peer, path *table.Path) {
+	nlri, ok := path.GetNlri().(*bgp.RouteTargetMembershipNLRI)
+	if !ok {
+		peer.fsm.logger.Warn("Path is not a Route Target Membership NLRI", slog.Any("Path", path))
+		return
+	}
+	rt := nlri.RouteTarget
+	hasRt := func(rt bgp.ExtendedCommunityInterface) bool {
+		if rt == nil {
+			return peer.rtmHandler.HasDefaultRouteTarget()
+		}
+		return peer.rtmHandler.HasRouteTarget(rt)
+	}
+
+	rtKnownBefore := hasRt(rt)
+
+	peer.rtmHandler.SyncAfterImport(path)
+
+	rtKnownAfter := hasRt(rt)
+
+	if !path.IsWithdraw && rtKnownBefore || path.IsWithdraw && rtKnownAfter {
+		return
+	}
+
+	fs := peerNonRTCFamilies(peer)
+	paths := s.rtcVPNCandidates(peer, path, rt, fs)
+
+	if path.IsWithdraw {
+		// Skips filtering: paths are already scoped to this RT and withdrawals
+		// do not need path attributes.
+		sendfsmOutgoingMsg(peer, paths)
+		return
+	}
+	if peer.getRtcEORWait() {
+		peer.fsm.logger.Debug("Nothing sent in response to RT received. Waiting for RTC EOR.", slog.Any("Path", path))
+		return
+	}
+	paths = s.processOutgoingPaths(peer, paths, nil)
+	sendfsmOutgoingMsg(peer, paths)
+}
+
+// peerNonRTCFamilies returns the peer's negotiated families excluding RF_RTC_UC.
+func peerNonRTCFamilies(peer *peer) []bgp.Family {
+	negotiated := peer.negotiatedRFList()
+	fs := make([]bgp.Family, 0, len(negotiated))
+	for _, f := range negotiated {
+		if f != bgp.RF_RTC_UC {
+			fs = append(fs, f)
+		}
+	}
+	return fs
+}
+
+// rtcVPNCandidates returns VPN paths to announce or withdraw in response to an RTC update.
+// For a specific rt it uses the VPN path index (O(1)); for the wildcard (nil rt) it falls
+// back to a full RIB scan because all VPN families are in scope.
+func (s *BgpServer) rtcVPNCandidates(peer *peer, path *table.Path, rt bgp.ExtendedCommunityInterface, fs []bgp.Family) []*table.Path {
+	if rt != nil {
+		raw := s.globalRib.GetPathsByRT(rt, fs)
+		paths := make([]*table.Path, 0, len(raw))
+		for _, p := range raw {
+			if path.IsWithdraw {
+				p = p.Clone(true)
+			}
+			paths = append(paths, p)
+		}
+		return paths
+	}
+	if path.IsWithdraw {
+		_, paths := s.getBestFromLocal(peer, fs, false)
+		return paths
+	}
+	return s.globalRib.GetBestPathList(peer.TableID(), 0, fs)
 }
 
 func dstsToPaths(id string, as uint32, dsts []*table.Update) ([]*table.Path, []*table.Path, [][]*table.Path) {


### PR DESCRIPTION
  Add VPNPathIndex — thread-safe per-Table index of paths by Route Target.
  Replaces the O(n·m) GetBestPathList + ext-community scan in the RTC block
  with a direct hash lookup via TableManager.GetPathsByRT

  Add two early exits via rtmSet (before any path computation):
  - duplicate announce: RT already known → skip (replaces GetPathListWithSource scan)
  - ADD-PATH or different AS withdraw: RT still held by another path-id/as → skip

  Extract RTC handling into processRTCMembership + helpers.
  
  Final part of #3368 