### PR TITLE
server: use sync.Map.Clear() in resetAdvertisedRoutes

### DIFF
--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -329,14 +329,8 @@ func (peer *peer) hasPathAlreadyBeenSent(path *table.Path) bool {
 }
 
 func (peer *peer) resetAdvertisedRoutes() {
-	peer.sentPaths.Range(func(key, _ any) bool {
-		peer.sentPaths.Delete(key)
-		return true
-	})
-	peer.sendMaxPathFiltered.Range(func(key, _ any) bool {
-		peer.sendMaxPathFiltered.Delete(key)
-		return true
-	})
+	peer.sentPaths.Clear()
+	peer.sendMaxPathFiltered.Clear()
 }
 
 func (peer *peer) isDynamicNeighbor() bool {


### PR DESCRIPTION
sync.Map.Clear() was added in Go 1.23 and go.mod requires Go 1.24.5, so the Range+Delete pattern is no longer necessary.