### PR TITLE
packet/bgp: reject malformed MPLS label stacks missing bottom-of-stac…

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -1819,6 +1819,9 @@ func (l *MPLSLabelStack) DecodeFromBytes(data []byte, options ...*MarshallingOpt
 	}
 
 	if !foundBottom {
+		if len(labels) > 0 {
+			return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "MPLS label stack missing bottom-of-stack bit")
+		}
 		l.Labels = []uint32{}
 		return nil
 	}
@@ -1827,6 +1830,9 @@ func (l *MPLSLabelStack) DecodeFromBytes(data []byte, options ...*MarshallingOpt
 }
 
 func (l *MPLSLabelStack) Serialize(options ...*MarshallingOption) ([]byte, error) {
+	if len(l.Labels) == 0 {
+		return nil, fmt.Errorf("empty MPLS label stack")
+	}
 	buf := make([]byte, len(l.Labels)*3)
 	for i, label := range l.Labels {
 		if label == WITHDRAW_LABEL {
@@ -1926,7 +1932,7 @@ func (l *LabeledVPNIPAddrPrefix) decodeFromBytes(data []byte, addrlen int, optio
 		return err
 	}
 	if bits-8*l.Labels.Len() < 0 {
-		l.Labels.Labels = []uint32{}
+		return NewMessageError(uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR), uint8(BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST), nil, "LabeledVPNIPAddrPrefix declared length too short for label stack")
 	}
 	if len(data) < l.Labels.Len()+8 {
 		return NewMessageError(uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR), uint8(BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST), nil, "LabeledVPNIPAddrPrefix not enough data")
@@ -2025,7 +2031,7 @@ func (l *LabeledIPAddrPrefix) decodeFromBytes(data []byte, addrlen int, options 
 	}
 
 	if bits-8*l.Labels.Len() < 0 {
-		l.Labels.Labels = []uint32{}
+		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "LabeledIPAddrPrefix declared length too short for label stack")
 	}
 	if len(data) < l.Labels.Len() {
 		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "LabeledIPAddrPrefix not enough data")

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -464,6 +464,44 @@ func Test_MPLSLabelStack(t *testing.T) {
 	assert.Equal(WITHDRAW_LABEL, mpls.Labels[0])
 }
 
+func TestMPLSLabelStackMissingBOS(t *testing.T) {
+	// Three-byte label with bottom-of-stack bit clear (label 100, S=0).
+	noBOS := []byte{0x00, 0x06, 0x40} // label=100, TC=0, S=0
+
+	t.Run("DecodeFromBytes_rejects_missing_BOS", func(t *testing.T) {
+		s := &MPLSLabelStack{}
+		err := s.DecodeFromBytes(noBOS)
+		require.Error(t, err, "label stack without BOS bit must be rejected")
+	})
+
+	t.Run("Serialize_empty_returns_error_not_panic", func(t *testing.T) {
+		s := &MPLSLabelStack{Labels: []uint32{}}
+		_, err := s.Serialize()
+		require.Error(t, err, "serializing empty label stack must return error")
+	})
+
+	t.Run("LabeledIPAddrPrefix_rejects_missing_BOS", func(t *testing.T) {
+		// bits=27 (3-byte label + 3-bit prefix), then label without BOS, then prefix byte.
+		// bits field: label(3B)=24 bits + prefix bits=3 → 27
+		data := []byte{27, 0x00, 0x06, 0x40, 0xa0} // bits=27, label noBOS, prefix
+		n := &LabeledIPAddrPrefix{}
+		err := n.decodeFromBytes(data, 4)
+		require.Error(t, err)
+	})
+
+	t.Run("LabeledVPNIPAddrPrefix_rejects_bits_too_short", func(t *testing.T) {
+		// Construct a VPN NLRI where bits < 8*labelLen to trigger the
+		// "declared length too short for label stack" path.
+		// Valid label with BOS: label=100, S=1 → [0x00, 0x06, 0x41]
+		// bits=1 (way too small for a 3-byte label stack + 8-byte RD + prefix)
+		validLabel := []byte{0x00, 0x06, 0x41}   // label=100, BOS=1
+		data := append([]byte{1}, validLabel...) // bits=1
+		n := &LabeledVPNIPAddrPrefix{}
+		err := n.decodeFromBytes(data, 4)
+		require.Error(t, err)
+	})
+}
+
 func Test_FlowSpecNlri(t *testing.T) {
 	assert := assert.New(t)
 	cmp := make([]FlowSpecComponentInterface, 0)


### PR DESCRIPTION
…k bit

A peer could send a labeled-unicast or VPN UPDATE with a label stack that had no bottom-of-stack bit set. DecodeFromBytes silently stored an empty label slice, and a later call to Serialize panicked on buf[len(buf)-1] with an empty buffer. Return an error in both DecodeFromBytes and Serialize for this case, and also reject labeled NLRI where the declared length is shorter than the parsed label stack.