### PR TITLE
packet/bgp: enforce CapLen boundary in BGP OPEN capability decoders

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -504,11 +504,11 @@ func (c *CapMultiProtocol) DecodeFromBytes(data []byte) error {
 	if err := c.DefaultParameterCapability.DecodeFromBytes(data); err != nil {
 		return err
 	}
-	data = data[2:]
-	if len(data) < 4 {
-		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "Not all CapabilityMultiProtocol bytes available")
+	if c.CapLen != 4 {
+		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "CapMultiProtocol requires exactly 4 bytes")
 	}
-	c.CapValue = NewFamily(binary.BigEndian.Uint16(data[:2]), data[3])
+	v := c.DefaultParameterCapability.CapValue
+	c.CapValue = NewFamily(binary.BigEndian.Uint16(v[:2]), v[3])
 	return nil
 }
 
@@ -685,27 +685,27 @@ func (c *CapGracefulRestart) DecodeFromBytes(data []byte) error {
 	if err := c.DefaultParameterCapability.DecodeFromBytes(data); err != nil {
 		return err
 	}
-	data = data[2:]
-	if len(data) < 2 {
+	if c.CapLen < 2 {
 		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "Not all CapabilityGracefulRestart bytes available")
 	}
-	restart := binary.BigEndian.Uint16(data[:2])
+	v := c.CapValue
+	restart := binary.BigEndian.Uint16(v[:2])
 	c.Flags = uint8(restart >> 12)
 	c.Time = restart & 0xfff
-	data = data[2:]
+	v = v[2:]
 
 	valueLen := int(c.CapLen) - 2
 
-	if valueLen >= 4 && len(data) >= valueLen {
+	if valueLen >= 4 && len(v) >= valueLen {
 		c.Tuples = make([]*CapGracefulRestartTuple, 0, valueLen/4)
 
 		for i := valueLen; i >= 4; i -= 4 {
 			t := &CapGracefulRestartTuple{
-				binary.BigEndian.Uint16(data[:2]),
-				data[2], data[3],
+				binary.BigEndian.Uint16(v[:2]),
+				v[2], v[3],
 			}
 			c.Tuples = append(c.Tuples, t)
-			data = data[4:]
+			v = v[4:]
 		}
 	}
 	return nil
@@ -766,11 +766,10 @@ func (c *CapFourOctetASNumber) DecodeFromBytes(data []byte) error {
 	if err := c.DefaultParameterCapability.DecodeFromBytes(data); err != nil {
 		return err
 	}
-	data = data[2:]
-	if len(data) < 4 {
-		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "Not all CapabilityFourOctetASNumber bytes available")
+	if c.CapLen != 4 {
+		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "CapFourOctetASNumber requires exactly 4 bytes")
 	}
-	c.CapValue = binary.BigEndian.Uint32(data[:4])
+	c.CapValue = binary.BigEndian.Uint32(c.DefaultParameterCapability.CapValue)
 	return nil
 }
 
@@ -1033,35 +1032,22 @@ func (c *CapFQDN) DecodeFromBytes(data []byte) error {
 	if err := c.DefaultParameterCapability.DecodeFromBytes(data); err != nil {
 		return err
 	}
-	if len(data) < 2 {
+	v := c.CapValue
+	if len(v) < 1 {
 		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "Not all CapabilityFQDN bytes allowed")
 	}
-	data = data[2:]
-	rest := len(data)
-	if rest < 1 {
-		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "Not all CapabilityFQDN bytes allowed")
-	}
-	rest -= 1
-	c.HostNameLen = data[0]
+	c.HostNameLen = v[0]
 	hostNameLen := int(c.HostNameLen)
-	if rest < hostNameLen {
+	if len(v) < 1+hostNameLen+1 {
 		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "Not all CapabilityFQDN bytes allowed")
 	}
-	if len(data) < hostNameLen+2 {
-		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "Not all CapabilityFQDN bytes allowed")
-	}
-	c.HostName = string(data[1 : hostNameLen+1])
-	rest -= hostNameLen
-	if rest < 1 {
-		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "Not all CapabilityFQDN bytes allowed")
-	}
-	rest -= 1
-	domainNameLen := data[hostNameLen+1]
-	if rest < int(domainNameLen) {
+	c.HostName = string(v[1 : hostNameLen+1])
+	domainNameLen := v[hostNameLen+1]
+	if len(v) < 1+hostNameLen+1+int(domainNameLen) {
 		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "Not all CapabilityFQDN bytes allowed")
 	}
 	c.DomainNameLen = domainNameLen
-	c.DomainName = string(data[hostNameLen+2 : hostNameLen+2+int(domainNameLen)])
+	c.DomainName = string(v[hostNameLen+2 : hostNameLen+2+int(domainNameLen)])
 	return nil
 }
 
@@ -1117,16 +1103,16 @@ func (c *CapSoftwareVersion) DecodeFromBytes(data []byte) error {
 	if err := c.DefaultParameterCapability.DecodeFromBytes(data); err != nil {
 		return err
 	}
-	data = data[2:]
-	if len(data) < 2 {
+	v := c.CapValue
+	if len(v) < 2 {
 		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "Not all CapabilitySoftwareVersion bytes allowed")
 	}
-	softwareVersionLen := data[0]
-	if len(data[1:]) < int(softwareVersionLen) || softwareVersionLen > 64 || softwareVersionLen == 0 {
+	softwareVersionLen := v[0]
+	if len(v[1:]) < int(softwareVersionLen) || softwareVersionLen > 64 || softwareVersionLen == 0 {
 		return NewMessageError(BGP_ERROR_OPEN_MESSAGE_ERROR, BGP_ERROR_SUB_UNSUPPORTED_CAPABILITY, nil, "invalid length of software version capablity")
 	}
 	c.SoftwareVersionLen = softwareVersionLen
-	c.SoftwareVersion = string(data[1 : 1+c.SoftwareVersionLen])
+	c.SoftwareVersion = string(v[1 : 1+c.SoftwareVersionLen])
 	return nil
 }
 

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -1723,6 +1723,87 @@ func TestCapSoftwareVersionRoundTrip(t *testing.T) {
 	}
 }
 
