### PR TITLE
fix(apiutil): nil-safe Flags access in UnmarshalSRSegments

### DIFF
--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -3132,16 +3132,19 @@ func UnmarshalSRSegments(s []*api.TunnelEncapSubTLVSRSegmentList_Segment) ([]bgp
 				},
 				Label: v.A.Label,
 			}
-			if v.A.Flags.VFlag {
+			// Flags is an optional sub-message; chain through the
+			// generated nil-safe getters so that an unset Flags does
+			// not panic with a nil pointer dereference.
+			if v.A.GetFlags().GetVFlag() {
 				seg.Flags += 0x80
 			}
-			if v.A.Flags.AFlag {
+			if v.A.GetFlags().GetAFlag() {
 				seg.Flags += 0x40
 			}
-			if v.A.Flags.SFlag {
+			if v.A.GetFlags().GetSFlag() {
 				seg.Flags += 0x20
 			}
-			if v.A.Flags.BFlag {
+			if v.A.GetFlags().GetBFlag() {
 				seg.Flags += 0x10
 			}
 			segments[i] = seg
@@ -3153,16 +3156,16 @@ func UnmarshalSRSegments(s []*api.TunnelEncapSubTLVSRSegmentList_Segment) ([]bgp
 				},
 				SID: v.B.GetSid(),
 			}
-			if v.B.Flags.VFlag {
+			if v.B.GetFlags().GetVFlag() {
 				seg.Flags += 0x80
 			}
-			if v.B.Flags.AFlag {
+			if v.B.GetFlags().GetAFlag() {
 				seg.Flags += 0x40
 			}
-			if v.B.Flags.SFlag {
+			if v.B.GetFlags().GetSFlag() {
 				seg.Flags += 0x20
 			}
-			if v.B.Flags.BFlag {
+			if v.B.GetFlags().GetBFlag() {
 				seg.Flags += 0x10
 			}
 			if v.B.EndpointBehaviorStructure != nil {


### PR DESCRIPTION
## Summary

`pkg/apiutil/attribute.go::UnmarshalSRSegments` dereferences `SegmentTypeA.Flags` and `SegmentTypeB.Flags` (both `*api.SegmentFlags`, an optional sub-message) without a nil check. Any API consumer that builds an `api.Path` containing an SR Policy segment without setting `Flags` triggers a **nil pointer dereference panic** in gobgpd.

This PR replaces the eight raw field accesses with the protobuf-generated **nil-safe getters** (`GetFlags().GetVFlag()` etc.), so an unset `Flags` is treated as all-zero flag bits rather than panicking.

---

## Root cause

`UnmarshalSRSegments` (before fix):

```go
case *api.TunnelEncapSubTLVSRSegmentList_Segment_B:
    seg := &bgp.SegmentTypeB{...}
    if v.B.Flags.VFlag {     // panics if v.B.Flags == nil
        seg.Flags += 0x80
    }
    if v.B.Flags.AFlag { ... }
    ...
```

`SegmentFlags` is a separately-allocated sub-message in the protobuf schema with no `Required` marker, so callers omitting it is legitimate. The current implementation implicitly assumes `v.B.Flags` is always non-nil.

The same issue exists for `SegmentTypeA` (`v.A.Flags.{V,A,S,B}Flag`).

---

## Reproduction

Minimal Go client that sends an SR Policy via gRPC `AddPath`:

```go
nlriAny, _ := anypb.New(&api.SRPolicyNLRI{
    Length: 192, Color: 100, Endpoint: endpoint,
})
segB, _ := anypb.New(&api.SegmentTypeB{
    Sid: sid,
    // Flags: not set <- triggers the panic
})
segListAny, _ := anypb.New(&api.TunnelEncapSubTLVSRSegmentList{
    Weight:   &api.SRWeight{Weight: 12},
    Segments: []*anypb.Any{segB},
})
// ... wrap in TunnelEncapAttribute and AddPath ...
```

gobgpd stack trace (excerpt):

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=...]

goroutine N [running]:
github.com/osrg/gobgp/v4/pkg/apiutil.UnmarshalSRSegments(...)
    pkg/apiutil/attribute.go:3156
github.com/osrg/gobgp/v4/pkg/apiutil.NewTunnelEncapAttributeFromNative(...)
    pkg/apiutil/attribute.go:212
```

The current workaround on the caller side is to set `Flags: &api.SegmentFlags{}` explicitly. The library should be defensive here.

---

## Severity / attack surface

**Low.** `UnmarshalSRSegments` is reached only from the gRPC / CLI protobuf conversion path (`pkg/apiutil/attribute.go:212` → `GetNativePathAttributes`), not from the BGP wire decode path (`pkg/packet/bgp` uses native `DecodeFromBytes`). A remote BGP peer cannot trigger this panic; only a local API consumer / CLI user with gRPC access can.

That makes this a programming-error / robustness fix rather than a remotely exploitable vulnerability, so it is filed as a normal PR rather than via the private vulnerability reporting channel in `.github/SECURITY.md`.

---

## Fix

The protobuf-generated `*SegmentFlags.GetVFlag()` (and `SegmentTypeA.GetFlags()` / `SegmentTypeB.GetFlags()`) are **nil-safe getters** that return the zero value on a nil receiver. Chaining them keeps the code safe even when `Flags` is nil:

```go
// after
if v.B.GetFlags().GetVFlag() {  // returns false if v.B.Flags == nil
    seg.Flags += 0x80
}
```

`MarshalSRSegments` always allocates `Flags`, so marshal/unmarshal round-trip behaviour is preserved.

---

## Compatibility

- Existing valid input (non-nil `Flags`) behaves exactly the same — the getters return the same field values as the direct dereferences.
- Invalid input (`Flags == nil`) is now treated as all-zero flag bits instead of panicking. This matches the optional nature of the sub-message in the protobuf schema.
- No change to the exported signature of `UnmarshalSRSegments`; fully backward compatible.
