### PR TITLE
table: eliminate string round-trips in Select for IPv4/IPv6 UC

### DIFF
--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -757,6 +757,17 @@ func (t *Table) GetKnownPathListWithMac(id string, as uint32, rt bgp.ExtendedCom
 	return paths
 }
 
+// mustIPAddrPrefix constructs an IPAddrPrefix from a netip.Prefix that is
+// guaranteed to be valid by the caller. It panics if prefix is not valid,
+// which indicates a programming error in the caller.
+func mustIPAddrPrefix(prefix netip.Prefix) *bgp.IPAddrPrefix {
+	nlri, err := bgp.NewIPAddrPrefix(prefix)
+	if err != nil {
+		panic("mustIPAddrPrefix called with invalid prefix: " + err.Error())
+	}
+	return nlri
+}
+
 // ContainsCIDR checks if one IPNet is a subnet of another.
 func containsCIDR(n1, n2 *net.IPNet) bool {
 	ones1, _ := n1.Mask.Size()
@@ -791,22 +802,6 @@ func (t *Table) Select(option ...TableSelectOption) (*Table, error) {
 	if len(prefixes) != 0 {
 		switch t.Family {
 		case bgp.RF_IPv4_UC, bgp.RF_IPv6_UC:
-			f := func(prefixStr string) (bool, error) {
-				prefix, err := netip.ParsePrefix(prefixStr)
-				if err != nil {
-					return false, err
-				}
-				nlri, err := bgp.NewIPAddrPrefix(prefix)
-				if err != nil {
-					return false, err
-				}
-				if d := t.SelectDestination(nlri, dOption); d != nil {
-					r.setDestination(d)
-					return true, nil
-				}
-				return false, nil
-			}
-
 			for _, p := range prefixes {
 				key := p.Prefix
 				switch p.LookupOption {
@@ -821,38 +816,38 @@ func (t *Table) Select(option ...TableSelectOption) (*Table, error) {
 						}
 					}
 				case apiutil.LOOKUP_SHORTER:
-					addr, prefix, err := net.ParseCIDR(key)
+					prefix, err := netip.ParsePrefix(key)
 					if err != nil {
 						return nil, err
 					}
-					ones, _ := prefix.Mask.Size()
-					for i := ones; i >= 0; i-- {
-						_, prefix, _ := net.ParseCIDR(fmt.Sprintf("%s/%d", addr.String(), i))
-						if _, err := f(prefix.String()); err != nil {
-							return nil, err
+					for i := prefix.Bits(); i >= 0; i-- {
+						nlri := mustIPAddrPrefix(netip.PrefixFrom(prefix.Addr(), i))
+						if d := t.SelectDestination(nlri, dOption); d != nil {
+							r.setDestination(d)
 						}
 					}
 				default:
-					if host := net.ParseIP(key); host != nil {
+					if addr, err := netip.ParseAddr(key); err == nil {
 						masklen := 32
 						if t.Family == bgp.RF_IPv6_UC {
 							masklen = 128
 						}
 						for i := masklen; i >= 0; i-- {
-							_, prefix, err := net.ParseCIDR(fmt.Sprintf("%s/%d", key, i))
-							if err != nil {
-								return nil, err
-							}
-							ret, err := f(prefix.String())
-							if err != nil {
-								return nil, err
-							}
-							if ret {
+							nlri := mustIPAddrPrefix(netip.PrefixFrom(addr, i))
+							if d := t.SelectDestination(nlri, dOption); d != nil {
+								r.setDestination(d)
 								break
 							}
 						}
-					} else if _, err := f(key); err != nil {
-						return nil, err
+					} else {
+						prefix, err := netip.ParsePrefix(key)
+						if err != nil {
+							return nil, err
+						}
+						nlri := mustIPAddrPrefix(prefix)
+						if d := t.SelectDestination(nlri, dOption); d != nil {
+							r.setDestination(d)
+						}
 					}
 				}
 			}

--- a/internal/pkg/table/table_test.go
+++ b/internal/pkg/table/table_test.go
@@ -33,6 +33,90 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSelectExactAndHostIPv4UC(t *testing.T) {
+	pi := &PeerInfo{}
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
+	addPath := func(tbl *Table, s string) {
+		nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix(s))
+		p := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
+		tbl.setDestination(newDestination(nlri, 0, p))
+	}
+
+	t.Run("CIDR exact match found", func(t *testing.T) {
+		tbl := NewTable(logger, bgp.RF_IPv4_UC)
+		addPath(tbl, "14.0.0.0/8")
+		addPath(tbl, "14.14.0.0/16")
+		result, err := tbl.Select(TableSelectOption{
+			LookupPrefixes: []*apiutil.LookupPrefix{{Prefix: "14.0.0.0/8"}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result.GetDestinations()))
+	})
+
+	t.Run("CIDR exact match not found", func(t *testing.T) {
+		tbl := NewTable(logger, bgp.RF_IPv4_UC)
+		addPath(tbl, "14.14.0.0/16")
+		result, err := tbl.Select(TableSelectOption{
+			LookupPrefixes: []*apiutil.LookupPrefix{{Prefix: "14.0.0.0/8"}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(result.GetDestinations()))
+	})
+
+	t.Run("host IP longest prefix match found", func(t *testing.T) {
+		tbl := NewTable(logger, bgp.RF_IPv4_UC)
+		addPath(tbl, "14.0.0.0/8")
+		addPath(tbl, "14.14.0.0/16")
+		// "14.14.14.14" is a bare host address — should match 14.14.0.0/16 (longest)
+		result, err := tbl.Select(TableSelectOption{
+			LookupPrefixes: []*apiutil.LookupPrefix{{Prefix: "14.14.14.14"}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result.GetDestinations()))
+	})
+
+	t.Run("host IP longest prefix match not found", func(t *testing.T) {
+		tbl := NewTable(logger, bgp.RF_IPv4_UC)
+		addPath(tbl, "10.0.0.0/8")
+		result, err := tbl.Select(TableSelectOption{
+			LookupPrefixes: []*apiutil.LookupPrefix{{Prefix: "14.14.14.14"}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(result.GetDestinations()))
+	})
+}
+
+func TestSelectExactAndHostIPv6UC(t *testing.T) {
+	pi := &PeerInfo{}
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
+	addPath := func(tbl *Table, s string) {
+		nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix(s))
+		p := NewPath(bgp.RF_IPv6_UC, pi, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
+		tbl.setDestination(newDestination(nlri, 0, p))
+	}
+
+	t.Run("host IPv6 longest prefix match found", func(t *testing.T) {
+		tbl := NewTable(logger, bgp.RF_IPv6_UC)
+		addPath(tbl, "2001:db8::/32")
+		addPath(tbl, "2001:db8:1::/48")
+		result, err := tbl.Select(TableSelectOption{
+			LookupPrefixes: []*apiutil.LookupPrefix{{Prefix: "2001:db8:1::1"}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result.GetDestinations()))
+	})
+
+	t.Run("host IPv6 longest prefix match not found", func(t *testing.T) {
+		tbl := NewTable(logger, bgp.RF_IPv6_UC)
+		addPath(tbl, "2001:db8::/32")
+		result, err := tbl.Select(TableSelectOption{
+			LookupPrefixes: []*apiutil.LookupPrefix{{Prefix: "2001:db9::1"}},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(result.GetDestinations()))
+	})
+}
+
 func TestSelectLongerShorterIPv4UC(t *testing.T) {
 	tbl := NewTable(logger, bgp.RF_IPv4_UC)
 	pi := &PeerInfo{}
@@ -269,6 +353,18 @@ func TestTableSelectMalformedIPv4UCPrefixes(t *testing.T) {
 			name:   "exact match with RD and prefix that does not exist",
 			prefix: "foo",
 			option: apiutil.LOOKUP_EXACT,
+			found:  0,
+		},
+		{
+			name:   "malformed prefix with LOOKUP_LONGER",
+			prefix: "foo",
+			option: apiutil.LOOKUP_LONGER,
+			found:  0,
+		},
+		{
+			name:   "malformed prefix with LOOKUP_SHORTER",
+			prefix: "foo",
+			option: apiutil.LOOKUP_SHORTER,
 			found:  0,
 		},
 	}


### PR DESCRIPTION
The LOOKUP_SHORTER and default (exact/host-IP) branches in Select used the legacy net package — ParseCIDR, ParseIP, fmt.Sprintf — to convert prefixes back to strings and re-parse them on every loop iteration. Replace them with direct netip operations:

  LOOKUP_SHORTER: net.ParseCIDR + fmt.Sprintf + net.ParseCIDR + f()
                → netip.ParsePrefix + netip.PrefixFrom per iteration

  default (host IP): net.ParseIP + fmt.Sprintf + net.ParseCIDR + f()
                   → netip.ParseAddr + netip.PrefixFrom per iteration

  default (CIDR exact): f() → netip.ParsePrefix inline

This removes the f closure entirely. Calls to bgp.NewIPAddrPrefix that are guaranteed to receive a valid prefix are wrapped in mustIPAddrPrefix, which panics instead of returning a dead error path.

Add tests for the previously uncovered default-case branches: CIDR exact match (found/not-found), host-IP longest-prefix match (IPv4/IPv6, found/not-found), and malformed input for LOOKUP_LONGER/LOOKUP_SHORTER.