### PR TITLE
fsm: Do not emit warnings upon sending notification

### DIFF
--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -767,7 +767,7 @@ func (fsm *fsm) sendNotification(conn net.Conn, msg *bgp.BGPMessage) error {
 	body := msg.Body.(*bgp.BGPNotification)
 	if body.ErrorCode == bgp.BGP_ERROR_CEASE && (body.ErrorSubcode == bgp.BGP_ERROR_SUB_ADMINISTRATIVE_SHUTDOWN || body.ErrorSubcode == bgp.BGP_ERROR_SUB_ADMINISTRATIVE_RESET) {
 		communication, rest := decodeAdministrativeCommunication(body.Data)
-		fsm.logger.Warn("sent notification",
+		fsm.logger.Info("sent notification",
 			slog.String("State", fsm.state.String()),
 			slog.Int("Code", int(body.ErrorCode)),
 			slog.Int("Subcode", int(body.ErrorSubcode)),
@@ -781,7 +781,7 @@ func (fsm *fsm) sendNotification(conn net.Conn, msg *bgp.BGPMessage) error {
 			fsm.lock.Unlock()
 		}
 	} else {
-		fsm.logger.Warn("sent notification",
+		fsm.logger.Info("sent notification",
 			slog.String("State", fsm.state.String()),
 			slog.Int("Code", int(body.ErrorCode)),
 			slog.Int("Subcode", int(body.ErrorSubcode)),


### PR DESCRIPTION
Warnings should point to potentially incorrect behavior. However, sending a notfication is completely expected during session lifetime and emiting a warning tends to point to incorrect direction when debugging in that case (e.g. emits a warning when a peer is deconfigured).