### PR TITLE
feat(netutils): add SetUDPTTLSockopt and SetReuseAddrSockopt helpers

### DIFF
--- a/internal/pkg/netutils/sockopt.go
+++ b/internal/pkg/netutils/sockopt.go
@@ -48,6 +48,14 @@ func SetIPTOSSockopt(conn net.Conn, tos uint8) error {
 	return SetIpTOSSockopt(conn, tos)
 }
 
+func SetUDPTTLSockopt(conn net.Conn, ttl int) error {
+	return SetUdpTTLSockopt(conn, ttl)
+}
+
+func SetReuseAddrSockopt(sc syscall.RawConn) error {
+	return SetReuseAddrSockoptImpl(sc)
+}
+
 func DialerControl(logger *slog.Logger, network, address string, c syscall.RawConn, ttl, minTtl uint8, mss uint16, password string, bindInterface string, tos uint8) error {
 	if password != "" {
 		logger.Warn("setting md5 for active connection is not supported",

--- a/internal/pkg/netutils/sockopt_bsd.go
+++ b/internal/pkg/netutils/sockopt_bsd.go
@@ -77,3 +77,16 @@ func SetIpTOSSockopt(conn net.Conn, tos uint8) error {
 	}
 	return setSockOptIpTos(sc, family, tos)
 }
+
+func SetUdpTTLSockopt(conn net.Conn, ttl int) error {
+	family := extractFamilyFromConn(conn)
+	sc, err := conn.(syscall.Conn).SyscallConn()
+	if err != nil {
+		return err
+	}
+	return setSockOptIpTtl(sc, family, ttl)
+}
+
+func SetReuseAddrSockoptImpl(sc syscall.RawConn) error {
+	return setSockOptInt(sc, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+}

--- a/internal/pkg/netutils/sockopt_darwin.go
+++ b/internal/pkg/netutils/sockopt_darwin.go
@@ -61,3 +61,19 @@ func SetIpTOSSockopt(conn net.Conn, tos uint8) error {
 	}
 	return setSockOptIpTos(sc, family, tos)
 }
+
+func SetUdpTTLSockopt(conn net.Conn, ttl int) error {
+	family := syscall.AF_INET
+	if strings.Contains(conn.RemoteAddr().String(), "[") {
+		family = syscall.AF_INET6
+	}
+	sc, err := conn.(syscall.Conn).SyscallConn()
+	if err != nil {
+		return err
+	}
+	return setSockOptIpTtl(sc, family, ttl)
+}
+
+func SetReuseAddrSockoptImpl(sc syscall.RawConn) error {
+	return setSockOptInt(sc, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+}

--- a/internal/pkg/netutils/sockopt_linux.go
+++ b/internal/pkg/netutils/sockopt_linux.go
@@ -119,6 +119,18 @@ func SetTCPMD5SigSockopt(l *net.TCPListener, address string, key string) error {
 	return sockerr
 }
 
+func setSockOptString(sc syscall.RawConn, level int, opt int, str string) error {
+	var opterr error
+	fn := func(s uintptr) {
+		opterr = syscall.SetsockoptString(int(s), level, opt, str)
+	}
+	err := sc.Control(fn)
+	if opterr == nil {
+		return err
+	}
+	return opterr
+}
+
 func SetBindToDevSockopt(sc syscall.RawConn, device string) error {
 	return setSockOptString(sc, syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, device)
 }
@@ -163,6 +175,19 @@ func SetIPTOSSockopt(conn net.Conn, tos uint8) error {
 		return err
 	}
 	return setSockOptIpTos(sc, family, tos)
+}
+
+func SetUDPTTLSockopt(conn net.Conn, ttl int) error {
+	family := extractFamilyFromConn(conn)
+	sc, err := conn.(syscall.Conn).SyscallConn()
+	if err != nil {
+		return err
+	}
+	return setSockOptIpTtl(sc, family, ttl)
+}
+
+func SetReuseAddrSockopt(sc syscall.RawConn) error {
+	return setSockOptInt(sc, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
 }
 
 func DialerControl(logger *slog.Logger, network, address string, c syscall.RawConn, ttl, minTtl uint8, mss uint16, password string, bindInterface string, tos uint8) error {

--- a/internal/pkg/netutils/sockopt_openbsd.go
+++ b/internal/pkg/netutils/sockopt_openbsd.go
@@ -409,6 +409,19 @@ func SetIPTOSSockopt(conn net.Conn, tos uint8) error {
 	return setSockOptIpTos(sc, family, tos)
 }
 
+func SetUDPTTLSockopt(conn net.Conn, ttl int) error {
+	family := extractFamilyFromConn(conn)
+	sc, err := conn.(syscall.Conn).SyscallConn()
+	if err != nil {
+		return err
+	}
+	return setSockOptIpTtl(sc, family, ttl)
+}
+
+func SetReuseAddrSockopt(sc syscall.RawConn) error {
+	return setSockOptInt(sc, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+}
+
 func DialerControl(logger *slog.Logger, network, address string, c syscall.RawConn, ttl, minTtl uint8, mss uint16, password string, bindInterface string, tos uint8) error {
 	family := syscall.AF_INET
 	raddr, _ := net.ResolveTCPAddr("tcp", address)

--- a/internal/pkg/netutils/sockopt_stub.go
+++ b/internal/pkg/netutils/sockopt_stub.go
@@ -20,6 +20,7 @@ package netutils
 import (
 	"fmt"
 	"net"
+	"syscall"
 )
 
 func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
@@ -40,4 +41,12 @@ func SetTcpMSSSockopt(conn net.Conn, mss uint16) error {
 
 func SetIpTOSSockopt(conn net.Conn, tos uint8) error {
 	return fmt.Errorf("setting ip tos is not supported")
+}
+
+func SetUdpTTLSockopt(conn net.Conn, ttl int) error {
+	return fmt.Errorf("setting udp ttl is not supported")
+}
+
+func SetReuseAddrSockoptImpl(_ syscall.RawConn) error {
+	return fmt.Errorf("setting SO_REUSEADDR is not supported")
 }

--- a/internal/pkg/netutils/sockopt_windows.go
+++ b/internal/pkg/netutils/sockopt_windows.go
@@ -81,6 +81,19 @@ func SetIPTOSSockopt(conn net.Conn, tos uint8) error {
 	return fmt.Errorf("setting ip tos is not supported")
 }
 
+func SetUDPTTLSockopt(conn net.Conn, ttl int) error {
+	family := extractFamilyFromConn(conn)
+	sc, err := conn.(syscall.Conn).SyscallConn()
+	if err != nil {
+		return err
+	}
+	return setSockOptIpTtl(sc, family, ttl)
+}
+
+func SetReuseAddrSockopt(sc syscall.RawConn) error {
+	return setSockOptInt(sc, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+}
+
 func DialerControl(logger *slog.Logger, network, address string, c syscall.RawConn, ttl, ttlMin uint8, mss uint16, password string, bindInterface string, tos uint8) error {
 	if password != "" {
 		logger.Warn("setting md5 for active connection is not supported",

--- a/internal/pkg/netutils/utils.go
+++ b/internal/pkg/netutils/utils.go
@@ -21,18 +21,6 @@ import (
 	"syscall"
 )
 
-func setSockOptString(sc syscall.RawConn, level int, opt int, str string) error {
-	var opterr error
-	fn := func(s uintptr) {
-		opterr = syscall.SetsockoptString(int(s), level, opt, str)
-	}
-	err := sc.Control(fn)
-	if opterr == nil {
-		return err
-	}
-	return opterr
-}
-
 func setSockOptInt(sc syscall.RawConn, level, name, value int) error {
 	var opterr error
 	fn := func(s uintptr) {

--- a/tools/spell-check/dictionary.txt
+++ b/tools/spell-check/dictionary.txt
@@ -39,6 +39,7 @@ pmsi
 prepend
 reachability
 reservable
+reuseaddr
 rpki
 sadb
 safi


### PR DESCRIPTION
Add two UDP socket option helpers needed for BFD transport:
- SetUDPTTLSockopt: sets TTL/hop-limit to 255 per RFC 5881
- SetReuseAddrSockopt: enables SO_REUSEADDR on the BFD server socket

Also moves setSockOptString from the platform-neutral utils.go into sockopt_linux.go where it is only compiled on Linux.

Part of #3388 