### PR TITLE
server: don't treat unestablished GR peers as having sent EOR

### DIFF
--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -335,8 +335,23 @@ func (peer *peer) setRtcEORWait(waiting bool) {
 	peer.fsm.logger.Debug("Set rtcEORWait", slog.Bool("Data", waiting))
 }
 
-func (peer *peer) recvedAllEOR() bool {
+// receivedAllEOR reports whether the restarting speaker has received EOR from
+// this peer for all negotiated GR address families. Per RFC 4724 Section 4.1,
+// a peer that does not advertise GR capability is excluded from the EOR wait.
+// A peer that has GR configured but has not yet reached ESTABLISHED is treated
+// as pending: its EOR has not been received and cannot be skipped.
+func (peer *peer) receivedAllEOR() bool {
 	conf := peer.fsm.pConf.ReadOnly()
+	if peer.fsm.state.Load() != bgp.BGP_FSM_ESTABLISHED {
+		// Session not yet established: if GR is configured for any family,
+		// we must wait — the peer may still advertise GR capability in its OPEN.
+		for _, a := range conf.AfiSafis {
+			if a.MpGracefulRestart.Config.Enabled {
+				return false
+			}
+		}
+		return true
+	}
 	for _, a := range conf.AfiSafis {
 		if s := a.MpGracefulRestart.State; s.Enabled && s.Received && !s.EndOfRibReceived {
 			return false

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1733,7 +1733,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 				// the Selection_Deferral_Timer referred to below has expired.
 				allEnd := func() bool {
 					for _, p := range s.neighborMap {
-						if !p.recvedAllEOR() {
+						if !p.receivedAllEOR() {
 							return false
 						}
 					}
@@ -1849,7 +1849,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 				if localRestarting {
 					allEnd := func() bool {
 						for _, p := range s.neighborMap {
-							if !p.recvedAllEOR() {
+							if !p.receivedAllEOR() {
 								return false
 							}
 						}
@@ -1883,7 +1883,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 				conf := peer.fsm.pConf.ReadOnly()
 				peerRestarting := conf.GracefulRestart.State.PeerRestarting
 				if peerRestarting {
-					if peer.recvedAllEOR() {
+					if peer.receivedAllEOR() {
 						peer.stopPeerRestarting()
 						pathList := peer.adjRibIn.DropStale(peer.configuredRFlist())
 

--- a/test/scenario_test/graceful_restart_test.py
+++ b/test/scenario_test/graceful_restart_test.py
@@ -142,6 +142,13 @@ class GoBGPTestBase(unittest.TestCase):
         g1.start_gobgp(graceful_restart=True)
         g1.add_route('10.10.20.0/24')
         g3.start_gobgp()
+        # RFC 4724 Section 4.1: the Restarting Speaker MUST defer route
+        # selection until it receives EOR from all peers that advertise GR
+        # capability (excluding those with the Restart State bit set).
+        # g2 advertises GR, so g1 must wait for g2's EOR before sending
+        # routes to any peer, including g3 which does not advertise GR.
+        g2 = self.bgpds['g2']
+        g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=g2)
         g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=g3)
         time.sleep(1)
         self.assertEqual(len(g3.get_global_rib('10.10.20.0/24')), 1)


### PR DESCRIPTION
recvedAllEOR() returned true for peers that had not yet reached ESTABLISHED state, causing LocalRestarting to be cleared too early when a restarting speaker has multiple GR-enabled peers.

Also rename recvedAllEOR to receivedAllEOR.