### PR TITLE
fix(table): preserve last action for the same path in coalesced updates

### DIFF
--- a/internal/pkg/table/message.go
+++ b/internal/pkg/table/message.go
@@ -682,13 +682,38 @@ func newPacker(f bgp.Family) packerInterface {
 func CreateUpdateMsgFromPaths(pathList []*Path, options ...*bgp.MarshallingOption) []*bgp.BGPMessage {
 	msgs := make([]*bgp.BGPMessage, 0, len(pathList))
 
-	m := make(map[bgp.Family]packerInterface)
+	// Since sendMessageloop coalesces outgoing BGP UPDATE messages and
+	// the packers emit withdrawals before announcements, we should keep only the
+	// last action for each NLRI/path-id within one packing pass.
+	last := make(map[PathLocalKey]*Path, len(pathList))
 	for _, path := range pathList {
+		if path == nil || path.IsEOR() {
+			continue
+		}
+		last[path.GetLocalKey()] = path
+	}
+
+	m := make(map[bgp.Family]packerInterface)
+	add := func(path *Path) {
 		f := path.GetFamily()
 		if _, y := m[f]; !y {
 			m[f] = newPacker(f)
 		}
 		m[f].add(path)
+	}
+
+	for _, path := range pathList {
+		if path == nil {
+			continue
+		}
+		if path.IsEOR() {
+			add(path)
+			continue
+		}
+		if last[path.GetLocalKey()] != path {
+			continue
+		}
+		add(path)
 	}
 
 	for _, p := range m {

--- a/internal/pkg/table/message_test.go
+++ b/internal/pkg/table/message_test.go
@@ -910,3 +910,81 @@ func TestAsPathAs4PathOrdering(t *testing.T) {
 	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[3], uint32(300000))
 	assert.Equal(t, msg.PathAttributes[0].(*bgp.PathAttributeAsPath).Value[0].(*bgp.As4PathParam).AS[4], uint32(40001))
 }
+
+func TestCreateUpdateMsgFromPathsKeepsLastAction(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		paths        func(*Path, *Path, *Path, *Path) []*Path
+		wantWithdraw bool
+		wantAnnounce bool
+		wantOther    bool
+		wantEOR      bool
+	}{
+		{
+			name: "withdraw last",
+			paths: func(announce, withdraw, other, eor *Path) []*Path {
+				return []*Path{announce, nil, eor, other, withdraw}
+			},
+			wantWithdraw: true,
+			wantOther:    true,
+			wantEOR:      true,
+		},
+		{
+			name: "announce last",
+			paths: func(announce, withdraw, other, eor *Path) []*Path {
+				return []*Path{withdraw, eor, announce}
+			},
+			wantAnnounce: true,
+			wantEOR:      true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			announce := newIPv4UpdatePath(t, "10.0.0.0/24")
+			withdraw := announce.Clone(true)
+			other := newIPv4UpdatePath(t, "10.0.1.0/24")
+			eor := NewEOR(bgp.RF_IPv4_UC)
+
+			msgs := CreateUpdateMsgFromPaths(tc.paths(announce, withdraw, other, eor))
+			withdrawn := make(map[string]bool)
+			announced := make(map[string]bool)
+			gotEOR := false
+			for _, msg := range msgs {
+				update := msg.Body.(*bgp.BGPUpdate)
+				if ok, family := update.IsEndOfRib(); ok && family == bgp.RF_IPv4_UC {
+					gotEOR = true
+				}
+				for _, nlri := range update.WithdrawnRoutes {
+					withdrawn[nlri.NLRI.String()] = true
+				}
+				for _, nlri := range update.NLRI {
+					announced[nlri.NLRI.String()] = true
+				}
+			}
+
+			assert.Equal(t, tc.wantWithdraw, withdrawn["10.0.0.0/24"])
+			assert.Equal(t, tc.wantAnnounce, announced["10.0.0.0/24"])
+			assert.Equal(t, tc.wantOther, announced["10.0.1.0/24"])
+			assert.Equal(t, tc.wantEOR, gotEOR)
+		})
+	}
+}
+
+func newIPv4UpdatePath(t *testing.T, prefix string) *Path {
+	t.Helper()
+	nlri, err := bgp.NewIPAddrPrefix(netip.MustParsePrefix(prefix))
+	if err != nil {
+		t.Fatal(err)
+	}
+	nexthop, err := bgp.NewPathAttributeNextHop(netip.MustParseAddr("192.0.2.1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{
+			bgp.NewAs4PathParam(2, []uint32{65001}),
+		}),
+		nexthop,
+	}
+	return NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
+}


### PR DESCRIPTION
As of c86f89ea33d3723107dd1114b96df7005ef423be outgoing BGP UPDATE messages are coalesced before packing them. The packers serialize withdrawals before announcements, so if an announcement and withdrawal for the same NLRI/path-id are coalesced in one packing pass, the final wire order can invert the original action sequence.

Collapse the path list by local NLRI/path-id before handing it to the family packers, keeping only the final action.
This makes announce-then-withdraw produce only a withdrawal, and withdraw-then-announce produce only an announcement.