### PR TITLE
fix bgp-ls mt-id rib collision

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -27,6 +27,7 @@ import (
 	"net/netip"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -4992,6 +4993,7 @@ type LsLinkDescriptor struct {
 	NeighborAddrIPv4  *netip.Addr
 	InterfaceAddrIPv6 *netip.Addr
 	NeighborAddrIPv6  *netip.Addr
+	MultiTopoIDs      map[uint16]struct{}
 }
 
 func (l *LsLinkDescriptor) ParseTLVs(tlvs []LsTLVInterface) {
@@ -5012,39 +5014,53 @@ func (l *LsLinkDescriptor) ParseTLVs(tlvs []LsTLVInterface) {
 
 		case *LsTLVIPv6NeighborAddr:
 			l.NeighborAddrIPv6 = &v.IP
+
+		case *LsTLVMultiTopoID:
+			if l.MultiTopoIDs == nil {
+				l.MultiTopoIDs = make(map[uint16]struct{}, len(v.MultiTopoIDs))
+			}
+
+			for _, id := range v.MultiTopoIDs {
+				l.MultiTopoIDs[id] = struct{}{}
+			}
 		}
 	}
 }
 
 func (l *LsLinkDescriptor) String() string {
+	var base string
 	switch {
 	case l.InterfaceAddrIPv4 != nil && l.NeighborAddrIPv4 != nil:
-		return fmt.Sprintf("%v->%v", l.InterfaceAddrIPv4, l.NeighborAddrIPv4)
+		base = fmt.Sprintf("%v->%v", l.InterfaceAddrIPv4, l.NeighborAddrIPv4)
 
 	case l.InterfaceAddrIPv6 != nil && l.NeighborAddrIPv6 != nil:
-		return fmt.Sprintf("%v->%v", l.InterfaceAddrIPv6, l.NeighborAddrIPv6)
+		base = fmt.Sprintf("%v->%v", l.InterfaceAddrIPv6, l.NeighborAddrIPv6)
 
 	case l.LinkLocalID != nil && l.LinkRemoteID != nil:
-		return fmt.Sprintf("%v->%v", *l.LinkLocalID, *l.LinkRemoteID)
+		base = fmt.Sprintf("%v->%v", *l.LinkLocalID, *l.LinkRemoteID)
 
 	case l.InterfaceAddrIPv4 != nil:
-		return fmt.Sprintf("%v->UNKNOWN", l.InterfaceAddrIPv4)
+		base = fmt.Sprintf("%v->UNKNOWN", l.InterfaceAddrIPv4)
 	case l.NeighborAddrIPv4 != nil:
-		return fmt.Sprintf("UNKNOWN->%v", l.NeighborAddrIPv4)
+		base = fmt.Sprintf("UNKNOWN->%v", l.NeighborAddrIPv4)
 
 	case l.InterfaceAddrIPv6 != nil:
-		return fmt.Sprintf("%v->UNKNOWN", l.InterfaceAddrIPv6)
+		base = fmt.Sprintf("%v->UNKNOWN", l.InterfaceAddrIPv6)
 	case l.NeighborAddrIPv6 != nil:
-		return fmt.Sprintf("UNKNOWN->%v", l.NeighborAddrIPv6)
+		base = fmt.Sprintf("UNKNOWN->%v", l.NeighborAddrIPv6)
 
 	case l.LinkLocalID != nil:
-		return fmt.Sprintf("%v->UNKNOWN", *l.LinkLocalID)
+		base = fmt.Sprintf("%v->UNKNOWN", *l.LinkLocalID)
 	case l.LinkRemoteID != nil:
-		return fmt.Sprintf("UNKNOWN->%v", *l.LinkRemoteID)
+		base = fmt.Sprintf("UNKNOWN->%v", *l.LinkRemoteID)
 
 	default:
-		return "UNKNOWN"
+		base = "UNKNOWN"
 	}
+	// MT-ID participates in the destination key (RFC 7752 §3.2.1.5).
+	// Two ISIS-MT advertisements of the same physical link must not
+	// collide in the RIB.
+	return base + multiTopoIDsToString(l.MultiTopoIDs)
 }
 
 func NewLsLinkTLVs(ld *LsLinkDescriptor) []LsTLVInterface {
@@ -5159,6 +5175,8 @@ func (l *LsLinkNLRI) DecodeFromBytes(data []byte) error {
 			subTLV = &LsTLVIPv6InterfaceAddr{}
 		case LS_TLV_IPV6_NEIGHBOR_ADDR:
 			subTLV = &LsTLVIPv6NeighborAddr{}
+		case LS_TLV_MULTI_TOPO_ID:
+			subTLV = &LsTLVMultiTopoID{}
 
 		default:
 			if sub.Len() > len(tlv) {
@@ -5242,6 +5260,7 @@ func (l *LsLinkNLRI) MarshalJSON() ([]byte, error) {
 type LsPrefixDescriptor struct {
 	IPReachability []netip.Prefix
 	OSPFRouteType  LsOspfRouteType
+	MultiTopoIDs   map[uint16]struct{}
 }
 
 func (l *LsPrefixDescriptor) ParseTLVs(tlvs []LsTLVInterface, ipv6 bool) {
@@ -5252,8 +5271,35 @@ func (l *LsPrefixDescriptor) ParseTLVs(tlvs []LsTLVInterface, ipv6 bool) {
 
 		case *LsTLVOspfRouteType:
 			l.OSPFRouteType = v.RouteType
+
+		case *LsTLVMultiTopoID:
+			if l.MultiTopoIDs == nil {
+				l.MultiTopoIDs = make(map[uint16]struct{}, len(v.MultiTopoIDs))
+			}
+
+			for _, id := range v.MultiTopoIDs {
+				l.MultiTopoIDs[id] = struct{}{}
+			}
 		}
 	}
+}
+
+// MultiTopoIDsToString renders an MT-ID list for use in NLRI String() output.
+// The empty case returns an empty string so callers can append it
+// unconditionally without affecting the existing format.
+func multiTopoIDsToString(ids map[uint16]struct{}) string {
+	if len(ids) == 0 {
+		return ""
+	}
+
+	mtIDs := make([]uint16, 0, len(ids))
+	for id := range ids {
+		mtIDs = append(mtIDs, id)
+	}
+
+	slices.Sort(mtIDs)
+
+	return fmt.Sprintf(" MT: %v", mtIDs)
 }
 
 type LsPrefixV4NLRI struct {
@@ -5280,7 +5326,7 @@ func (l *LsPrefixV4NLRI) String() string {
 		ospf = fmt.Sprintf("OSPF_ROUTE_TYPE:%v ", prefix.OSPFRouteType)
 	}
 
-	return fmt.Sprintf("PREFIXv4 { LOCAL_NODE: %s PREFIX: %v %s}", local.IGPRouterID, ips, ospf)
+	return fmt.Sprintf("PREFIXv4 { LOCAL_NODE: %s PREFIX: %v %s%s}", local.IGPRouterID, ips, ospf, multiTopoIDsToString(prefix.MultiTopoIDs))
 }
 
 func (l *LsPrefixV4NLRI) DecodeFromBytes(data []byte) error {
@@ -5307,6 +5353,8 @@ func (l *LsPrefixV4NLRI) DecodeFromBytes(data []byte) error {
 			subTLV = &LsTLVOspfRouteType{}
 		case LS_TLV_IP_REACH_INFO:
 			subTLV = &LsTLVIPReachability{}
+		case LS_TLV_MULTI_TOPO_ID:
+			subTLV = &LsTLVMultiTopoID{}
 
 		default:
 			if sub.Len() > len(tlv) {
@@ -5455,7 +5503,7 @@ func (l *LsPrefixV6NLRI) String() string {
 		ospf = fmt.Sprintf("OSPF_ROUTE_TYPE:%v ", prefix.OSPFRouteType)
 	}
 
-	return fmt.Sprintf("PREFIXv6 { LOCAL_NODE: %v PREFIX: %v %v}", local.IGPRouterID, ips, ospf)
+	return fmt.Sprintf("PREFIXv6 { LOCAL_NODE: %v PREFIX: %v %v%s}", local.IGPRouterID, ips, ospf, multiTopoIDsToString(prefix.MultiTopoIDs))
 }
 
 func (l *LsPrefixV6NLRI) DecodeFromBytes(data []byte) error {
@@ -5482,6 +5530,8 @@ func (l *LsPrefixV6NLRI) DecodeFromBytes(data []byte) error {
 			subTLV = &LsTLVOspfRouteType{}
 		case LS_TLV_IP_REACH_INFO:
 			subTLV = &LsTLVIPReachability{}
+		case LS_TLV_MULTI_TOPO_ID:
+			subTLV = &LsTLVMultiTopoID{}
 
 		default:
 			if sub.Len() > len(tlv) {

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -4992,3 +4992,279 @@ func Test_LsPrefixV6NLRI_UnknownSubTLV(t *testing.T) {
 		})
 	}
 }
+
+// mtTLVBytes builds an LS Multi-Topology ID sub-TLV (RFC 7752 §3.2.1.5,
+// type 263) carrying the given MT-IDs. Used by the table-driven tests below
+// to compose synthetic NLRI payloads.
+func mtTLVBytes(ids ...uint16) []byte {
+	out := []byte{0x01, 0x07, 0x00, byte(2 * len(ids))}
+	for _, id := range ids {
+		out = append(out, byte(id>>8), byte(id))
+	}
+	return out
+}
+
+// Test_LsLinkNLRI_MultiTopoID verifies that the Multi-Topology ID sub-TLV
+// (RFC 7752 §3.2.1.5, type 263) is parsed into LinkDesc, that
+// LsLinkDescriptor.String() emits the MT-ID suffix, and that two
+// otherwise-identical link NLRIs with different MT-IDs produce different
+// destination keys (regression test for RIB collision via implicit-withdraw).
+func Test_LsLinkNLRI_MultiTopoID(t *testing.T) {
+	commonHeader := []byte{
+		0x02,                                           // Protocol: ISIS L2
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Identifier
+		// Local Node Descriptor, value length=18
+		0x01, 0x00, 0x00, 0x12,
+		0x02, 0x00, 0x00, 0x04, 0x07, 0x07, 0x07, 0x07,
+		0x02, 0x03, 0x00, 0x06, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+		// Remote Node Descriptor, value length=18
+		0x01, 0x01, 0x00, 0x12,
+		0x02, 0x00, 0x00, 0x04, 0x07, 0x07, 0x07, 0x07,
+		0x02, 0x03, 0x00, 0x06, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		// IPv4 Interface Address: 10.0.0.1
+		0x01, 0x03, 0x00, 0x04, 0x0a, 0x00, 0x00, 0x01,
+		// IPv4 Neighbor Address: 10.0.0.2
+		0x01, 0x04, 0x00, 0x04, 0x0a, 0x00, 0x00, 0x02,
+	}
+
+	tests := []struct {
+		name         string
+		extraTLV     []byte
+		wantMTIDs    map[uint16]struct{}
+		wantContains string // expected substring in LsLinkDescriptor.String()
+		wantNoMT     bool   // String() must NOT contain "MT:"
+	}{
+		{
+			name:     "no MT-ID (backward compat)",
+			extraTLV: nil,
+			wantNoMT: true,
+		},
+		{
+			name:     "single MT-ID 0",
+			extraTLV: mtTLVBytes(0),
+			wantMTIDs: map[uint16]struct{}{
+				0: {},
+			},
+			wantContains: " MT: [0]",
+		},
+		{
+			name:     "single MT-ID 2",
+			extraTLV: mtTLVBytes(2),
+			wantMTIDs: map[uint16]struct{}{
+				2: {},
+			},
+			wantContains: " MT: [2]",
+		},
+		{
+			name:     "multiple MT-IDs",
+			extraTLV: mtTLVBytes(1, 2),
+			wantMTIDs: map[uint16]struct{}{
+				1: {},
+				2: {},
+			},
+			wantContains: " MT: [1 2]",
+		},
+	}
+
+	// Track per-case String() outputs to assert that distinct MT sets yield
+	// distinct destination keys (RIB collision regression).
+	keys := make(map[string]string, len(tests))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			data := append(append([]byte{}, commonHeader...), tt.extraTLV...)
+			nlri := &LsLinkNLRI{}
+			nlri.Length = uint16(len(data))
+			assert.NoError(nlri.DecodeFromBytes(data))
+
+			desc := &LsLinkDescriptor{}
+			desc.ParseTLVs(nlri.LinkDesc)
+
+			assert.Equal(tt.wantMTIDs, desc.MultiTopoIDs)
+
+			s := desc.String()
+			if tt.wantNoMT {
+				assert.NotContains(s, "MT:",
+					"non-MT NLRI must not gain an MT suffix (backward compat)")
+			} else {
+				assert.Contains(s, tt.wantContains)
+			}
+			keys[tt.name] = s
+		})
+	}
+
+	// Cross-case regression: every distinct case must produce a distinct key.
+	t.Run("distinct MT sets yield distinct keys", func(t *testing.T) {
+		seen := make(map[string]string, len(keys))
+		for name, key := range keys {
+			if other, ok := seen[key]; ok {
+				t.Fatalf("RIB key collision: %q and %q both produced %q", name, other, key)
+			}
+			seen[key] = name
+		}
+	})
+}
+
+func Test_LsPrefixV4NLRI_MultiTopoID(t *testing.T) {
+	commonHeader := []byte{
+		0x02,                                           // Protocol: ISIS L2
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Identifier
+		0x01, 0x00, 0x00, 0x12,
+		0x02, 0x00, 0x00, 0x04, 0x07, 0x07, 0x07, 0x07,
+		0x02, 0x03, 0x00, 0x06, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+		// IP Reachability Info: prefix-len=24, prefix=10.0.0.0/24
+		0x01, 0x09, 0x00, 0x04, 0x18, 0x0a, 0x00, 0x00,
+	}
+
+	tests := []struct {
+		name         string
+		extraTLV     []byte
+		wantMTIDs    map[uint16]struct{}
+		wantContains string
+		wantNoMT     bool
+	}{
+		{
+			name:     "no MT-ID (backward compat)",
+			extraTLV: nil,
+			wantNoMT: true,
+		},
+		{
+			name:     "single MT-ID 2",
+			extraTLV: mtTLVBytes(2),
+			wantMTIDs: map[uint16]struct{}{
+				2: {},
+			},
+			wantContains: " MT: [2]",
+		},
+		{
+			name:     "multiple MT-IDs",
+			extraTLV: mtTLVBytes(0, 2),
+			wantMTIDs: map[uint16]struct{}{
+				0: {},
+				2: {},
+			},
+			wantContains: " MT: [0 2]",
+		},
+	}
+
+	keys := make(map[string]string, len(tests))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			data := append(append([]byte{}, commonHeader...), tt.extraTLV...)
+			nlri := &LsPrefixV4NLRI{}
+			nlri.Length = uint16(len(data))
+			assert.NoError(nlri.DecodeFromBytes(data))
+
+			pd := &LsPrefixDescriptor{}
+			pd.ParseTLVs(nlri.PrefixDesc, false)
+
+			assert.Equal(tt.wantMTIDs, pd.MultiTopoIDs)
+
+			s := nlri.String()
+			if tt.wantNoMT {
+				assert.NotContains(s, "MT:")
+			} else {
+				assert.Contains(s, tt.wantContains)
+			}
+			keys[tt.name] = s
+		})
+	}
+
+	// Cross-case regression: every distinct case must produce a distinct key.
+	t.Run("distinct MT sets yield distinct keys", func(t *testing.T) {
+		seen := make(map[string]string, len(keys))
+		for name, key := range keys {
+			if other, ok := seen[key]; ok {
+				t.Fatalf("RIB key collision: %q and %q both produced %q", name, other, key)
+			}
+			seen[key] = name
+		}
+	})
+}
+
+func Test_LsPrefixV6NLRI_MultiTopoID(t *testing.T) {
+	commonHeader := []byte{
+		0x02,                                           // Protocol: ISIS L2
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Identifier
+		0x01, 0x00, 0x00, 0x12,
+		0x02, 0x00, 0x00, 0x04, 0x07, 0x07, 0x07, 0x07,
+		0x02, 0x03, 0x00, 0x06, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+		// IP Reachability Info: prefix-len=64, prefix=2001:db8::/64
+		0x01, 0x09, 0x00, 0x09,
+		0x40,
+		0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+	}
+
+	tests := []struct {
+		name         string
+		extraTLV     []byte
+		wantMTIDs    map[uint16]struct{}
+		wantContains string
+		wantNoMT     bool
+	}{
+		{
+			name:     "no MT-ID (backward compat)",
+			extraTLV: nil,
+			wantNoMT: true,
+		},
+		{
+			name:     "single MT-ID 2",
+			extraTLV: mtTLVBytes(2),
+			wantMTIDs: map[uint16]struct{}{
+				2: {},
+			},
+			wantContains: " MT: [2]",
+		},
+		{
+			name:     "multiple MT-IDs",
+			extraTLV: mtTLVBytes(0, 2),
+			wantMTIDs: map[uint16]struct{}{
+				0: {},
+				2: {},
+			},
+			wantContains: " MT: [0 2]",
+		},
+	}
+
+	keys := make(map[string]string, len(tests))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			data := append(append([]byte{}, commonHeader...), tt.extraTLV...)
+			nlri := &LsPrefixV6NLRI{}
+			nlri.Length = uint16(len(data))
+			assert.NoError(nlri.DecodeFromBytes(data))
+
+			pd := &LsPrefixDescriptor{}
+			pd.ParseTLVs(nlri.PrefixDesc, true)
+
+			assert.Equal(tt.wantMTIDs, pd.MultiTopoIDs)
+
+			s := nlri.String()
+			if tt.wantNoMT {
+				assert.NotContains(s, "MT:")
+			} else {
+				assert.Contains(s, tt.wantContains)
+			}
+			keys[tt.name] = s
+		})
+	}
+
+	// Cross-case regression: every distinct case must produce a distinct key.
+	t.Run("distinct MT sets yield distinct keys", func(t *testing.T) {
+		seen := make(map[string]string, len(keys))
+		for name, key := range keys {
+			if other, ok := seen[key]; ok {
+				t.Fatalf("RIB key collision: %q and %q both produced %q", name, other, key)
+			}
+			seen[key] = name
+		}
+	})
+}


