### PR TITLE
feat(table): extract communityAnyIndex and add fast match for ext-comms

### DIFF
--- a/internal/pkg/table/community_match_chart_test.go
+++ b/internal/pkg/table/community_match_chart_test.go
@@ -13,7 +13,20 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
 
-// createPathWithCommunities builds a path that carries the given community values.
+const gobgpCommunityBenchCompareEnv = "GOBGP_COMMUNITY_BENCH_COMPARE"
+
+func communityBenchComparePrintEnabled() bool {
+	return os.Getenv(gobgpCommunityBenchCompareEnv) == "1"
+}
+
+func writeCommunityBenchCompareChartHeader(tw *tabwriter.Writer) error {
+	if _, err := fmt.Fprintln(tw, "bench\tnew ns/op\tlegacy ns/op\tlegacy/new\tname"); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintln(tw, "-----\t---------\t-----------\t--------\t----")
+	return err
+}
+
 func createPathWithCommunities(communities []uint32) *Path {
 	p := netip.MustParsePrefix("10.0.0.0/24")
 	nlri, _ := bgp.NewIPAddrPrefix(p)
@@ -27,11 +40,21 @@ func createPathWithCommunities(communities []uint32) *Path {
 	return NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
 }
 
-// communityChartCase describes one benchmark scenario for community matching.
+func createPathWithExtCommunities(ecs []bgp.ExtendedCommunityInterface) *Path {
+	p := netip.MustParsePrefix("10.0.0.0/24")
+	nlri, _ := bgp.NewIPAddrPrefix(p)
+	nexthop, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("10.0.0.1"))
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		nexthop,
+		bgp.NewPathAttributeExtendedCommunities(ecs),
+	}
+	return NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
+}
+
 type communityChartCase struct {
-	// Bench is a short b.Run() sub-name (ASCII, no spaces) so console output stays narrow.
 	Bench    string
-	Name     string // human-readable; used in failure messages
+	Name     string
 	Patterns []string
 	Regexps  []string
 	WantHit  bool
@@ -148,7 +171,6 @@ func communityBenchmarkPath() *Path {
 	})
 }
 
-// communityMatchLegacyLoop is the naive fmt.Sprintf + regexp baseline (not semantically identical to MATCH_OPTION_ANY).
 func communityMatchLegacyLoop(path *Path, regs []*regexp.Regexp) {
 	cs := path.GetCommunities()
 	for _, x := range regs {
@@ -160,9 +182,90 @@ func communityMatchLegacyLoop(path *Path, regs []*regexp.Regexp) {
 	}
 }
 
-// BenchmarkCommunityCondition runs New and Legacy side by side per scenario (names like exact_1/New, exact_1/Legacy).
+type extCommunityLegacyEntry struct {
+	subtype bgp.ExtendedCommunityAttrSubType
+	re      *regexp.Regexp
+}
+
+func parseExtCommunityLegacyEntries(patterns []string) ([]extCommunityLegacyEntry, error) {
+	entries := make([]extCommunityLegacyEntry, len(patterns))
+	for i, p := range patterns {
+		st, re, err := ParseExtCommunityRegexp(p)
+		if err != nil {
+			return nil, err
+		}
+		entries[i] = extCommunityLegacyEntry{subtype: st, re: re}
+	}
+	return entries, nil
+}
+
+func extCommunityMatchLegacyLoop(path *Path, entries []extCommunityLegacyEntry) {
+	ecs := path.GetExtCommunities()
+	for _, x := range ecs {
+		if !isTransitiveType(x) {
+			continue
+		}
+		xStr := x.String()
+		for _, e := range entries {
+			if subTypeEqual(x, e.subtype) && e.re.MatchString(xStr) {
+				break
+			}
+		}
+	}
+}
+
+type extCommunityChartCase struct {
+	Bench    string
+	Name     string
+	Patterns []string
+	Path     *Path
+	WantHit  bool
+}
+
+func extCommunityChartCases() []extCommunityChartCase {
+	makeRT := func(as uint16, la uint32) bgp.ExtendedCommunityInterface {
+		return bgp.NewTwoOctetAsSpecificExtended(bgp.EC_SUBTYPE_ROUTE_TARGET, as, la, true)
+	}
+	makeExtPath := func(ecs ...bgp.ExtendedCommunityInterface) *Path {
+		p := netip.MustParsePrefix("10.0.0.0/8")
+		nlri, _ := bgp.NewIPAddrPrefix(p)
+		nh, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("10.0.0.1"))
+		return NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false,
+			[]bgp.PathAttributeInterface{
+				bgp.NewPathAttributeOrigin(0), nh,
+				bgp.NewPathAttributeExtendedCommunities(ecs),
+			}, time.Now(), false)
+	}
+
+	pols1 := []string{
+		"rt:^65448:614$", "rt:^65448:654$", "rt:^65448:664$", "rt:^65448:665$", "rt:^65448:684$",
+		"rt:^65533:614$", "rt:^65533:654$", "rt:^65533:664$", "rt:^65533:684$",
+	}
+	pols2 := []string{
+		"rt:^65440:.*$", "rt:^65442:.*$",
+		"rt:^65448:614$", "rt:^65448:654$", "rt:^65448:664$", "rt:^65448:665$", "rt:^65448:684$",
+		"rt:^65533:614$", "rt:^65533:616$", "rt:^65533:654$", "rt:^65533:656$",
+		"rt:^65533:664$", "rt:^65533:666$", "rt:^65533:684$", "rt:^65533:686$",
+	}
+	pathSingle := makeExtPath(makeRT(65533, 664))
+	pathMulti := makeExtPath(makeRT(65448, 614), makeRT(65533, 654), makeRT(65533, 664))
+
+	return []extCommunityChartCase{
+		{"rt9_exact_last", "RT / 9 exact patterns / last matches", pols1, pathSingle, true},
+		{"rt9_exact_none", "RT / 9 exact patterns / no match", pols1, makeExtPath(makeRT(65099, 1)), false},
+		{"rt15_mix_exact", "RT / 15 patterns / wildcard prefix / exact RT match", pols2, pathSingle, true},
+		{"rt15_mix_wild", "RT / 15 patterns / wildcard prefix / wildcard RT match", pols2, makeExtPath(makeRT(65440, 100)), true},
+		{"rt15_multi_3rt", "RT / 15 patterns / 3 RTs / early match", pols2, pathMulti, true},
+		{"rt_local_digit", "RT / ^\\d+:local / bitmap-style / match", []string{`rt:^\d+:664$`}, pathSingle, true},
+		{"rt_local_alt", "RT / ^\\d+:(a|b) / bitmap-style / match", []string{`rt:^\d+:(614|664)$`}, pathSingle, true},
+		{"rt_local_miss", "RT / ^\\d+:local / no match", []string{`rt:^\d+:1$`}, pathSingle, false},
+	}
+}
+
+// BenchmarkCommunityCondition and BenchmarkExtCommunityCondition run New vs Legacy side by side
+// per scenario (e.g. exact_1/New, exact_1/Legacy and rt9_exact_last/New, rt9_exact_last/Legacy).
 //
