### PR TITLE
fix: preserve unknown IPv6 Extended Communities in round-trip encoding

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -14034,9 +14034,11 @@ func parseIP6FlowSpecExtended(data []byte) (ExtendedCommunityInterface, error) {
 			return NewRedirectIPv6AddressSpecificExtended(ipv6, localAdmin)
 		}
 	}
-	return &UnknownExtended{
+	v := make([]byte, 19)
+	copy(v, data[1:20])
+	return &UnknownIP6Extended{
 		Type:  ExtendedCommunityAttrType(data[0]),
-		Value: data[1:20],
+		Value: v,
 	}, nil
 }
 
@@ -14090,6 +14092,52 @@ func NewUnknownExtended(typ ExtendedCommunityAttrType, value []byte) *UnknownExt
 		Type:  typ,
 		Value: v,
 	}
+}
+
+// UnknownIP6Extended represents an unknown IPv6 Extended Community (type 25).
+// IPv6 Extended Communities are 20 bytes long, unlike the 8-byte regular Extended Communities.
+type UnknownIP6Extended struct {
+	Type  ExtendedCommunityAttrType
+	Value []byte // 19 bytes (type byte is separate)
+}
+
+func (e *UnknownIP6Extended) Serialize() ([]byte, error) {
+	if len(e.Value) != 19 {
+		return nil, fmt.Errorf("invalid value length for unknown IPv6 extended community: %d", len(e.Value))
+	}
+	buf := make([]byte, 20)
+	buf[0] = uint8(e.Type)
+	copy(buf[1:], e.Value)
+	return buf, nil
+}
+
+func (e *UnknownIP6Extended) String() string {
+	return fmt.Sprintf("%d %x", e.Type, e.Value)
+}
+
+func (e *UnknownIP6Extended) MarshalJSON() ([]byte, error) {
+	t, s := e.GetTypes()
+	return json.Marshal(struct {
+		Type    ExtendedCommunityAttrType    `json:"type"`
+		Subtype ExtendedCommunityAttrSubType `json:"subtype"`
+		Value   []byte                       `json:"value"`
+	}{
+		Type:    t,
+		Subtype: s,
+		Value:   e.Value,
+	})
+}
+
+func (e *UnknownIP6Extended) GetTypes() (ExtendedCommunityAttrType, ExtendedCommunityAttrSubType) {
+	var subType ExtendedCommunityAttrSubType
+	if len(e.Value) > 0 {
+		subType = ExtendedCommunityAttrSubType(e.Value[0])
+	}
+	return e.Type, subType
+}
+
+func (e *UnknownIP6Extended) Flat() map[string]string {
+	return map[string]string{}
 }
 
 type PathAttributeExtendedCommunities struct {
@@ -15161,9 +15209,11 @@ func ParseIP6Extended(data []byte) (ExtendedCommunityInterface, error) {
 	case EC_TYPE_GENERIC_TRANSITIVE_EXPERIMENTAL:
 		return parseIP6FlowSpecExtended(data)
 	default:
-		return &UnknownExtended{
+		v := make([]byte, 19)
+		copy(v, data[1:20])
+		return &UnknownIP6Extended{
 			Type:  ExtendedCommunityAttrType(data[0]),
-			Value: data[1:8],
+			Value: v,
 		}, nil
 	}
 }

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -586,6 +586,78 @@ func Test_IP6FlowSpecExtended(t *testing.T) {
 	assert.Equal(t, m1, m2)
 }
 
+func Test_UnknownIP6Extended_RoundTrip(t *testing.T) {
+	assert := assert.New(t)
+
+	// 20-byte unknown IPv6 Extended Community (type 0x99, 19-byte value)
+	raw := []byte{
+		0x99, 0x77, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+		0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+		0x0f, 0x10, 0x11, 0x12,
+	}
+
+	e, err := ParseIP6Extended(raw)
+	require.NoError(t, err)
+
+	unknown, ok := e.(*UnknownIP6Extended)
+	require.True(t, ok, "expected *UnknownIP6Extended")
+	assert.Equal(ExtendedCommunityAttrType(0x99), unknown.Type)
+	assert.Equal(raw[1:], unknown.Value)
+
+	serialized, err := unknown.Serialize()
+	require.NoError(t, err)
+	assert.Equal(raw, serialized, "round-trip must be byte-for-byte identical")
+}
+
+func Test_UnknownIP6Extended_PathAttribute_RoundTrip(t *testing.T) {
+	assert := assert.New(t)
+
+	// Construct a PathAttributeIP6ExtendedCommunities with an unknown type.
+	// PathAttribute header (4 bytes) + 20-byte community value.
+	// Flags: optional+transitive = 0xc0, type = 25 (0x19), length = 20 (0x14)
+	raw := []byte{
+		0xc0, 0x19, 0x14,
+		0x99, 0x77, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+		0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+		0x0f, 0x10, 0x11, 0x12,
+	}
+
+	attr := &PathAttributeIP6ExtendedCommunities{}
+	err := attr.DecodeFromBytes(raw)
+	require.NoError(t, err)
+	require.Len(t, attr.Value, 1)
+
+	_, ok := attr.Value[0].(*UnknownIP6Extended)
+	assert.True(ok, "expected *UnknownIP6Extended")
+
+	serialized, err := attr.Serialize()
+	require.NoError(t, err)
+	assert.Equal(raw, serialized, "round-trip must be byte-for-byte identical")
+}
+
+func Test_UnknownIP6FlowSpecExtended_RoundTrip(t *testing.T) {
+	assert := assert.New(t)
+
+	// EC_TYPE_GENERIC_TRANSITIVE_EXPERIMENTAL (0x80) with unknown subtype
+	// so that parseIP6FlowSpecExtended falls through to the UnknownIP6Extended path.
+	raw := []byte{
+		0x80, 0xff, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+		0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+		0x0f, 0x10, 0x11, 0x12,
+	}
+
+	e, err := ParseIP6Extended(raw)
+	require.NoError(t, err)
+
+	unknown, ok := e.(*UnknownIP6Extended)
+	require.True(t, ok, "expected *UnknownIP6Extended")
+	assert.Equal(raw[1:], unknown.Value)
+
+	serialized, err := unknown.Serialize()
+	require.NoError(t, err)
+	assert.Equal(raw, serialized, "round-trip must be byte-for-byte identical")
+}
+
 func Test_FlowSpecNlriv6(t *testing.T) {
 	cmp := make([]FlowSpecComponentInterface, 0)
 	nlri, _ := NewIPAddrPrefix(netip.MustParsePrefix("2001::/64"))


### PR DESCRIPTION
ParseIP6Extended stored unknown types in UnknownExtended with only 7 bytes (data[1:8]), silently discarding the remaining 12 bytes of the 20-byte value. Re-serialization produced an 8-byte attribute instead of the required 20, yielding malformed outbound UPDATEs.

parseIP6FlowSpecExtended stored 19 bytes in UnknownExtended.Value, but UnknownExtended.Serialize() rejects anything other than 7 bytes, so routes with unknown IPv6 FlowSpec Extended Communities could not be re-advertised at all.

Introduce UnknownIP6Extended to correctly handle unknown 20-byte IPv6 Extended Communities, and add round-trip tests for both code paths.