### PR TITLE
table: cache NLRI string in originInfo to avoid repeated allocations

### DIFF
--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -88,6 +88,7 @@ func NewBitmap(size int) *Bitmap {
 
 type originInfo struct {
 	nlri               bgp.NLRI
+	nlriString         string
 	source             *PeerInfo
 	timestamp          int64
 	noImplicitWithdraw bool
@@ -183,9 +184,14 @@ func NewPath(family bgp.Family, source *PeerInfo, pathnlri bgp.PathNLRI, isWithd
 	if !isWithdraw && pattrs == nil {
 		return nil
 	}
+	nlriString := ""
+	if pathnlri.NLRI != nil {
+		nlriString = pathnlri.NLRI.String()
+	}
 	return &Path{
 		info: &originInfo{
 			nlri:               pathnlri.NLRI,
+			nlriString:         nlriString,
 			source:             source,
 			timestamp:          timestamp.Unix(),
 			noImplicitWithdraw: noImplicitWithdraw,
@@ -623,7 +629,7 @@ func (path *Path) GetLocalKey() PathLocalKey {
 func (path *Path) GetDestLocalKey() PathDestLocalKey {
 	return PathDestLocalKey{
 		Family: path.GetFamily(),
-		Prefix: path.GetNlri().String(),
+		Prefix: path.OriginInfo().nlriString,
 	}
 }
 


### PR DESCRIPTION
GetDestLocalKey() called nlri.String() on every invocation, allocating a new string each time. Since originInfo is shared across all clones of a path, computing the string once at NewPath() and storing it in originInfo amortizes the cost across all callers with no additional memory overhead: the bytes already live in sentPaths map keys, so the cached field merely adds a pointer to the same underlying data.