### PR TITLE
fix(cmd): avoid nil pointer panic in CLI when NLRI cannot be decoded

### DIFF
--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -589,7 +589,12 @@ func getPathAttributeString(nlri bgp.NLRI, attrs []bgp.PathAttributeInterface) s
 }
 
 func makeShowRouteArgs(p *api.Path, idx int, now time.Time, showAge, showBest, showLabel, showMUP, showSendMaxFiltered bool, showIdentifier bgp.BGPAddPathMode) []any {
-	nlri, _ := apiutil.GetNativeNlri(p)
+	nlri, err := apiutil.GetNativeNlri(p)
+	// nlri is nil when the NLRI cannot be decoded; avoid a nil dereference below.
+	nlriStr := "?"
+	if err == nil && nlri != nil {
+		nlriStr = nlri.String()
+	}
 
 	// Path Symbols (e.g. "*>")
 	args := []any{getPathSymbolString(p, idx, showBest)}
@@ -603,7 +608,7 @@ func makeShowRouteArgs(p *api.Path, idx int, now time.Time, showAge, showBest, s
 	}
 
 	// NLRI
-	args = append(args, nlri)
+	args = append(args, nlriStr)
 
 	// Label
 	label := ""
@@ -662,7 +667,7 @@ func makeShowRouteArgs(p *api.Path, idx int, now time.Time, showAge, showBest, s
 		}
 	}
 
-	updateColumnWidth(nlri.String(), nexthop, aspathstr, label, teid, qfi, endpoint)
+	updateColumnWidth(nlriStr, nexthop, aspathstr, label, teid, qfi, endpoint)
 
 	return args
 }

--- a/cmd/gobgp/neighbor_test.go
+++ b/cmd/gobgp/neighbor_test.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"time"
+
+	"testing"
+
+	"github.com/osrg/gobgp/v4/api"
+	bgp "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_makeShowRouteArgsUndecodableNlri(t *testing.T) {
+	assert := assert.New(t)
+	// A path whose NLRI cannot be decoded must not panic the CLI formatter.
+	p := &api.Path{}
+	var args []any
+	assert.NotPanics(func() {
+		args = makeShowRouteArgs(p, 0, time.Now(), false, true, false, false, false, bgp.BGP_ADD_PATH_NONE)
+	})
+	assert.Contains(args, "?")
+}

--- a/cmd/gobgp/neighbor_test.go
+++ b/cmd/gobgp/neighbor_test.go
@@ -16,9 +16,8 @@
 package main
 
 import (
-	"time"
-
 	"testing"
+	"time"
 
 	"github.com/osrg/gobgp/v4/api"
 	bgp "github.com/osrg/gobgp/v4/pkg/packet/bgp"


### PR DESCRIPTION
`gobgp global rib -a evpn` panics with a nil pointer dereference when a path's NLRI cannot be decoded (issue #3354). `makeShowRouteArgs` ignores the error from `apiutil.GetNativeNlri` and then calls `nlri.String()` on the nil interface.

This guards the decode result: when the NLRI is nil, a "?" placeholder is used instead of dereferencing it, so the rest of the table still renders. The JSON output (`-j`) was unaffected because it does not go through this formatter.

Added a regression test that asserts `makeShowRouteArgs` no longer panics for an undecodable path.