### PR TITLE
perf(table): bitmap-based fast path for standard BGP CommunitySet

### DIFF
--- a/internal/pkg/table/community_match_chart_test.go
+++ b/internal/pkg/table/community_match_chart_test.go
@@ -1,0 +1,250 @@
+package table
+
+import (
+	"fmt"
+	"net/netip"
+	"os"
+	"regexp"
+	"testing"
+	"text/tabwriter"
+	"time"
+
+	"github.com/osrg/gobgp/v4/pkg/config/oc"
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+)
+
+// createPathWithCommunities builds a path that carries the given community values.
+func createPathWithCommunities(communities []uint32) *Path {
+	p := netip.MustParsePrefix("10.0.0.0/24")
+	nlri, _ := bgp.NewIPAddrPrefix(p)
+	nexthop, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("10.0.0.1"))
+	commAttr := bgp.NewPathAttributeCommunities(communities)
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		nexthop,
+		commAttr,
+	}
+	return NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
+}
+
+// communityChartCase describes one benchmark scenario for community matching.
+type communityChartCase struct {
+	// Bench is a short b.Run() sub-name (ASCII, no spaces) so console output stays narrow.
+	Bench    string
+	Name     string // human-readable; used in failure messages
+	Patterns []string
+	Regexps  []string
+	WantHit  bool
+}
+
+func communityChartCases() []communityChartCase {
+	return []communityChartCase{
+		{
+			Bench:    "exact_1",
+			Name:     "Exact / 1 pattern / match",
+			Patterns: []string{"65000:100"},
+			Regexps:  []string{"^65000:100$"},
+			WantHit:  true,
+		},
+		{
+			Bench: "exact_10_last",
+			Name:  "Exact / 10 patterns / last matches",
+			Patterns: func() []string {
+				s := make([]string, 10)
+				for i := range 9 {
+					s[i] = fmt.Sprintf("65099:%d", i)
+				}
+				s[9] = "65002:999"
+				return s
+			}(),
+			Regexps: func() []string {
+				s := make([]string, 10)
+				for i := range 9 {
+					s[i] = fmt.Sprintf("^65099:%d$", i)
+				}
+				s[9] = "^65002:999$"
+				return s
+			}(),
+			WantHit: true,
+		},
+		{
+			Bench: "exact_10_none",
+			Name:  "Exact / 10 patterns / no match",
+			Patterns: func() []string {
+				s := make([]string, 10)
+				for i := range 10 {
+					s[i] = fmt.Sprintf("65099:%d", i)
+				}
+				return s
+			}(),
+			Regexps: func() []string {
+				s := make([]string, 10)
+				for i := range 10 {
+					s[i] = fmt.Sprintf("^65099:%d$", i)
+				}
+				return s
+			}(),
+			WantHit: false,
+		},
+		{
+			Bench:    "wildcard_yes",
+			Name:     "Wildcard regexp / match",
+			Patterns: []string{"^65000:.*$"},
+			Regexps:  []string{"^65000:.*$"},
+			WantHit:  true,
+		},
+		{
+			Bench:    "wildcard_no",
+			Name:     "Wildcard regexp / no match",
+			Patterns: []string{"^65099:.*$"},
+			Regexps:  []string{"^65099:.*$"},
+			WantHit:  false,
+		},
+		{
+			Bench:    "mixed_miss_then_hit",
+			Name:     "Mixed: regex(miss) + exact(hit)",
+			Patterns: []string{"^65099:.*$", "65001:300"},
+			Regexps:  []string{"^65099:.*$", "^65001:300$"},
+			WantHit:  true,
+		},
+		{
+			Bench:    "local_star_100",
+			Name:     "Local-independent / ^[0-9]*:local / match",
+			Patterns: []string{"^[0-9]*:100$"},
+			Regexps:  []string{"^[0-9]*:100$"},
+			WantHit:  true,
+		},
+		{
+			Bench:    "local_star_alt",
+			Name:     "Local-independent / ^[0-9]*:(a|b) / match",
+			Patterns: []string{"^[0-9]*:(999|888)$"},
+			Regexps:  []string{"^[0-9]*:(999|888)$"},
+			WantHit:  true,
+		},
+		{
+			Bench:    "local_star_miss",
+			Name:     "Local-independent / no match",
+			Patterns: []string{"^[0-9]*:42$"},
+			Regexps:  []string{"^[0-9]*:42$"},
+			WantHit:  false,
+		},
+		{
+			Bench:    "local_dplus",
+			Name:     "Local-independent / \\d+ form / match",
+			Patterns: []string{`^\d+:300$`},
+			Regexps:  []string{`^\d+:300$`},
+			WantHit:  true,
+		},
+	}
+}
+
+func communityBenchmarkPath() *Path {
+	return createPathWithCommunities([]uint32{
+		65000<<16 | 100,
+		65000<<16 | 200,
+		65001<<16 | 100,
+		65001<<16 | 300,
+		65002<<16 | 999,
+	})
+}
+
+// communityMatchLegacyLoop is the naive fmt.Sprintf + regexp baseline (not semantically identical to MATCH_OPTION_ANY).
+func communityMatchLegacyLoop(path *Path, regs []*regexp.Regexp) {
+	cs := path.GetCommunities()
+	for _, x := range regs {
+		for _, y := range cs {
+			if x.MatchString(fmt.Sprintf("%d:%d", y>>16, y&0xffff)) {
+				break
+			}
+		}
+	}
+}
+
+// BenchmarkCommunityCondition runs New and Legacy side by side per scenario (names like exact_1/New, exact_1/Legacy).
+//
+//	go test ./internal/pkg/table/ -run '^$' -bench 'BenchmarkCommunityCondition' -benchmem -count=5
+func BenchmarkCommunityCondition(b *testing.B) {
+	path := communityBenchmarkPath()
+	for _, sc := range communityChartCases() {
+		b.Run(sc.Bench+"/New", func(b *testing.B) {
+			cs, err := NewCommunitySet(oc.CommunitySet{
+				CommunitySetName: "bench",
+				CommunityList:    sc.Patterns,
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+			cond := &CommunityCondition{set: cs, option: MATCH_OPTION_ANY}
+			if got := cond.Evaluate(path, nil); got != sc.WantHit {
+				b.Fatalf("%s: expected match=%v got %v", sc.Name, sc.WantHit, got)
+			}
+			b.ResetTimer()
+			for range b.N {
+				cond.Evaluate(path, nil)
+			}
+		})
+		b.Run(sc.Bench+"/Legacy", func(b *testing.B) {
+			regs := make([]*regexp.Regexp, len(sc.Regexps))
+			for i, p := range sc.Regexps {
+				regs[i] = regexp.MustCompile(p)
+			}
+			b.ResetTimer()
+			for range b.N {
+				communityMatchLegacyLoop(path, regs)
+			}
+		})
+	}
+}
+
+func TestCommunityConditionCompareSummary(t *testing.T) {
+	if os.Getenv("GOBGP_COMMUNITY_BENCH_COMPARE") != "1" {
+		t.Skip(`set GOBGP_COMMUNITY_BENCH_COMPARE=1 to print New vs Legacy ns/op and speedup (legacy/new)`)
+	}
+	path := communityBenchmarkPath()
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, err := fmt.Fprintln(tw, "bench\tnew ns/op\tlegacy ns/op\tlegacy/new\tname")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = fmt.Fprintln(tw, "-----\t---------\t-----------\t--------\t----")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, sc := range communityChartCases() {
+		rNew := testing.Benchmark(func(b *testing.B) {
+			cs, err := NewCommunitySet(oc.CommunitySet{
+				CommunitySetName: "bench",
+				CommunityList:    sc.Patterns,
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+			cond := &CommunityCondition{set: cs, option: MATCH_OPTION_ANY}
+			if got := cond.Evaluate(path, nil); got != sc.WantHit {
+				b.Fatalf("%s: expected match=%v got %v", sc.Name, sc.WantHit, got)
+			}
+			b.ResetTimer()
+			for range b.N {
+				cond.Evaluate(path, nil)
+			}
+		})
+		regs := make([]*regexp.Regexp, len(sc.Regexps))
+		for i, p := range sc.Regexps {
+			regs[i] = regexp.MustCompile(p)
+		}
+		rLeg := testing.Benchmark(func(b *testing.B) {
+			b.ResetTimer()
+			for range b.N {
+				communityMatchLegacyLoop(path, regs)
+			}
+		})
+		newNs := float64(rNew.NsPerOp())
+		legNs := float64(rLeg.NsPerOp())
+		ratio := legNs / newNs
+		_, err := fmt.Fprintf(tw, "%s\t%.0f\t%.0f\t%.2fx\t%s\n", sc.Bench, newNs, legNs, ratio, sc.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = tw.Flush()
+}

--- a/internal/pkg/table/community_match_fuzz_test.go
+++ b/internal/pkg/table/community_match_fuzz_test.go
@@ -1,0 +1,95 @@
+package table
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/osrg/gobgp/v4/pkg/config/oc"
+)
+
+// legacyEvaluate is the reference implementation of community matching using standard regexp.
+func legacyEvaluate(cs []uint32, regs []*regexp.Regexp, option MatchOption) bool {
+	if len(regs) == 0 {
+		return false
+	}
+	result := false
+	for _, x := range regs {
+		result = false
+		for _, y := range cs {
+			if x.MatchString(fmt.Sprintf("%d:%d", y>>16, y&0xffff)) {
+				result = true
+				break
+			}
+		}
+		if option == MATCH_OPTION_ALL && !result {
+			break
+		}
+		if (option == MATCH_OPTION_ANY || option == MATCH_OPTION_INVERT) && result {
+			break
+		}
+	}
+	if option == MATCH_OPTION_INVERT {
+		result = !result
+	}
+	return result
+}
+
+func FuzzCommunityCondition(f *testing.F) {
+	// Add some seed corpus
+	f.Add("65000:100", uint32(65000<<16|100), uint8(MATCH_OPTION_ANY))
+	f.Add("^65000:.*$", uint32(65000<<16|200), uint8(MATCH_OPTION_ANY))
+	f.Add("^[0-9]*:100$", uint32(65001<<16|100), uint8(MATCH_OPTION_ANY))
+	f.Add(`^\d+:300$`, uint32(65001<<16|300), uint8(MATCH_OPTION_ANY))
+	f.Add("65000:100", uint32(65001<<16|100), uint8(MATCH_OPTION_ANY))
+	f.Add("65000:100", uint32(65000<<16|100), uint8(MATCH_OPTION_INVERT))
+	f.Add("65000:100", uint32(65000<<16|100), uint8(MATCH_OPTION_ALL))
+
+	f.Fuzz(func(t *testing.T, pattern string, comm uint32, opt uint8) {
+		option := MatchOption(opt % 3) // 0: ANY, 1: ALL, 2: INVERT
+
+		// Map 0, 1, 2 to the actual constants if they differ
+		switch option {
+		case 0:
+			option = MATCH_OPTION_ANY
+		case 1:
+			option = MATCH_OPTION_ALL
+		case 2:
+			option = MATCH_OPTION_INVERT
+		}
+
+		// Try to compile the pattern as a regexp. If it fails, we skip this input.
+		// We use ParseCommunityRegexp to handle the ^ and $ additions if needed,
+		// but to be safe we just use ParseCommunityRegexp logic or just regexp.Compile.
+		// Actually, NewCommunitySet does some parsing. Let's see if it errors.
+		cs, err := NewCommunitySet(oc.CommunitySet{
+			CommunitySetName: "fuzz",
+			CommunityList:    []string{pattern},
+		})
+		if err != nil {
+			// Invalid pattern, skip
+			return
+		}
+
+		// For legacy, we need to mimic how ParseCommunityRegexp transforms the pattern.
+		// ParseCommunityRegexp in gobgp usually adds ^ and $ if not present, but let's just use the compiled regexp from cs if possible, or compile it ourselves.
+		// Wait, NewCommunitySet parses it. Let's just use the exact same regexp string that gobgp uses.
+		// Actually, if we just compile the pattern directly, it might not match exactly what gobgp does (e.g., exact match vs partial).
+		// Let's look at ParseCommunityRegexp.
+		exp, err := ParseCommunityRegexp(pattern)
+		if err != nil {
+			return
+		}
+		reg := exp
+
+		cond := &CommunityCondition{set: cs, option: option}
+		path := createPathWithCommunities([]uint32{comm})
+
+		newResult := cond.Evaluate(path, nil)
+		legacyResult := legacyEvaluate([]uint32{comm}, []*regexp.Regexp{reg}, option)
+
+		if newResult != legacyResult {
+			t.Errorf("Mismatch for pattern %q, comm %d, option %v: new=%v, legacy=%v", pattern, comm, option, newResult, legacyResult)
+		}
+	})
+}

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -829,12 +829,10 @@ func (path *Path) ReplaceAS(localAS, peerAS uint32) *Path {
 }
 
 func (path *Path) GetCommunities() []uint32 {
-	communityList := []uint32{}
 	if attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_COMMUNITIES); attr != nil {
-		communities := attr.(*bgp.PathAttributeCommunities)
-		communityList = append(communityList, communities.Value...)
+		return attr.(*bgp.PathAttributeCommunities).Value
 	}
-	return communityList
+	return nil
 }
 
 // SetCommunities adds or replaces communities with new ones.
@@ -899,12 +897,10 @@ func (path *Path) RemoveCommunities(communities []uint32) int {
 }
 
 func (path *Path) GetExtCommunities() []bgp.ExtendedCommunityInterface {
-	eCommunityList := make([]bgp.ExtendedCommunityInterface, 0)
 	if attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_EXTENDED_COMMUNITIES); attr != nil {
-		eCommunities := attr.(*bgp.PathAttributeExtendedCommunities).Value
-		eCommunityList = append(eCommunityList, eCommunities...)
+		return attr.(*bgp.PathAttributeExtendedCommunities).Value
 	}
-	return eCommunityList
+	return nil
 }
 
 func (path *Path) SetExtCommunities(exts []bgp.ExtendedCommunityInterface, doReplace bool) {
@@ -934,10 +930,7 @@ func (path *Path) GetRouteTargets() []bgp.ExtendedCommunityInterface {
 
 func (path *Path) GetLargeCommunities() []*bgp.LargeCommunity {
 	if a := path.getPathAttr(bgp.BGP_ATTR_TYPE_LARGE_COMMUNITY); a != nil {
-		v := a.(*bgp.PathAttributeLargeCommunities).Values
-		ret := make([]*bgp.LargeCommunity, 0, len(v))
-		ret = append(ret, v...)
-		return ret
+		return a.(*bgp.PathAttributeLargeCommunities).Values
 	}
 	return nil
 }

--- a/internal/pkg/table/policy.go
+++ b/internal/pkg/table/policy.go
@@ -1018,8 +1018,287 @@ func (lhs *regExpSet) Replace(arg DefinedSet) error {
 	return nil
 }
 
+// communityLocalBitmapWords is ceil(65536/64): one bit per 16-bit BGP community
+// local-admin value.
+const communityLocalBitmapWords = 1024
+
+type communityLocalBitmap [communityLocalBitmapWords]uint64
+
+type communityMatchMode uint8
+
+const (
+	communityMatchExact            communityMatchMode = iota // full uint32 equality
+	communityMatchFixedASWildcard                            // fixed AS, any local admin
+	communityMatchFixedASBitmap                              // fixed AS + precomputed local-admin bitmap
+	communityMatchLocalIndependent                           // ASN-independent bitmap on low 16 bits
+	communityMatchRegexp                                     // regexp on "ASN:local" bytes — last resort
+)
+
+const communityMatcherNoListIdx = -1
+
+// communityMatcher is a compiled community pattern.
+// Exactly one mode is active; other fields are meaningful only for that mode.
+type communityMatcher struct {
+	mode      communityMatchMode
+	listIndex int                   // list index when mode == communityMatchRegexp; communityMatcherNoListIdx otherwise
+	asn       uint16                // FixedAS*: high 16 bits of wire community
+	exact     uint32                // Exact: wire-format community
+	bitmap    *communityLocalBitmap // FixedASBitmap / LocalIndependent: local-admin match set
+}
+
+func regexpAnchoredBody(s string) (body string, ok bool) {
+	if len(s) < 3 || s[0] != '^' || s[len(s)-1] != '$' {
+		return "", false
+	}
+	return s[1 : len(s)-1], true
+}
+
+func parseRegexpExactASCIIASColonLocal(body string, localBits int) (asn uint16, local uint32, ok bool) {
+	idx := strings.IndexByte(body, ':')
+	if idx <= 0 || idx != strings.LastIndexByte(body, ':') {
+		return 0, 0, false
+	}
+	asn64, err1 := strconv.ParseUint(body[:idx], 10, 16)
+	loc64, err2 := strconv.ParseUint(body[idx+1:], 10, localBits)
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return uint16(asn64), uint32(loc64), true
+}
+
+func communityBitmapIsSet(bm *communityLocalBitmap, local uint16) bool {
+	return bm[local>>6]&(1<<(local&63)) != 0
+}
+
+func communityBitmapSet(bm *communityLocalBitmap, local uint16) {
+	bm[local>>6] |= 1 << (local & 63)
+}
+
+func communityBitmapOr(dst, src *communityLocalBitmap) {
+	for i := range dst {
+		dst[i] |= src[i]
+	}
+}
+
+func communityBitmapFillAll(bm *communityLocalBitmap) {
+	for i := range bm {
+		bm[i] = ^uint64(0)
+	}
+}
+
+func communityRegexpWildcardASLHS(lhs string) bool {
+	switch lhs {
+	case `[0-9]*`, `[0-9]+`, `\d*`, `\d+`:
+		return true
+	default:
+		return false
+	}
+}
+
+func parseCommunityRegexpFiniteLocalBitmapRHS(rhs string) (*communityLocalBitmap, bool) {
+	rhs = strings.TrimSpace(rhs)
+	var locals []uint16
+	switch {
+	case strings.HasPrefix(rhs, "(") && strings.HasSuffix(rhs, ")"):
+		for _, tok := range strings.Split(rhs[1:len(rhs)-1], "|") {
+			n, err := strconv.ParseUint(strings.TrimSpace(tok), 10, 16)
+			if err != nil {
+				return nil, false
+			}
+			locals = append(locals, uint16(n))
+		}
+	default:
+		n, err := strconv.ParseUint(rhs, 10, 16)
+		if err != nil {
+			return nil, false
+		}
+		locals = []uint16{uint16(n)}
+	}
+	if len(locals) == 0 {
+		return nil, false
+	}
+	bm := new(communityLocalBitmap)
+	for _, loc := range locals {
+		if communityBitmapIsSet(bm, loc) {
+			return nil, false
+		}
+		communityBitmapSet(bm, loc)
+	}
+	return bm, true
+}
+
+func tryWildcardASIndependentLocalCommunityBitmap(re *regexp.Regexp) (*communityLocalBitmap, bool) {
+	body, ok := regexpAnchoredBody(re.String())
+	if !ok {
+		return nil, false
+	}
+	idx := strings.IndexByte(body, ':')
+	if idx <= 0 || idx >= len(body)-1 || strings.LastIndexByte(body, ':') != idx {
+		return nil, false
+	}
+	asPart, rhsPart := body[:idx], body[idx+1:]
+	if !communityRegexpWildcardASLHS(asPart) {
+		return nil, false
+	}
+	return parseCommunityRegexpFiniteLocalBitmapRHS(rhsPart)
+}
+
+func buildLocalAdminBitmap(re *regexp.Regexp, asn uint16) *communityLocalBitmap {
+	bm := new(communityLocalBitmap)
+	var buf [32]byte
+	pfx := strconv.AppendUint(buf[:0], uint64(asn), 10)
+	pfx = append(pfx, ':')
+	pfxLen := len(pfx)
+	for local := range uint32(0x10000) {
+		b := strconv.AppendUint(pfx[:pfxLen], uint64(local), 10)
+		if re.Match(b) {
+			communityBitmapSet(bm, uint16(local))
+		}
+	}
+	return bm
+}
+
+func extractASFromRegexpString(s string) (uint16, bool) {
+	if len(s) == 0 || s[0] != '^' {
+		return 0, false
+	}
+	start := 1
+	idx := strings.IndexByte(s[start:], ':')
+	if idx <= 0 {
+		return 0, false
+	}
+	asn, err := strconv.ParseUint(s[start:start+idx], 10, 16)
+	return uint16(asn), err == nil
+}
+
+func isASOnlyPatternStr(s string) bool {
+	return strings.HasSuffix(s, `:\d+$`) ||
+		strings.HasSuffix(s, `:[0-9]+$`) ||
+		strings.HasSuffix(s, `:.*$`)
+}
+
+func newCommunityMatcherFromRegexp(re *regexp.Regexp, listIndex int) communityMatcher {
+	s := re.String()
+	if inner, ok := regexpAnchoredBody(s); ok {
+		if asn, loc, ok2 := parseRegexpExactASCIIASColonLocal(inner, 16); ok2 {
+			return communityMatcher{
+				mode:      communityMatchExact,
+				listIndex: communityMatcherNoListIdx,
+				exact:     uint32(asn)<<16 | loc,
+			}
+		}
+	}
+	if asn, ok := extractASFromRegexpString(s); ok {
+		if isASOnlyPatternStr(s) {
+			return communityMatcher{
+				mode:      communityMatchFixedASWildcard,
+				listIndex: communityMatcherNoListIdx,
+				asn:       asn,
+			}
+		}
+		return communityMatcher{
+			mode:      communityMatchFixedASBitmap,
+			listIndex: communityMatcherNoListIdx,
+			asn:       asn,
+			bitmap:    buildLocalAdminBitmap(re, asn),
+		}
+	}
+	if bm, ok := tryWildcardASIndependentLocalCommunityBitmap(re); ok {
+		return communityMatcher{
+			mode:      communityMatchLocalIndependent,
+			listIndex: communityMatcherNoListIdx,
+			bitmap:    bm,
+		}
+	}
+	return communityMatcher{mode: communityMatchRegexp, listIndex: listIndex}
+}
+
+func (m communityMatcher) matchesCommunity(c uint32, patterns []*regexp.Regexp) bool {
+	switch m.mode {
+	case communityMatchExact:
+		return c == m.exact
+	case communityMatchFixedASWildcard:
+		return uint16(c>>16) == m.asn
+	case communityMatchFixedASBitmap:
+		if uint16(c>>16) != m.asn {
+			return false
+		}
+		return communityBitmapIsSet(m.bitmap, uint16(c))
+	case communityMatchLocalIndependent:
+		return communityBitmapIsSet(m.bitmap, uint16(c))
+	case communityMatchRegexp:
+		if m.listIndex < 0 || m.listIndex >= len(patterns) {
+			panic(fmt.Sprintf("table: community regexp listIndex %d (len(patterns)=%d)", m.listIndex, len(patterns)))
+		}
+		re := patterns[m.listIndex]
+		var buf [32]byte
+		b := strconv.AppendUint(buf[:0], uint64(c>>16), 10)
+		b = append(b, ':')
+		b = strconv.AppendUint(b, uint64(c&0xffff), 10)
+		return re.Match(b)
+	default:
+		panic(fmt.Sprintf("table: invalid communityMatchMode %d", m.mode))
+	}
+}
+
+func buildCommunityMatchers(list []*regexp.Regexp) ([]communityMatcher, []asBitmapEntry, *communityLocalBitmap, bool) {
+	ms := make([]communityMatcher, len(list))
+	for i, re := range list {
+		ms[i] = newCommunityMatcherFromRegexp(re, i)
+	}
+	combined, anyLocalIn, hasRe := buildCommunityMatcherBitmaps(ms)
+	return ms, combined, anyLocalIn, hasRe
+}
+
+// asBitmapEntry pairs an AS number with its combined OR-bitmap for fast lookup.
+type asBitmapEntry struct {
+	asn uint16
+	bm  *communityLocalBitmap
+}
+
 type CommunitySet struct {
 	regExpSet
+	matchers                  []communityMatcher
+	anyBitmaps                []asBitmapEntry       // per-AS OR-bitmaps for ANY/INVERT fast path
+	anyLocalIndependentBitmap *communityLocalBitmap // OR-bitmap for ASN-independent patterns
+	hasReMatchers             bool                  // true when any matcher still needs regexp
+}
+
+func buildCommunityMatcherBitmaps(matchers []communityMatcher) ([]asBitmapEntry, *communityLocalBitmap, bool) {
+	var combined []asBitmapEntry
+	var anyLocal *communityLocalBitmap
+	hasRe := false
+	for _, m := range matchers {
+		switch m.mode {
+		case communityMatchExact:
+			asn := uint16(m.exact >> 16)
+			bm := orBitmapSliceGet(&combined, asn)
+			communityBitmapSet(bm, uint16(m.exact))
+		case communityMatchFixedASWildcard:
+			communityBitmapFillAll(orBitmapSliceGet(&combined, m.asn))
+		case communityMatchFixedASBitmap:
+			communityBitmapOr(orBitmapSliceGet(&combined, m.asn), m.bitmap)
+		case communityMatchLocalIndependent:
+			if anyLocal == nil {
+				anyLocal = new(communityLocalBitmap)
+			}
+			communityBitmapOr(anyLocal, m.bitmap)
+		default:
+			hasRe = true
+		}
+	}
+	return combined, anyLocal, hasRe
+}
+
+func orBitmapSliceGet(entries *[]asBitmapEntry, asn uint16) *communityLocalBitmap {
+	for i := range *entries {
+		if (*entries)[i].asn == asn {
+			return (*entries)[i].bm
+		}
+	}
+	bm := new(communityLocalBitmap)
+	*entries = append(*entries, asBitmapEntry{asn: asn, bm: bm})
+	return bm
 }
 
 func (s *CommunitySet) List() []string {
@@ -1078,7 +1357,7 @@ func ParseExtCommunity(arg string) (bgp.ExtendedCommunityInterface, error) {
 		r = r || s == bgp.VALIDATION_STATE_NOT_FOUND.String()
 		return r || s == bgp.VALIDATION_STATE_INVALID.String()
 	}
-	if len(elems) < 2 && (len(elems) < 1 && !isValidationState(elems[0])) {
+	if len(elems) < 2 && !isValidationState(elems[0]) {
 		return nil, fmt.Errorf("invalid ext-community (rt|soo|encap|lb):<value> | valid | not-found | invalid")
 	}
 	if isValidationState(elems[0]) {
@@ -1161,13 +1440,46 @@ func NewCommunitySet(c oc.CommunitySet) (*CommunitySet, error) {
 		}
 		list = append(list, exp)
 	}
+	ms, combined, anyLocalInd, hasRe := buildCommunityMatchers(list)
 	return &CommunitySet{
 		regExpSet: regExpSet{
 			typ:  DEFINED_TYPE_COMMUNITY,
 			name: name,
 			list: list,
 		},
+		matchers:                  ms,
+		anyBitmaps:                combined,
+		anyLocalIndependentBitmap: anyLocalInd,
+		hasReMatchers:             hasRe,
 	}, nil
+}
+
+func (s *CommunitySet) rebuildMatchers() {
+	s.matchers, s.anyBitmaps, s.anyLocalIndependentBitmap, s.hasReMatchers = buildCommunityMatchers(s.list)
+}
+
+func (s *CommunitySet) Append(arg DefinedSet) error {
+	if err := s.regExpSet.Append(arg); err != nil {
+		return err
+	}
+	s.rebuildMatchers()
+	return nil
+}
+
+func (s *CommunitySet) Remove(arg DefinedSet) error {
+	if err := s.regExpSet.Remove(arg); err != nil {
+		return err
+	}
+	s.rebuildMatchers()
+	return nil
+}
+
+func (s *CommunitySet) Replace(arg DefinedSet) error {
+	if err := s.regExpSet.Replace(arg); err != nil {
+		return err
+	}
+	s.rebuildMatchers()
+	return nil
 }
 
 type ExtCommunitySet struct {
@@ -1620,11 +1932,42 @@ func (c *CommunityCondition) Option() MatchOption {
 
 func (c *CommunityCondition) Evaluate(path *Path, _ *PolicyOptions) bool {
 	cs := path.GetCommunities()
+
+	// Fast path for ANY / INVERT: combined OR-bitmap per AS eliminates the
+	// pattern loop entirely — one bit-test per community suffices.
+	if (c.option == MATCH_OPTION_ANY || c.option == MATCH_OPTION_INVERT) &&
+		!c.set.hasReMatchers &&
+		(len(c.set.anyBitmaps) > 0 || c.set.anyLocalIndependentBitmap != nil) {
+		found := false
+		for _, y := range cs {
+			local := uint16(y)
+			if bm := c.set.anyLocalIndependentBitmap; bm != nil && communityBitmapIsSet(bm, local) {
+				found = true
+				break
+			}
+			asn := uint16(y >> 16)
+			for i := range c.set.anyBitmaps {
+				if c.set.anyBitmaps[i].asn == asn && communityBitmapIsSet(c.set.anyBitmaps[i].bm, local) {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if c.option == MATCH_OPTION_INVERT {
+			return !found
+		}
+		return found
+	}
+
+	// General path: MATCH_OPTION_ALL or sets with re-only patterns.
 	result := false
-	for _, x := range c.set.list {
+	for _, m := range c.set.matchers {
 		result = false
 		for _, y := range cs {
-			if x.MatchString(fmt.Sprintf("%d:%d", y>>16, y&0x0000ffff)) {
+			if m.matchesCommunity(y, c.set.list) {
 				result = true
 				break
 			}

--- a/tools/spell-check/dictionary.txt
+++ b/tools/spell-check/dictionary.txt
@@ -38,6 +38,7 @@ ospf
 pmsi
 prepend
 reachability
+regexp
 reservable
 reuseaddr
 rpki


### PR DESCRIPTION
Replace the regexp-per-community hot loop with a precomputed bitmap index.

At policy compile time each pattern is classified:
- communityMatchExact: single uint32 equality check
- communityMatchFixedASWildcard: uint16 AS-only check (any local)
- communityMatchFixedASBitmap: AS check + 8 KB per-AS bitmap built by running the regexp against all 65536 local-admin values once
- communityMatchLocalIndependent: bit-test on low 16 bits, any AS (e.g. ^[0-9]*:300$)
- communityMatchRegexp: last-resort full regexp (rare)

At evaluation time the MATCH_OPTION_ANY / INVERT fast path merges all per-AS bitmaps into anyBitmaps and all AS-independent patterns into anyLocalIndependentBitmap. Checking a path with N communities costs O(N × distinct_AS) integer ops with zero allocations.

Also remove redundant copy in GetCommunities / GetExtCommunities / GetLargeCommunities (return the stored slice directly).

Also fix ParseExtCommunity guard condition: the inner `len(elems) < 1` sub-expression was always false (strings.SplitN never returns an empty slice), making the whole guard dead code.

Part of the big PR with perf for policies -- next will improve large-comms and ext-comms