### PR TITLE
server: withdraw policy-filtered routes on soft reset out

### DIFF
--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -248,17 +248,28 @@ func (peer *peer) getRoutesCount(family bgp.Family, dstPrefix string) uint8 {
 	return 0
 }
 
+func (peer *peer) advertisedPathID(path *table.Path) uint32 {
+	if peer.isAddPathSendEnabled(path.GetFamily()) {
+		return path.LocalID()
+	}
+	return 0
+}
+
 func (peer *peer) updateRoutes(paths ...*table.Path) {
 	if len(paths) == 0 {
 		return
 	}
 	for _, path := range paths {
-		localKey := path.GetLocalKey()
-		destLocalKey := localKey.PathDestLocalKey
+		if path == nil || path.IsEOR() {
+			continue
+		}
+		destLocalKey := path.GetDestLocalKey()
+		pathID := peer.advertisedPathID(path)
+
 		identifiersValue, destExists := peer.sentPaths.Load(destLocalKey)
 		if path.IsWithdraw && destExists {
 			identifiers := identifiersValue.(pathIDSet)
-			delete(identifiers, path.LocalID())
+			delete(identifiers, pathID)
 			if len(identifiers) == 0 {
 				peer.sentPaths.Delete(destLocalKey)
 			}
@@ -269,12 +280,10 @@ func (peer *peer) updateRoutes(paths ...*table.Path) {
 			} else {
 				identifiers = make(pathIDSet)
 			}
-			if len(identifiers) < int(peer.getAddPathSendMax(destLocalKey.Family)) {
-				identifiers[localKey.Id] = struct{}{}
-				if !destExists {
-					// store only the first insert, mutations are inplace
-					peer.sentPaths.Store(destLocalKey, identifiers)
-				}
+			identifiers[pathID] = struct{}{}
+			if !destExists {
+				// store only the first insert, mutations are inplace
+				peer.sentPaths.Store(destLocalKey, identifiers)
 			}
 		}
 	}
@@ -315,8 +324,19 @@ func (peer *peer) hasPathAlreadyBeenSent(path *table.Path) bool {
 	if !dstExist {
 		return false
 	}
-	_, pathExist := identifiers.(pathIDSet)[path.LocalID()]
+	_, pathExist := identifiers.(pathIDSet)[peer.advertisedPathID(path)]
 	return pathExist
+}
+
+func (peer *peer) resetAdvertisedRoutes() {
+	peer.sentPaths.Range(func(key, _ any) bool {
+		peer.sentPaths.Delete(key)
+		return true
+	})
+	peer.sendMaxPathFiltered.Range(func(key, _ any) bool {
+		peer.sendMaxPathFiltered.Delete(key)
+		return true
+	})
 }
 
 func (peer *peer) isDynamicNeighbor() bool {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1037,7 +1037,7 @@ func (s *BgpServer) getBestFromLocalCallbackLocked(peer *peer, rfList []bgp.Fami
 			if p := s.filterpath(peer, path, nil); p != nil {
 				pathList = append(pathList, p)
 			} else {
-				filtered = append(filtered, path)
+				filtered = append(filtered, filteredPathForPeer(peer, path))
 			}
 		}
 	}
@@ -1055,6 +1055,22 @@ func (s *BgpServer) getBestFromLocalCallbackLocked(peer *peer, rfList []bgp.Fami
 		}
 	}
 	fn(pathList, filtered)
+}
+
+func filteredPathForPeer(peer *peer, path *table.Path) *table.Path {
+	if path == nil {
+		return nil
+	}
+	conf := peer.fsm.pConf.ReadOnly()
+	if conf.Config.Vrf == "" {
+		return path
+	}
+	switch path.GetFamily() {
+	case bgp.RF_IPv4_VPN, bgp.RF_IPv6_VPN, bgp.RF_FS_IPv4_VPN, bgp.RF_FS_IPv6_VPN:
+		return path.ToLocal()
+	default:
+		return path
+	}
 }
 
 func needToAdvertise(peer *peer) bool {
@@ -1156,6 +1172,7 @@ func (s *BgpServer) handleRouteRefresh(peer *peer, e *fsmMsg) {
 	rfList := []bgp.Family{rf}
 	s.getBestFromLocalCallback(peer, rfList, true, true, func(paths []*table.Path, filtered []*table.Path) {
 		if len(paths) > 0 {
+			peer.updateRoutes(paths...)
 			sendfsmOutgoingMsg(peer, paths)
 		}
 	})
@@ -1257,8 +1274,8 @@ func (s *BgpServer) processRTCMembership(peer *peer, path *table.Path) {
 		return
 	}
 
-	peer.routeRefreshInProgress.RLock()
-	defer peer.routeRefreshInProgress.RUnlock()
+	peer.routeRefreshInProgress.Lock()
+	defer peer.routeRefreshInProgress.Unlock()
 
 	rt := nlri.RouteTarget
 	hasRt := func(rt bgp.ExtendedCommunityInterface) bool {
@@ -1283,6 +1300,7 @@ func (s *BgpServer) processRTCMembership(peer *peer, path *table.Path) {
 		if path.IsWithdraw {
 			// Skips filtering: paths are already scoped to this RT and withdrawals
 			// do not need path attributes.
+			peer.updateRoutes(filtered...)
 			sendfsmOutgoingMsg(peer, filtered)
 			return
 		}
@@ -1291,6 +1309,7 @@ func (s *BgpServer) processRTCMembership(peer *peer, path *table.Path) {
 			return
 		}
 		filtered = s.processOutgoingPaths(peer, filtered, nil)
+		peer.updateRoutes(filtered...)
 		sendfsmOutgoingMsg(peer, filtered)
 	})
 }
@@ -1464,12 +1483,14 @@ func (s *BgpServer) propagateUpdateToNeighbors(rib *table.TableManager, source *
 					}
 				}
 				if needToAdvertise(targetPeer) && len(bestList) > 0 {
+					// targetPeer.updateRoutes was already called while constructing bestList above.
 					sendfsmOutgoingMsg(targetPeer, bestList)
 				}
 			} else {
 				if targetPeer.isRouteServerClient() {
 					if targetPeer.isSecondaryRouteEnabled() {
 						if paths := s.sendSecondaryRoutes(targetPeer, newPath, dsts); len(paths) > 0 {
+							targetPeer.updateRoutes(paths...)
 							sendfsmOutgoingMsg(targetPeer, paths)
 						}
 						return
@@ -1483,6 +1504,7 @@ func (s *BgpServer) propagateUpdateToNeighbors(rib *table.TableManager, source *
 					oldList = nil
 				}
 				if paths := s.processOutgoingPaths(targetPeer, bestList, oldList); len(paths) > 0 {
+					targetPeer.updateRoutes(paths...)
 					sendfsmOutgoingMsg(targetPeer, paths)
 				}
 			}
@@ -1564,6 +1586,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 			peer.fsm.pConf.Update(&conf)
 			peer.prefixLimitWarned = make(map[bgp.Family]bool)
 			peer.fsm.lock.Unlock()
+			s.resetAdvertisedRoutes(peer)
 			s.propagateUpdate(peer, peer.DropAll(dropFamilies))
 
 			if conf.Config.PeerAs == 0 {
@@ -1710,6 +1733,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 					peer.setRtcEORWait(true)
 					s.getBestFromLocalCallback(peer, []bgp.Family{bgp.RF_RTC_UC}, true, true, func(paths []*table.Path, filtered []*table.Path) {
 						if len(paths) > 0 {
+							peer.updateRoutes(paths...)
 							sendfsmOutgoingMsg(peer, paths)
 						}
 					})
@@ -1718,6 +1742,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 				} else {
 					s.getBestFromLocalCallback(peer, peer.negotiatedRFList(), true, true, func(paths []*table.Path, filtered []*table.Path) {
 						if len(paths) > 0 {
+							peer.updateRoutes(paths...)
 							sendfsmOutgoingMsg(peer, paths)
 						}
 					})
@@ -1752,6 +1777,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 						}
 						s.getBestFromLocalCallback(p, p.configuredRFlist(), true, true, func(paths []*table.Path, filtered []*table.Path) {
 							if len(paths) > 0 {
+								p.updateRoutes(paths...)
 								sendfsmOutgoingMsg(p, paths)
 							}
 						})
@@ -1868,6 +1894,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 							}
 							s.getBestFromLocalCallback(p, p.negotiatedRFList(), true, true, func(paths []*table.Path, filtered []*table.Path) {
 								if len(paths) > 0 {
+									p.updateRoutes(paths...)
 									sendfsmOutgoingMsg(p, paths)
 								}
 							})
@@ -1909,12 +1936,25 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 					}
 					s.getBestFromLocalCallback(peer, families, true, true, func(paths []*table.Path, filtered []*table.Path) {
 						if len(paths) > 0 {
+							peer.updateRoutes(paths...)
 							sendfsmOutgoingMsg(peer, paths)
 						}
 					})
 				}
 			}
 		}
