### PR TITLE
fix: rpki server listing panics

### DIFF
--- a/cmd/gobgp/rpki.go
+++ b/cmd/gobgp/rpki.go
@@ -143,6 +143,7 @@ func newRPKICmd() *cobra.Command {
 				if err != nil {
 					exitWithError(err)
 				}
+				return
 			} else if len(args) != 2 {
 				exitWithError(fmt.Errorf("usage: gobgp rpki server <ip address> [reset|softreset|enable]"))
 			}


### PR DESCRIPTION
The PR is to fix the problem described in #3382.
The root cause is that in `cmd/gobgp/rpki.go`, `newRPKICmd()` calls `showRPKIServer(args)` when `len(args) == 0 || len(args) == 1`,
but execution continues into:
```go
addr := net.ParseIP(args[0])
switch args[1] {
```
So:

- the 0-arg path reaches args[0]
- the 1-arg path can reach args[1]

`showRPKIServer(args)` already implements the intended display behavior for both:

0 args: list all RPKI servers
1 arg: show details for the specified server

My proposed fix return immediately after a successful showRPKIServer(args) call for the 0-arg and 1-arg paths.