+func TestCapabilityBoundaryEnforcement(t *testing.T) {
+	// Each fixed-size capability must reject a CapLen that does not match the
+	// required size. Before the fix, decoders used data[2:] (the full remaining
+	// buffer) instead of the CapLen-bounded slice, allowing bytes from a
+	// following capability to be misread as the capability value.
+
+	t.Run("CapFourOctetASNumber_CapLen0_rejected", func(t *testing.T) {
+		// CapLen=0; the 4 bytes after the header belong to the next capability.
+		// Before the fix these were silently read as the AS number.
+		data := []byte{
+			byte(BGP_CAP_FOUR_OCTET_AS_NUMBER), 0x00, // code=65, CapLen=0
+			0x00, 0x00, 0xfd, 0xe8, // next cap bytes (AS 65000 in big-endian)
+		}
+		c := &CapFourOctetASNumber{}
+		require.Error(t, c.DecodeFromBytes(data))
+	})
+
+	t.Run("CapFourOctetASNumber_CapLen2_rejected", func(t *testing.T) {
+		data := []byte{byte(BGP_CAP_FOUR_OCTET_AS_NUMBER), 0x02, 0x00, 0x01}
+		c := &CapFourOctetASNumber{}
+		require.Error(t, c.DecodeFromBytes(data))
+	})
+
+	t.Run("CapFourOctetASNumber_valid", func(t *testing.T) {
+		cap := NewCapFourOctetASNumber(65000)
+		buf, err := cap.Serialize()
+		require.NoError(t, err)
+		decoded := &CapFourOctetASNumber{}
+		require.NoError(t, decoded.DecodeFromBytes(buf))
+		require.Equal(t, uint32(65000), decoded.CapValue)
+	})
+
+	t.Run("CapMultiProtocol_CapLen0_rejected", func(t *testing.T) {
+		data := []byte{
+			byte(BGP_CAP_MULTIPROTOCOL), 0x00, // CapLen=0
+			0x00, 0x01, 0x00, 0x01, // next cap bytes
+		}
+		c := &CapMultiProtocol{}
+		require.Error(t, c.DecodeFromBytes(data))
+	})
+
+	t.Run("CapMultiProtocol_CapLen2_rejected", func(t *testing.T) {
+		data := []byte{byte(BGP_CAP_MULTIPROTOCOL), 0x02, 0x00, 0x01}
+		c := &CapMultiProtocol{}
+		require.Error(t, c.DecodeFromBytes(data))
+	})
+
+	t.Run("CapMultiProtocol_valid", func(t *testing.T) {
+		cap := NewCapMultiProtocol(RF_IPv4_UC)
+		buf, err := cap.Serialize()
+		require.NoError(t, err)
+		decoded := &CapMultiProtocol{}
+		require.NoError(t, decoded.DecodeFromBytes(buf))
+		require.Equal(t, RF_IPv4_UC, decoded.CapValue)
+	})
+
+	t.Run("CapGracefulRestart_CapLen0_rejected", func(t *testing.T) {
+		data := []byte{
+			byte(BGP_CAP_GRACEFUL_RESTART), 0x00, // CapLen=0
+			0x80, 0x78, // next cap bytes (would be misread as Flags/Time)
+		}
+		c := &CapGracefulRestart{}
+		require.Error(t, c.DecodeFromBytes(data))
+	})
+
+	t.Run("CapGracefulRestart_CapLen1_rejected", func(t *testing.T) {
+		data := []byte{byte(BGP_CAP_GRACEFUL_RESTART), 0x01, 0x80}
+		c := &CapGracefulRestart{}
+		require.Error(t, c.DecodeFromBytes(data))
+	})
+
+	t.Run("CapGracefulRestart_valid", func(t *testing.T) {
+		cap := NewCapGracefulRestart(false, false, 120, []*CapGracefulRestartTuple{})
+		buf, err := cap.Serialize()
+		require.NoError(t, err)
+		decoded := &CapGracefulRestart{}
+		require.NoError(t, decoded.DecodeFromBytes(buf))
+		require.Equal(t, uint16(120), decoded.Time)
+	})
+}
+
 func TestFuzzCrashers(t *testing.T) {
 	crashers := []string{
 		"000000000000000000\x01",


### PR DESCRIPTION
Several capability decoders called data = data[2:] after DefaultParameterCapability.DecodeFromBytes and then checked the length of the full remaining buffer rather than the CapLen-bounded slice. With a crafted CapLen smaller than the required value, bytes belonging to the following capability could be misread as the capability value.

The most security-relevant case was CapFourOctetASNumber: with CapLen=0 the four-octet AS value was read from the adjacent capability's bytes, and that value flowed into ValidateOpenMsg for peer AS validation.

Fix each affected decoder to read from DefaultParameterCapability.CapValue, which is already sliced to [2 : 2+CapLen] by the base decoder, and to reject any CapLen that does not match the required size.

Affected decoders: CapFourOctetASNumber (requires CapLen==4), CapMultiProtocol (requires CapLen==4), CapGracefulRestart (requires CapLen>=2), CapFQDN, and CapSoftwareVersion.