+	}
+}
+
+func (s *BgpServer) resetAdvertisedRoutes(peer *peer) {
+	for i := range s.shared.propagateBuckets {
+		s.shared.propagateBuckets[i].Lock()
+	}
+	peer.routeRefreshInProgress.Lock()
+	peer.resetAdvertisedRoutes()
+	peer.routeRefreshInProgress.Unlock()
+	for i := len(s.shared.propagateBuckets) - 1; i >= 0; i-- {
+		s.shared.propagateBuckets[i].Unlock()
 	}
 }
 
@@ -2733,6 +2773,23 @@ func (s *BgpServer) softResetOut(addr string, family bgp.Family, deferral bool) 
 		}
 
 		s.getBestFromLocalCallback(peer, families, true, true, func(paths []*table.Path, filtered []*table.Path) {
+			if len(filtered) > 0 && !deferral {
+				// withdraw paths that export policy now rejects
+				withdrawals := make([]*table.Path, 0, len(filtered))
+				for _, path := range filtered {
+					if path == nil || path.IsEOR() {
+						continue
+					}
+					if !peer.IsFamilyEnabled(path.GetFamily()) {
+						continue
+					}
+					if !peer.hasPathAlreadyBeenSent(path) {
+						continue
+					}
+					withdrawals = append(withdrawals, path.Clone(true))
+				}
+				paths = append(withdrawals, paths...)
+			}
 			if len(paths) > 0 {
 				if deferral {
 					paths = func() []*table.Path {
@@ -2745,6 +2802,7 @@ func (s *BgpServer) softResetOut(addr string, family bgp.Family, deferral bool) 
 						return l
 					}()
 				}
+				peer.updateRoutes(paths...)
 				sendfsmOutgoingMsg(peer, paths)
 			}
 		})

