### PR TITLE
table: skip paths with unconfigured family in AdjRib.Update

### DIFF
--- a/internal/pkg/table/adj.go
+++ b/internal/pkg/table/adj.go
@@ -46,7 +46,10 @@ func (adj *AdjRib) Update(pathList []*Path) {
 			continue
 		}
 		rf := path.GetFamily()
-		t := adj.table[path.GetFamily()]
+		t := adj.table[rf]
+		if t == nil {
+			continue
+		}
 		nlri := path.GetNlri()
 		shard := t.destinations.getShard(nlri)
 
@@ -113,6 +116,9 @@ func (adj *AdjRib) UpdateAdjRibOut(pathList []*Path) {
 			continue
 		}
 		t := adj.table[path.GetFamily()]
+		if t == nil {
+			continue
+		}
 		nlri := path.GetNlri()
 		shard := t.destinations.getShard(nlri)
 

--- a/internal/pkg/table/adj_test.go
+++ b/internal/pkg/table/adj_test.go
@@ -187,6 +187,23 @@ func TestLLGRStale(t *testing.T) {
 	assert.Contains(t, retainedRejected.GetCommunities(), uint32(bgp.COMMUNITY_LLGR_STALE))
 }
 
+func TestUpdateUnknownFamily(t *testing.T) {
+	// A path whose address family is not registered in adj.table must be
+	// silently skipped — not panic — in both Update and UpdateAdjRibOut.
+	// This covers the treat-as-withdraw path triggered by a malformed BGP
+	// UPDATE (RFC 7606): the peer may send NLRI for a family the local side
+	// never negotiated, causing a nil table lookup.
+	pi := &PeerInfo{}
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
+
+	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.0.0.0/24"))
+	p4 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri1}, false, attrs, time.Now(), false)
+	// AdjRib only knows about IPv6; IPv4 path is unconfigured.
+	adj := NewAdjRib(slog.Default(), []bgp.Family{bgp.RF_IPv6_UC})
+	assert.NotPanics(t, func() { adj.Update([]*Path{p4}) })
+	assert.NotPanics(t, func() { adj.UpdateAdjRibOut([]*Path{p4}) })
+}
+
 func TestWithdrawUnknownPath(t *testing.T) {
 	pi := &PeerInfo{}
 	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}


### PR DESCRIPTION
When a malformed BGP UPDATE is treated as withdraw per RFC 7606, ProcessMessage still creates withdraw paths from any MP_REACH_NLRI present in the message, including those with bogus AFI/SAFI values not among the peer's configured address families. AdjRib.Update looked up adj.table by family without checking for nil, causing a nil pointer dereference on t.destinations.getShard().

Apply the same nil guard to UpdateAdjRibOut as a defensive measure, as its callers currently filter by configuredRFlist() but the function itself had the same latent issue.