### PR DESCRIPTION
## Problem

In ISIS-MT deployments a router advertises the same physical link/prefix
once per topology (e.g. classic IPv4/MT-0 alongside SRv6/MT-2). The
advertisements differ only by the Multi-Topology ID sub-TLV (RFC 7752
§3.2.1.5, type 263). Before this change BGP-LS NLRI decoders did not parse
that sub-TLV, so `String()` — which is used as the RIB destination key —
was identical for MT-distinct advertisements. Result: the second NLRI
implicit-withdrew the first, and only one topology survived in the RIB.

## Fix

- Parse `LS_TLV_MULTI_TOPO_ID` in `LsLinkNLRI`, `LsPrefixV4NLRI` and
  `LsPrefixV6NLRI` decoders.
- Add `MultiTopoIDs map[uint16]struct{}` to `LsLinkDescriptor` and
  `LsPrefixDescriptor`; populate from the new sub-TLV in `ParseTLVs`.
- Append a sorted ` MT: [v1 v2 …]` suffix in `String()` so MT-distinct
  NLRIs get distinct keys. Empty MT set → no suffix (backward compatible).

## Compatibility

- No wire-format change; only decoder, struct fields and string formatting.
- For non-MT NLRIs `String()` output is byte-for-byte identical — existing
  RIB keys and CLI output are unaffected.