--- a/pkg/server/server_handlefsmmessage_test.go
+++ b/pkg/server/server_handlefsmmessage_test.go
@@ -208,6 +208,377 @@ func TestSoftResetOutSerializesNormalReset(t *testing.T) {
 	}
 }
 
+func TestSoftResetOutRefreshesExportPolicyFilteredRoutes(t *testing.T) {
+	ctx := context.Background()
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(ctx, &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+
+	peerAddr := netip.MustParseAddr("10.0.0.1")
+	p := newPeerandInfo(t, 65001, 65002, peerAddr.String(), s.globalRib)
+	p.policy = s.policy
+	p.fsm.state.Store(bgp.BGP_FSM_ESTABLISHED)
+	p.fsm.familyMap.Store(map[bgp.Family]bgp.BGPAddPathMode{
+		bgp.RF_IPv4_UC: bgp.BGP_ADD_PATH_NONE,
+	})
+	err = s.mgmtOperation(func() error {
+		s.neighborMap[peerAddr] = p
+		return nil
+	}, true)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := s.mgmtOperation(func() error {
+			delete(s.neighborMap, peerAddr)
+			return nil
+		}, false)
+		require.NoError(t, err)
+		cleanInfiniteChannel(p.fsm.outgoingCh)
+		require.NoError(t, s.StopBgp(ctx, &api.StopBgpRequest{}))
+	})
+
+	setExportDefault := func(action api.RouteAction) {
+		t.Helper()
+		err := s.SetPolicyAssignment(ctx, &api.SetPolicyAssignmentRequest{
+			Assignment: &api.PolicyAssignment{
+				Name:          table.GLOBAL_RIB_NAME,
+				Direction:     api.PolicyDirection_POLICY_DIRECTION_EXPORT,
+				DefaultAction: action,
+			},
+		})
+		require.NoError(t, err)
+	}
+	requireNoOutgoing := func() {
+		t.Helper()
+		select {
+		case o := <-p.fsm.outgoingCh.Out():
+			t.Fatalf("unexpected outbound paths: %#v", o)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	requireOutgoing := func() []*table.Path {
+		t.Helper()
+		select {
+		case o := <-p.fsm.outgoingCh.Out():
+			msg, ok := o.(*fsmOutgoingMsg)
+			require.True(t, ok)
+			paths := make([]*table.Path, 0, len(msg.Paths))
+			for _, path := range msg.Paths {
+				if path != nil && !path.IsEOR() {
+					paths = append(paths, path)
+				}
+			}
+			return paths
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for outbound soft-reset paths")
+			return nil
+		}
+	}
+	requirePaths := func(paths []*table.Path, withdraw bool, prefixes ...string) {
+		t.Helper()
+		require.Len(t, paths, len(prefixes))
+		seen := make(map[string]struct{}, len(paths))
+		for _, path := range paths {
+			require.Equal(t, withdraw, path.IsWithdraw)
+			seen[path.GetPrefix()] = struct{}{}
+		}
+		for _, prefix := range prefixes {
+			require.Contains(t, seen, prefix)
+		}
+	}
+
+	advertised := makePath(t, "192.0.2.0/32", "192.0.2.254", 0)
+	neverAdvertised := makePath(t, "192.0.2.1/32", "192.0.2.254", 0)
+
+	setExportDefault(api.RouteAction_ROUTE_ACTION_ACCEPT)
+	s.propagateUpdate(nil, []*table.Path{advertised})
+	requirePaths(requireOutgoing(), false, "192.0.2.0/32")
+
+	setExportDefault(api.RouteAction_ROUTE_ACTION_REJECT)
+	s.propagateUpdate(nil, []*table.Path{neverAdvertised})
+	requireNoOutgoing()
+
+	require.NoError(t, s.softResetOut(peerAddr.String(), bgp.RF_IPv4_UC, false))
+	requirePaths(requireOutgoing(), true, "192.0.2.0/32")
+
+	require.NoError(t, s.softResetOut(peerAddr.String(), bgp.RF_IPv4_UC, false))
+	requireNoOutgoing()
+
+	setExportDefault(api.RouteAction_ROUTE_ACTION_ACCEPT)
+	require.NoError(t, s.softResetOut(peerAddr.String(), bgp.RF_IPv4_UC, false))
+	requirePaths(requireOutgoing(), false, "192.0.2.0/32", "192.0.2.1/32")
+
+	setExportDefault(api.RouteAction_ROUTE_ACTION_REJECT)
+	require.NoError(t, s.softResetOut(peerAddr.String(), bgp.RF_IPv4_UC, false))
+	requirePaths(requireOutgoing(), true, "192.0.2.0/32", "192.0.2.1/32")
+}
+
+func TestSoftResetOutVRFWithdrawsExportPolicyFilteredRoutes(t *testing.T) {
+	ctx := context.Background()
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(ctx, &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	addVrf(t, s, "vrf1", "65001:100", []string{"65001:100"}, []string{"65001:100"}, 1)
+
+	peerAddr := netip.MustParseAddr("10.0.0.1")
+	p := newPeerandInfo(t, 65001, 65002, peerAddr.String(), s.globalRib)
+	p.policy = s.policy
+	p.fsm.state.Store(bgp.BGP_FSM_ESTABLISHED)
+	p.fsm.familyMap.Store(map[bgp.Family]bgp.BGPAddPathMode{
+		bgp.RF_IPv4_UC: bgp.BGP_ADD_PATH_NONE,
+	})
+	p.fsm.lock.Lock()
+	conf := p.fsm.pConf.ReadCopy()
+	conf.Config.Vrf = "vrf1"
+	conf.State.Vrf = "vrf1"
+	p.fsm.pConf.Update(&conf)
+	p.fsm.lock.Unlock()
+	err = s.mgmtOperation(func() error {
+		s.neighborMap[peerAddr] = p
+		return nil
+	}, true)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := s.mgmtOperation(func() error {
+			delete(s.neighborMap, peerAddr)
+			return nil
+		}, false)
+		require.NoError(t, err)
+		cleanInfiniteChannel(p.fsm.outgoingCh)
+		require.NoError(t, s.StopBgp(ctx, &api.StopBgpRequest{}))
+	})
+
+	setExportDefault := func(action api.RouteAction) {
+		t.Helper()
+		err := s.SetPolicyAssignment(ctx, &api.SetPolicyAssignmentRequest{
+			Assignment: &api.PolicyAssignment{
+				Name:          table.GLOBAL_RIB_NAME,
+				Direction:     api.PolicyDirection_POLICY_DIRECTION_EXPORT,
+				DefaultAction: action,
+			},
+		})
+		require.NoError(t, err)
+	}
+	requireNoOutgoing := func() {
+		t.Helper()
+		select {
+		case o := <-p.fsm.outgoingCh.Out():
+			t.Fatalf("unexpected outbound paths: %#v", o)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	requireOutgoing := func() []*table.Path {
+		t.Helper()
+		select {
+		case o := <-p.fsm.outgoingCh.Out():
+			msg, ok := o.(*fsmOutgoingMsg)
+			require.True(t, ok)
+			paths := make([]*table.Path, 0, len(msg.Paths))
+			for _, path := range msg.Paths {
+				if path != nil && !path.IsEOR() {
+					paths = append(paths, path)
+				}
+			}
+			return paths
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for outbound VRF soft-reset paths")
+			return nil
+		}
+	}
+	makeVPNPath := func(prefix string) *table.Path {
+		t.Helper()
+		rd, rt, err := parseRDRT("65001:100")
+		require.NoError(t, err)
+		labels := bgp.NewMPLSLabelStack(100)
+		nlri, err := bgp.NewLabeledVPNIPAddrPrefix(netip.MustParsePrefix(prefix), *labels, rd)
+		require.NoError(t, err)
+		nextHop, err := bgp.NewPathAttributeNextHop(netip.MustParseAddr("192.0.2.254"))
+		require.NoError(t, err)
+		return table.NewPath(bgp.RF_IPv4_VPN, nil, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{
+			bgp.NewPathAttributeOrigin(0),
+			bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{
+				bgp.NewAs4PathParam(2, []uint32{65010}),
+			}),
+			nextHop,
+			bgp.NewPathAttributeExtendedCommunities([]bgp.ExtendedCommunityInterface{rt}),
+		}, time.Now(), false)
+	}
+
+	advertised := makeVPNPath("192.0.2.0/32")
+
+	setExportDefault(api.RouteAction_ROUTE_ACTION_ACCEPT)
+	s.propagateUpdate(nil, []*table.Path{advertised})
+	paths := requireOutgoing()
+	require.Len(t, paths, 1)
+	require.False(t, paths[0].IsWithdraw)
+	require.Equal(t, bgp.RF_IPv4_UC, paths[0].GetFamily())
+	require.Equal(t, "192.0.2.0/32", paths[0].GetPrefix())
+
+	setExportDefault(api.RouteAction_ROUTE_ACTION_REJECT)
+	require.NoError(t, s.softResetOut(peerAddr.String(), bgp.RF_IPv4_UC, false))
+	paths = requireOutgoing()
+	require.Len(t, paths, 1)
+	require.True(t, paths[0].IsWithdraw)
+	require.Equal(t, bgp.RF_IPv4_UC, paths[0].GetFamily())
+	require.Equal(t, "192.0.2.0/32", paths[0].GetPrefix())
+
+	require.NoError(t, s.softResetOut(peerAddr.String(), bgp.RF_IPv4_UC, false))
+	requireNoOutgoing()
+}
+
+func TestSoftResetOutAddPathWithdrawsOnlyAdvertisedFilteredRoutes(t *testing.T) {
+	ctx := context.Background()
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(ctx, &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+
+	peerAddr := netip.MustParseAddr("10.0.0.1")
+	p := newPeerandInfo(t, 65001, 65002, peerAddr.String(), s.globalRib)
+	p.policy = s.policy
+	p.fsm.state.Store(bgp.BGP_FSM_ESTABLISHED)
+	p.fsm.familyMap.Store(map[bgp.Family]bgp.BGPAddPathMode{
+		bgp.RF_IPv4_UC: bgp.BGP_ADD_PATH_SEND,
+	})
+	p.fsm.lock.Lock()
+	conf := p.fsm.pConf.ReadCopy()
+	foundFamily := false
+	for i := range conf.AfiSafis {
+		if conf.AfiSafis[i].State.Family != bgp.RF_IPv4_UC {
+			continue
+		}
+		conf.AfiSafis[i].AddPaths.Config.SendMax = 1
+		conf.AfiSafis[i].AddPaths.State.SendMax = 1
+		foundFamily = true
+	}
+	p.fsm.pConf.Update(&conf)
+	p.fsm.lock.Unlock()
+	require.True(t, foundFamily)
+
+	err = s.mgmtOperation(func() error {
+		s.neighborMap[peerAddr] = p
+		return nil
+	}, true)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := s.mgmtOperation(func() error {
+			delete(s.neighborMap, peerAddr)
+			return nil
+		}, false)
+		require.NoError(t, err)
+		cleanInfiniteChannel(p.fsm.outgoingCh)
+		require.NoError(t, s.StopBgp(ctx, &api.StopBgpRequest{}))
+	})
+
+	makeSourcePath := func(source string) *table.Path {
+		t.Helper()
+		nlri, err := bgp.NewIPAddrPrefix(netip.MustParsePrefix("192.0.2.0/32"))
+		require.NoError(t, err)
+		nextHop, err := bgp.NewPathAttributeNextHop(netip.MustParseAddr("192.0.2.254"))
+		require.NoError(t, err)
+		sourceAddr := netip.MustParseAddr(source)
+		return table.NewPath(bgp.RF_IPv4_UC, &table.PeerInfo{
+			AS:           65010,
+			ID:           sourceAddr,
+			Address:      sourceAddr,
+			LocalAS:      65001,
+			LocalID:      netip.MustParseAddr("1.1.1.1"),
+			LocalAddress: netip.MustParseAddr("1.1.1.1"),
+		}, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{
+			bgp.NewPathAttributeOrigin(0),
+			bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{
+				bgp.NewAs4PathParam(2, []uint32{65010}),
+			}),
+			nextHop,
+		}, time.Now(), false)
+	}
+	requireNoOutgoing := func() {
+		t.Helper()
+		select {
+		case o := <-p.fsm.outgoingCh.Out():
+			t.Fatalf("unexpected outbound paths: %#v", o)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	requireOutgoing := func() []*table.Path {
+		t.Helper()
+		select {
+		case o := <-p.fsm.outgoingCh.Out():
+			msg, ok := o.(*fsmOutgoingMsg)
+			require.True(t, ok)
+			paths := make([]*table.Path, 0, len(msg.Paths))
+			for _, path := range msg.Paths {
+				if path != nil && !path.IsEOR() {
+					paths = append(paths, path)
+				}
+			}
+			return paths
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for outbound add-path soft-reset paths")
+			return nil
+		}
+	}
+	setExportDefault := func(action api.RouteAction) {
+		t.Helper()
+		err := s.SetPolicyAssignment(ctx, &api.SetPolicyAssignmentRequest{
+			Assignment: &api.PolicyAssignment{
+				Name:          table.GLOBAL_RIB_NAME,
+				Direction:     api.PolicyDirection_POLICY_DIRECTION_EXPORT,
+				DefaultAction: action,
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	advertised := makeSourcePath("10.0.0.2")
+	neverAdvertised := makeSourcePath("10.0.0.3")
+
+	setExportDefault(api.RouteAction_ROUTE_ACTION_ACCEPT)
+	s.propagateUpdate(nil, []*table.Path{advertised})
+	paths := requireOutgoing()
+	require.Len(t, paths, 1)
+	require.False(t, paths[0].IsWithdraw)
+	require.Equal(t, advertised.LocalID(), paths[0].LocalID())
+
+	s.propagateUpdate(nil, []*table.Path{neverAdvertised})
+	require.NotEqual(t, advertised.LocalID(), neverAdvertised.LocalID())
+	requireNoOutgoing()
+
+	setExportDefault(api.RouteAction_ROUTE_ACTION_REJECT)
+	require.NoError(t, s.softResetOut(peerAddr.String(), bgp.RF_IPv4_UC, false))
+	paths = requireOutgoing()
+	require.Len(t, paths, 1)
+	require.True(t, paths[0].IsWithdraw)
+	require.Equal(t, "192.0.2.0/32", paths[0].GetPrefix())
+	require.Equal(t, advertised.LocalID(), paths[0].LocalID())
+	require.NotEqual(t, neverAdvertised.LocalID(), paths[0].LocalID())
+
+	require.NoError(t, s.softResetOut(peerAddr.String(), bgp.RF_IPv4_UC, false))
+	requireNoOutgoing()
+}
+
 func TestRTCMembershipSerializesTriggeredVPNUpdates(t *testing.T) {
 	s := NewBgpServer()
 	go s.Serve()


### PR DESCRIPTION
When an export policy change causes a previously advertised path to be filtered, soft reset out must send an explicit withdrawal, otherwise the neighbor can keep using stale routes.

Track advertised paths for all peers so that soft reset can distinguish routes that were actually sent from routes that were already filtered.

For VRF peers, normalize filtered VPN candidates to the local unicast form before checking advertised state, matching the path key used when the route was originally sent.

Add regression coverage for regular, add-path, and VRF soft-reset withdrawals.