-//	go test ./internal/pkg/table/ -run '^$' -bench 'BenchmarkCommunityCondition' -benchmem -count=5
+//	go test ./internal/pkg/table/ -run '^$' -bench 'BenchmarkCommunity(Condition|ExtCommunityCondition)$' -benchmem -count=5
 func BenchmarkCommunityCondition(b *testing.B) {
 	path := communityBenchmarkPath()
 	for _, sc := range communityChartCases() {
@@ -196,18 +299,48 @@ func BenchmarkCommunityCondition(b *testing.B) {
 	}
 }
 
+func BenchmarkExtCommunityCondition(b *testing.B) {
+	for _, sc := range extCommunityChartCases() {
+		b.Run(sc.Bench+"/New", func(b *testing.B) {
+			es, err := NewExtCommunitySet(oc.ExtCommunitySet{ExtCommunitySetName: "bench", ExtCommunityList: sc.Patterns})
+			if err != nil {
+				b.Fatal(err)
+			}
+			cond := &ExtCommunityCondition{set: es, option: MATCH_OPTION_ANY}
+			if got := cond.Evaluate(sc.Path, nil); got != sc.WantHit {
+				b.Fatalf("%s: expected match=%v got %v", sc.Name, sc.WantHit, got)
+			}
+			b.ResetTimer()
+			for range b.N {
+				cond.Evaluate(sc.Path, nil)
+			}
+		})
+		b.Run(sc.Bench+"/Legacy", func(b *testing.B) {
+			entries, err := parseExtCommunityLegacyEntries(sc.Patterns)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ResetTimer()
+			for range b.N {
+				extCommunityMatchLegacyLoop(sc.Path, entries)
+			}
+		})
+	}
+}
+
 func TestCommunityConditionCompareSummary(t *testing.T) {
-	if os.Getenv("GOBGP_COMMUNITY_BENCH_COMPARE") != "1" {
-		t.Skip(`set GOBGP_COMMUNITY_BENCH_COMPARE=1 to print New vs Legacy ns/op and speedup (legacy/new)`)
+	if testing.Short() {
+		t.Skip("skipping community bench compare summary in short mode")
+	}
+	if !communityBenchComparePrintEnabled() {
+		t.Skipf(`set %s=1 to print standard vs Legacy ns/op and speedup (legacy/new)`, gobgpCommunityBenchCompareEnv)
 	}
 	path := communityBenchmarkPath()
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, err := fmt.Fprintln(tw, "bench\tnew ns/op\tlegacy ns/op\tlegacy/new\tname")
-	if err != nil {
+	if _, err := fmt.Fprintln(tw, "\n[standard community]"); err != nil {
 		t.Fatal(err)
 	}
-	_, err = fmt.Fprintln(tw, "-----\t---------\t-----------\t--------\t----")
-	if err != nil {
+	if err := writeCommunityBenchCompareChartHeader(tw); err != nil {
 		t.Fatal(err)
 	}
 	for _, sc := range communityChartCases() {
@@ -243,6 +376,58 @@ func TestCommunityConditionCompareSummary(t *testing.T) {
 		ratio := legNs / newNs
 		_, err := fmt.Fprintf(tw, "%s\t%.0f\t%.0f\t%.2fx\t%s\n", sc.Bench, newNs, legNs, ratio, sc.Name)
 		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = tw.Flush()
+}
+
+func TestExtCommunityConditionCompareSummary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping ext-community bench compare summary in short mode")
+	}
+	if !communityBenchComparePrintEnabled() {
+		t.Skipf(`set %s=1 to print standard vs Legacy ns/op and speedup (legacy/new)`, gobgpCommunityBenchCompareEnv)
+	}
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "\n[extended community]"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeCommunityBenchCompareChartHeader(tw); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, sc := range extCommunityChartCases() {
+		es, err := NewExtCommunitySet(oc.ExtCommunitySet{ExtCommunitySetName: "bench", ExtCommunityList: sc.Patterns})
+		if err != nil {
+			t.Fatal(err)
+		}
+		cond := &ExtCommunityCondition{set: es, option: MATCH_OPTION_ANY}
+		if got := cond.Evaluate(sc.Path, nil); got != sc.WantHit {
+			t.Fatalf("%s: want match=%v got %v", sc.Name, sc.WantHit, got)
+		}
+
+		entries, err := parseExtCommunityLegacyEntries(sc.Patterns)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rNew := testing.Benchmark(func(b *testing.B) {
+			b.ResetTimer()
+			for range b.N {
+				cond.Evaluate(sc.Path, nil)
+			}
+		})
+		rLeg := testing.Benchmark(func(b *testing.B) {
+			b.ResetTimer()
+			for range b.N {
+				extCommunityMatchLegacyLoop(sc.Path, entries)
+			}
+		})
+		newNs := float64(rNew.NsPerOp())
+		legNs := float64(rLeg.NsPerOp())
+		ratio := legNs / newNs
+		if _, err := fmt.Fprintf(tw, "%s\t%.0f\t%.0f\t%.2fx\t%s\n", sc.Bench, newNs, legNs, ratio, sc.Name); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/pkg/table/community_match_fuzz_test.go
+++ b/internal/pkg/table/community_match_fuzz_test.go
@@ -1,23 +1,21 @@
 package table
 
 import (
-	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/osrg/gobgp/v4/pkg/config/oc"
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 )
 
-// legacyEvaluate is the reference implementation of community matching using standard regexp.
-func legacyEvaluate(cs []uint32, regs []*regexp.Regexp, option MatchOption) bool {
-	if len(regs) == 0 {
-		return false
-	}
+// slowCommunityEvaluate drives the compiled communityMatchers directly,
+// bypassing the fast-path index. Used as the reference in FuzzCommunityCondition
+// to verify that the bitmap/map index always agrees with the matcher loop.
+func slowCommunityEvaluate(s *CommunitySet, communities []uint32, option MatchOption) bool {
 	result := false
-	for _, x := range regs {
+	for _, m := range s.matchers {
 		result = false
-		for _, y := range cs {
-			if x.MatchString(fmt.Sprintf("%d:%d", y>>16, y&0xffff)) {
+		for _, y := range communities {
+			if m.matchesCommunity(y, s.list) {
 				result = true
 				break
 			}
@@ -36,7 +34,6 @@ func legacyEvaluate(cs []uint32, regs []*regexp.Regexp, option MatchOption) bool
 }
 
 func FuzzCommunityCondition(f *testing.F) {
-	// Add some seed corpus
 	f.Add("65000:100", uint32(65000<<16|100), uint8(MATCH_OPTION_ANY))
 	f.Add("^65000:.*$", uint32(65000<<16|200), uint8(MATCH_OPTION_ANY))
 	f.Add("^[0-9]*:100$", uint32(65001<<16|100), uint8(MATCH_OPTION_ANY))
@@ -46,50 +43,91 @@ func FuzzCommunityCondition(f *testing.F) {
 	f.Add("65000:100", uint32(65000<<16|100), uint8(MATCH_OPTION_ALL))
 
 	f.Fuzz(func(t *testing.T, pattern string, comm uint32, opt uint8) {
-		option := MatchOption(opt % 3) // 0: ANY, 1: ALL, 2: INVERT
+		option := [...]MatchOption{MATCH_OPTION_ANY, MATCH_OPTION_ALL, MATCH_OPTION_INVERT}[opt%3]
 
-		// Map 0, 1, 2 to the actual constants if they differ
-		switch option {
-		case 0:
-			option = MATCH_OPTION_ANY
-		case 1:
-			option = MATCH_OPTION_ALL
-		case 2:
-			option = MATCH_OPTION_INVERT
-		}
-
-		// Try to compile the pattern as a regexp. If it fails, we skip this input.
-		// We use ParseCommunityRegexp to handle the ^ and $ additions if needed,
-		// but to be safe we just use ParseCommunityRegexp logic or just regexp.Compile.
-		// Actually, NewCommunitySet does some parsing. Let's see if it errors.
 		cs, err := NewCommunitySet(oc.CommunitySet{
 			CommunitySetName: "fuzz",
 			CommunityList:    []string{pattern},
 		})
 		if err != nil {
-			// Invalid pattern, skip
 			return
 		}
-
-		// For legacy, we need to mimic how ParseCommunityRegexp transforms the pattern.
-		// ParseCommunityRegexp in gobgp usually adds ^ and $ if not present, but let's just use the compiled regexp from cs if possible, or compile it ourselves.
-		// Wait, NewCommunitySet parses it. Let's just use the exact same regexp string that gobgp uses.
-		// Actually, if we just compile the pattern directly, it might not match exactly what gobgp does (e.g., exact match vs partial).
-		// Let's look at ParseCommunityRegexp.
-		exp, err := ParseCommunityRegexp(pattern)
-		if err != nil {
-			return
-		}
-		reg := exp
 
 		cond := &CommunityCondition{set: cs, option: option}
 		path := createPathWithCommunities([]uint32{comm})
 
-		newResult := cond.Evaluate(path, nil)
-		legacyResult := legacyEvaluate([]uint32{comm}, []*regexp.Regexp{reg}, option)
+		fastResult := cond.Evaluate(path, nil)
+		slowResult := slowCommunityEvaluate(cs, []uint32{comm}, option)
 
-		if newResult != legacyResult {
-			t.Errorf("Mismatch for pattern %q, comm %d, option %v: new=%v, legacy=%v", pattern, comm, option, newResult, legacyResult)
+		if fastResult != slowResult {
+			t.Errorf("fast/slow mismatch: pattern=%q comm=%d option=%v fast=%v slow=%v",
+				pattern, comm, option, fastResult, slowResult)
+		}
+	})
+}
+
+// slowExtCommunityEvaluate drives the compiled extCommunityMatchers directly,
+// bypassing the fast-path index. Used as the reference in FuzzExtCommunityCondition
+// to verify that the bitmap/map index always agrees with the matcher loop.
+func slowExtCommunityEvaluate(es *ExtCommunitySet, ecs []bgp.ExtendedCommunityInterface, option MatchOption) bool {
+	result := false
+	for _, x := range ecs {
+		result = false
+		if !isTransitiveType(x) {
+			continue
+		}
+		var xStr string
+		for _, m := range es.matchers {
+			if m.matchesExtCommunity(x, &xStr) {
+				result = true
+				break
+			}
+		}
+		if option == MATCH_OPTION_ALL && !result {
+			break
+		}
+		if option == MATCH_OPTION_ANY && result {
+			break
+		}
+	}
+	if option == MATCH_OPTION_INVERT {
+		result = !result
+	}
+	return result
+}
+
+func FuzzExtCommunityCondition(f *testing.F) {
+	f.Add("rt:65000:100", uint16(65000), uint32(100), uint8(0))
+	f.Add("rt:^65000:.*$", uint16(65000), uint32(200), uint8(0))
+	f.Add("rt:^65000:.*$", uint16(65001), uint32(200), uint8(0))
+	f.Add(`rt:^\d+:100$`, uint16(65001), uint32(100), uint8(0))
+	f.Add(`rt:^\d+:(100|200)$`, uint16(65001), uint32(200), uint8(0))
+	f.Add("rt:^65000:(100|200)$", uint16(65000), uint32(100), uint8(0))
+	f.Add("rt:65000:100", uint16(65001), uint32(100), uint8(0))
+	f.Add("rt:65000:100", uint16(65000), uint32(100), uint8(2))    // INVERT
+	f.Add("rt:65000:100", uint16(65000), uint32(100), uint8(1))    // ALL
+	f.Add("rt:^65000:.*$", uint16(65000), uint32(65536), uint8(0)) // LA > 65535
+
+	f.Fuzz(func(t *testing.T, pattern string, as uint16, la uint32, opt uint8) {
+		option := [...]MatchOption{MATCH_OPTION_ANY, MATCH_OPTION_ALL, MATCH_OPTION_INVERT}[opt%3]
+
+		es, err := NewExtCommunitySet(oc.ExtCommunitySet{
+			ExtCommunitySetName: "fuzz",
+			ExtCommunityList:    []string{pattern},
+		})
+		if err != nil {
+			return
+		}
+
+		ec := bgp.NewTwoOctetAsSpecificExtended(bgp.EC_SUBTYPE_ROUTE_TARGET, as, la, true)
+		p := createPathWithExtCommunities([]bgp.ExtendedCommunityInterface{ec})
+
+		fastResult := (&ExtCommunityCondition{set: es, option: option}).Evaluate(p, nil)
+		slowResult := slowExtCommunityEvaluate(es, []bgp.ExtendedCommunityInterface{ec}, option)
+
+		if fastResult != slowResult {
+			t.Errorf("fast/slow mismatch: pattern=%q as=%d la=%d option=%v fast=%v slow=%v",
+				pattern, as, la, option, fastResult, slowResult)
 		}
 	})
 }

--- a/internal/pkg/table/policy.go
+++ b/internal/pkg/table/policy.go
@@ -1018,42 +1018,77 @@ func (lhs *regExpSet) Replace(arg DefinedSet) error {
 	return nil
 }
 
-// communityLocalBitmapWords is ceil(65536/64): one bit per 16-bit BGP community
-// local-admin value.
-const communityLocalBitmapWords = 1024
+// localAdminBitmapWords is ceil(65536/64): one bit per 16-bit BGP community local-admin value.
+const localAdminBitmapWords = 1024
 
-type communityLocalBitmap [communityLocalBitmapWords]uint64
+type localAdminBitmap [localAdminBitmapWords]uint64
+
+func (b *localAdminBitmap) isSet(v uint16) bool { return b[v>>6]&(1<<(v&63)) != 0 }
+func (b *localAdminBitmap) set(v uint16)        { b[v>>6] |= 1 << (v & 63) }
+func (b *localAdminBitmap) or(src *localAdminBitmap) {
+	for i := range b {
+		b[i] |= src[i]
+	}
+}
+
+func (b *localAdminBitmap) fillAll() {
+	for i := range b {
+		b[i] = ^uint64(0)
+	}
+}
 
 type communityMatchMode uint8
 
 const (
-	communityMatchExact            communityMatchMode = iota // full uint32 equality
-	communityMatchFixedASWildcard                            // fixed AS, any local admin
-	communityMatchFixedASBitmap                              // fixed AS + precomputed local-admin bitmap
-	communityMatchLocalIndependent                           // ASN-independent bitmap on low 16 bits
-	communityMatchRegexp                                     // regexp on "ASN:local" bytes — last resort
+	communityMatchExact communityMatchMode = iota
+	communityMatchFixedASWildcard
+	communityMatchFixedASBitmap
+	communityMatchLocalIndependent
+	communityMatchRegexp
 )
 
 const communityMatcherNoListIdx = -1
 
-// communityMatcher is a compiled community pattern.
-// Exactly one mode is active; other fields are meaningful only for that mode.
+// communityMatcher is a compiled BGP standard-community pattern.
+//
+// compileCommunityMatcher analyses each regexp at construction time and
+// promotes it to the fastest representation that is semantically equivalent:
+//
+//	Exact (communityMatchExact)
+//	  Pattern: ^<decimal-ASN>:<decimal-local>$
+//	  Match:   c == m.exact
+//
+//	Fixed-AS wildcard (communityMatchFixedASWildcard)
+//	  Pattern: ^<decimal-ASN>:(\d+|[0-9]+|.*)$  — any local-admin value
+//	  Match:   uint16(c>>16) == m.asn
+//
+//	Fixed-AS bitmap (communityMatchFixedASBitmap)
+//	  Pattern: ^<decimal-ASN>:<regexp>$  — ASN is literal, local-admin set is finite
+//	  Match:   uint16(c>>16) == m.asn && m.bitmap.isSet(uint16(c))
+//
+//	Wildcard-AS bitmap (communityMatchLocalIndependent)
+//	  Pattern: ^(\d+|[0-9]+):<finite-local-set>$  — any ASN, fixed local-admin set
+//	  Match:   m.bitmap.isSet(uint16(c))
+//
+//	Regexp fallback (communityMatchRegexp)
+//	  Everything else: format c as "ASN:local" and evaluate the NFA.
+//	  m.listIndex points to the corresponding entry in regExpSet.list.
 type communityMatcher struct {
 	mode      communityMatchMode
-	listIndex int                   // list index when mode == communityMatchRegexp; communityMatcherNoListIdx otherwise
-	asn       uint16                // FixedAS*: high 16 bits of wire community
-	exact     uint32                // Exact: wire-format community
-	bitmap    *communityLocalBitmap // FixedASBitmap / LocalIndependent: local-admin match set
+	listIndex int
+	asn       uint16
+	exact     uint32
+	bitmap    *localAdminBitmap
 }
 
-func regexpAnchoredBody(s string) (body string, ok bool) {
+func anchoredBody(s string) (body string, ok bool) {
 	if len(s) < 3 || s[0] != '^' || s[len(s)-1] != '$' {
 		return "", false
 	}
 	return s[1 : len(s)-1], true
 }
 
-func parseRegexpExactASCIIASColonLocal(body string, localBits int) (asn uint16, local uint32, ok bool) {
+func parseExactASColonLocal(body string, localBits int) (asn uint16, local uint32, ok bool) {
 	idx := strings.IndexByte(body, ':')
 	if idx <= 0 || idx != strings.LastIndexByte(body, ':') {
 		return 0, 0, false
@@ -1066,36 +1101,16 @@ func parseRegexpExactASCIIASColonLocal(body string, localBits int) (asn uint16, 
 	return uint16(asn64), uint32(loc64), true
 }
 
-func communityBitmapIsSet(bm *communityLocalBitmap, local uint16) bool {
-	return bm[local>>6]&(1<<(local&63)) != 0
+func isWildcardASN(lhs string) bool {
+	return lhs == `[0-9]*` || lhs == `[0-9]+` || lhs == `\d*` || lhs == `\d+`
 }
 
-func communityBitmapSet(bm *communityLocalBitmap, local uint16) {
-	bm[local>>6] |= 1 << (local & 63)
+func isWildcardLocal(s string) bool {
+	s = strings.TrimSuffix(s, "$")
+	return strings.HasSuffix(s, `:\d+`) || strings.HasSuffix(s, `:[0-9]+`) || strings.HasSuffix(s, `:.*`)
 }
 
-func communityBitmapOr(dst, src *communityLocalBitmap) {
-	for i := range dst {
-		dst[i] |= src[i]
-	}
-}
-
-func communityBitmapFillAll(bm *communityLocalBitmap) {
-	for i := range bm {
-		bm[i] = ^uint64(0)
-	}
-}
-
-func communityRegexpWildcardASLHS(lhs string) bool {
-	switch lhs {
-	case `[0-9]*`, `[0-9]+`, `\d*`, `\d+`:
-		return true
-	default:
-		return false
-	}
-}
-
-func parseCommunityRegexpFiniteLocalBitmapRHS(rhs string) (*communityLocalBitmap, bool) {
+func parseLocalAdminSet(rhs string) (*localAdminBitmap, bool) {
 	rhs = strings.TrimSpace(rhs)
 	var locals []uint16
 	switch {
@@ -1117,18 +1132,18 @@ func parseCommunityRegexpFiniteLocalBitmapRHS(rhs string) (*communityLocalBitmap
 	if len(locals) == 0 {
 		return nil, false
 	}
-	bm := new(communityLocalBitmap)
+	bm := new(localAdminBitmap)
 	for _, loc := range locals {
-		if communityBitmapIsSet(bm, loc) {
+		if bm.isSet(loc) {
 			return nil, false
 		}
-		communityBitmapSet(bm, loc)
+		bm.set(loc)
 	}
 	return bm, true
 }
 
-func tryWildcardASIndependentLocalCommunityBitmap(re *regexp.Regexp) (*communityLocalBitmap, bool) {
-	body, ok := regexpAnchoredBody(re.String())
+func tryWildcardASNBitmap(re *regexp.Regexp) (*localAdminBitmap, bool) {
+	body, ok := anchoredBody(re.String())
 	if !ok {
 		return nil, false
 	}
@@ -1137,14 +1152,14 @@ func tryWildcardASIndependentLocalCommunityBitmap(re *regexp.Regexp) (*community
 		return nil, false
 	}
 	asPart, rhsPart := body[:idx], body[idx+1:]
-	if !communityRegexpWildcardASLHS(asPart) {
+	if !isWildcardASN(asPart) {
 		return nil, false
 	}
-	return parseCommunityRegexpFiniteLocalBitmapRHS(rhsPart)
+	return parseLocalAdminSet(rhsPart)
 }
 
-func buildLocalAdminBitmap(re *regexp.Regexp, asn uint16) *communityLocalBitmap {
-	bm := new(communityLocalBitmap)
+func scanLocalAdminBitmap(re *regexp.Regexp, asn uint16) *localAdminBitmap {
+	bm := new(localAdminBitmap)
 	var buf [32]byte
 	pfx := strconv.AppendUint(buf[:0], uint64(asn), 10)
 	pfx = append(pfx, ':')
@@ -1152,13 +1167,13 @@ func buildLocalAdminBitmap(re *regexp.Regexp, asn uint16) *communityLocalBitmap 
 	for local := range uint32(0x10000) {
 		b := strconv.AppendUint(pfx[:pfxLen], uint64(local), 10)
 		if re.Match(b) {
-			communityBitmapSet(bm, uint16(local))
+			bm.set(uint16(local))
 		}
 	}
 	return bm
 }
 
-func extractASFromRegexpString(s string) (uint16, bool) {
+func extractLiteralASN(s string) (uint16, bool) {
 	if len(s) == 0 || s[0] != '^' {
 		return 0, false
 	}
@@ -1171,16 +1186,10 @@ func extractASFromRegexpString(s string) (uint16, bool) {
 	return uint16(asn), err == nil
 }
 
-func isASOnlyPatternStr(s string) bool {
-	return strings.HasSuffix(s, `:\d+$`) ||
-		strings.HasSuffix(s, `:[0-9]+$`) ||
-		strings.HasSuffix(s, `:.*$`)
-}
-
-func newCommunityMatcherFromRegexp(re *regexp.Regexp, listIndex int) communityMatcher {
+func compileCommunityMatcher(re *regexp.Regexp, listIndex int) communityMatcher {
 	s := re.String()
-	if inner, ok := regexpAnchoredBody(s); ok {
-		if asn, loc, ok2 := parseRegexpExactASCIIASColonLocal(inner, 16); ok2 {
+	if inner, ok := anchoredBody(s); ok {
+		if asn, loc, ok2 := parseExactASColonLocal(inner, 16); ok2 {
 			return communityMatcher{
 				mode:      communityMatchExact,
 				listIndex: communityMatcherNoListIdx,
@@ -1188,8 +1197,8 @@ func newCommunityMatcherFromRegexp(re *regexp.Regexp, listIndex int) communityMa
 			}
 		}
 	}
-	if asn, ok := extractASFromRegexpString(s); ok {
-		if isASOnlyPatternStr(s) {
+	if asn, ok := extractLiteralASN(s); ok {
+		if isWildcardLocal(s) {
 			return communityMatcher{
 				mode:      communityMatchFixedASWildcard,
 				listIndex: communityMatcherNoListIdx,
@@ -1200,10 +1209,10 @@ func newCommunityMatcherFromRegexp(re *regexp.Regexp, listIndex int) communityMa
 			mode:      communityMatchFixedASBitmap,
 			listIndex: communityMatcherNoListIdx,
 			asn:       asn,
-			bitmap:    buildLocalAdminBitmap(re, asn),
+			bitmap:    scanLocalAdminBitmap(re, asn),
 		}
 	}
-	if bm, ok := tryWildcardASIndependentLocalCommunityBitmap(re); ok {
+	if bm, ok := tryWildcardASNBitmap(re); ok {
 		return communityMatcher{
 			mode:      communityMatchLocalIndependent,
 			listIndex: communityMatcherNoListIdx,
@@ -1223,9 +1232,9 @@ func (m communityMatcher) matchesCommunity(c uint32, patterns []*regexp.Regexp) 
 		if uint16(c>>16) != m.asn {
 			return false
 		}
-		return communityBitmapIsSet(m.bitmap, uint16(c))
+		return m.bitmap.isSet(uint16(c))
 	case communityMatchLocalIndependent:
-		return communityBitmapIsSet(m.bitmap, uint16(c))
+		return m.bitmap.isSet(uint16(c))
 	case communityMatchRegexp:
 		if m.listIndex < 0 || m.listIndex >= len(patterns) {
 			panic(fmt.Sprintf("table: community regexp listIndex %d (len(patterns)=%d)", m.listIndex, len(patterns)))
@@ -1241,62 +1250,85 @@ func (m communityMatcher) matchesCommunity(c uint32, patterns []*regexp.Regexp) 
 	}
 }
 
-func buildCommunityMatchers(list []*regexp.Regexp) ([]communityMatcher, []asBitmapEntry, *communityLocalBitmap, bool) {
+func buildCommunityMatchers(list []*regexp.Regexp) ([]communityMatcher, communityAnyIndex) {
 	ms := make([]communityMatcher, len(list))
 	for i, re := range list {
-		ms[i] = newCommunityMatcherFromRegexp(re, i)
+		ms[i] = compileCommunityMatcher(re, i)
 	}
-	combined, anyLocalIn, hasRe := buildCommunityMatcherBitmaps(ms)
-	return ms, combined, anyLocalIn, hasRe
+	return ms, buildCommunityMatcherBitmaps(ms)
 }
 
 // asBitmapEntry pairs an AS number with its combined OR-bitmap for fast lookup.
 type asBitmapEntry struct {
 	asn uint16
-	bm  *communityLocalBitmap
+	bm  *localAdminBitmap
+}
+
+// communityAnyIndex is the precomputed OR-index used for MATCH_OPTION_ANY / MATCH_OPTION_INVERT.
+// It is rebuilt whenever the pattern set changes.
+type communityAnyIndex struct {
+	perAS          []asBitmapEntry   // per-AS OR-bitmaps for fixed-ASN patterns
+	asnIndependent *localAdminBitmap // OR-bitmap for wildcard-ASN patterns (e.g. \d+:100)
+	hasRegexp      bool              // true → fast path unavailable, caller must use slow scan
+}
+
+// matchesAny reports whether any community in cs matches the index.
+// Returns false immediately when hasRegexp is set; the caller must fall back to slow scan.
+func (idx *communityAnyIndex) matchesAny(cs []uint32) bool {
+	if idx.hasRegexp {
+		return false
+	}
+	for _, y := range cs {
+		local := uint16(y)
+		if idx.asnIndependent != nil && idx.asnIndependent.isSet(local) {
+			return true
+		}
+		asn := uint16(y >> 16)
+		for i := range idx.perAS {
+			if idx.perAS[i].asn == asn && idx.perAS[i].bm.isSet(local) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 type CommunitySet struct {
 	regExpSet
-	matchers                  []communityMatcher
-	anyBitmaps                []asBitmapEntry       // per-AS OR-bitmaps for ANY/INVERT fast path
-	anyLocalIndependentBitmap *communityLocalBitmap // OR-bitmap for ASN-independent patterns
-	hasReMatchers             bool                  // true when any matcher still needs regexp
+	matchers []communityMatcher
+	anyIdx   communityAnyIndex // precomputed index for ANY/INVERT fast path
 }
 
-func buildCommunityMatcherBitmaps(matchers []communityMatcher) ([]asBitmapEntry, *communityLocalBitmap, bool) {
-	var combined []asBitmapEntry
-	var anyLocal *communityLocalBitmap
-	hasRe := false
+func buildCommunityMatcherBitmaps(matchers []communityMatcher) communityAnyIndex {
+	var idx communityAnyIndex
 	for _, m := range matchers {
 		switch m.mode {
 		case communityMatchExact:
 			asn := uint16(m.exact >> 16)
-			bm := orBitmapSliceGet(&combined, asn)
-			communityBitmapSet(bm, uint16(m.exact))
+			orBitmapSliceGet(&idx.perAS, asn).set(uint16(m.exact))
 		case communityMatchFixedASWildcard:
-			communityBitmapFillAll(orBitmapSliceGet(&combined, m.asn))
+			orBitmapSliceGet(&idx.perAS, m.asn).fillAll()
 		case communityMatchFixedASBitmap:
-			communityBitmapOr(orBitmapSliceGet(&combined, m.asn), m.bitmap)
+			orBitmapSliceGet(&idx.perAS, m.asn).or(m.bitmap)
 		case communityMatchLocalIndependent:
-			if anyLocal == nil {
-				anyLocal = new(communityLocalBitmap)
+			if idx.asnIndependent == nil {
+				idx.asnIndependent = new(localAdminBitmap)
 			}
-			communityBitmapOr(anyLocal, m.bitmap)
+			idx.asnIndependent.or(m.bitmap)
 		default:
-			hasRe = true
+			idx.hasRegexp = true
 		}
 	}
-	return combined, anyLocal, hasRe
+	return idx
 }
 
-func orBitmapSliceGet(entries *[]asBitmapEntry, asn uint16) *communityLocalBitmap {
+func orBitmapSliceGet(entries *[]asBitmapEntry, asn uint16) *localAdminBitmap {
 	for i := range *entries {
 		if (*entries)[i].asn == asn {
 			return (*entries)[i].bm
 		}
 	}
-	bm := new(communityLocalBitmap)
+	bm := new(localAdminBitmap)
 	*entries = append(*entries, asBitmapEntry{asn: asn, bm: bm})
 	return bm
 }
@@ -1440,22 +1472,20 @@ func NewCommunitySet(c oc.CommunitySet) (*CommunitySet, error) {
 		}
 		list = append(list, exp)
 	}
-	ms, combined, anyLocalInd, hasRe := buildCommunityMatchers(list)
+	ms, anyIdx := buildCommunityMatchers(list)
 	return &CommunitySet{
 		regExpSet: regExpSet{
 			typ:  DEFINED_TYPE_COMMUNITY,
 			name: name,
 			list: list,
 		},
-		matchers:                  ms,
-		anyBitmaps:                combined,
-		anyLocalIndependentBitmap: anyLocalInd,
-		hasReMatchers:             hasRe,
+		matchers: ms,
+		anyIdx:   anyIdx,
 	}, nil
 }
 
 func (s *CommunitySet) rebuildMatchers() {
-	s.matchers, s.anyBitmaps, s.anyLocalIndependentBitmap, s.hasReMatchers = buildCommunityMatchers(s.list)
+	s.matchers, s.anyIdx = buildCommunityMatchers(s.list)
 }
 
 func (s *CommunitySet) Append(arg DefinedSet) error {
@@ -1482,9 +1512,200 @@ func (s *CommunitySet) Replace(arg DefinedSet) error {
 	return nil
 }
 
+type extCommunityMatchMode uint8
+
+const (
+	extCommMatchExact extCommunityMatchMode = iota
+	extCommMatchASOnly
+	extCommMatchASBitmap
+	extCommMatchLocalBitmap
+	extCommMatchRegexp
+)
+
+// extCommunityMatcher is a compiled EC pattern. Follows the same promotion strategy as
+// communityMatcher: anchored decimal exact → AS-only wildcard → fixed/wildcard-AS bitmap →
+// regexp fallback. Non-regexp modes only handle TwoOctetAsSpecificExtended; everything else
+// falls to regexp. The regexp mode checks the subtype field before evaluating the regexp.
+type extCommunityMatcher struct {
+	subtype         bgp.ExtendedCommunityAttrSubType
+	mode            extCommunityMatchMode
+	exactAS         uint16
+	exactLocalAdmin uint32
+	bitmap          *localAdminBitmap
+	re              *regexp.Regexp
+}
+
+func compileExtCommunityMatcher(subtype bgp.ExtendedCommunityAttrSubType, re *regexp.Regexp) extCommunityMatcher {
+	s := re.String()
+	body, anchored := anchoredBody(s)
+	if anchored {
+		if asn, la, ok := parseExactASColonLocal(body, 32); ok {
+			return extCommunityMatcher{subtype: subtype, mode: extCommMatchExact, exactAS: asn, exactLocalAdmin: la}
+		}
+	}
+	if asn, ok := extractLiteralASN(s); ok {
+		if isWildcardLocal(s) {
+			return extCommunityMatcher{subtype: subtype, mode: extCommMatchASOnly, exactAS: asn}
+		}
+		if anchored {
+			if colon := strings.IndexByte(body, ':'); colon > 0 {
+				if bm, ok2 := parseLocalAdminSet(body[colon+1:]); ok2 {
+					return extCommunityMatcher{subtype: subtype, mode: extCommMatchASBitmap, exactAS: asn, bitmap: bm}
+				}
+			}
+		}
+		return extCommunityMatcher{subtype: subtype, mode: extCommMatchRegexp, re: re}
+	}
+	if anchored {
+		if bm, ok := tryWildcardASNBitmap(re); ok {
+			return extCommunityMatcher{subtype: subtype, mode: extCommMatchLocalBitmap, bitmap: bm}
+		}
+	}
+	return extCommunityMatcher{subtype: subtype, mode: extCommMatchRegexp, re: re}
+}
+
+func (m extCommunityMatcher) matchesExtCommunity(x bgp.ExtendedCommunityInterface, xStr *string) bool {
+	switch m.mode {
+	case extCommMatchExact:
+		ec, ok := x.(*bgp.TwoOctetAsSpecificExtended)
+		return ok && subTypeEqual(x, m.subtype) && ec.AS == m.exactAS && ec.LocalAdmin == m.exactLocalAdmin
+	case extCommMatchASOnly:
+		ec, ok := x.(*bgp.TwoOctetAsSpecificExtended)
+		return ok && subTypeEqual(x, m.subtype) && ec.AS == m.exactAS
+	case extCommMatchASBitmap:
+		ec, ok := x.(*bgp.TwoOctetAsSpecificExtended)
+		return ok && subTypeEqual(x, m.subtype) && ec.AS == m.exactAS && ec.LocalAdmin <= 0xffff && m.bitmap.isSet(uint16(ec.LocalAdmin))
+	case extCommMatchLocalBitmap:
+		ec, ok := x.(*bgp.TwoOctetAsSpecificExtended)
+		return ok && subTypeEqual(x, m.subtype) && ec.LocalAdmin <= 0xffff && m.bitmap.isSet(uint16(ec.LocalAdmin))
+	case extCommMatchRegexp:
+		if !subTypeEqual(x, m.subtype) {
+			return false
+		}
+		if *xStr == "" {
+			*xStr = x.String()
+		}
+		return m.re.MatchString(*xStr)
+	default:
+		panic(fmt.Sprintf("table: invalid extCommunityMatchMode %d", m.mode))
+	}
+}
+
+func buildExtCommunityMatchers(list []*regexp.Regexp, subtypes []bgp.ExtendedCommunityAttrSubType) []extCommunityMatcher {
+	ms := make([]extCommunityMatcher, len(list))
+	for i, re := range list {
+		ms[i] = compileExtCommunityMatcher(subtypes[i], re)
+	}
+	return ms
+}
+
+type twoOctetExactKey struct {
+	as uint16
+	la uint32
+}
+
+// extSubtypeAnyIndex is the precomputed fast-path index for MATCH_OPTION_ANY on one EC subtype.
+// Exact matches with LA ≤ 65535 and ASBitmap patterns share the perAS bitmap structure.
+// LA > 65535 exact matches go into highLA; ASOnly patterns go into asOnly.
+type extSubtypeAnyIndex struct {
+	subtype bgp.ExtendedCommunityAttrSubType
+	perAS   []asBitmapEntry               // Exact (LA≤65535) + ASBitmap matchers
+	global  *localAdminBitmap             // LocalBitmap matchers (wildcard ASN)
+	asOnly  map[uint16]struct{}           // ASOnly matchers
+	highLA  map[twoOctetExactKey]struct{} // Exact matchers with LA > 65535
+}
+
+func (idx *extSubtypeAnyIndex) matchesTwoOctet(ec *bgp.TwoOctetAsSpecificExtended) bool {
+	if _, ok := idx.asOnly[ec.AS]; ok {
+		return true
+	}
+	la := ec.LocalAdmin
+	if la <= 0xffff {
+		local := uint16(la)
+		if idx.global != nil && idx.global.isSet(local) {
+			return true
+		}
+		for i := range idx.perAS {
+			if idx.perAS[i].asn == ec.AS && idx.perAS[i].bm.isSet(local) {
+				return true
+			}
+		}
+	} else {
+		_, ok := idx.highLA[twoOctetExactKey{ec.AS, la}]
+		return ok
+	}
+	return false
+}
+
+func buildExtCommunityAnyIndexes(matchers []extCommunityMatcher) ([]*extSubtypeAnyIndex, bool) {
+	type merge struct {
+		perAS  []asBitmapEntry
+		global *localAdminBitmap
+		asOnly map[uint16]struct{}
+		highLA map[twoOctetExactKey]struct{}
+	}
+	bySubtype := make(map[bgp.ExtendedCommunityAttrSubType]*merge)
+	needSlowScan := false
+	get := func(st bgp.ExtendedCommunityAttrSubType) *merge {
+		if m, ok := bySubtype[st]; ok {
+			return m
+		}
+		m := &merge{}
+		bySubtype[st] = m
+		return m
+	}
+	for _, m := range matchers {
+		switch m.mode {
+		case extCommMatchExact:
+			g := get(m.subtype)
+			if m.exactLocalAdmin <= 0xffff {
+				orBitmapSliceGet(&g.perAS, m.exactAS).set(uint16(m.exactLocalAdmin))
+			} else {
+				if g.highLA == nil {
+					g.highLA = make(map[twoOctetExactKey]struct{})
+				}
+				g.highLA[twoOctetExactKey{m.exactAS, m.exactLocalAdmin}] = struct{}{}
+			}
+		case extCommMatchASOnly:
+			g := get(m.subtype)
+			if g.asOnly == nil {
+				g.asOnly = make(map[uint16]struct{})
+			}
+			g.asOnly[m.exactAS] = struct{}{}
+		case extCommMatchASBitmap:
+			orBitmapSliceGet(&get(m.subtype).perAS, m.exactAS).or(m.bitmap)
+		case extCommMatchLocalBitmap:
+			g := get(m.subtype)
+			if g.global == nil {
+				g.global = new(localAdminBitmap)
+			}
+			g.global.or(m.bitmap)
+		default:
+			needSlowScan = true
+		}
+	}
+	out := make([]*extSubtypeAnyIndex, 0, len(bySubtype))
+	for st, g := range bySubtype {
+		out = append(out, &extSubtypeAnyIndex{subtype: st, perAS: g.perAS, global: g.global, asOnly: g.asOnly, highLA: g.highLA})
+	}
+	return out, needSlowScan
+}
+
+func findExtSubtypeAnyIndex(indexes []*extSubtypeAnyIndex, st bgp.ExtendedCommunityAttrSubType) *extSubtypeAnyIndex {
+	for _, idx := range indexes {
+		if idx.subtype == st {
+			return idx
+		}
+	}
+	return nil
+}
+
 type ExtCommunitySet struct {
 	regExpSet
-	subtypeList []bgp.ExtendedCommunityAttrSubType
+	subtypeList  []bgp.ExtendedCommunityAttrSubType
+	matchers     []extCommunityMatcher
+	anyIndex     []*extSubtypeAnyIndex
+	needSlowScan bool
 }
 
 func (s *ExtCommunitySet) List() []string {
@@ -1526,6 +1747,11 @@ func (s *ExtCommunitySet) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.ToConfig())
 }
 
+func (s *ExtCommunitySet) rebuildExtMatchers() {
+	s.matchers = buildExtCommunityMatchers(s.list, s.subtypeList)
+	s.anyIndex, s.needSlowScan = buildExtCommunityAnyIndexes(s.matchers)
+}
+
 func NewExtCommunitySet(c oc.ExtCommunitySet) (*ExtCommunitySet, error) {
 	name := c.ExtCommunitySetName
 	if name == "" {
@@ -1544,23 +1770,61 @@ func NewExtCommunitySet(c oc.ExtCommunitySet) (*ExtCommunitySet, error) {
 		list = append(list, exp)
 		subtypeList = append(subtypeList, subtype)
 	}
-	return &ExtCommunitySet{
+	s := &ExtCommunitySet{
 		regExpSet: regExpSet{
 			typ:  DEFINED_TYPE_EXT_COMMUNITY,
 			name: name,
 			list: list,
 		},
 		subtypeList: subtypeList,
-	}, nil
+	}
+	s.rebuildExtMatchers()
+	return s, nil
 }
 
 func (s *ExtCommunitySet) Append(arg DefinedSet) error {
-	err := s.regExpSet.Append(arg)
-	if err != nil {
+	if err := s.regExpSet.Append(arg); err != nil {
 		return err
 	}
-	sList := arg.(*ExtCommunitySet).subtypeList
-	s.subtypeList = append(s.subtypeList, sList...)
+	s.subtypeList = append(s.subtypeList, arg.(*ExtCommunitySet).subtypeList...)
+	s.rebuildExtMatchers()
+	return nil
+}
+
+func (s *ExtCommunitySet) Remove(arg DefinedSet) error {
+	if s.Type() != arg.Type() {
+		return fmt.Errorf("can't remove from different type of defined-set")
+	}
+	other := arg.(*ExtCommunitySet)
+	newList := make([]*regexp.Regexp, 0, len(s.list))
+	newSubtypes := make([]bgp.ExtendedCommunityAttrSubType, 0, len(s.subtypeList))
+	for i, x := range s.list {
+		found := false
+		for _, y := range other.list {
+			if x.String() == y.String() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			newList = append(newList, x)
+			newSubtypes = append(newSubtypes, s.subtypeList[i])
+		}
+	}
+	s.list = newList
+	s.subtypeList = newSubtypes
+	s.rebuildExtMatchers()
+	return nil
+}
+
+func (s *ExtCommunitySet) Replace(arg DefinedSet) error {
+	other, ok := arg.(*ExtCommunitySet)
+	if !ok {
+		return fmt.Errorf("type cast failed")
+	}
+	s.list = other.list
+	s.subtypeList = other.subtypeList
+	s.rebuildExtMatchers()
 	return nil
 }
 
@@ -1933,33 +2197,17 @@ func (c *CommunityCondition) Option() MatchOption {
 func (c *CommunityCondition) Evaluate(path *Path, _ *PolicyOptions) bool {
 	cs := path.GetCommunities()
 
-	// Fast path for ANY / INVERT: combined OR-bitmap per AS eliminates the
-	// pattern loop entirely — one bit-test per community suffices.
-	if (c.option == MATCH_OPTION_ANY || c.option == MATCH_OPTION_INVERT) &&
-		!c.set.hasReMatchers &&
-		(len(c.set.anyBitmaps) > 0 || c.set.anyLocalIndependentBitmap != nil) {
-		found := false
-		for _, y := range cs {
-			local := uint16(y)
-			if bm := c.set.anyLocalIndependentBitmap; bm != nil && communityBitmapIsSet(bm, local) {
-				found = true
-				break
-			}
-			asn := uint16(y >> 16)
-			for i := range c.set.anyBitmaps {
-				if c.set.anyBitmaps[i].asn == asn && communityBitmapIsSet(c.set.anyBitmaps[i].bm, local) {
-					found = true
-					break
+	// Fast path for ANY / INVERT: bitmap index eliminates the pattern loop entirely.
+	if c.option == MATCH_OPTION_ANY || c.option == MATCH_OPTION_INVERT {
+		if idx := &c.set.anyIdx; len(idx.perAS) > 0 || idx.asnIndependent != nil {
+			found := idx.matchesAny(cs)
+			if !idx.hasRegexp {
+				if c.option == MATCH_OPTION_INVERT {
+					return !found
 				}
-			}
-			if found {
-				break
+				return found
 			}
 		}
-		if c.option == MATCH_OPTION_INVERT {
-			return !found
-		}
-		return found
 	}
 
 	// General path: MATCH_OPTION_ALL or sets with re-only patterns.
@@ -2024,6 +2272,31 @@ func (c *ExtCommunityCondition) Option() MatchOption {
 
 func (c *ExtCommunityCondition) Evaluate(path *Path, _ *PolicyOptions) bool {
 	es := path.GetExtCommunities()
+
+	// Fast path for ANY / INVERT: bitmap/map index, no regexp evaluation.
+	if (c.option == MATCH_OPTION_ANY || c.option == MATCH_OPTION_INVERT) &&
+		!c.set.needSlowScan && len(c.set.anyIndex) > 0 {
+		found := false
+		for _, x := range es {
+			if !isTransitiveType(x) {
+				continue
+			}
+			ec, ok := x.(*bgp.TwoOctetAsSpecificExtended)
+			if !ok {
+				continue
+			}
+			if idx := findExtSubtypeAnyIndex(c.set.anyIndex, ec.SubType); idx != nil && idx.matchesTwoOctet(ec) {
+				found = true
+				break
+			}
+		}
+		if c.option == MATCH_OPTION_INVERT {
+			return !found
+		}
+		return found
+	}
+
+	// General path: loop over path ECs, try each matcher. Semantics preserved from original.
 	result := false
 	for _, x := range es {
 		result = false
@@ -2032,17 +2305,10 @@ func (c *ExtCommunityCondition) Evaluate(path *Path, _ *PolicyOptions) bool {
 			continue
 		}
 		var xStr string
-		for idx, y := range c.set.list {
-			if subTypeEqual(x, c.set.subtypeList[idx]) {
-				if len(xStr) == 0 {
-					// caching x.String() saves a lot of resources when matching against
-					// a lot of conditions, link hundreds of RTs.
-					xStr = x.String()
-				}
-				if y.MatchString(xStr) {
-					result = true
-					break
-				}
+		for _, m := range c.set.matchers {
+			if m.matchesExtCommunity(x, &xStr) {
+				result = true
+				break
 			}
 		}
 		if c.option == MATCH_OPTION_ALL && !result {


### PR DESCRIPTION
- Rename communityLocalBitmap → localAdminBitmap and add receiver methods (isSet/set/or/fillAll) replacing four standalone functions
- Extract communityAnyIndex (perAS, asnIndependent, hasRegexp) with matchesAny() method, replacing three separate fields on CommunitySet
- buildCommunityMatcherBitmaps now returns communityAnyIndex directly
- CommunityCondition.Evaluate() delegates fast path to anyIdx.matchesAny()