### PR TITLE
fix(cmd/gobgp): allow multiple RTs in mup route commands

### DIFF
--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -1079,7 +1079,7 @@ func parseMUPInterworkSegmentDiscoveryRouteArgs(args []string, afi uint16, nexth
 		"locator-node-length": paramSingle,
 		"function-length":     paramSingle,
 		"behavior":            paramSingle,
-		"rt":                  paramSingle,
+		"rt":                  paramList,
 	})
 	if err != nil {
 		return nil, nil, nil, err
@@ -1159,7 +1159,7 @@ func parseMUPDirectSegmentDiscoveryRouteArgs(args []string, afi uint16, nexthop 
 	}
 	m, err := extractReserved(args, map[string]int{
 		"rd":                  paramSingle,
-		"rt":                  paramSingle,
+		"rt":                  paramList,
 		"prefix":              paramSingle,
 		"locator-node-length": paramSingle,
 		"function-length":     paramSingle,
@@ -1273,7 +1273,7 @@ func parseMUPType1SessionTransformedRouteArgs(args []string, afi uint16) (bgp.NL
 	}
 	m, err := extractReserved(args, map[string]int{
 		"rd":       paramSingle,
-		"rt":       paramSingle,
+		"rt":       paramList,
 		"teid":     paramSingle,
 		"qfi":      paramSingle,
 		"endpoint": paramSingle,
@@ -1344,7 +1344,7 @@ func parseMUPType2SessionTransformedRouteArgs(args []string, afi uint16) (bgp.NL
 	}
 	m, err := extractReserved(args, map[string]int{
 		"rd":                      paramSingle,
-		"rt":                      paramSingle,
+		"rt":                      paramList,
 		"endpoint-address-length": paramSingle,
 		"teid":                    paramSingle,
 		"mup":                     paramSingle,


### PR DESCRIPTION
MUP route parsers restricted `rt` to a single value, while other VPN/EVPN/Flowspec
parsers and the documented syntax (`[rt <rt>...]` in srv6_mup.md) allow multiple.
Switch all four MUP parsers to `paramList`.