### PR TITLE
feat(bfd): add BFD server and peer state machine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	github.com/vishvananda/netlink v1.3.1
+	go.uber.org/goleak v1.3.0
 	golang.org/x/sys v0.39.0
 	golang.org/x/text v0.32.0
 	golang.org/x/time v0.12.0

--- a/pkg/server/bfd_peer.go
+++ b/pkg/server/bfd_peer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"net/netip"
 	"sync/atomic"
 	"time"
 
@@ -38,7 +39,7 @@ type bfdPeerStats struct {
 type bfdPeer struct {
 	peerState   peerState
 	logger      *slog.Logger
-	peerAddress string
+	peerAddress netip.Addr
 	peerPort    int
 
 	udpClient *net.UDPConn
@@ -61,7 +62,7 @@ type bfdPeer struct {
 	stats bfdPeerStats
 }
 
-func NewBfdPeer(ps peerState, logger *slog.Logger, peerAddress string, config oc.BfdConfig) *bfdPeer {
+func NewBfdPeer(ps peerState, logger *slog.Logger, peerAddress netip.Addr, config oc.BfdConfig) *bfdPeer {
 	p := &bfdPeer{
 		peerState:   ps,
 		logger:      logger,
@@ -153,7 +154,7 @@ func (p *bfdPeer) stop() {
 	if err != nil {
 		p.logger.Warn("Can't close UDP",
 			slog.String("Topic", "bfd"),
-			slog.String("Peer", p.peerAddress),
+			slog.String("Peer", p.peerAddress.String()),
 		)
 	}
 
@@ -161,7 +162,7 @@ func (p *bfdPeer) stop() {
 
 	p.logger.Debug("BFD client is stopped",
 		slog.String("Topic", "bfd"),
-		slog.String("Peer", p.peerAddress),
+		slog.String("Peer", p.peerAddress.String()),
 	)
 }
 
@@ -171,7 +172,7 @@ func (p *bfdPeer) startClient() {
 	}
 
 	remoteAddress := &net.UDPAddr{
-		IP:   net.ParseIP(p.peerAddress),
+		IP:   p.peerAddress.AsSlice(),
 		Port: p.peerPort,
 	}
 
@@ -180,7 +181,7 @@ func (p *bfdPeer) startClient() {
 	if err != nil {
 		p.logger.Warn("Can't dial UDP",
 			slog.String("Topic", "bfd"),
-			slog.String("Peer", p.peerAddress),
+			slog.String("Peer", p.peerAddress.String()),
 			slog.String("LocalAddress", localAddress.String()),
 			slog.String("RemoteAddress", remoteAddress.String()),
 			slog.Any("Error", err),
@@ -197,7 +198,7 @@ func (p *bfdPeer) startClient() {
 	if err != nil {
 		p.logger.Error("Can't set TTL to 255",
 			slog.String("Topic", "bfd"),
-			slog.String("Peer", p.peerAddress),
+			slog.String("Peer", p.peerAddress.String()),
 			slog.String("LocalAddress", localAddress.String()),
 			slog.String("RemoteAddress", remoteAddress.String()),
 			slog.Any("Error", err),
@@ -207,7 +208,7 @@ func (p *bfdPeer) startClient() {
 		if err != nil {
 			p.logger.Warn("Can't close UDP",
 				slog.String("Topic", "bfd"),
-				slog.String("Peer", p.peerAddress),
+				slog.String("Peer", p.peerAddress.String()),
 			)
 		}
 
@@ -217,7 +218,7 @@ func (p *bfdPeer) startClient() {
 
 	p.logger.Debug("BFD client is started",
 		slog.String("Topic", "bfd"),
-		slog.String("Peer", p.peerAddress),
+		slog.String("Peer", p.peerAddress.String()),
 		slog.String("LocalAddress", localAddress.String()),
 		slog.String("RemoteAddress", remoteAddress.String()),
 	)
@@ -268,17 +269,17 @@ func (p *bfdPeer) tx() {
 func (p *bfdPeer) expiry() {
 	p.logger.Warn("Expired",
 		slog.String("Topic", "bfd"),
-		slog.String("Peer", p.peerAddress),
+		slog.String("Peer", p.peerAddress.String()),
 	)
 
 	if err := p.peerState.ResetPeer(context.Background(), &api.ResetPeerRequest{
-		Address:       p.peerAddress,
+		Address:       p.peerAddress.String(),
 		Communication: "BFD is down",
 		Soft:          false,
 	}); err != nil {
 		p.logger.Warn("ResetPeer failed",
 			slog.String("Topic", "bfd"),
-			slog.String("Peer", p.peerAddress),
+			slog.String("Peer", p.peerAddress.String()),
 			slog.String("Err", err.Error()),
 		)
 	}
@@ -317,7 +318,7 @@ func (p *bfdPeer) sendPacket(state bfd.StateType, poll bool, final bool, yourDis
 		// should never happen
 		p.logger.Error("MarshalBinary",
 			slog.String("Topic", "bfd"),
-			slog.String("Peer", p.peerAddress),
+			slog.String("Peer", p.peerAddress.String()),
 		)
 		return
 	}
@@ -326,7 +327,7 @@ func (p *bfdPeer) sendPacket(state bfd.StateType, poll bool, final bool, yourDis
 	if err != nil {
 		p.logger.Debug("Can't send UDP packet",
 			slog.String("Topic", "bfd"),
-			slog.String("Peer", p.peerAddress),
+			slog.String("Peer", p.peerAddress.String()),
 		)
 
 		p.stats.txError.Add(1)
@@ -339,7 +340,7 @@ func (p *bfdPeer) sendPacket(state bfd.StateType, poll bool, final bool, yourDis
 func (p *bfdPeer) setStateDown() {
 	p.logger.Debug("Set state to DOWN",
 		slog.String("Topic", "bfd"),
-		slog.String("Peer", p.peerAddress),
+		slog.String("Peer", p.peerAddress.String()),
 	)
 
 	p.state.Store(int32(api.BfdSessionState_BFD_SESSION_STATE_DOWN))
@@ -351,7 +352,7 @@ func (p *bfdPeer) setStateDown() {
 func (p *bfdPeer) setStateUp(yourDiscriminator uint32) {
 	p.logger.Debug("Set state to UP",
 		slog.String("Topic", "bfd"),
-		slog.String("Peer", p.peerAddress),
+		slog.String("Peer", p.peerAddress.String()),
 	)
 
 	p.state.Store(int32(api.BfdSessionState_BFD_SESSION_STATE_UP))

--- a/pkg/server/bfd_peer.go
+++ b/pkg/server/bfd_peer.go
@@ -1,0 +1,364 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"sync/atomic"
+	"time"
+
+	api "github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/internal/pkg/netutils"
+	"github.com/osrg/gobgp/v4/pkg/config/oc"
+	"github.com/osrg/gobgp/v4/pkg/packet/bfd"
+)
+
+const (
+	// https://datatracker.ietf.org/doc/html/rfc5881
+	//   The source port MUST be in the range 49152 through 65535
+	bfdSourcePortMin = 49152
+	bfdSourcePortMax = 65535
+
+	// Some default values
+	defaultMultiplier = 3
+	defaultRxInterval = 1000 * time.Millisecond
+	defaultTxInterval = 1000 * time.Millisecond
+)
+
+type bfdPeerStats struct {
+	rxPacket             atomic.Uint64
+	txPacket             atomic.Uint64
+	txDrop               atomic.Uint64
+	txError              atomic.Uint64
+	invalidDiscriminator atomic.Uint64
+	expired              atomic.Uint64
+	badInitPacket        atomic.Uint64
+}
+
+type bfdPeer struct {
+	peerState   peerState
+	logger      *slog.Logger
+	peerAddress string
+	peerPort    int
+
+	udpClient *net.UDPConn
+
+	expiryInterval time.Duration
+
+	state             atomic.Int32
+	myDiscriminator   uint32
+	yourDiscriminator uint32
+	multiplier        uint8
+	rxInterval        time.Duration
+	txInterval        time.Duration
+
+	eventStart    *time.Ticker
+	eventRxPacket chan *bfd.BFDHeader
+	eventTx       *time.Ticker
+	eventExpiry   *time.Ticker
+	eventShutdown chan struct{}
+
+	stats bfdPeerStats
+}
+
+func NewBfdPeer(ps peerState, logger *slog.Logger, peerAddress string, config oc.BfdConfig) *bfdPeer {
+	p := &bfdPeer{
+		peerState:   ps,
+		logger:      logger,
+		peerAddress: peerAddress,
+		peerPort:    int(config.Port),
+
+		myDiscriminator: randomBFDMyDiscriminator(),
+		multiplier:      defaultMultiplier,
+		rxInterval:      defaultRxInterval,
+		txInterval:      defaultTxInterval,
+
+		eventStart:    time.NewTicker(time.Second),
+		eventRxPacket: make(chan *bfd.BFDHeader, 1),
+		eventShutdown: make(chan struct{}),
+	}
+
+	p.state.Store(int32(api.BfdSessionState_BFD_SESSION_STATE_DOWN))
+
+	if config.DetectionMultiplier > 0 {
+		p.multiplier = config.DetectionMultiplier
+	}
+
+	if config.RequiredMinimumReceive > 0 {
+		p.rxInterval = time.Duration(config.RequiredMinimumReceive) * time.Microsecond
+	}
+
+	if config.DesiredMinimumTxInterval > 0 {
+		p.txInterval = time.Duration(config.DesiredMinimumTxInterval) * time.Microsecond
+	}
+
+	p.expiryInterval = time.Duration(p.multiplier) * p.rxInterval
+	p.eventTx = time.NewTicker(p.txInterval)
+
+	p.eventExpiry = time.NewTicker(p.expiryInterval)
+	p.eventExpiry.Stop()
+
+	go p.loop()
+	return p
+}
+
+func (p *bfdPeer) Rx(packet *bfd.BFDHeader) bool {
+	select {
+	case p.eventRxPacket <- packet:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *bfdPeer) Stop() {
+	close(p.eventShutdown)
+}
+
+func (p *bfdPeer) loop() {
+	for {
+		select {
+		case <-p.eventStart.C:
+			success := p.start()
+			if success {
+				p.eventStart.Stop()
+			}
+		case bfdPacket := <-p.eventRxPacket:
+			p.rxPacket(bfdPacket)
+		case <-p.eventTx.C:
+			p.tx()
+		case <-p.eventExpiry.C:
+			p.expiry()
+		case <-p.eventShutdown:
+			p.shutdown()
+			return
+		}
+	}
+}
+
+func (p *bfdPeer) start() bool {
+	if p.udpClient == nil {
+		p.startClient()
+	}
+
+	return p.udpClient != nil
+}
+
+func (p *bfdPeer) stop() {
+	if p.udpClient == nil {
+		return
+	}
+
+	err := p.udpClient.Close()
+	if err != nil {
+		p.logger.Warn("Can't close UDP",
+			slog.String("Topic", "bfd"),
+			slog.String("Peer", p.peerAddress),
+		)
+	}
+
+	p.udpClient = nil
+
+	p.logger.Debug("BFD client is stopped",
+		slog.String("Topic", "bfd"),
+		slog.String("Peer", p.peerAddress),
+	)
+}
+
+func (p *bfdPeer) startClient() {
+	localAddress := &net.UDPAddr{
+		Port: randRange(bfdSourcePortMin, bfdSourcePortMax),
+	}
+
+	remoteAddress := &net.UDPAddr{
+		IP:   net.ParseIP(p.peerAddress),
+		Port: p.peerPort,
+	}
+
+	var err error
+	p.udpClient, err = net.DialUDP("udp", localAddress, remoteAddress)
+	if err != nil {
+		p.logger.Warn("Can't dial UDP",
+			slog.String("Topic", "bfd"),
+			slog.String("Peer", p.peerAddress),
+			slog.String("LocalAddress", localAddress.String()),
+			slog.String("RemoteAddress", remoteAddress.String()),
+			slog.Any("Error", err),
+		)
+
+		return
+	}
+
+	// https://datatracker.ietf.org/doc/html/rfc5881
+	//   If BFD authentication is not in use on a session, all BFD Control
+	//   packets for the session MUST be sent with a Time to Live (TTL) or Hop
+	//   Limit value of 255
+	err = netutils.SetUDPTTLSockopt(p.udpClient, 255)
+	if err != nil {
+		p.logger.Error("Can't set TTL to 255",
+			slog.String("Topic", "bfd"),
+			slog.String("Peer", p.peerAddress),
+			slog.String("LocalAddress", localAddress.String()),
+			slog.String("RemoteAddress", remoteAddress.String()),
+			slog.Any("Error", err),
+		)
+
+		err = p.udpClient.Close()
+		if err != nil {
+			p.logger.Warn("Can't close UDP",
+				slog.String("Topic", "bfd"),
+				slog.String("Peer", p.peerAddress),
+			)
+		}
+
+		p.udpClient = nil
+		return
+	}
+
+	p.logger.Debug("BFD client is started",
+		slog.String("Topic", "bfd"),
+		slog.String("Peer", p.peerAddress),
+		slog.String("LocalAddress", localAddress.String()),
+		slog.String("RemoteAddress", remoteAddress.String()),
+	)
+}
+
+func (p *bfdPeer) rxPacket(h *bfd.BFDHeader) {
+	if h.YourDiscriminator != 0 && h.YourDiscriminator != p.myDiscriminator {
+		p.stats.invalidDiscriminator.Add(1)
+		return
+	}
+
+	p.stats.rxPacket.Add(1)
+
+	// NOTE: remote DesiredMinTxInterval and RequiredMinRxInterval ignored
+
+	switch h.State {
+	case bfd.StateDown:
+		p.sendPacket(bfd.StateInit, false, false, h.MyDiscriminator)
+	case bfd.StateInit:
+		if api.BfdSessionState(p.state.Load()) == api.BfdSessionState_BFD_SESSION_STATE_UP {
+			p.stats.badInitPacket.Add(1)
+			return
+		}
+
+		p.setStateUp(h.MyDiscriminator)
+	case bfd.StateUp:
+		if api.BfdSessionState(p.state.Load()) != api.BfdSessionState_BFD_SESSION_STATE_UP {
+			p.setStateUp(h.MyDiscriminator)
+		}
+
+		if h.Poll {
+			// send final packet
+			p.sendPacket(bfd.StateUp, false, true, h.MyDiscriminator)
+		}
+
+		p.eventExpiry.Reset(p.expiryInterval)
+	}
+}
+
+func (p *bfdPeer) tx() {
+	if api.BfdSessionState(p.state.Load()) == api.BfdSessionState_BFD_SESSION_STATE_UP {
+		p.sendPacket(bfd.StateUp, false, false, p.yourDiscriminator)
+	} else {
+		p.sendPacket(bfd.StateDown, false, false, 0)
+	}
+}
+
+func (p *bfdPeer) expiry() {
+	p.logger.Warn("Expired",
+		slog.String("Topic", "bfd"),
+		slog.String("Peer", p.peerAddress),
+	)
+
+	if err := p.peerState.ResetPeer(context.Background(), &api.ResetPeerRequest{
+		Address:       p.peerAddress,
+		Communication: "BFD is down",
+		Soft:          false,
+	}); err != nil {
+		p.logger.Warn("ResetPeer failed",
+			slog.String("Topic", "bfd"),
+			slog.String("Peer", p.peerAddress),
+			slog.String("Err", err.Error()),
+		)
+	}
+
+	p.stats.expired.Add(1)
+
+	p.setStateDown()
+}
+
+func (p *bfdPeer) shutdown() {
+	p.stop()
+	p.eventTx.Stop()
+	p.eventExpiry.Stop()
+}
+
+func (p *bfdPeer) sendPacket(state bfd.StateType, poll bool, final bool, yourDiscriminator uint32) {
+	if p.udpClient == nil {
+		p.stats.txDrop.Add(1)
+		return
+	}
+
+	packet := &bfd.BFDHeader{
+		Version:               1,
+		State:                 state,
+		Poll:                  poll,
+		Final:                 final,
+		DetectTimeMultiplier:  p.multiplier,
+		MyDiscriminator:       p.myDiscriminator,
+		YourDiscriminator:     yourDiscriminator,
+		DesiredMinTxInterval:  uint32(p.txInterval.Microseconds()),
+		RequiredMinRxInterval: uint32(p.rxInterval.Microseconds()),
+	}
+
+	buffer, err := packet.MarshalBinary()
+	if err != nil {
+		// should never happen
+		p.logger.Error("MarshalBinary",
+			slog.String("Topic", "bfd"),
+			slog.String("Peer", p.peerAddress),
+		)
+		return
+	}
+
+	_, err = p.udpClient.Write(buffer)
+	if err != nil {
+		p.logger.Debug("Can't send UDP packet",
+			slog.String("Topic", "bfd"),
+			slog.String("Peer", p.peerAddress),
+		)
+
+		p.stats.txError.Add(1)
+		return
+	}
+
+	p.stats.txPacket.Add(1)
+}
+
+func (p *bfdPeer) setStateDown() {
+	p.logger.Debug("Set state to DOWN",
+		slog.String("Topic", "bfd"),
+		slog.String("Peer", p.peerAddress),
+	)
+
+	p.state.Store(int32(api.BfdSessionState_BFD_SESSION_STATE_DOWN))
+	p.yourDiscriminator = 0
+
+	p.eventExpiry.Stop()
+}
+
+func (p *bfdPeer) setStateUp(yourDiscriminator uint32) {
+	p.logger.Debug("Set state to UP",
+		slog.String("Topic", "bfd"),
+		slog.String("Peer", p.peerAddress),
+	)
+
+	p.state.Store(int32(api.BfdSessionState_BFD_SESSION_STATE_UP))
+	p.yourDiscriminator = yourDiscriminator
+
+	p.eventExpiry.Reset(p.expiryInterval)
+
+	// send poll packet
+	p.sendPacket(bfd.StateUp, true, false, yourDiscriminator)
+}

--- a/pkg/server/bfd_peer.go
+++ b/pkg/server/bfd_peer.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -33,7 +34,6 @@ type bfdPeerStats struct {
 	txError              atomic.Uint64
 	invalidDiscriminator atomic.Uint64
 	expired              atomic.Uint64
-	badInitPacket        atomic.Uint64
 }
 
 type bfdPeer struct {
@@ -58,16 +58,24 @@ type bfdPeer struct {
 	eventTx       *time.Ticker
 	eventExpiry   *time.Ticker
 	eventShutdown chan struct{}
+	shutdownOnce  sync.Once
+	shutdownWait  sync.WaitGroup
+	stopped       atomic.Bool
 
 	stats bfdPeerStats
 }
 
 func NewBfdPeer(ps peerState, logger *slog.Logger, peerAddress netip.Addr, config oc.BfdConfig) *bfdPeer {
+	peerPort := int(config.Port)
+	if peerPort == 0 {
+		peerPort = BfdServerPort
+	}
+
 	p := &bfdPeer{
 		peerState:   ps,
 		logger:      logger,
 		peerAddress: peerAddress,
-		peerPort:    int(config.Port),
+		peerPort:    peerPort,
 
 		myDiscriminator: randomBFDMyDiscriminator(),
 		multiplier:      defaultMultiplier,
@@ -99,24 +107,37 @@ func NewBfdPeer(ps peerState, logger *slog.Logger, peerAddress netip.Addr, confi
 	p.eventExpiry = time.NewTicker(p.expiryInterval)
 	p.eventExpiry.Stop()
 
+	p.shutdownWait.Add(1)
 	go p.loop()
 	return p
 }
 
 func (p *bfdPeer) Rx(packet *bfd.BFDHeader) bool {
+	if p.stopped.Load() {
+		return false
+	}
+
 	select {
 	case p.eventRxPacket <- packet:
 		return true
+	case <-p.eventShutdown:
+		return false
 	default:
 		return false
 	}
 }
 
 func (p *bfdPeer) Stop() {
-	close(p.eventShutdown)
+	p.shutdownOnce.Do(func() {
+		p.stopped.Store(true)
+		close(p.eventShutdown)
+		p.shutdownWait.Wait()
+	})
 }
 
 func (p *bfdPeer) loop() {
+	defer p.shutdownWait.Done()
+
 	for {
 		select {
 		case <-p.eventStart.C:
@@ -235,33 +256,45 @@ func (p *bfdPeer) rxPacket(h *bfd.BFDHeader) {
 	// NOTE: remote DesiredMinTxInterval and RequiredMinRxInterval ignored
 
 	switch h.State {
-	case bfd.StateDown:
-		p.sendPacket(bfd.StateInit, false, false, h.MyDiscriminator)
-	case bfd.StateInit:
-		if api.BfdSessionState(p.state.Load()) == api.BfdSessionState_BFD_SESSION_STATE_UP {
-			p.stats.badInitPacket.Add(1)
-			return
+	case bfd.StateAdminDown:
+		if p.sessionState() != api.BfdSessionState_BFD_SESSION_STATE_DOWN {
+			p.remoteDown()
 		}
-
-		p.setStateUp(h.MyDiscriminator)
-	case bfd.StateUp:
-		if api.BfdSessionState(p.state.Load()) != api.BfdSessionState_BFD_SESSION_STATE_UP {
+	case bfd.StateDown:
+		switch p.sessionState() {
+		case api.BfdSessionState_BFD_SESSION_STATE_DOWN:
+			p.setStateInit(h.MyDiscriminator)
+		case api.BfdSessionState_BFD_SESSION_STATE_UP:
+			p.remoteDown()
+		}
+	case bfd.StateInit:
+		switch p.sessionState() {
+		case api.BfdSessionState_BFD_SESSION_STATE_DOWN, api.BfdSessionState_BFD_SESSION_STATE_INIT:
 			p.setStateUp(h.MyDiscriminator)
 		}
-
-		if h.Poll {
-			// send final packet
-			p.sendPacket(bfd.StateUp, false, true, h.MyDiscriminator)
+	case bfd.StateUp:
+		if p.sessionState() == api.BfdSessionState_BFD_SESSION_STATE_INIT {
+			p.setStateUp(h.MyDiscriminator)
 		}
+	}
 
+	if h.Poll {
+		p.sendPacket(p.sessionStateToWire(), false, true, h.MyDiscriminator)
+	}
+
+	if p.sessionState() == api.BfdSessionState_BFD_SESSION_STATE_INIT ||
+		p.sessionState() == api.BfdSessionState_BFD_SESSION_STATE_UP {
 		p.eventExpiry.Reset(p.expiryInterval)
 	}
 }
 
 func (p *bfdPeer) tx() {
-	if api.BfdSessionState(p.state.Load()) == api.BfdSessionState_BFD_SESSION_STATE_UP {
+	switch p.sessionState() {
+	case api.BfdSessionState_BFD_SESSION_STATE_UP:
 		p.sendPacket(bfd.StateUp, false, false, p.yourDiscriminator)
-	} else {
+	case api.BfdSessionState_BFD_SESSION_STATE_INIT:
+		p.sendPacket(bfd.StateInit, false, false, p.yourDiscriminator)
+	default:
 		p.sendPacket(bfd.StateDown, false, false, 0)
 	}
 }
@@ -272,6 +305,30 @@ func (p *bfdPeer) expiry() {
 		slog.String("Peer", p.peerAddress.String()),
 	)
 
+	p.stats.expired.Add(1)
+
+	p.resetPeer()
+	p.setStateDown()
+}
+
+func (p *bfdPeer) shutdown() {
+	p.stop()
+	p.eventStart.Stop()
+	p.eventTx.Stop()
+	p.eventExpiry.Stop()
+}
+
+func (p *bfdPeer) remoteDown() {
+	p.logger.Warn("Remote peer signaled BFD down",
+		slog.String("Topic", "bfd"),
+		slog.String("Peer", p.peerAddress.String()),
+	)
+
+	p.resetPeer()
+	p.setStateDown()
+}
+
+func (p *bfdPeer) resetPeer() {
 	if err := p.peerState.ResetPeer(context.Background(), &api.ResetPeerRequest{
 		Address:       p.peerAddress.String(),
 		Communication: "BFD is down",
@@ -283,16 +340,6 @@ func (p *bfdPeer) expiry() {
 			slog.String("Err", err.Error()),
 		)
 	}
-
-	p.stats.expired.Add(1)
-
-	p.setStateDown()
-}
-
-func (p *bfdPeer) shutdown() {
-	p.stop()
-	p.eventTx.Stop()
-	p.eventExpiry.Stop()
 }
 
 func (p *bfdPeer) sendPacket(state bfd.StateType, poll bool, final bool, yourDiscriminator uint32) {
@@ -337,6 +384,23 @@ func (p *bfdPeer) sendPacket(state bfd.StateType, poll bool, final bool, yourDis
 	p.stats.txPacket.Add(1)
 }
 
+func (p *bfdPeer) sessionState() api.BfdSessionState {
+	return api.BfdSessionState(p.state.Load())
+}
+
+func (p *bfdPeer) sessionStateToWire() bfd.StateType {
+	switch p.sessionState() {
+	case api.BfdSessionState_BFD_SESSION_STATE_UP:
+		return bfd.StateUp
+	case api.BfdSessionState_BFD_SESSION_STATE_INIT:
+		return bfd.StateInit
+	case api.BfdSessionState_BFD_SESSION_STATE_ADMIN_DOWN:
+		return bfd.StateAdminDown
+	default:
+		return bfd.StateDown
+	}
+}
+
 func (p *bfdPeer) setStateDown() {
 	p.logger.Debug("Set state to DOWN",
 		slog.String("Topic", "bfd"),
@@ -347,6 +411,16 @@ func (p *bfdPeer) setStateDown() {
 	p.yourDiscriminator = 0
 
 	p.eventExpiry.Stop()
+}
+
+func (p *bfdPeer) setStateInit(yourDiscriminator uint32) {
+	p.logger.Debug("Set state to INIT",
+		slog.String("Topic", "bfd"),
+		slog.String("Peer", p.peerAddress.String()),
+	)
+
+	p.state.Store(int32(api.BfdSessionState_BFD_SESSION_STATE_INIT))
+	p.yourDiscriminator = yourDiscriminator
 }
 
 func (p *bfdPeer) setStateUp(yourDiscriminator uint32) {

--- a/pkg/server/bfd_peer_test.go
+++ b/pkg/server/bfd_peer_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"log/slog"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -15,7 +16,7 @@ func Test_NewBfdPeer(t *testing.T) {
 	assert := assert.New(t)
 
 	ps := &mockPeerState{}
-	p := NewBfdPeer(ps, slog.Default(), "127.0.0.1", oc.BfdConfig{
+	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
 		Port:                     13784,
 		Enabled:                  true,
 		DetectionMultiplier:      5,
@@ -31,7 +32,7 @@ func Test_RxPacket(t *testing.T) {
 	assert := assert.New(t)
 
 	ps := &mockPeerState{}
-	p := NewBfdPeer(ps, slog.Default(), "127.0.0.1", oc.BfdConfig{
+	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
 		Port:                     13784,
 		Enabled:                  true,
 		DetectionMultiplier:      5,
@@ -53,7 +54,7 @@ func Test_TxPacket(t *testing.T) {
 	assert := assert.New(t)
 
 	ps := &mockPeerState{}
-	p := NewBfdPeer(ps, slog.Default(), "127.0.0.1", oc.BfdConfig{
+	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
 		Port:                     13784,
 		Enabled:                  true,
 		DetectionMultiplier:      5,

--- a/pkg/server/bfd_peer_test.go
+++ b/pkg/server/bfd_peer_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/osrg/gobgp/v4/pkg/config/oc"
+	"github.com/osrg/gobgp/v4/pkg/packet/bfd"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewBfdPeer(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	p := NewBfdPeer(ps, slog.Default(), "127.0.0.1", oc.BfdConfig{
+		Port:                     13784,
+		Enabled:                  true,
+		DetectionMultiplier:      5,
+		RequiredMinimumReceive:   200000,
+		DesiredMinimumTxInterval: 200000,
+	})
+	defer p.Stop()
+
+	assert.NotNil(p)
+}
+
+func Test_RxPacket(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	p := NewBfdPeer(ps, slog.Default(), "127.0.0.1", oc.BfdConfig{
+		Port:                     13784,
+		Enabled:                  true,
+		DetectionMultiplier:      5,
+		RequiredMinimumReceive:   200000,
+		DesiredMinimumTxInterval: 200000,
+	})
+
+	assert.Equal(p.stats.rxPacket.Load(), uint64(0))
+
+	p.Rx(&bfd.BFDHeader{})
+
+	time.Sleep(2 * time.Second)
+	p.Stop()
+
+	assert.NotEqual(p.stats.rxPacket.Load(), uint64(0))
+}
+
+func Test_TxPacket(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	p := NewBfdPeer(ps, slog.Default(), "127.0.0.1", oc.BfdConfig{
+		Port:                     13784,
+		Enabled:                  true,
+		DetectionMultiplier:      5,
+		RequiredMinimumReceive:   200000,
+		DesiredMinimumTxInterval: 200000,
+	})
+
+	err := eventually(4*time.Second, func() error {
+		if p.stats.txPacket.Load() > 3 {
+			return nil
+		}
+		return fmt.Errorf("must be: txPacket > 3")
+	})
+	assert.NoError(err)
+
+	p.Stop()
+}

--- a/pkg/server/bfd_peer_test.go
+++ b/pkg/server/bfd_peer_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	api "github.com/osrg/gobgp/v4/api"
 	"github.com/osrg/gobgp/v4/pkg/config/oc"
 	"github.com/osrg/gobgp/v4/pkg/packet/bfd"
 	"github.com/stretchr/testify/assert"
@@ -26,6 +28,33 @@ func Test_NewBfdPeer(t *testing.T) {
 	defer p.Stop()
 
 	assert.NotNil(p)
+}
+
+func Test_NewBfdPeerDefaultPort(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
+		Enabled: true,
+	})
+	defer p.Stop()
+
+	assert.Equal(BfdServerPort, p.peerPort)
+}
+
+func Test_BfdPeerStopIdempotent(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
+		Port:    13784,
+		Enabled: true,
+	})
+
+	p.Stop()
+	p.Stop()
+
+	assert.True(p.stopped.Load())
 }
 
 func Test_RxPacket(t *testing.T) {
@@ -48,6 +77,71 @@ func Test_RxPacket(t *testing.T) {
 	p.Stop()
 
 	assert.NotEqual(p.stats.rxPacket.Load(), uint64(0))
+}
+
+func Test_RxPacketRemoteDownResetsPeer(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
+		Port:                     13784,
+		Enabled:                  true,
+		DetectionMultiplier:      5,
+		RequiredMinimumReceive:   200000,
+		DesiredMinimumTxInterval: 200000,
+	})
+	defer p.Stop()
+
+	p.state.Store(int32(api.BfdSessionState_BFD_SESSION_STATE_UP))
+	p.yourDiscriminator = 12345
+
+	p.rxPacket(&bfd.BFDHeader{
+		State:             bfd.StateDown,
+		MyDiscriminator:   67890,
+		YourDiscriminator: p.myDiscriminator,
+	})
+
+	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_DOWN, api.BfdSessionState(p.state.Load()))
+	assert.Equal(int64(1), atomic.LoadInt64(&ps.resetPeerCount))
+}
+
+func Test_RxPacketRFCStateTransitions(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
+		Port:                     13784,
+		Enabled:                  true,
+		DetectionMultiplier:      5,
+		RequiredMinimumReceive:   200000,
+		DesiredMinimumTxInterval: 200000,
+	})
+	defer p.Stop()
+
+	p.rxPacket(&bfd.BFDHeader{
+		State:             bfd.StateDown,
+		MyDiscriminator:   111,
+		YourDiscriminator: p.myDiscriminator,
+	})
+	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_INIT, api.BfdSessionState(p.state.Load()))
+	assert.Equal(uint32(111), p.yourDiscriminator)
+
+	p.setStateDown()
+	p.rxPacket(&bfd.BFDHeader{
+		State:             bfd.StateUp,
+		MyDiscriminator:   222,
+		YourDiscriminator: p.myDiscriminator,
+	})
+	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_DOWN, api.BfdSessionState(p.state.Load()))
+
+	p.setStateInit(333)
+	p.rxPacket(&bfd.BFDHeader{
+		State:             bfd.StateUp,
+		MyDiscriminator:   444,
+		YourDiscriminator: p.myDiscriminator,
+	})
+	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_UP, api.BfdSessionState(p.state.Load()))
+	assert.Equal(uint32(444), p.yourDiscriminator)
 }
 
 func Test_TxPacket(t *testing.T) {

--- a/pkg/server/bfd_server.go
+++ b/pkg/server/bfd_server.go
@@ -1,0 +1,504 @@
+// This is partial implementation of BFD protocol (https://datatracker.ietf.org/doc/html/rfc5880)
+// only for fast detection of connection failures between BGP peers.
+package server
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"net/netip"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	api "github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/internal/pkg/netutils"
+	"github.com/osrg/gobgp/v4/pkg/config/oc"
+	"github.com/osrg/gobgp/v4/pkg/packet/bfd"
+)
+
+type bfdServerStats struct {
+	rxPacket      atomic.Uint64
+	rxDrop        atomic.Uint64
+	rxError       atomic.Uint64
+	invalidPacket atomic.Uint64
+	unknownPeer   atomic.Uint64
+}
+
+type bfdEventPeerUpdate struct {
+	isAdd       bool
+	peerAddress string
+	address     netip.Addr
+	config      oc.BfdConfig
+}
+
+type bfdPeerState struct {
+	peerAddress string
+	state       api.BfdPeerState
+}
+
+type bfdEventGetPeerState struct {
+	in  netip.Addr
+	out chan *bfdPeerState
+}
+
+type bfdEventGetPeerStateList struct {
+	out chan []*bfdPeerState
+}
+
+type peerState interface {
+	ResetPeer(ctx context.Context, r *api.ResetPeerRequest) error
+}
+
+type bfdServer struct {
+	peerState peerState
+	logger    *slog.Logger
+
+	config *oc.BfdConfig
+
+	udpServer *net.UDPConn
+
+	peersMutex sync.RWMutex
+	peers      map[netip.Addr]*bfdPeer
+
+	eventStartStop   *time.Ticker
+	eventConfig      chan *oc.BfdConfig
+	eventPeerUpdate  chan *bfdEventPeerUpdate
+	eventGetPeer     chan *bfdEventGetPeerState
+	eventGetPeerList chan *bfdEventGetPeerStateList
+	eventShutdown    chan struct{}
+
+	shutdownWait sync.WaitGroup
+
+	serverStop chan struct{}
+	serverWait sync.WaitGroup
+
+	stats bfdServerStats
+}
+
+func NewBfdServer(ps peerState, logger *slog.Logger) *bfdServer {
+	s := &bfdServer{
+		peerState: ps,
+		logger:    logger,
+
+		peers: make(map[netip.Addr]*bfdPeer),
+
+		eventStartStop:   time.NewTicker(time.Second),
+		eventConfig:      make(chan *oc.BfdConfig, 1),
+		eventPeerUpdate:  make(chan *bfdEventPeerUpdate, 1),
+		eventGetPeer:     make(chan *bfdEventGetPeerState, 1),
+		eventGetPeerList: make(chan *bfdEventGetPeerStateList, 1),
+		eventShutdown:    make(chan struct{}),
+	}
+
+	s.shutdownWait.Add(1)
+	go s.loop()
+	return s
+}
+
+func (s *bfdServer) Start(config oc.BfdConfig) {
+	s.eventConfig <- &config
+}
+
+func (s *bfdServer) Stop() {
+	close(s.eventShutdown)
+	s.shutdownWait.Wait()
+}
+
+func (s *bfdServer) AddPeer(peerAddress string, config oc.BfdConfig) error {
+	if !config.Enabled {
+		return nil
+	}
+
+	address, err := convertToIPAddress(peerAddress)
+	if err != nil {
+		s.logger.Warn("Can't parse peer address",
+			slog.String("Topic", "bfd"),
+			slog.String("Peer", peerAddress),
+		)
+
+		return err
+	}
+
+	s.eventPeerUpdate <- &bfdEventPeerUpdate{
+		isAdd:       true,
+		peerAddress: peerAddress,
+		address:     address,
+		config:      config,
+	}
+
+	return nil
+}
+
+func (s *bfdServer) DeletePeer(peerAddress string) error {
+	address, err := convertToIPAddress(peerAddress)
+	if err != nil {
+		s.logger.Warn("Can't parse peer address",
+			slog.String("Topic", "bfd"),
+			slog.String("Peer", peerAddress),
+		)
+
+		return err
+	}
+
+	s.eventPeerUpdate <- &bfdEventPeerUpdate{
+		isAdd:       false,
+		peerAddress: peerAddress,
+		address:     address,
+	}
+
+	return nil
+}
+
+func (s *bfdServer) GetPeerState(ctx context.Context, peerAddress string) (*bfdPeerState, error) {
+	address, err := convertToIPAddress(peerAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	list := &bfdEventGetPeerState{
+		in:  address,
+		out: make(chan *bfdPeerState),
+	}
+
+	s.eventGetPeer <- list
+
+	select {
+	case out, ok := <-list.out:
+		if !ok {
+			return nil, errors.New("channel is closed")
+		}
+
+		if out == nil {
+			return nil, errors.New("peer not found")
+		}
+
+		return out, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (s *bfdServer) GetPeerStateList(ctx context.Context) ([]*bfdPeerState, error) {
+	list := &bfdEventGetPeerStateList{
+		out: make(chan []*bfdPeerState),
+	}
+
+	s.eventGetPeerList <- list
+
+	select {
+	case out, ok := <-list.out:
+		if !ok {
+			return nil, errors.New("channel is closed")
+		}
+
+		return out, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (s *bfdServer) GetServerStats() *api.BfdState {
+	return &api.BfdState{
+		ReceivedPacket: s.stats.rxPacket.Load(),
+		ReceivedDrop:   s.stats.rxDrop.Load(),
+		ReceivedError:  s.stats.rxError.Load(),
+		InvalidPacket:  s.stats.invalidPacket.Load(),
+		UnknownPeer:    s.stats.unknownPeer.Load(),
+	}
+}
+
+func convertToIPAddress(stringAddress string) (netip.Addr, error) {
+	address, err := netip.ParseAddr(stringAddress)
+	if err != nil {
+		return netip.IPv4Unspecified(), err
+	}
+
+	// ReadFromUDP() return address in format '::ffff:1.2.3.4'
+	// Fill peers map in a similar way
+	return netip.AddrFrom16(address.As16()), nil
+}
+
+func (s *bfdServer) loop() {
+	defer s.shutdownWait.Done()
+
+	for {
+		select {
+		case <-s.eventStartStop.C:
+			success := true
+
+			s.peersMutex.RLock()
+			peersLen := len(s.peers)
+			s.peersMutex.RUnlock()
+
+			if peersLen > 0 {
+				success = s.start()
+			} else {
+				s.stop()
+			}
+
+			if success {
+				s.eventStartStop.Stop()
+			}
+		case ev := <-s.eventConfig:
+			s.config = ev
+		case ev := <-s.eventPeerUpdate:
+			if ev.isAdd {
+				s.addBfdPeer(ev.peerAddress, ev.address, ev.config)
+			} else {
+				s.deleteBfdPeer(ev.peerAddress, ev.address)
+			}
+
+			s.eventStartStop.Reset(time.Second)
+		case ev := <-s.eventGetPeer:
+			ev.out <- s.getPeerState(ev.in)
+			close(ev.out)
+		case ev := <-s.eventGetPeerList:
+			ev.out <- s.getPeerStateList()
+			close(ev.out)
+		case <-s.eventShutdown:
+			s.shutdown()
+			return
+		}
+	}
+}
+
+func (s *bfdServer) start() bool {
+	if s.udpServer == nil {
+		s.startServer()
+	}
+
+	return s.udpServer != nil
+}
+
+func (s *bfdServer) startServer() {
+	if s.config == nil {
+		// BFD server not configured
+		return
+	}
+
+	addressString := ":" + strconv.FormatUint(uint64(s.config.Port), 10)
+
+	var lc net.ListenConfig
+	lc.Control = func(network, address string, sc syscall.RawConn) error {
+		return netutils.SetReuseAddrSockopt(sc)
+	}
+
+	l, err := lc.ListenPacket(context.Background(), "udp", addressString)
+	if err != nil {
+		s.logger.Error("Can't listen UDP",
+			slog.String("Topic", "bfd"),
+			slog.String("Address", addressString),
+			slog.Any("Error", err),
+		)
+		return
+	}
+
+	var ok bool
+	s.udpServer, ok = l.(*net.UDPConn)
+	if !ok {
+		s.logger.Error("Unexpected connection listener",
+			slog.String("Topic", "bfd"),
+			slog.String("Address", addressString),
+			slog.Any("Error", err),
+		)
+		return
+	}
+
+	s.logger.Info("BFD server is started",
+		slog.String("Topic", "bfd"),
+		slog.String("Address", addressString),
+	)
+
+	s.serverStop = make(chan struct{})
+	s.serverWait.Add(1)
+	go s.serverLoop()
+}
+
+func (s *bfdServer) stop() {
+	if s.udpServer == nil {
+		return
+	}
+
+	close(s.serverStop)
+	s.udpServer.Close()
+	s.serverWait.Wait()
+	s.udpServer = nil
+
+	s.logger.Info("BFD server is stopped",
+		slog.String("Topic", "bfd"),
+	)
+}
+
+func (s *bfdServer) addBfdPeer(peerAddress string, address netip.Addr, config oc.BfdConfig) {
+	s.peersMutex.RLock()
+	_, ok := s.peers[address]
+	s.peersMutex.RUnlock()
+
+	if ok {
+		s.logger.Debug("BFD peer already exist",
+			slog.String("Topic", "bfd"),
+			slog.String("Peer", peerAddress),
+		)
+
+		return
+	}
+
+	bfdPeer := NewBfdPeer(s.peerState, s.logger, peerAddress, config)
+	if bfdPeer != nil {
+		s.logger.Info("Insert BFD peer",
+			slog.String("Topic", "bfd"),
+			slog.String("Peer", peerAddress),
+		)
+
+		s.peersMutex.Lock()
+		s.peers[address] = bfdPeer
+		s.peersMutex.Unlock()
+	}
+}
+
+func (s *bfdServer) deleteBfdPeer(peerAddress string, address netip.Addr) {
+	s.peersMutex.RLock()
+	peer, ok := s.peers[address]
+	s.peersMutex.RUnlock()
+
+	if !ok {
+		s.logger.Debug("Unknown BFD peer",
+			slog.String("Topic", "bfd"),
+			slog.String("Peer", peerAddress),
+		)
+
+		return
+	}
+
+	s.peersMutex.Lock()
+	delete(s.peers, address)
+	s.peersMutex.Unlock()
+	peer.Stop()
+
+	s.logger.Info("Remove BFD peer",
+		slog.String("Topic", "bfd"),
+		slog.String("Peer", peerAddress),
+	)
+}
+
+func (s *bfdServer) getPeerState(address netip.Addr) *bfdPeerState {
+	s.peersMutex.RLock()
+	peer, ok := s.peers[address]
+	s.peersMutex.RUnlock()
+
+	if !ok {
+		return nil
+	}
+
+	return &bfdPeerState{
+		peerAddress: peer.peerAddress,
+		state: api.BfdPeerState{
+			SessionState: api.BfdSessionState(peer.state.Load()),
+			BfdAsync: &api.BfdAsyncCounters{
+				ReceivedPackets:    peer.stats.rxPacket.Load(),
+				TransmittedPackets: peer.stats.txPacket.Load(),
+			},
+		},
+	}
+}
+
+func (s *bfdServer) getPeerStateList() []*bfdPeerState {
+	s.peersMutex.RLock()
+	list := make([]*bfdPeerState, 0, len(s.peers))
+	for _, peer := range s.peers {
+		list = append(list, &bfdPeerState{
+			peerAddress: peer.peerAddress,
+			state: api.BfdPeerState{
+				SessionState: api.BfdSessionState(peer.state.Load()),
+				BfdAsync: &api.BfdAsyncCounters{
+					ReceivedPackets:    peer.stats.rxPacket.Load(),
+					TransmittedPackets: peer.stats.txPacket.Load(),
+				},
+			},
+		})
+	}
+	s.peersMutex.RUnlock()
+
+	return list
+}
+
+func (s *bfdServer) shutdown() {
+	s.peersMutex.Lock()
+	peers := make([]*bfdPeer, 0, len(s.peers))
+	for address, peer := range s.peers {
+		peers = append(peers, peer)
+		delete(s.peers, address)
+	}
+	s.peersMutex.Unlock()
+
+	for _, peer := range peers {
+		peer.Stop()
+	}
+
+	s.stop()
+	s.eventStartStop.Stop()
+}
+
+func (s *bfdServer) serverLoop() {
+	defer s.serverWait.Done()
+
+	// buffer size must be more than BFD Control Packet size
+	buffer := make([]byte, 4096)
+	for {
+		length, address, err := s.udpServer.ReadFromUDP(buffer)
+		if err != nil {
+			select {
+			case <-s.serverStop:
+				return
+			default:
+				s.stats.rxError.Add(1)
+			}
+
+			continue
+		}
+
+		bfdPacket := &bfd.BFDHeader{}
+		err = bfdPacket.UnmarshalBinary(buffer[:length])
+		if err != nil {
+			s.logger.Debug("Invalid packet",
+				slog.String("Topic", "bfd"),
+				slog.Any("Error", err),
+			)
+
+			s.stats.invalidPacket.Add(1)
+			continue
+		}
+
+		s.rxPacket(address, bfdPacket)
+	}
+}
+
+func (s *bfdServer) rxPacket(address *net.UDPAddr, packet *bfd.BFDHeader) {
+	addr := address.AddrPort().Addr()
+
+	s.peersMutex.RLock()
+	peer, ok := s.peers[addr]
+	s.peersMutex.RUnlock()
+
+	if !ok {
+		s.logger.Debug("Unknown BFD peer",
+			slog.String("Topic", "bfd"),
+			slog.Any("Peer", addr),
+		)
+
+		s.stats.unknownPeer.Add(1)
+		return
+	}
+
+	ok = peer.Rx(packet)
+	if !ok {
+		s.stats.rxDrop.Add(1)
+		return
+	}
+
+	s.stats.rxPacket.Add(1)
+}

--- a/pkg/server/bfd_server.go
+++ b/pkg/server/bfd_server.go
@@ -30,23 +30,13 @@ type bfdServerStats struct {
 
 type bfdEventPeerUpdate struct {
 	isAdd       bool
-	peerAddress string
-	address     netip.Addr
+	peerAddress netip.Addr
 	config      oc.BfdConfig
 }
 
 type bfdPeerState struct {
-	peerAddress string
+	peerAddress netip.Addr
 	state       api.BfdPeerState
-}
-
-type bfdEventGetPeerState struct {
-	in  netip.Addr
-	out chan *bfdPeerState
-}
-
-type bfdEventGetPeerStateList struct {
-	out chan []*bfdPeerState
 }
 
 type peerState interface {
@@ -64,12 +54,10 @@ type bfdServer struct {
 	peersMutex sync.RWMutex
 	peers      map[netip.Addr]*bfdPeer
 
-	eventStartStop   *time.Ticker
-	eventConfig      chan *oc.BfdConfig
-	eventPeerUpdate  chan *bfdEventPeerUpdate
-	eventGetPeer     chan *bfdEventGetPeerState
-	eventGetPeerList chan *bfdEventGetPeerStateList
-	eventShutdown    chan struct{}
+	eventStartStop  *time.Ticker
+	eventConfig     chan *oc.BfdConfig
+	eventPeerUpdate chan *bfdEventPeerUpdate
+	eventShutdown   chan struct{}
 
 	shutdownWait sync.WaitGroup
 
@@ -86,12 +74,10 @@ func NewBfdServer(ps peerState, logger *slog.Logger) *bfdServer {
 
 		peers: make(map[netip.Addr]*bfdPeer),
 
-		eventStartStop:   time.NewTicker(time.Second),
-		eventConfig:      make(chan *oc.BfdConfig, 1),
-		eventPeerUpdate:  make(chan *bfdEventPeerUpdate, 1),
-		eventGetPeer:     make(chan *bfdEventGetPeerState, 1),
-		eventGetPeerList: make(chan *bfdEventGetPeerStateList, 1),
-		eventShutdown:    make(chan struct{}),
+		eventStartStop:  time.NewTicker(time.Second),
+		eventConfig:     make(chan *oc.BfdConfig, 1),
+		eventPeerUpdate: make(chan *bfdEventPeerUpdate, 1),
+		eventShutdown:   make(chan struct{}),
 	}
 
 	s.shutdownWait.Add(1)
@@ -99,8 +85,15 @@ func NewBfdServer(ps peerState, logger *slog.Logger) *bfdServer {
 	return s
 }
 
-func (s *bfdServer) Start(config oc.BfdConfig) {
-	s.eventConfig <- &config
+func (s *bfdServer) Start(ctx context.Context, config oc.BfdConfig) error {
+	select {
+	case s.eventConfig <- &config:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s.eventShutdown:
+		return errors.New("bfd server stopped")
+	}
 }
 
 func (s *bfdServer) Stop() {
@@ -108,97 +101,42 @@ func (s *bfdServer) Stop() {
 	s.shutdownWait.Wait()
 }
 
-func (s *bfdServer) AddPeer(peerAddress string, config oc.BfdConfig) error {
+func (s *bfdServer) AddPeer(ctx context.Context, peerAddress netip.Addr, config oc.BfdConfig) error {
 	if !config.Enabled {
 		return nil
 	}
 
-	address, err := convertToIPAddress(peerAddress)
-	if err != nil {
-		s.logger.Warn("Can't parse peer address",
-			slog.String("Topic", "bfd"),
-			slog.String("Peer", peerAddress),
-		)
-
-		return err
-	}
-
-	s.eventPeerUpdate <- &bfdEventPeerUpdate{
-		isAdd:       true,
-		peerAddress: peerAddress,
-		address:     address,
-		config:      config,
-	}
-
-	return nil
-}
-
-func (s *bfdServer) DeletePeer(peerAddress string) error {
-	address, err := convertToIPAddress(peerAddress)
-	if err != nil {
-		s.logger.Warn("Can't parse peer address",
-			slog.String("Topic", "bfd"),
-			slog.String("Peer", peerAddress),
-		)
-
-		return err
-	}
-
-	s.eventPeerUpdate <- &bfdEventPeerUpdate{
-		isAdd:       false,
-		peerAddress: peerAddress,
-		address:     address,
-	}
-
-	return nil
-}
-
-func (s *bfdServer) GetPeerState(ctx context.Context, peerAddress string) (*bfdPeerState, error) {
-	address, err := convertToIPAddress(peerAddress)
-	if err != nil {
-		return nil, err
-	}
-
-	list := &bfdEventGetPeerState{
-		in:  address,
-		out: make(chan *bfdPeerState),
-	}
-
-	s.eventGetPeer <- list
-
 	select {
-	case out, ok := <-list.out:
-		if !ok {
-			return nil, errors.New("channel is closed")
-		}
-
-		if out == nil {
-			return nil, errors.New("peer not found")
-		}
-
-		return out, nil
+	case s.eventPeerUpdate <- &bfdEventPeerUpdate{isAdd: true, peerAddress: peerAddress, config: config}:
+		return nil
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return ctx.Err()
+	case <-s.eventShutdown:
+		return errors.New("bfd server stopped")
 	}
 }
 
-func (s *bfdServer) GetPeerStateList(ctx context.Context) ([]*bfdPeerState, error) {
-	list := &bfdEventGetPeerStateList{
-		out: make(chan []*bfdPeerState),
-	}
-
-	s.eventGetPeerList <- list
-
+func (s *bfdServer) DeletePeer(ctx context.Context, peerAddress netip.Addr) error {
 	select {
-	case out, ok := <-list.out:
-		if !ok {
-			return nil, errors.New("channel is closed")
-		}
-
-		return out, nil
+	case s.eventPeerUpdate <- &bfdEventPeerUpdate{isAdd: false, peerAddress: peerAddress}:
+		return nil
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return ctx.Err()
+	case <-s.eventShutdown:
+		return errors.New("bfd server stopped")
 	}
+}
+
+func (s *bfdServer) GetPeerState(peerAddress netip.Addr) (*bfdPeerState, error) {
+	state := s.getPeerState(peerAddress)
+	if state == nil {
+		return nil, errors.New("peer not found")
+	}
+	return state, nil
+}
+
+func (s *bfdServer) GetPeerStateList() []*bfdPeerState {
+	return s.getPeerStateList()
 }
 
 func (s *bfdServer) GetServerStats() *api.BfdState {
@@ -209,17 +147,6 @@ func (s *bfdServer) GetServerStats() *api.BfdState {
 		InvalidPacket:  s.stats.invalidPacket.Load(),
 		UnknownPeer:    s.stats.unknownPeer.Load(),
 	}
-}
-
-func convertToIPAddress(stringAddress string) (netip.Addr, error) {
-	address, err := netip.ParseAddr(stringAddress)
-	if err != nil {
-		return netip.IPv4Unspecified(), err
-	}
-
-	// ReadFromUDP() return address in format '::ffff:1.2.3.4'
-	// Fill peers map in a similar way
-	return netip.AddrFrom16(address.As16()), nil
 }
 
 func (s *bfdServer) loop() {
@@ -247,18 +174,12 @@ func (s *bfdServer) loop() {
 			s.config = ev
 		case ev := <-s.eventPeerUpdate:
 			if ev.isAdd {
-				s.addBfdPeer(ev.peerAddress, ev.address, ev.config)
+				s.addBfdPeer(ev.peerAddress, ev.config)
 			} else {
-				s.deleteBfdPeer(ev.peerAddress, ev.address)
+				s.deleteBfdPeer(ev.peerAddress)
 			}
 
 			s.eventStartStop.Reset(time.Second)
-		case ev := <-s.eventGetPeer:
-			ev.out <- s.getPeerState(ev.in)
-			close(ev.out)
-		case ev := <-s.eventGetPeerList:
-			ev.out <- s.getPeerStateList()
-			close(ev.out)
 		case <-s.eventShutdown:
 			s.shutdown()
 			return
@@ -333,15 +254,15 @@ func (s *bfdServer) stop() {
 	)
 }
 
-func (s *bfdServer) addBfdPeer(peerAddress string, address netip.Addr, config oc.BfdConfig) {
+func (s *bfdServer) addBfdPeer(peerAddress netip.Addr, config oc.BfdConfig) {
 	s.peersMutex.RLock()
-	_, ok := s.peers[address]
+	_, ok := s.peers[peerAddress]
 	s.peersMutex.RUnlock()
 
 	if ok {
 		s.logger.Debug("BFD peer already exist",
 			slog.String("Topic", "bfd"),
-			slog.String("Peer", peerAddress),
+			slog.String("Peer", peerAddress.String()),
 		)
 
 		return
@@ -351,37 +272,37 @@ func (s *bfdServer) addBfdPeer(peerAddress string, address netip.Addr, config oc
 	if bfdPeer != nil {
 		s.logger.Info("Insert BFD peer",
 			slog.String("Topic", "bfd"),
-			slog.String("Peer", peerAddress),
+			slog.String("Peer", peerAddress.String()),
 		)
 
 		s.peersMutex.Lock()
-		s.peers[address] = bfdPeer
+		s.peers[peerAddress] = bfdPeer
 		s.peersMutex.Unlock()
 	}
 }
 
-func (s *bfdServer) deleteBfdPeer(peerAddress string, address netip.Addr) {
+func (s *bfdServer) deleteBfdPeer(peerAddress netip.Addr) {
 	s.peersMutex.RLock()
-	peer, ok := s.peers[address]
+	peer, ok := s.peers[peerAddress]
 	s.peersMutex.RUnlock()
 
 	if !ok {
 		s.logger.Debug("Unknown BFD peer",
 			slog.String("Topic", "bfd"),
-			slog.String("Peer", peerAddress),
+			slog.String("Peer", peerAddress.String()),
 		)
 
 		return
 	}
 
 	s.peersMutex.Lock()
-	delete(s.peers, address)
+	delete(s.peers, peerAddress)
 	s.peersMutex.Unlock()
 	peer.Stop()
 
 	s.logger.Info("Remove BFD peer",
 		slog.String("Topic", "bfd"),
-		slog.String("Peer", peerAddress),
+		slog.String("Peer", peerAddress.String()),
 	)
 }
 
@@ -478,7 +399,7 @@ func (s *bfdServer) serverLoop() {
 }
 
 func (s *bfdServer) rxPacket(address *net.UDPAddr, packet *bfd.BFDHeader) {
-	addr := address.AddrPort().Addr()
+	addr := address.AddrPort().Addr().Unmap()
 
 	s.peersMutex.RLock()
 	peer, ok := s.peers[addr]

--- a/pkg/server/bfd_server.go
+++ b/pkg/server/bfd_server.go
@@ -58,6 +58,8 @@ type bfdServer struct {
 	eventConfig     chan *oc.BfdConfig
 	eventPeerUpdate chan *bfdEventPeerUpdate
 	eventShutdown   chan struct{}
+	shutdownOnce    sync.Once
+	stopped         atomic.Bool
 
 	shutdownWait sync.WaitGroup
 
@@ -86,8 +88,16 @@ func NewBfdServer(ps peerState, logger *slog.Logger) *bfdServer {
 }
 
 func (s *bfdServer) Start(ctx context.Context, config oc.BfdConfig) error {
+	if s.stopped.Load() {
+		return errors.New("bfd server stopped")
+	}
+
 	select {
 	case s.eventConfig <- &config:
+		if s.stopped.Load() {
+			return errors.New("bfd server stopped")
+		}
+
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -97,17 +107,28 @@ func (s *bfdServer) Start(ctx context.Context, config oc.BfdConfig) error {
 }
 
 func (s *bfdServer) Stop() {
-	close(s.eventShutdown)
-	s.shutdownWait.Wait()
+	s.shutdownOnce.Do(func() {
+		s.stopped.Store(true)
+		close(s.eventShutdown)
+		s.shutdownWait.Wait()
+	})
 }
 
 func (s *bfdServer) AddPeer(ctx context.Context, peerAddress netip.Addr, config oc.BfdConfig) error {
+	if s.stopped.Load() {
+		return errors.New("bfd server stopped")
+	}
+
 	if !config.Enabled {
 		return nil
 	}
 
 	select {
 	case s.eventPeerUpdate <- &bfdEventPeerUpdate{isAdd: true, peerAddress: peerAddress, config: config}:
+		if s.stopped.Load() {
+			return errors.New("bfd server stopped")
+		}
+
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -117,8 +138,16 @@ func (s *bfdServer) AddPeer(ctx context.Context, peerAddress netip.Addr, config 
 }
 
 func (s *bfdServer) DeletePeer(ctx context.Context, peerAddress netip.Addr) error {
+	if s.stopped.Load() {
+		return errors.New("bfd server stopped")
+	}
+
 	select {
 	case s.eventPeerUpdate <- &bfdEventPeerUpdate{isAdd: false, peerAddress: peerAddress}:
+		if s.stopped.Load() {
+			return errors.New("bfd server stopped")
+		}
+
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/pkg/server/bfd_server_test.go
+++ b/pkg/server/bfd_server_test.go
@@ -1,0 +1,447 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	api "github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/config/oc"
+	"github.com/stretchr/testify/assert"
+)
+
+func eventually(timeout time.Duration, what func() error) error {
+	var err error
+	deadline := time.After(timeout)
+	for {
+		select {
+		case <-deadline:
+			if err != nil {
+				return err
+			}
+			return what()
+		default:
+			err = what()
+			if err == nil {
+				return nil
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func eventuallyCheckState(timeout time.Duration, s *bfdServer, peerAddress string, expected api.BfdSessionState) error {
+	return eventually(timeout, func() error {
+		state, err := s.GetPeerState(context.Background(), peerAddress)
+		if err != nil {
+			return err
+		}
+		if state.state.SessionState != expected {
+			return fmt.Errorf("must be: peerState == %s", expected)
+		}
+		return nil
+	})
+}
+
+type mockPeerState struct {
+	resetPeerCount int64
+}
+
+// ResetPeer implements peerState.
+func (m *mockPeerState) ResetPeer(ctx context.Context, r *api.ResetPeerRequest) error {
+	atomic.AddInt64(&m.resetPeerCount, 1)
+	return nil
+}
+
+func Test_StartStop(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	s1 := NewBfdServer(ps, slog.Default())
+	assert.NotNil(s1)
+
+	s1.Start(oc.BfdConfig{
+		Port: 13784,
+	})
+	defer s1.Stop()
+}
+
+func newServer(port uint16) *bfdServer {
+	ps := &mockPeerState{}
+	s := NewBfdServer(ps, slog.Default())
+	s.Start(oc.BfdConfig{
+		Port: port,
+	})
+	return s
+}
+
+func newServerWithMock(port uint16) (*bfdServer, *mockPeerState) {
+	ps := &mockPeerState{}
+	s := NewBfdServer(ps, slog.Default())
+	s.Start(oc.BfdConfig{
+		Port: port,
+	})
+	return s, ps
+}
+
+func addPeer(s *bfdServer, port uint16) error {
+	return s.AddPeer("127.0.0.1", oc.BfdConfig{
+		Port:                     port,
+		Enabled:                  true,
+		DetectionMultiplier:      5,
+		RequiredMinimumReceive:   200000,
+		DesiredMinimumTxInterval: 200000,
+	})
+}
+
+func Test_AddDeletePeer(t *testing.T) {
+	assert := assert.New(t)
+
+	s1 := newServer(13784)
+	defer s1.Stop()
+
+	// Add peer
+	err := addPeer(s1, 23784)
+	assert.NoError(err)
+
+	// Wait bfdServer.loop() thread
+	time.Sleep(time.Second * 2)
+
+	// Get state
+	state, err := s1.GetPeerState(context.Background(), "127.0.0.1")
+	assert.NotNil(state)
+	assert.NoError(err)
+
+	assert.Equal(state.peerAddress, "127.0.0.1")
+
+	// Delete peer
+	err = s1.DeletePeer("127.0.0.1")
+	assert.NoError(err)
+
+	// Wait bfdServer.loop() thread
+	time.Sleep(time.Second * 2)
+
+	// Get state
+	state, err = s1.GetPeerState(context.Background(), "127.0.0.1")
+	assert.Nil(state)
+	assert.Error(err)
+}
+
+func Test_StateUpDown(t *testing.T) {
+	assert := assert.New(t)
+
+	s1 := newServer(13784)
+	defer s1.Stop()
+
+	s2 := newServer(23784)
+
+	// Add peer
+	err := addPeer(s1, 23784)
+	assert.NoError(err)
+
+	// Add peer
+	err = addPeer(s2, 13784)
+	assert.NoError(err)
+
+	// Wait bfdServer.loop() thread
+	time.Sleep(time.Second * 2)
+
+	// Get state
+	state, err := s1.GetPeerState(context.Background(), "127.0.0.1")
+	assert.NotNil(state)
+	assert.NoError(err)
+	assert.Equal(state.state.SessionState, api.BfdSessionState_BFD_SESSION_STATE_UP)
+	assert.NotEqual(state.state.BfdAsync.ReceivedPackets, uint64(0))
+	assert.NotEqual(state.state.BfdAsync.TransmittedPackets, uint64(0))
+
+	// Get state
+	state, err = s2.GetPeerState(context.Background(), "127.0.0.1")
+	assert.NotNil(state)
+	assert.NoError(err)
+	assert.Equal(state.state.SessionState, api.BfdSessionState_BFD_SESSION_STATE_UP)
+	assert.NotEqual(state.state.BfdAsync.ReceivedPackets, uint64(0))
+	assert.NotEqual(state.state.BfdAsync.TransmittedPackets, uint64(0))
+
+	// Stop s2
+	s2.Stop()
+
+	// Check state
+	err = eventuallyCheckState(2*time.Second, s1, "127.0.0.1", api.BfdSessionState_BFD_SESSION_STATE_DOWN)
+	assert.NoError(err)
+}
+
+func Test_ResetPeer(t *testing.T) {
+	assert := assert.New(t)
+
+	s1, m1 := newServerWithMock(13784)
+
+	s2 := newServer(23784)
+
+	// Add peer
+	err := addPeer(s1, 23784)
+	assert.NoError(err)
+
+	// Add peer
+	err = addPeer(s2, 13784)
+	assert.NoError(err)
+
+	time.Sleep(time.Second * 2)
+
+	// Stop s2
+	s2.Stop()
+
+	// Wait BFD peer down
+	time.Sleep(time.Second * 2)
+
+	s1.Stop()
+
+	assert.Equal(int64(1), atomic.LoadInt64(&m1.resetPeerCount))
+}
+
+func Test_BgpAddDeletePeer(t *testing.T) {
+	assert := assert.New(t)
+
+	s := NewBgpServer()
+	go s.Serve()
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        1,
+			RouterId:   "1.1.1.1",
+			ListenPort: 10179,
+		},
+	})
+	assert.NoError(err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	nConf1 := &oc.Neighbor{
+		Config: oc.NeighborConfig{
+			NeighborAddress: netip.MustParseAddr("127.0.0.1"),
+			PeerGroup:       "group_on",
+		},
+	}
+	nConf2 := &oc.Neighbor{
+		Config: oc.NeighborConfig{
+			NeighborAddress: netip.MustParseAddr("127.0.0.2"),
+			PeerGroup:       "group_on",
+		},
+	}
+	pgConf := &oc.PeerGroup{
+		Config: oc.PeerGroupConfig{
+			PeerGroupName: "group_on",
+		},
+		Bfd: oc.Bfd{
+			Config: oc.BfdConfig{
+				Enabled:                  true,
+				DetectionMultiplier:      7,
+				RequiredMinimumReceive:   123000,
+				DesiredMinimumTxInterval: 456000,
+			},
+		},
+	}
+	gConf := &oc.Global{}
+
+	err = oc.SetDefaultNeighborConfigValues(nConf1, pgConf, gConf)
+	assert.NoError(err)
+	err = oc.SetDefaultNeighborConfigValues(nConf2, pgConf, gConf)
+	assert.NoError(err)
+
+	// Add 'group_on' with enabled BFD
+	err = s.AddPeerGroup(context.Background(), &api.AddPeerGroupRequest{
+		PeerGroup: oc.NewPeerGroupFromConfigStruct(pgConf),
+	})
+	assert.NoError(err)
+
+	var count int
+
+	// Add 1 peer
+	err = s.AddPeer(context.Background(), &api.AddPeerRequest{
+		Peer: oc.NewPeerFromConfigStruct(nConf1),
+	})
+	assert.NoError(err)
+	time.Sleep(time.Second)
+
+	count = 0
+	s.ListBfdPeer(context.Background(), func(peerAddress string, state *api.BfdPeerState) {
+		count++
+	})
+	assert.Equal(count, 1)
+
+	// Delete 1 peer
+	err = s.DeletePeer(context.Background(), &api.DeletePeerRequest{
+		Address: "127.0.0.1",
+	})
+	assert.NoError(err)
+	time.Sleep(time.Second)
+
+	count = 0
+	s.ListBfdPeer(context.Background(), func(peerAddress string, state *api.BfdPeerState) {
+		count++
+	})
+	assert.Equal(count, 0)
+
+	// Add 2 peer
+	err = s.AddPeer(context.Background(), &api.AddPeerRequest{
+		Peer: oc.NewPeerFromConfigStruct(nConf1),
+	})
+	assert.NoError(err)
+	err = s.AddPeer(context.Background(), &api.AddPeerRequest{
+		Peer: oc.NewPeerFromConfigStruct(nConf2),
+	})
+	assert.NoError(err)
+	time.Sleep(time.Second)
+
+	count = 0
+	s.ListBfdPeer(context.Background(), func(peerAddress string, state *api.BfdPeerState) {
+		count++
+	})
+	assert.Equal(count, 2)
+
+	// Delete 1 peer
+	err = s.DeletePeer(context.Background(), &api.DeletePeerRequest{
+		Address: "127.0.0.1",
+	})
+	assert.NoError(err)
+	time.Sleep(time.Second)
+
+	count = 0
+	s.ListBfdPeer(context.Background(), func(peerAddress string, state *api.BfdPeerState) {
+		count++
+	})
+	assert.Equal(count, 1)
+
+	// Delete 1 peer
+	err = s.DeletePeer(context.Background(), &api.DeletePeerRequest{
+		Address: "127.0.0.2",
+	})
+	assert.NoError(err)
+	time.Sleep(time.Second)
+
+	count = 0
+	s.ListBfdPeer(context.Background(), func(peerAddress string, state *api.BfdPeerState) {
+		count++
+	})
+	assert.Equal(count, 0)
+}
+
+func Test_BgpAddDeletePeerWithDisabledBfd(t *testing.T) {
+	assert := assert.New(t)
+
+	s := NewBgpServer()
+	go s.Serve()
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        1,
+			RouterId:   "1.1.1.1",
+			ListenPort: 10179,
+		},
+	})
+	assert.NoError(err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	nConf1 := &oc.Neighbor{
+		Config: oc.NeighborConfig{
+			NeighborAddress: netip.MustParseAddr("127.0.0.1"),
+			PeerGroup:       "group_off",
+		},
+	}
+	nConf2 := &oc.Neighbor{
+		Config: oc.NeighborConfig{
+			NeighborAddress: netip.MustParseAddr("127.0.0.2"),
+			PeerGroup:       "group_on",
+		},
+	}
+	pgConf1 := &oc.PeerGroup{
+		Config: oc.PeerGroupConfig{
+			PeerGroupName: "group_off",
+		},
+	}
+	pgConf2 := &oc.PeerGroup{
+		Config: oc.PeerGroupConfig{
+			PeerGroupName: "group_on",
+		},
+		Bfd: oc.Bfd{
+			Config: oc.BfdConfig{
+				Enabled:                  true,
+				DetectionMultiplier:      7,
+				RequiredMinimumReceive:   123000,
+				DesiredMinimumTxInterval: 456000,
+			},
+		},
+	}
+	gConf := &oc.Global{}
+
+	err = oc.SetDefaultNeighborConfigValues(nConf1, pgConf1, gConf)
+	assert.NoError(err)
+	err = oc.SetDefaultNeighborConfigValues(nConf2, pgConf2, gConf)
+	assert.NoError(err)
+
+	// Add 'group_on' with enabled BFD
+	err = s.AddPeerGroup(context.Background(), &api.AddPeerGroupRequest{
+		PeerGroup: oc.NewPeerGroupFromConfigStruct(pgConf1),
+	})
+	assert.NoError(err)
+
+	// Add 'group_off' without BFD
+	err = s.AddPeerGroup(context.Background(), &api.AddPeerGroupRequest{
+		PeerGroup: oc.NewPeerGroupFromConfigStruct(pgConf2),
+	})
+	assert.NoError(err)
+
+	var count int
+
+	// Add 1 peer (group_off)
+	err = s.AddPeer(context.Background(), &api.AddPeerRequest{
+		Peer: oc.NewPeerFromConfigStruct(nConf1),
+	})
+	assert.NoError(err)
+	time.Sleep(time.Second)
+
+	count = 0
+	s.ListBfdPeer(context.Background(), func(peerAddress string, state *api.BfdPeerState) {
+		count++
+	})
+	assert.Equal(count, 0)
+
+	// Add 1 peer (group_on)
+	err = s.AddPeer(context.Background(), &api.AddPeerRequest{
+		Peer: oc.NewPeerFromConfigStruct(nConf2),
+	})
+	assert.NoError(err)
+	time.Sleep(time.Second)
+
+	count = 0
+	s.ListBfdPeer(context.Background(), func(peerAddress string, state *api.BfdPeerState) {
+		count++
+	})
+	assert.Equal(count, 1)
+
+	// Delete 1 peer (group_on)
+	err = s.DeletePeer(context.Background(), &api.DeletePeerRequest{
+		Address: "127.0.0.2",
+	})
+	assert.NoError(err)
+	time.Sleep(time.Second)
+
+	count = 0
+	s.ListBfdPeer(context.Background(), func(peerAddress string, state *api.BfdPeerState) {
+		count++
+	})
+	assert.Equal(count, 0)
+
+	// Delete 1 peer (group_off)
+	err = s.DeletePeer(context.Background(), &api.DeletePeerRequest{
+		Address: "127.0.0.1",
+	})
+	assert.NoError(err)
+	time.Sleep(time.Second)
+
+	count = 0
+	s.ListBfdPeer(context.Background(), func(peerAddress string, state *api.BfdPeerState) {
+		count++
+	})
+	assert.Equal(count, 0)
+}

--- a/pkg/server/bfd_server_test.go
+++ b/pkg/server/bfd_server_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,6 +14,7 @@ import (
 	api "github.com/osrg/gobgp/v4/api"
 	"github.com/osrg/gobgp/v4/pkg/config/oc"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 )
 
 func eventually(timeout time.Duration, what func() error) error {
@@ -34,9 +37,9 @@ func eventually(timeout time.Duration, what func() error) error {
 	}
 }
 
-func eventuallyCheckState(timeout time.Duration, s *bfdServer, peerAddress string, expected api.BfdSessionState) error {
+func eventuallyCheckState(timeout time.Duration, s *bfdServer, peerAddress netip.Addr, expected api.BfdSessionState) error {
 	return eventually(timeout, func() error {
-		state, err := s.GetPeerState(context.Background(), peerAddress)
+		state, err := s.GetPeerState(peerAddress)
 		if err != nil {
 			return err
 		}
@@ -64,7 +67,7 @@ func Test_StartStop(t *testing.T) {
 	s1 := NewBfdServer(ps, slog.Default())
 	assert.NotNil(s1)
 
-	s1.Start(oc.BfdConfig{
+	s1.Start(context.Background(), oc.BfdConfig{ //nolint:errcheck
 		Port: 13784,
 	})
 	defer s1.Stop()
@@ -73,7 +76,7 @@ func Test_StartStop(t *testing.T) {
 func newServer(port uint16) *bfdServer {
 	ps := &mockPeerState{}
 	s := NewBfdServer(ps, slog.Default())
-	s.Start(oc.BfdConfig{
+	s.Start(context.Background(), oc.BfdConfig{ //nolint:errcheck
 		Port: port,
 	})
 	return s
@@ -82,14 +85,14 @@ func newServer(port uint16) *bfdServer {
 func newServerWithMock(port uint16) (*bfdServer, *mockPeerState) {
 	ps := &mockPeerState{}
 	s := NewBfdServer(ps, slog.Default())
-	s.Start(oc.BfdConfig{
+	s.Start(context.Background(), oc.BfdConfig{ //nolint:errcheck
 		Port: port,
 	})
 	return s, ps
 }
 
 func addPeer(s *bfdServer, port uint16) error {
-	return s.AddPeer("127.0.0.1", oc.BfdConfig{
+	return s.AddPeer(context.Background(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
 		Port:                     port,
 		Enabled:                  true,
 		DetectionMultiplier:      5,
@@ -112,21 +115,21 @@ func Test_AddDeletePeer(t *testing.T) {
 	time.Sleep(time.Second * 2)
 
 	// Get state
-	state, err := s1.GetPeerState(context.Background(), "127.0.0.1")
+	state, err := s1.GetPeerState(netip.MustParseAddr("127.0.0.1"))
 	assert.NotNil(state)
 	assert.NoError(err)
 
-	assert.Equal(state.peerAddress, "127.0.0.1")
+	assert.Equal(state.peerAddress, netip.MustParseAddr("127.0.0.1"))
 
 	// Delete peer
-	err = s1.DeletePeer("127.0.0.1")
+	err = s1.DeletePeer(context.Background(), netip.MustParseAddr("127.0.0.1"))
 	assert.NoError(err)
 
 	// Wait bfdServer.loop() thread
 	time.Sleep(time.Second * 2)
 
 	// Get state
-	state, err = s1.GetPeerState(context.Background(), "127.0.0.1")
+	state, err = s1.GetPeerState(netip.MustParseAddr("127.0.0.1"))
 	assert.Nil(state)
 	assert.Error(err)
 }
@@ -151,7 +154,7 @@ func Test_StateUpDown(t *testing.T) {
 	time.Sleep(time.Second * 2)
 
 	// Get state
-	state, err := s1.GetPeerState(context.Background(), "127.0.0.1")
+	state, err := s1.GetPeerState(netip.MustParseAddr("127.0.0.1"))
 	assert.NotNil(state)
 	assert.NoError(err)
 	assert.Equal(state.state.SessionState, api.BfdSessionState_BFD_SESSION_STATE_UP)
@@ -159,7 +162,7 @@ func Test_StateUpDown(t *testing.T) {
 	assert.NotEqual(state.state.BfdAsync.TransmittedPackets, uint64(0))
 
 	// Get state
-	state, err = s2.GetPeerState(context.Background(), "127.0.0.1")
+	state, err = s2.GetPeerState(netip.MustParseAddr("127.0.0.1"))
 	assert.NotNil(state)
 	assert.NoError(err)
 	assert.Equal(state.state.SessionState, api.BfdSessionState_BFD_SESSION_STATE_UP)
@@ -170,7 +173,7 @@ func Test_StateUpDown(t *testing.T) {
 	s2.Stop()
 
 	// Check state
-	err = eventuallyCheckState(2*time.Second, s1, "127.0.0.1", api.BfdSessionState_BFD_SESSION_STATE_DOWN)
+	err = eventuallyCheckState(2*time.Second, s1, netip.MustParseAddr("127.0.0.1"), api.BfdSessionState_BFD_SESSION_STATE_DOWN)
 	assert.NoError(err)
 }
 
@@ -215,7 +218,7 @@ func Test_BgpAddDeletePeer(t *testing.T) {
 		},
 	})
 	assert.NoError(err)
-	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+	defer s.Stop()
 
 	nConf1 := &oc.Neighbor{
 		Config: oc.NeighborConfig{
@@ -340,7 +343,7 @@ func Test_BgpAddDeletePeerWithDisabledBfd(t *testing.T) {
 		},
 	})
 	assert.NoError(err)
-	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+	defer s.Stop()
 
 	nConf1 := &oc.Neighbor{
 		Config: oc.NeighborConfig{
@@ -444,4 +447,113 @@ func Test_BgpAddDeletePeerWithDisabledBfd(t *testing.T) {
 		count++
 	})
 	assert.Equal(count, 0)
+}
+
+func Test_BfdServer_NoGoroutineLeakAfterStop(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	assert := assert.New(t)
+	ps := &mockPeerState{}
+	s := NewBfdServer(ps, slog.Default())
+	err := s.Start(context.Background(), oc.BfdConfig{
+		Port: 33884,
+	})
+	assert.NoError(err)
+
+	err = s.AddPeer(context.Background(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
+		Port:                     44884,
+		Enabled:                  true,
+		DetectionMultiplier:      5,
+		RequiredMinimumReceive:   200000,
+		DesiredMinimumTxInterval: 200000,
+	})
+	assert.NoError(err)
+
+	time.Sleep(500 * time.Millisecond)
+	s.Stop()
+}
+
+func Test_BfdServer_RepeatedLifecycleNoGoroutineLeak(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	assert := assert.New(t)
+	for i := range 8 {
+		ps := &mockPeerState{}
+		s := NewBfdServer(ps, slog.Default())
+		port := uint16(35000 + i)
+		err := s.Start(context.Background(), oc.BfdConfig{Port: port})
+		assert.NoError(err)
+		err = s.AddPeer(context.Background(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
+			Port:                     port + 2000,
+			Enabled:                  true,
+			DetectionMultiplier:      5,
+			RequiredMinimumReceive:   200000,
+			DesiredMinimumTxInterval: 200000,
+		})
+		assert.NoError(err)
+		time.Sleep(80 * time.Millisecond)
+		s.Stop()
+		runtime.GC()
+		time.Sleep(80 * time.Millisecond)
+	}
+}
+
+func Test_BfdServer_ConcurrentPublicMethods(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	assert := assert.New(t)
+	ps := &mockPeerState{}
+	s := NewBfdServer(ps, slog.Default())
+	err := s.Start(context.Background(), oc.BfdConfig{
+		Port: 35884,
+	})
+	assert.NoError(err)
+
+	cfg := oc.BfdConfig{
+		Enabled:                  true,
+		DetectionMultiplier:      3,
+		RequiredMinimumReceive:   100000,
+		DesiredMinimumTxInterval: 100000,
+	}
+
+	const workers = 48
+	const rounds = 40
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var errs []error
+	addErr := func(err error) {
+		if err != nil {
+			mu.Lock()
+			errs = append(errs, err)
+			mu.Unlock()
+		}
+	}
+
+	wg.Add(workers)
+	for w := range workers {
+		go func(id int) {
+			defer wg.Done()
+			peerAddr := netip.MustParseAddr(fmt.Sprintf("127.0.0.%d", id%254+1))
+			remotePort := uint16(46000 + id)
+			for range rounds {
+				addErr(s.Start(context.Background(), oc.BfdConfig{Port: 35884}))
+				addErr(s.AddPeer(context.Background(), peerAddr, oc.BfdConfig{
+					Port:                     remotePort,
+					Enabled:                  cfg.Enabled,
+					DetectionMultiplier:      cfg.DetectionMultiplier,
+					RequiredMinimumReceive:   cfg.RequiredMinimumReceive,
+					DesiredMinimumTxInterval: cfg.DesiredMinimumTxInterval,
+				}))
+				_, _ = s.GetPeerState(peerAddr)
+				list := s.GetPeerStateList()
+				_ = list
+				st := s.GetServerStats()
+				_ = st
+				addErr(s.DeletePeer(context.Background(), peerAddr))
+			}
+		}(w)
+	}
+	wg.Wait()
+	assert.Empty(errs, "concurrent public API calls: %v", errs)
+	s.Stop()
 }

--- a/pkg/server/bfd_server_test.go
+++ b/pkg/server/bfd_server_test.go
@@ -73,6 +73,51 @@ func Test_StartStop(t *testing.T) {
 	defer s1.Stop()
 }
 
+func Test_BfdServerStopIdempotentAndPublicMethodsAfterStop(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	s := NewBfdServer(ps, slog.Default())
+	s.Stop()
+	s.Stop()
+
+	assert.Error(s.Start(context.Background(), oc.BfdConfig{Port: 13784}))
+	assert.Error(s.AddPeer(context.Background(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
+		Port:    23784,
+		Enabled: true,
+	}))
+	assert.Error(s.DeletePeer(context.Background(), netip.MustParseAddr("127.0.0.1")))
+}
+
+func Test_ApiBfdSessionStateToOC(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal(oc.BFD_SESSION_STATE_UP, apiBfdSessionStateToOC(api.BfdSessionState_BFD_SESSION_STATE_UP))
+	assert.Equal(oc.BFD_SESSION_STATE_DOWN, apiBfdSessionStateToOC(api.BfdSessionState_BFD_SESSION_STATE_DOWN))
+	assert.Equal(oc.BFD_SESSION_STATE_ADMIN_DOWN, apiBfdSessionStateToOC(api.BfdSessionState_BFD_SESSION_STATE_ADMIN_DOWN))
+	assert.Equal(oc.BFD_SESSION_STATE_INIT, apiBfdSessionStateToOC(api.BfdSessionState_BFD_SESSION_STATE_INIT))
+}
+
+func Test_NewBfdConfigFromAPIStructRejectsOverflow(t *testing.T) {
+	assert := assert.New(t)
+
+	_, err := newBfdConfigFromAPIStruct(&api.BfdPeerConfig{Port: 1 << 16})
+	assert.Error(err)
+
+	_, err = newBfdConfigFromAPIStruct(&api.BfdPeerConfig{DetectionMultiplier: 1 << 8})
+	assert.Error(err)
+
+	config, err := newBfdConfigFromAPIStruct(&api.BfdPeerConfig{
+		Enabled:             true,
+		Port:                BfdServerPort,
+		DetectionMultiplier: 3,
+	})
+	assert.NoError(err)
+	assert.True(config.Enabled)
+	assert.Equal(uint16(BfdServerPort), config.Port)
+	assert.Equal(uint8(3), config.DetectionMultiplier)
+}
+
 func newServer(port uint16) *bfdServer {
 	ps := &mockPeerState{}
 	s := NewBfdServer(ps, slog.Default())
@@ -447,6 +492,73 @@ func Test_BgpAddDeletePeerWithDisabledBfd(t *testing.T) {
 		count++
 	})
 	assert.Equal(count, 0)
+}
+
+func Test_BgpUpdatePeerBfdConfig(t *testing.T) {
+	assert := assert.New(t)
+
+	s := NewBgpServer()
+	go s.Serve()
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        1,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	assert.NoError(err)
+	defer s.Stop()
+
+	peer := &api.Peer{
+		Conf: &api.PeerConf{
+			NeighborAddress: "127.0.0.3",
+			PeerAsn:         1,
+		},
+		Bfd: &api.BfdPeerConfig{Enabled: false},
+	}
+
+	err = s.AddPeer(context.Background(), &api.AddPeerRequest{Peer: peer})
+	assert.NoError(err)
+
+	countBfdPeers := func() int {
+		count := 0
+		s.ListBfdPeer(context.Background(), func(peerAddress string, state *api.BfdPeerState) {
+			count++
+		})
+		return count
+	}
+
+	assert.Equal(0, countBfdPeers())
+
+	peer.Bfd = &api.BfdPeerConfig{
+		Enabled:                  true,
+		Port:                     BfdServerPort,
+		DetectionMultiplier:      3,
+		RequiredMinimumReceive:   1000000,
+		DesiredMinimumTxInterval: 1000000,
+	}
+	_, err = s.UpdatePeer(context.Background(), &api.UpdatePeerRequest{Peer: peer})
+	assert.NoError(err)
+
+	err = eventually(time.Second, func() error {
+		if countBfdPeers() == 1 {
+			return nil
+		}
+		return fmt.Errorf("must be: bfd peer count == 1")
+	})
+	assert.NoError(err)
+
+	peer.Bfd.Enabled = false
+	_, err = s.UpdatePeer(context.Background(), &api.UpdatePeerRequest{Peer: peer})
+	assert.NoError(err)
+
+	err = eventually(time.Second, func() error {
+		if countBfdPeers() == 0 {
+			return nil
+		}
+		return fmt.Errorf("must be: bfd peer count == 0")
+	})
+	assert.NoError(err)
 }
 
 func Test_BfdServer_NoGoroutineLeakAfterStop(t *testing.T) {

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -299,7 +299,7 @@ func (s *server) listPath(ctx context.Context, r *api.ListPathRequest, fn func(*
 			req.Prefixes = append(req.Prefixes, &apiutil.LookupPrefix{
 				Prefix:       p.Prefix,
 				RD:           p.Rd,
-				LookupOption: apiutil.LookupOption(p.Type),
+				LookupOption: apiutil.LookupOptionFromAPI(p.Type),
 			})
 		}
 	}

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -299,7 +299,7 @@ func (s *server) listPath(ctx context.Context, r *api.ListPathRequest, fn func(*
 			req.Prefixes = append(req.Prefixes, &apiutil.LookupPrefix{
 				Prefix:       p.Prefix,
 				RD:           p.Rd,
-				LookupOption: apiutil.LookupOptionFromAPI(p.Type),
+				LookupOption: apiutil.LookupOption(p.Type),
 			})
 		}
 	}
@@ -1089,6 +1089,13 @@ func newNeighborFromAPIStruct(a *api.Peer) (*oc.Neighbor, error) {
 		pconf.TtlSecurity.Config.Enabled = a.TtlSecurity.Enabled
 		pconf.TtlSecurity.Config.TtlMin = uint8(a.TtlSecurity.TtlMin)
 	}
+	if a.Bfd != nil {
+		pconf.Bfd.Config.Enabled = a.Bfd.Enabled
+		pconf.Bfd.Config.Port = uint16(a.Bfd.Port)
+		pconf.Bfd.Config.DesiredMinimumTxInterval = a.Bfd.DesiredMinimumTxInterval
+		pconf.Bfd.Config.RequiredMinimumReceive = a.Bfd.RequiredMinimumReceive
+		pconf.Bfd.Config.DetectionMultiplier = uint8(a.Bfd.DetectionMultiplier)
+	}
 	if a.State != nil {
 		var sessionState oc.SessionState
 		switch a.State.SessionState {
@@ -1229,6 +1236,13 @@ func newPeerGroupFromAPIStruct(a *api.PeerGroup) (*oc.PeerGroup, error) {
 	if a.TtlSecurity != nil {
 		pconf.TtlSecurity.Config.Enabled = a.TtlSecurity.Enabled
 		pconf.TtlSecurity.Config.TtlMin = uint8(a.TtlSecurity.TtlMin)
+	}
+	if a.Bfd != nil {
+		pconf.Bfd.Config.Enabled = a.Bfd.Enabled
+		pconf.Bfd.Config.Port = uint16(a.Bfd.Port)
+		pconf.Bfd.Config.DesiredMinimumTxInterval = a.Bfd.DesiredMinimumTxInterval
+		pconf.Bfd.Config.RequiredMinimumReceive = a.Bfd.RequiredMinimumReceive
+		pconf.Bfd.Config.DetectionMultiplier = uint8(a.Bfd.DetectionMultiplier)
 	}
 	if a.Info != nil {
 		pconf.State.TotalPaths = a.Info.TotalPaths

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -970,6 +970,26 @@ func PeerTypeFromApi(a api.PeerType) (oc.PeerType, error) {
 	}
 }
 
+func newBfdConfigFromAPIStruct(a *api.BfdPeerConfig) (oc.BfdConfig, error) {
+	if a == nil {
+		return oc.BfdConfig{}, nil
+	}
+	if a.Port > uint32(^uint16(0)) {
+		return oc.BfdConfig{}, fmt.Errorf("invalid BFD port: %d", a.Port)
+	}
+	if a.DetectionMultiplier > uint32(^uint8(0)) {
+		return oc.BfdConfig{}, fmt.Errorf("invalid BFD detection multiplier: %d", a.DetectionMultiplier)
+	}
+
+	return oc.BfdConfig{
+		Enabled:                  a.Enabled,
+		Port:                     uint16(a.Port),
+		DesiredMinimumTxInterval: a.DesiredMinimumTxInterval,
+		RequiredMinimumReceive:   a.RequiredMinimumReceive,
+		DetectionMultiplier:      uint8(a.DetectionMultiplier),
+	}, nil
+}
+
 func newNeighborFromAPIStruct(a *api.Peer) (*oc.Neighbor, error) {
 	pconf := &oc.Neighbor{}
 	if a.Conf != nil {
@@ -1090,11 +1110,11 @@ func newNeighborFromAPIStruct(a *api.Peer) (*oc.Neighbor, error) {
 		pconf.TtlSecurity.Config.TtlMin = uint8(a.TtlSecurity.TtlMin)
 	}
 	if a.Bfd != nil {
-		pconf.Bfd.Config.Enabled = a.Bfd.Enabled
-		pconf.Bfd.Config.Port = uint16(a.Bfd.Port)
-		pconf.Bfd.Config.DesiredMinimumTxInterval = a.Bfd.DesiredMinimumTxInterval
-		pconf.Bfd.Config.RequiredMinimumReceive = a.Bfd.RequiredMinimumReceive
-		pconf.Bfd.Config.DetectionMultiplier = uint8(a.Bfd.DetectionMultiplier)
+		bfdConfig, err := newBfdConfigFromAPIStruct(a.Bfd)
+		if err != nil {
+			return nil, err
+		}
+		pconf.Bfd.Config = bfdConfig
 	}
 	if a.State != nil {
 		var sessionState oc.SessionState
@@ -1238,11 +1258,11 @@ func newPeerGroupFromAPIStruct(a *api.PeerGroup) (*oc.PeerGroup, error) {
 		pconf.TtlSecurity.Config.TtlMin = uint8(a.TtlSecurity.TtlMin)
 	}
 	if a.Bfd != nil {
-		pconf.Bfd.Config.Enabled = a.Bfd.Enabled
-		pconf.Bfd.Config.Port = uint16(a.Bfd.Port)
-		pconf.Bfd.Config.DesiredMinimumTxInterval = a.Bfd.DesiredMinimumTxInterval
-		pconf.Bfd.Config.RequiredMinimumReceive = a.Bfd.RequiredMinimumReceive
-		pconf.Bfd.Config.DetectionMultiplier = uint8(a.Bfd.DetectionMultiplier)
+		bfdConfig, err := newBfdConfigFromAPIStruct(a.Bfd)
+		if err != nil {
+			return nil, err
+		}
+		pconf.Bfd.Config = bfdConfig
 	}
 	if a.Info != nil {
 		pconf.State.TotalPaths = a.Info.TotalPaths

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -219,6 +219,10 @@ func (s *BgpServer) Stop() {
 		)
 	}
 
+	if s.bfdServer != nil {
+		s.bfdServer.Stop()
+	}
+
 	if s.apiServer != nil {
 		s.apiServer.grpcServer.Stop()
 	}
@@ -823,7 +827,7 @@ func (s *BgpServer) toConfig(peer *peer, getAdvertised bool) *oc.Neighbor {
 	conf.Timers.State.UpdateRecvTime = atomic.LoadInt64(&peer.fsm.timerStats.State.UpdateRecvTime)
 
 	if s.bfdServer != nil {
-		bfdPeer, err := s.bfdServer.GetPeerState(context.Background(), conf.State.NeighborAddress.String())
+		bfdPeer, err := s.bfdServer.GetPeerState(conf.State.NeighborAddress)
 		if err == nil {
 			st := &bfdPeer.state
 			conf.Bfd.State.SessionState = oc.IntToBfdSessionStateMap[int(st.SessionState)]
@@ -2536,7 +2540,9 @@ func (s *BgpServer) StartBgp(ctx context.Context, r *api.StartBgpRequest) error 
 		table.SelectionOptions = c.RouteSelectionOptions.Config
 		table.UseMultiplePaths = c.UseMultiplePaths.Config
 		if s.bfdServer != nil {
-			s.bfdServer.Start(oc.BfdConfig{Port: BfdServerPort})
+			if err := s.bfdServer.Start(ctx, oc.BfdConfig{Port: BfdServerPort}); err != nil {
+				return err
+			}
 		}
 		return nil
 	}, false)
@@ -3362,7 +3368,11 @@ func (s *BgpServer) addNeighbor(c *oc.Neighbor) error {
 		s.peerGroupMap[name].AddMember(*c)
 	}
 	if s.bfdServer != nil {
-		if err := s.bfdServer.AddPeer(addr, c.Bfd.Config); err != nil {
+		ipAddr, err := netip.ParseAddr(addr)
+		if err != nil {
+			return fmt.Errorf("failed to parse IP address: %v", err)
+		}
+		if err := s.bfdServer.AddPeer(context.Background(), ipAddr, c.Bfd.Config); err != nil {
 			s.logger.Warn("failed to add BFD peer",
 				slog.String("Topic", "Peer"),
 				slog.String("Key", addr),
@@ -3486,7 +3496,11 @@ func (s *BgpServer) deleteNeighbor(c *oc.Neighbor, code, subcode uint8, sendNoti
 	n.fsm.logger.Info("Delete a peer configuration")
 
 	if s.bfdServer != nil {
-		if err := s.bfdServer.DeletePeer(addr); err != nil {
+		ipAddr, err := netip.ParseAddr(addr)
+		if err != nil {
+			return fmt.Errorf("failed to parse IP address: %v", err)
+		}
+		if err := s.bfdServer.DeletePeer(context.Background(), ipAddr); err != nil {
 			s.logger.Warn("failed to delete BFD peer",
 				slog.String("Topic", "Peer"),
 				slog.String("Key", addr),
@@ -5038,15 +5052,8 @@ func (s *BgpServer) ListBfdPeer(ctx context.Context, fn func(string, *api.BfdPee
 	if s.bfdServer == nil {
 		return
 	}
-	list, err := s.bfdServer.GetPeerStateList(ctx)
-	if err != nil {
-		s.logger.Debug("GetPeerStateList",
-			slog.String("Topic", "bfd"),
-			slog.Any("Error", err),
-		)
-		return
-	}
+	list := s.bfdServer.GetPeerStateList()
 	for _, state := range list {
-		fn(state.peerAddress, &state.state)
+		fn(state.peerAddress.String(), &state.state)
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -59,6 +59,13 @@ const (
 	FSMOperationTypeCount
 )
 
+// RFC 5881 requires the BFD server to listen on port 3784.
+// Per-peer BfdConfig.Port configures the destination port for outgoing
+// packets and may differ, but the listen port is not user-configurable.
+const (
+	BfdServerPort = 3784
+)
+
 type FSMTimingHook interface {
 	Observe(op FSMOperation, tOp, tWait time.Duration)
 }
@@ -146,6 +153,7 @@ type BgpServer struct {
 	mrtManager   *mrtManager
 	roaTable     *table.ROATable
 	uuidMap      map[string]uuid.UUID
+	bfdServer    *bfdServer
 	logger       *slog.Logger
 	logLevelVar  *slog.LevelVar
 	timingHook   FSMTimingHook
@@ -190,6 +198,7 @@ func NewBgpServer(opt ...ServerOption) *BgpServer {
 	}
 	s.bmpManager = newBmpClientManager(s)
 	s.mrtManager = newMrtManager(s)
+	s.bfdServer = NewBfdServer(s, logger)
 	if len(opts.grpcAddress) != 0 {
 		grpc.EnableTracing = false
 		s.apiServer = newAPIserver(s, shared, grpc.NewServer(opts.grpcOption...), opts.grpcAddress)
@@ -812,6 +821,21 @@ func (s *BgpServer) toConfig(peer *peer, getAdvertised bool) *oc.Neighbor {
 	conf.State.Messages.Sent.WithdrawPrefix = atomic.LoadUint32(&peer.fsm.counterStats.Sent.WithdrawPrefix)
 	conf.State.Messages.Sent.Discarded = atomic.LoadUint64(&peer.fsm.counterStats.Sent.Discarded)
 	conf.Timers.State.UpdateRecvTime = atomic.LoadInt64(&peer.fsm.timerStats.State.UpdateRecvTime)
+
+	if s.bfdServer != nil {
+		bfdPeer, err := s.bfdServer.GetPeerState(context.Background(), conf.State.NeighborAddress.String())
+		if err == nil {
+			st := &bfdPeer.state
+			conf.Bfd.State.SessionState = oc.IntToBfdSessionStateMap[int(st.SessionState)]
+			conf.Bfd.State.LastFailureTime = st.LastFailureTime
+			conf.Bfd.State.FailureTransitions = st.FailureTransitions
+			conf.Bfd.State.LocalDiscriminator = st.LocalDiscriminator
+			if st.BfdAsync != nil {
+				conf.Bfd.State.BfdAsync.TransmittedPackets = st.BfdAsync.TransmittedPackets
+				conf.Bfd.State.BfdAsync.ReceivedPackets = st.BfdAsync.ReceivedPackets
+			}
+		}
+	}
 
 	return &conf
 }
@@ -2511,6 +2535,9 @@ func (s *BgpServer) StartBgp(ctx context.Context, r *api.StartBgpRequest) error 
 		// update route selection options
 		table.SelectionOptions = c.RouteSelectionOptions.Config
 		table.UseMultiplePaths = c.UseMultiplePaths.Config
+		if s.bfdServer != nil {
+			s.bfdServer.Start(oc.BfdConfig{Port: BfdServerPort})
+		}
 		return nil
 	}, false)
 }
@@ -3334,6 +3361,14 @@ func (s *BgpServer) addNeighbor(c *oc.Neighbor) error {
 	if name := c.Config.PeerGroup; name != "" {
 		s.peerGroupMap[name].AddMember(*c)
 	}
+	if s.bfdServer != nil {
+		if err := s.bfdServer.AddPeer(addr, c.Bfd.Config); err != nil {
+			s.logger.Warn("failed to add BFD peer",
+				slog.String("Topic", "Peer"),
+				slog.String("Key", addr),
+				slog.String("Err", err.Error()))
+		}
+	}
 	s.startFsmHandler(peer)
 	return nil
 }
@@ -3450,6 +3485,14 @@ func (s *BgpServer) deleteNeighbor(c *oc.Neighbor, code, subcode uint8, sendNoti
 	}
 	n.fsm.logger.Info("Delete a peer configuration")
 
+	if s.bfdServer != nil {
+		if err := s.bfdServer.DeletePeer(addr); err != nil {
+			s.logger.Warn("failed to delete BFD peer",
+				slog.String("Topic", "Peer"),
+				slog.String("Key", addr),
+				slog.String("Err", err.Error()))
+		}
+	}
 	if sendNotification {
 		n.fsm.deconfiguredNotification <- bgp.NewBGPNotificationMessage(code, subcode, nil)
 	}
@@ -4982,4 +5025,28 @@ func (s *BgpServer) watch(opts ...WatchOption) (w *watcher) {
 		return nil
 	}, false)
 	return w
+}
+
+func (s *BgpServer) GetBfdServerStats() *api.BfdState {
+	if s.bfdServer == nil {
+		return nil
+	}
+	return s.bfdServer.GetServerStats()
+}
+
+func (s *BgpServer) ListBfdPeer(ctx context.Context, fn func(string, *api.BfdPeerState)) {
+	if s.bfdServer == nil {
+		return
+	}
+	list, err := s.bfdServer.GetPeerStateList(ctx)
+	if err != nil {
+		s.logger.Debug("GetPeerStateList",
+			slog.String("Topic", "bfd"),
+			slog.Any("Error", err),
+		)
+		return
+	}
+	for _, state := range list {
+		fn(state.peerAddress, &state.state)
+	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -830,7 +830,7 @@ func (s *BgpServer) toConfig(peer *peer, getAdvertised bool) *oc.Neighbor {
 		bfdPeer, err := s.bfdServer.GetPeerState(conf.State.NeighborAddress)
 		if err == nil {
 			st := &bfdPeer.state
-			conf.Bfd.State.SessionState = oc.IntToBfdSessionStateMap[int(st.SessionState)]
+			conf.Bfd.State.SessionState = apiBfdSessionStateToOC(st.SessionState)
 			conf.Bfd.State.LastFailureTime = st.LastFailureTime
 			conf.Bfd.State.FailureTransitions = st.FailureTransitions
 			conf.Bfd.State.LocalDiscriminator = st.LocalDiscriminator
@@ -3383,6 +3383,46 @@ func (s *BgpServer) addNeighbor(c *oc.Neighbor) error {
 	return nil
 }
 
+func apiBfdSessionStateToOC(state api.BfdSessionState) oc.BfdSessionState {
+	switch state {
+	case api.BfdSessionState_BFD_SESSION_STATE_UP:
+		return oc.BFD_SESSION_STATE_UP
+	case api.BfdSessionState_BFD_SESSION_STATE_DOWN:
+		return oc.BFD_SESSION_STATE_DOWN
+	case api.BfdSessionState_BFD_SESSION_STATE_ADMIN_DOWN:
+		return oc.BFD_SESSION_STATE_ADMIN_DOWN
+	case api.BfdSessionState_BFD_SESSION_STATE_INIT:
+		return oc.BFD_SESSION_STATE_INIT
+	default:
+		return oc.BFD_SESSION_STATE_DOWN
+	}
+}
+
+func (s *BgpServer) updateBfdPeer(addr string, oldConfig, newConfig oc.BfdConfig) error {
+	if s.bfdServer == nil || oldConfig.Equal(&newConfig) {
+		return nil
+	}
+
+	ipAddr, err := netip.ParseAddr(addr)
+	if err != nil {
+		return fmt.Errorf("failed to parse IP address: %v", err)
+	}
+
+	if oldConfig.Enabled {
+		if err := s.bfdServer.DeletePeer(context.Background(), ipAddr); err != nil {
+			return err
+		}
+	}
+
+	if newConfig.Enabled {
+		if err := s.bfdServer.AddPeer(context.Background(), ipAddr, newConfig); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (s *BgpServer) AddPeerGroup(ctx context.Context, r *api.AddPeerGroupRequest) error {
 	if r == nil || r.PeerGroup == nil {
 		return fmt.Errorf("nil request")
@@ -3658,6 +3698,12 @@ func (s *BgpServer) updateNeighbor(c *oc.Neighbor) (needsSoftResetIn bool, err e
 		needsSoftResetIn = true
 	}
 
+	bfdConfigChanged := !original.Bfd.Config.Equal(&c.Bfd.Config)
+	if bfdConfigChanged {
+		peer.fsm.logger.Info("Update BFD configuration")
+		conf.Bfd.Config = c.Bfd.Config
+	}
+
 	if original.NeedsResendOpenMessage(c) {
 		sub := uint8(bgp.BGP_ERROR_SUB_OTHER_CONFIGURATION_CHANGE)
 		if original.Config.AdminDown != c.Config.AdminDown {
@@ -3701,8 +3747,13 @@ func (s *BgpServer) updateNeighbor(c *oc.Neighbor) (needsSoftResetIn bool, err e
 	if err == nil {
 		peer.fsm.pConf.Update(&conf)
 		peer.fsm.lock.Unlock()
+		if bfdConfigChanged {
+			err = s.updateBfdPeer(addr, original.Bfd.Config, c.Bfd.Config)
+		}
 		if isLimit {
-			err = s.setAdminState(addr, "", adminStatePfxCt)
+			if err == nil {
+				err = s.setAdminState(addr, "", adminStatePfxCt)
+			}
 		}
 	} else {
 		// rollback to original ApplyPolicy

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -16,10 +16,28 @@
 package server
 
 import (
+	"math/rand/v2"
+
 	"github.com/eapache/channels"
 
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
+
+func randRange(min int, max int) int {
+	return min + rand.IntN(max-min+1)
+}
+
+// randomBFDMyDiscriminator returns a non-zero 32-bit value for RFC 5880
+// My Discriminator. It does not use randRange with MaxUint32 because int
+// on 32-bit architectures cannot represent that upper bound.
+func randomBFDMyDiscriminator() uint32 {
+	for {
+		v := rand.Uint32()
+		if v != 0 {
+			return v
+		}
+	}
+}
 
 func nonblockSendChannel[T any](ch chan<- T, item T) bool {
 	select {


### PR DESCRIPTION
  Implements RFC 5880/5881 BFD liveness detection for BGP peers:
  - UDP server listening on port 3784 with per-peer session management
  - State machine: Down → Init → Up with detection timeout and hard reset
  - Per-peer async counters and session state
  - Integration with BGP peer lifecycle (AddPeer/DeletePeer/ResetPeer)
  - Tests covering state transitions, peer reset, and BGP integration