### PR TITLE
watcher: serialize new watcher registration

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -127,6 +127,7 @@ type BgpServer struct {
 	rsRib        *table.TableManager
 	roaManager   *roaManager
 	watcherMap   map[watchEventType][]*watcher
+	watcherMu    sync.RWMutex
 	zclient      *zebraClient
 	bmpManager   *bmpClientManager
 	mrtManager   *mrtManager
@@ -4673,6 +4674,7 @@ func (w *watcher) loop() {
 //nolint:errcheck // we don't care about the error here.
 func (w *watcher) Stop() {
 	w.s.mgmtOperation(func() error {
+		w.s.watcherMu.Lock()
 		for k, l := range w.s.watcherMap {
 			for i, v := range l {
 				if w == v {
@@ -4681,6 +4683,7 @@ func (w *watcher) Stop() {
 				}
 			}
 		}
+		w.s.watcherMu.Unlock()
 
 		cleanInfiniteChannel(w.ch)
 		// the loop function goroutine might be blocked for
@@ -4692,6 +4695,8 @@ func (w *watcher) Stop() {
 }
 
 func (s *BgpServer) isWatched(typ watchEventType) bool {
+	s.watcherMu.RLock()
+	defer s.watcherMu.RUnlock()
 	return len(s.watcherMap[typ]) != 0
 }
 
@@ -4699,6 +4704,7 @@ func (s *BgpServer) isWatched(typ watchEventType) bool {
 // If the filter is set(and not nil) for the watchEventType, it will be used for filtering.
 // Otherwise, all events will be processed without any filtering.
 func (s *BgpServer) notifyWatcher(typ watchEventType, ev watchEvent) {
+	s.watcherMu.RLock()
 	for _, w := range s.watcherMap[typ] {
 		if f := w.filters[typ]; f != nil && !f(ev) {
 			// Filter is set and the event doesn't pass it.
@@ -4706,6 +4712,7 @@ func (s *BgpServer) notifyWatcher(typ watchEventType, ev watchEvent) {
 		}
 		w.notify(ev)
 	}
+	s.watcherMu.RUnlock()
 }
 
 func (s *BgpServer) watch(opts ...WatchOption) (w *watcher) {
@@ -4722,27 +4729,22 @@ func (s *BgpServer) watch(opts ...WatchOption) (w *watcher) {
 			opt(&w.opts)
 		}
 
+		s.watcherMu.Lock()
+		defer s.watcherMu.Unlock()
+
 		register := func(t watchEventType, w *watcher) {
 			s.watcherMap[t] = append(s.watcherMap[t], w)
 		}
 
-		if w.opts.bestPath {
-			register(watchEventTypeBestPath, w)
-		}
 		if w.opts.preUpdate {
 			if w.opts.preUpdateFilter != nil {
 				w.filters[watchEventTypePreUpdate] = w.opts.preUpdateFilter
 			}
-			register(watchEventTypePreUpdate, w)
 		}
 		if w.opts.postUpdate {
 			if w.opts.postUpdateFilter != nil {
 				w.filters[watchEventTypePostUpdate] = w.opts.postUpdateFilter
 			}
-			register(watchEventTypePostUpdate, w)
-		}
-		if w.opts.eor {
-			register(watchEventTypeEor, w)
 		}
 		if w.opts.peerState {
 			for _, p := range s.neighborMap {
@@ -4750,8 +4752,6 @@ func (s *BgpServer) watch(opts ...WatchOption) (w *watcher) {
 				w.notify(newWatchEventPeer(p, nil, state, state, apiutil.PEER_EVENT_INIT))
 			}
 			w.notify(&watchEventPeer{Type: apiutil.PEER_EVENT_END_OF_INIT})
-
-			register(watchEventTypePeerState, w)
 		}
 
 		if w.opts.initBest && s.active() == nil {
@@ -4881,6 +4881,21 @@ func (s *BgpServer) watch(opts ...WatchOption) (w *watcher) {
 					})
 				}
 			}
+		}
+		if w.opts.bestPath {
+			register(watchEventTypeBestPath, w)
+		}
+		if w.opts.preUpdate {
+			register(watchEventTypePreUpdate, w)
+		}
+		if w.opts.postUpdate {
+			register(watchEventTypePostUpdate, w)
+		}
+		if w.opts.eor {
+			register(watchEventTypeEor, w)
+		}
+		if w.opts.peerState {
+			register(watchEventTypePeerState, w)
 		}
 		if w.opts.recvMessage {
 			register(watchEventTypeRecvMsg, w)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -92,6 +92,123 @@ func TestStop(t *testing.T) {
 	assert.Error(err)
 }
 
+func TestWatchUpdateCurrentDeliversInitBeforeLiveEvents(t *testing.T) {
+	ctx := context.Background()
+	s1 := runNewServer(t, 1, "1.1.1.1", 10179)
+	defer s1.StopBgp(context.Background(), &api.StopBgpRequest{})
+	s2 := runNewServer(t, 1, "2.2.2.2", 20179)
+	defer s2.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	established := newPeerStateWaiter(s1, api.PeerState_SESSION_STATE_ESTABLISHED)
+	err := peerServers(t, ctx, []*BgpServer{s1, s2}, []oc.AfiSafiType{oc.AFI_SAFI_TYPE_IPV4_UNICAST})
+	require.NoError(t, err)
+	established.Wait(t, 10*time.Second)
+
+	panh, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("10.0.0.1"))
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		panh,
+	}
+	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.0/24"))
+	path, _ := apiutil.NewPath(bgp.RF_IPv4_UC, nlri, false, attrs, time.Now())
+	_, err = s2.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(path)}})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		found := false
+		_ = s1.mgmtOperation(func() error {
+			for _, peer := range s1.neighborMap {
+				if peer.adjRibIn.Count([]bgp.Family{bgp.RF_IPv4_UC}) > 0 {
+					found = true
+					break
+				}
+			}
+			return nil
+		}, true)
+		return found
+	}, 10*time.Second, 100*time.Millisecond)
+
+	enterFilter := make(chan struct{})
+	releaseFilter := make(chan struct{})
+	var filterBlocked atomic.Bool
+	var watcher *watcher
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		watcher = s1.watch(func(o *watchOptions) {
+			o.preUpdate = true
+			o.initUpdate = true
+			o.preUpdateFilter = func(w watchEvent) bool {
+				if filterBlocked.CompareAndSwap(false, true) {
+					close(enterFilter)
+					<-releaseFilter
+				}
+				return true
+			}
+		})
+	}()
+
+	select {
+	case <-enterFilter:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for watch() to enter initial update filter")
+	}
+
+	liveUpdate := &watchEventUpdate{
+		PeerAS:      1,
+		PeerAddress: netip.MustParseAddr("127.0.0.1"),
+		PeerID:      netip.MustParseAddr("2.2.2.2"),
+		PostPolicy:  false,
+		Init:        false,
+		PathList: []*table.Path{
+			table.NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, true, nil, time.Now(), false),
+		},
+	}
+	liveDone := make(chan struct{})
+	go func() {
+		defer close(liveDone)
+		s1.notifyWatcher(watchEventTypePreUpdate, liveUpdate)
+	}()
+
+	close(releaseFilter)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for watch() to finish")
+	}
+
+	require.NotNil(t, watcher)
+	defer watcher.Stop()
+
+	select {
+	case <-liveDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for live update notification")
+	}
+
+	ev := <-watcher.Event()
+	initUpdate, ok := ev.(*watchEventUpdate)
+	require.True(t, ok)
+	assert.True(t, initUpdate.Init)
+	assert.Len(t, initUpdate.PathList, 1)
+	assert.Equal(t, "10.10.0.0/24", initUpdate.PathList[0].GetNlri().String())
+
+	ev = <-watcher.Event()
+	initEOR, ok := ev.(*watchEventUpdate)
+	require.True(t, ok)
+	assert.True(t, initEOR.Init)
+	assert.Empty(t, initEOR.PathList)
+
+	ev = <-watcher.Event()
+	live, ok := ev.(*watchEventUpdate)
+	require.True(t, ok)
+	assert.False(t, live.Init)
+	assert.Len(t, live.PathList, 1)
+	assert.True(t, live.PathList[0].IsWithdraw)
+}
+
 func TestModPolicyAssign(t *testing.T) {
 	assert := assert.New(t)
 	s := NewBgpServer()


### PR DESCRIPTION
To avoid out of order or duplicated events
When registering a watcher, first dump the state, then register for the nexts notifyWatcher().
