### PR TITLE
feat(bfd): add RFC 5880 BFD packet codec

### DIFF
--- a/pkg/packet/bfd/bfd.go
+++ b/pkg/packet/bfd/bfd.go
@@ -1,0 +1,128 @@
+package bfd
+
+import (
+	"encoding"
+	"encoding/binary"
+	"errors"
+)
+
+type StateType uint8
+
+const (
+	StateAdminDown StateType = iota
+	StateDown
+	StateInit
+	StateUp
+)
+
+func (s StateType) String() string {
+	switch s {
+	case StateDown:
+		return "Down"
+	case StateInit:
+		return "Init"
+	case StateUp:
+		return "Up"
+	case StateAdminDown:
+		return "Admin Down"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	packetSizeMin = 24
+)
+
+var (
+	ErrInvalidPacketLength = errors.New("invalid packet length")
+	ErrInvalidHeader       = errors.New("invalid header")
+)
+
+type BFDHeader struct {
+	Version               uint8
+	State                 StateType
+	Poll                  bool
+	Final                 bool
+	DetectTimeMultiplier  uint8
+	MyDiscriminator       uint32
+	YourDiscriminator     uint32
+	DesiredMinTxInterval  uint32
+	RequiredMinRxInterval uint32
+}
+
+var (
+	_ encoding.BinaryMarshaler   = &BFDHeader{}
+	_ encoding.BinaryUnmarshaler = &BFDHeader{}
+)
+
+/*
+    0               1               2               3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |Vers |  Diag   |Sta|P|F|C|A|D|M|  Detect Mult  |    Length     |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                       My Discriminator                        |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                      Your Discriminator                       |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                    Desired Min TX Interval                    |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                   Required Min RX Interval                    |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                 Required Min Echo RX Interval                 |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+*/
+
+func byteToBool(b byte) bool {
+	return b != 0
+}
+
+func boolToByte(b bool) byte {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func (h *BFDHeader) UnmarshalBinary(buf []byte) error {
+	if len(buf) < packetSizeMin {
+		return ErrInvalidPacketLength
+	}
+
+	if len(buf) != int(buf[3]) {
+		return ErrInvalidHeader
+	}
+
+	h.Version = buf[0] >> 5
+	h.State = StateType(buf[1] >> 6)
+	h.Poll = byteToBool(buf[1] >> 5 & 1)
+	h.Final = byteToBool(buf[1] >> 4 & 1)
+	// ignore other flags
+
+	h.DetectTimeMultiplier = buf[2]
+
+	h.MyDiscriminator = binary.BigEndian.Uint32(buf[4:])
+	h.YourDiscriminator = binary.BigEndian.Uint32(buf[8:])
+	h.DesiredMinTxInterval = binary.BigEndian.Uint32(buf[12:])
+	h.RequiredMinRxInterval = binary.BigEndian.Uint32(buf[16:])
+	// ignore other variables
+
+	return nil
+}
+
+func (h *BFDHeader) MarshalBinary() ([]byte, error) {
+	buf := make([]byte, packetSizeMin)
+
+	buf[0] = h.Version << 5
+	buf[1] = byte(h.State)<<6 | boolToByte(h.Poll)<<5 | boolToByte(h.Final)<<4
+	buf[2] = h.DetectTimeMultiplier
+	buf[3] = byte(packetSizeMin)
+
+	binary.BigEndian.PutUint32(buf[4:], h.MyDiscriminator)
+	binary.BigEndian.PutUint32(buf[8:], h.YourDiscriminator)
+	binary.BigEndian.PutUint32(buf[12:], h.DesiredMinTxInterval)
+	binary.BigEndian.PutUint32(buf[16:], h.RequiredMinRxInterval)
+
+	return buf, nil
+}

--- a/pkg/packet/bfd/bfd_test.go
+++ b/pkg/packet/bfd/bfd_test.go
@@ -1,0 +1,112 @@
+package bfd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_MarshalBinary(t *testing.T) {
+	assert := assert.New(t)
+
+	target := []byte{
+		0x20, 0xc0, 0x08, 0x18,
+		0x4f, 0x2f, 0xd5, 0xf2,
+		0xd6, 0x7e, 0xae, 0xdf,
+		0x00, 0x04, 0x93, 0xe0,
+		0x00, 0x0c, 0x35, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	packet := &BFDHeader{
+		Version:               1,
+		State:                 StateUp,
+		Poll:                  false,
+		Final:                 false,
+		DetectTimeMultiplier:  8,
+		MyDiscriminator:       0x4f2fd5f2,
+		YourDiscriminator:     0xd67eaedf,
+		DesiredMinTxInterval:  300000,
+		RequiredMinRxInterval: 800000,
+	}
+
+	packetBytes, err := packet.MarshalBinary()
+	assert.NoError(err)
+	assert.Equal(packetBytes, target)
+}
+
+func Test_UnmarshalBinary(t *testing.T) {
+	assert := assert.New(t)
+
+	packetBytes := []byte{
+		0x20, 0xc0, 0x03, 0x18,
+		0x12, 0x34, 0x56, 0x78,
+		0xab, 0xcd, 0xef, 0x12,
+		0x00, 0x01, 0x86, 0xa0,
+		0x00, 0x03, 0x0d, 0x40,
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	target := &BFDHeader{
+		Version:               1,
+		State:                 StateUp,
+		Poll:                  false,
+		Final:                 false,
+		DetectTimeMultiplier:  3,
+		MyDiscriminator:       0x12345678,
+		YourDiscriminator:     0xabcdef12,
+		DesiredMinTxInterval:  100000,
+		RequiredMinRxInterval: 200000,
+	}
+
+	packet := &BFDHeader{}
+	err := packet.UnmarshalBinary(packetBytes)
+	assert.NoError(err)
+	assert.Equal(packet, target)
+}
+
+func Test_UnmarshalBinaryInvalidPacketLength(t *testing.T) {
+	assert := assert.New(t)
+
+	packetBytes := []byte{
+		0x20, 0xc0, 0x03, 0x18,
+		0x12, 0x34, 0x56, 0x78,
+		0xab, 0xcd, 0xef, 0x12,
+		0x00, 0x01, 0x86, 0xa0,
+		0x00, 0x03, 0x0d, 0x40,
+		0x00, 0x00, 0x00,
+	}
+
+	packet := &BFDHeader{}
+	err := packet.UnmarshalBinary(packetBytes)
+	assert.ErrorIs(err, ErrInvalidPacketLength)
+}
+
+func Test_UnmarshalBinaryInvalidHeader(t *testing.T) {
+	assert := assert.New(t)
+
+	packetBytes := []byte{
+		0x20, 0xc0, 0x03, 0x17,
+		0x12, 0x34, 0x56, 0x78,
+		0xab, 0xcd, 0xef, 0x12,
+		0x00, 0x01, 0x86, 0xa0,
+		0x00, 0x03, 0x0d, 0x40,
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	packet := &BFDHeader{}
+	err := packet.UnmarshalBinary(packetBytes)
+	assert.ErrorIs(err, ErrInvalidHeader)
+
+	packetBytes = []byte{
+		0x20, 0xc0, 0x03, 0x19,
+		0x12, 0x34, 0x56, 0x78,
+		0xab, 0xcd, 0xef, 0x12,
+		0x00, 0x01, 0x86, 0xa0,
+		0x00, 0x03, 0x0d, 0x40,
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	err = packet.UnmarshalBinary(packetBytes)
+	assert.ErrorIs(err, ErrInvalidHeader)
+}


### PR DESCRIPTION
Implements binary marshal/unmarshal for BFD control packets per RFC 5880. The codec is self-contained with no dependency on the rest of the codebase and covers the mandatory 24-byte header fields used in single-hop sessions.

Part of #3388