### PR TITLE
table: Do not emit warnings upon no-op withdrawals

### DIFF
--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -372,9 +372,10 @@ func (dest *destination) explicitWithdraw(logger *slog.Logger, withdraw *Path) *
 		}
 	}
 
-	// We do no have any match for this withdraw.
+	// We do not have any match for this withdraw.
+	// May be caused by bgp policy if not all paths got installed into the table.
 	if isFound == -1 {
-		logger.Warn("No matching path for withdraw found, may be path was not installed into table",
+		logger.Debug("No matching path for withdraw found, may be path was not installed into table",
 			slog.String("Topic", "Table"),
 			slog.String("Key", dest.GetNlri().String()),
 			slog.String("Path", withdraw.String()))


### PR DESCRIPTION
As already described in the explicitWithdraw func comment, if policies are used, some paths may not be installed into the table, which causes warnings upon explicit withdrawal.

As this is a known situation under this scenario, we should not emit warnings and pollute logs with non-helpful warnings when policies are in use.