### PR TITLE
fix(rtc): fix VPN path indexing — track best path (no-add-path) or all path-IDs (add-path)

### DIFF
--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -250,19 +250,20 @@ func (dd *destination) GetMultiBestPath(id string) []*Path {
 // paths from known paths. Also, adds new paths to known paths.
 // INTERNAL USE ONLY: Caller MUST hold the appropriate shard lock.
 // This method must NEVER be called on snapshot destinations.
-func (dest *destination) Calculate(logger *slog.Logger, newPath *Path) *Update {
+func (dest *destination) Calculate(logger *slog.Logger, newPath *Path) (*Update, *Path) {
 	oldKnownPathList := make([]*Path, len(dest.knownPathList))
 	copy(oldKnownPathList, dest.knownPathList)
 
+	var oldPath *Path
 	if newPath.IsWithdraw {
-		p := dest.explicitWithdraw(logger, newPath)
-		if p != nil && newPath.IsDropped() {
-			if id := p.localID; id != 0 {
+		oldPath = dest.explicitWithdraw(logger, newPath)
+		if oldPath != nil && newPath.IsDropped() {
+			if id := oldPath.localID; id != 0 {
 				dest.localIdMap.Unflag(uint(id))
 			}
 		}
 	} else {
-		dest.implicitWithdraw(logger, newPath)
+		oldPath = dest.implicitWithdraw(logger, newPath)
 		dest.insertSort(newPath)
 	}
 
@@ -282,7 +283,7 @@ func (dest *destination) Calculate(logger *slog.Logger, newPath *Path) *Update {
 	return &Update{
 		KnownPathList:    l,
 		OldKnownPathList: oldKnownPathList,
-	}
+	}, oldPath
 }
 
 // Removes withdrawn paths.
@@ -292,6 +293,7 @@ func (dest *destination) Calculate(logger *slog.Logger, newPath *Path) *Update {
 // since not all paths get installed into the table due to bgp policy and
 // we can receive withdraws for such paths and withdrawals may not be
 // stopped by the same policies.
+// Returns the old path that was withdrawn.
 func (dest *destination) explicitWithdraw(logger *slog.Logger, withdraw *Path) *Path {
 	logger.Debug("Removing withdrawals",
 		slog.String("Topic", "Table"),
@@ -334,7 +336,8 @@ func (dest *destination) explicitWithdraw(logger *slog.Logger, withdraw *Path) *
 //
 // Known paths will no longer have paths whose new version is present in
 // new paths.
-func (dest *destination) implicitWithdraw(logger *slog.Logger, newPath *Path) {
+// Returns the old path that was withdrawn.
+func (dest *destination) implicitWithdraw(logger *slog.Logger, newPath *Path) *Path {
 	found := -1
 	for i, path := range dest.knownPathList {
 		if path.NoImplicitWithdraw() {
@@ -356,8 +359,11 @@ func (dest *destination) implicitWithdraw(logger *slog.Logger, newPath *Path) {
 		}
 	}
 	if found != -1 {
+		withdrawnPath := dest.knownPathList[found]
 		dest.knownPathList = append(dest.knownPathList[:found], dest.knownPathList[found+1:]...)
+		return withdrawnPath
 	}
+	return nil
 }
 
 func (dest *destination) insertSort(newPath *Path) {

--- a/internal/pkg/table/destination_test.go
+++ b/internal/pkg/table/destination_test.go
@@ -334,14 +334,15 @@ func TestMultipath(t *testing.T) {
 	d := newDestination(nlri, 0)
 	d.Calculate(logger, path2)
 
-	best, old, multi := d.Calculate(logger, path1).GetChanges(GLOBAL_RIB_NAME, 0, false)
+	dd, _ := d.Calculate(logger, path1)
+	best, old, multi := dd.GetChanges(GLOBAL_RIB_NAME, 0, false)
 	assert.NotNil(t, best)
 	assert.Equal(t, old, path2)
 	assert.Equal(t, len(multi), 2)
 	assert.Equal(t, len(d.GetKnownPathList(GLOBAL_RIB_NAME, 0)), 2)
 
 	path3 := path2.Clone(true)
-	dd := d.Calculate(logger, path3)
+	dd, _ = d.Calculate(logger, path3)
 	best, old, multi = dd.GetChanges(GLOBAL_RIB_NAME, 0, false)
 	assert.Nil(t, best)
 	assert.Equal(t, old, path1)
@@ -359,7 +360,7 @@ func TestMultipath(t *testing.T) {
 	}
 	updateMsg = bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path4 := ProcessMessage(updateMsg, peer3, time.Now(), false)[0]
-	dd = d.Calculate(logger, path4)
+	dd, _ = d.Calculate(logger, path4)
 	best, _, multi = dd.GetChanges(GLOBAL_RIB_NAME, 0, false)
 	assert.NotNil(t, best)
 	assert.Equal(t, len(multi), 1)
@@ -374,7 +375,8 @@ func TestMultipath(t *testing.T) {
 	}
 	updateMsg = bgp.NewBGPUpdateMessage(nil, pathAttributes, []bgp.PathNLRI{{NLRI: nlri}})
 	path5 := ProcessMessage(updateMsg, peer2, time.Now(), false)[0]
-	best, _, multi = d.Calculate(logger, path5).GetChanges(GLOBAL_RIB_NAME, 0, false)
+	dd, _ = d.Calculate(logger, path5)
+	best, _, multi = dd.GetChanges(GLOBAL_RIB_NAME, 0, false)
 	assert.NotNil(t, best)
 	assert.Equal(t, len(multi), 2)
 	assert.Equal(t, len(d.GetKnownPathList(GLOBAL_RIB_NAME, 0)), 3)
@@ -441,10 +443,15 @@ func TestDestination_Calculate_ExplicitWithdraw(t *testing.T) {
 
 	// Test explicit withdraw
 	withdrawPath := NewPath(bgp.RF_IPv4_UC, peer1, bgp.PathNLRI{NLRI: nlri}, true, attrs, time.Now(), false)
-	update := d.Calculate(logger, withdrawPath)
+	dd, oldPath := d.Calculate(logger, withdrawPath)
+	update := dd
 
+	assert.Same(t, p1, oldPath)
 	assert.Len(t, update.KnownPathList, 1)
 	assert.Equal(t, peer2.Address.String(), update.KnownPathList[0].GetSource().Address.String())
+
+	_, oldPath = d.Calculate(logger, withdrawPath)
+	assert.Nil(t, oldPath)
 }
 
 func TestDestination_Calculate_ImplicitWithdraw(t *testing.T) {
@@ -455,9 +462,10 @@ func TestDestination_Calculate_ImplicitWithdraw(t *testing.T) {
 	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.0.0.0/24"))
 	peer1 := &PeerInfo{AS: 65001, Address: netip.MustParseAddr("1.1.1.1")}
 
-	// Create initial path
 	p1 := NewPath(bgp.RF_IPv4_UC, peer1, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
-	d := newDestination(nlri, 0, p1)
+	d := newDestination(nlri, 0)
+	_, oldPath := d.Calculate(logger, p1)
+	assert.Nil(t, oldPath)
 
 	// Send new path from same peer (should trigger implicit withdraw)
 	newAttrs := []bgp.PathAttributeInterface{
@@ -465,8 +473,10 @@ func TestDestination_Calculate_ImplicitWithdraw(t *testing.T) {
 		bgp.NewPathAttributeMultiExitDisc(100),
 	}
 	p2 := NewPath(bgp.RF_IPv4_UC, peer1, bgp.PathNLRI{NLRI: nlri}, false, newAttrs, time.Now(), false)
-	update := d.Calculate(logger, p2)
+	dd, oldPath := d.Calculate(logger, p2)
+	update := dd
 
+	assert.Same(t, p1, oldPath)
 	assert.Len(t, update.KnownPathList, 1)
 	assert.Equal(t, uint32(100), update.KnownPathList[0].getPathAttr(bgp.BGP_ATTR_TYPE_MULTI_EXIT_DISC).(*bgp.PathAttributeMultiExitDisc).Value)
 }
@@ -686,7 +696,8 @@ func TestDestination_Calculate_AddAndWithdrawPath(t *testing.T) {
 
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("13.2.6.0/24"))
 	p4 := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
-	update := d.Calculate(logger, p4)
+	dd, _ := d.Calculate(logger, p4)
+	update := dd
 	assert.Len(t, update.KnownPathList, 3)
 	assert.Len(t, update.KnownPathList, 3)
 	assert.NotEqualValues(t, update.OldKnownPathList, update.KnownPathList)
@@ -697,7 +708,7 @@ func TestDestination_Calculate_AddAndWithdrawPath(t *testing.T) {
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("13.2.3.0/24"))
 	p1 = NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), true)
 	d = newDestination(nlri, 0, p1, p2, p3)
-	update = d.Calculate(logger, p4)
+	update, _ = d.Calculate(logger, p4)
 	assert.Len(t, update.KnownPathList, 3)
 	assert.Len(t, update.KnownPathList, 3)
 	assert.NotEqualValues(t, update.OldKnownPathList, update.KnownPathList)
@@ -709,7 +720,7 @@ func TestDestination_Calculate_AddAndWithdrawPath(t *testing.T) {
 	nlri, _ = bgp.NewIPAddrPrefix(netip.MustParsePrefix("13.2.8.0/24"))
 	p5 := NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
 	d = newDestination(nlri, 0, p1, p2, p3, p5)
-	update = d.Calculate(logger, p4)
+	update, _ = d.Calculate(logger, p4)
 
 	assert.Len(t, update.KnownPathList, 4)
 	assert.Len(t, update.KnownPathList, 4)
@@ -739,7 +750,7 @@ func TestNHT_InvalidateNewPathWithoutMED(t *testing.T) {
 	// Step 2: path is added to destination (first time — no old entry)
 	d := &destination{nlri: nlri, localIdMap: NewBitmap(64)}
 	d.localIdMap.Flag(0)
-	update1 := d.Calculate(logger, original)
+	update1, _ := d.Calculate(logger, original)
 
 	best1, old1, _ := update1.GetChanges(GLOBAL_RIB_NAME, 0, false)
 	assert.NotNil(t, best1, "new path should become best")
@@ -752,7 +763,7 @@ func TestNHT_InvalidateNewPathWithoutMED(t *testing.T) {
 	invalidClone.IsNexthopInvalid = true
 
 	// Step 4: feed the invalidated clone into Calculate (what updatePath does)
-	update2 := d.Calculate(logger, invalidClone)
+	update2, _ := d.Calculate(logger, invalidClone)
 
 	best2, old2, _ := update2.GetChanges(GLOBAL_RIB_NAME, 0, false)
 	assert.NotNil(t, best2, "invalidation should produce a change")
@@ -782,7 +793,7 @@ func TestNHT_InvalidateExistingPathWithMED(t *testing.T) {
 	invalidClone := original.Clone(false)
 	invalidClone.IsNexthopInvalid = true
 
-	update := d.Calculate(logger, invalidClone)
+	update, _ := d.Calculate(logger, invalidClone)
 	best, old, _ := update.GetChanges(GLOBAL_RIB_NAME, 0, false)
 
 	assert.NotNil(t, best, "invalidation should produce a change")
@@ -819,7 +830,7 @@ func TestNHT_RevalidatePath(t *testing.T) {
 	err := validClone.SetMed(30, true)
 	assert.NoError(t, err)
 
-	update := d.Calculate(logger, validClone)
+	update, _ := d.Calculate(logger, validClone)
 	best, _, _ := update.GetChanges(GLOBAL_RIB_NAME, 0, false)
 
 	assert.NotNil(t, best, "revalidation should produce a change")
@@ -850,7 +861,7 @@ func TestNHT_NewPathWithInvalidNexthop(t *testing.T) {
 	d := &destination{nlri: nlri, localIdMap: NewBitmap(64)}
 	d.localIdMap.Flag(0)
 
-	update := d.Calculate(logger, newPath)
+	update, _ := d.Calculate(logger, newPath)
 	best, old, _ := update.GetChanges(GLOBAL_RIB_NAME, 0, false)
 
 	// No old path, new path is invalid -> no change should be emitted.

--- a/internal/pkg/table/table.go
+++ b/internal/pkg/table/table.go
@@ -24,7 +24,6 @@ import (
 	"math/bits"
 	"net"
 	"net/netip"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -463,7 +462,7 @@ func (t *Table) update(newPath *Path) *Update {
 	defer shard.mu.Unlock()
 
 	dst := t.getOrCreateDest(shard, nlri, 64)
-	u := dst.Calculate(t.logger, newPath)
+	u, oldPath := dst.Calculate(t.logger, newPath)
 
 	if len(dst.knownPathList) == 0 {
 		t.deleteDest(shard, dst)
@@ -477,26 +476,42 @@ func (t *Table) update(newPath *Path) *Update {
 		}
 	}
 
-	if t.vpnIdx != nil {
-		syncVPNIndex(t.vpnIdx, u.KnownPathList, u.OldKnownPathList)
-	}
-
+	t.updateVPNIdx(u, newPath, oldPath)
 	return u
 }
 
-// syncVPNIndex unregisters paths removed from the known list and registers paths added.
-// Both lists are small (typically ≤ a handful of paths per destination), so the O(n²)
-// pointer scan is negligible in practice.
-func syncVPNIndex(idx *VPNPathIndex, after, before []*Path) {
-	for _, old := range before {
-		if !slices.Contains(after, old) {
-			idx.UnregisterPath(old)
-		}
+// updateVPNIdx keeps the vpnIdx in sync with the VPN path table after each
+// update. It must be called immediately after dst.Calculate so that
+// OldKnownPathList and KnownPathList reflect the state before and after the
+// change respectively.
+func (t *Table) updateVPNIdx(u *Update, newPath, oldPath *Path) {
+	if t.vpnIdx == nil {
+		return
 	}
-	for _, p := range after {
-		if !slices.Contains(before, p) {
-			idx.RegisterPath(p)
+	if newPath.RemoteID() != 0 {
+		// ADD-PATH: each (source, path-ID) pair is a distinct entry.
+		// oldPath is the previous path with the same source×pathID returned by
+		// implicitWithdraw (non-withdrawal) or explicitWithdraw (withdrawal).
+		if newPath.IsWithdraw {
+			t.vpnIdx.UnregisterPath(oldPath)
+		} else {
+			t.vpnIdx.UnregisterPath(oldPath)
+			t.vpnIdx.RegisterPath(newPath)
 		}
+		return
+	}
+	// No-add-path: track only the best path per NLRI.
+	// KnownPathList is sorted by computeKnownBestPath, so [0] is the best.
+	var oldBest, newBest *Path
+	if len(u.OldKnownPathList) > 0 {
+		oldBest = u.OldKnownPathList[0]
+	}
+	if len(u.KnownPathList) > 0 {
+		newBest = u.KnownPathList[0]
+	}
+	if oldBest != newBest {
+		t.vpnIdx.UnregisterPath(oldBest)
+		t.vpnIdx.RegisterPath(newBest)
 	}
 }
 

--- a/internal/pkg/table/table_manager_test.go
+++ b/internal/pkg/table/table_manager_test.go
@@ -2414,3 +2414,78 @@ func TestVRF(t *testing.T) {
 		assert.Contains(t, deletedRTsStr, importRTStr)
 	}
 }
+
+func TestTableVPNPathIndexPathCount(t *testing.T) {
+	rt, err := bgp.ParseRouteTarget("100:100")
+	assert.NoError(t, err)
+
+	pi1 := &PeerInfo{Address: netip.AddrFrom4([4]byte{1, 1, 1, 1}), ID: netip.AddrFrom4([4]byte{1, 1, 1, 1})}
+	pi2 := &PeerInfo{Address: netip.AddrFrom4([4]byte{2, 2, 2, 2}), ID: netip.AddrFrom4([4]byte{2, 2, 2, 2})}
+	rf := bgp.RF_IPv4_VPN
+	extComm := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rt}),
+	}
+
+	rdVPN, err := bgp.ParseRouteDistinguisher("100:1")
+	assert.NoError(t, err)
+	labels := bgp.NewMPLSLabelStack()
+	ipPrefix := netip.MustParsePrefix("10.10.10.10/32")
+
+	newVPNPath := func(t *testing.T, pi *PeerInfo, pathID uint32) *Path {
+		t.Helper()
+		nlri, err := bgp.NewLabeledVPNIPAddrPrefix(ipPrefix, *labels, rdVPN)
+		assert.NoError(t, err)
+		return NewPath(rf, pi, bgp.PathNLRI{NLRI: nlri, ID: pathID}, false, extComm, time.Now(), false)
+	}
+
+	// Without add-path two peers advertise the same NLRI — only the best must be
+	// in vpnIdx, not both
+	t.Run("no-add-path: only best path stored per NLRI", func(t *testing.T) {
+		globalRib := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_VPN, bgp.RF_RTC_UC})
+
+		path1 := newVPNPath(t, pi1, 0) // pi1 is best: lower router-id
+		path2 := newVPNPath(t, pi2, 0)
+		globalRib.Update(path1)
+		globalRib.Update(path2)
+		assert.Equal(t, 1, len(globalRib.GetPathsByRT(rt, []bgp.Family{bgp.RF_IPv4_VPN})),
+			"vpnIdx must hold only the best path, not one per peer")
+
+		// Non-best (path2) withdrawn: best unchanged, vpnIdx unchanged.
+		globalRib.Update(path2.Clone(true))
+		assert.Equal(t, 1, len(globalRib.GetPathsByRT(rt, []bgp.Family{bgp.RF_IPv4_VPN})),
+			"vpnIdx must hold only the best path, not one per peer")
+
+		// Best (path1) withdrawn: path2 already gone, vpnIdx empty.
+		globalRib.Update(path1.Clone(true))
+		assert.Equal(t, 0, len(globalRib.GetPathsByRT(rt, []bgp.Family{bgp.RF_IPv4_VPN})),
+			"vpnIdx must be empty")
+	})
+
+	// With add-path each path-ID is a distinct path and all must be in vpnIdx
+	// so that RTC redistribution delivers every path to subscribing peers.
+	t.Run("add-path: all path-IDs stored per NLRI", func(t *testing.T) {
+		globalRib := NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_VPN, bgp.RF_RTC_UC})
+
+		path1 := newVPNPath(t, pi1, 1)
+		path2 := newVPNPath(t, pi1, 2)
+		path3 := newVPNPath(t, pi1, 1)
+		globalRib.Update(path1)
+		globalRib.Update(path2)
+		assert.Equal(t, 2, len(globalRib.GetPathsByRT(rt, []bgp.Family{bgp.RF_IPv4_VPN})),
+			"vpnIdx must hold all add-path entries")
+
+		// Withdraw one path-ID: only that one is removed.
+		globalRib.Update(path2.Clone(true))
+		assert.Equal(t, 1, len(globalRib.GetPathsByRT(rt, []bgp.Family{bgp.RF_IPv4_VPN})),
+			"vpnIdx must hold only the best path, not one per peer")
+
+		// Add a new path with the same path-ID: no-op
+		globalRib.Update(path3)
+		assert.Equal(t, 1, len(globalRib.GetPathsByRT(rt, []bgp.Family{bgp.RF_IPv4_VPN})),
+			"vpnIdx must hold only the best path, not one per peer")
+
+		globalRib.Update(path1.Clone(true))
+		assert.Equal(t, 0, len(globalRib.GetPathsByRT(rt, []bgp.Family{bgp.RF_IPv4_VPN})),
+			"vpnIdx must be empty")
+	})
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1206,7 +1206,7 @@ func (s *BgpServer) processRTCMembership(peer *peer, path *table.Path) {
 	}
 
 	fs := peerNonRTCFamilies(peer)
-	paths := s.rtcVPNCandidates(peer, path, rt, fs)
+	paths := s.rtcVPNCandidates(peer, path.IsWithdraw, rt, fs)
 
 	if path.IsWithdraw {
 		// Skips filtering: paths are already scoped to this RT and withdrawals
@@ -1237,19 +1237,19 @@ func peerNonRTCFamilies(peer *peer) []bgp.Family {
 // rtcVPNCandidates returns VPN paths to announce or withdraw in response to an RTC update.
 // For a specific rt it uses the VPN path index (O(1)); for the wildcard (nil rt) it falls
 // back to a full RIB scan because all VPN families are in scope.
-func (s *BgpServer) rtcVPNCandidates(peer *peer, path *table.Path, rt bgp.ExtendedCommunityInterface, fs []bgp.Family) []*table.Path {
+func (s *BgpServer) rtcVPNCandidates(peer *peer, isWithdraw bool, rt bgp.ExtendedCommunityInterface, fs []bgp.Family) []*table.Path {
 	if rt != nil {
 		raw := s.globalRib.GetPathsByRT(rt, fs)
 		paths := make([]*table.Path, 0, len(raw))
 		for _, p := range raw {
-			if path.IsWithdraw {
+			if isWithdraw {
 				p = p.Clone(true)
 			}
 			paths = append(paths, p)
 		}
 		return paths
 	}
-	if path.IsWithdraw {
+	if isWithdraw {
 		_, paths := s.getBestFromLocal(peer, fs, false)
 		return paths
 	}


### PR DESCRIPTION
The previous syncVPNIndex compared KnownPathList snapshots and registered every path present after an update. For non-add-path sessions this caused two peers advertising the same NLRI to both appear in vpnIdx, so RTC would redistribute duplicate paths to subscribing peers instead of only the best one.

Fix the indexing logic:
- Extend destination.Calculate to return the displaced old path (from explicitWithdraw / implicitWithdraw), giving callers precise before/after information without needing snapshot comparison.
- Replace syncVPNIndex with updateVPNIdx that branches on the session type:
  - ADD-PATH (RemoteID != 0): each (source, path-ID) pair is distinct; the exact old path is unregistered and the new one registered.
  - non-add-path: only the best path per NLRI is tracked; changes are detected by comparing OldKnownPathList[0] with KnownPathList[0].
- Refactor rtcVPNCandidates to accept isWithdraw bool instead of *Path to reduce coupling.

Add TestTableVPNPathIndexPathCount covering both scenarios end-to-end.