### PR TITLE
Implement RFC 8654 Extended Message Support for BGP

### DIFF
--- a/api/capability.pb.go
+++ b/api/capability.pb.go
@@ -91,7 +91,7 @@ func (x AddPathCapabilityTuple_Mode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AddPathCapabilityTuple_Mode.Descriptor instead.
 func (AddPathCapabilityTuple_Mode) EnumDescriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{9, 0}
+	return file_api_capability_proto_rawDescGZIP(), []int{10, 0}
 }
 
 type Capability struct {
@@ -111,6 +111,7 @@ type Capability struct {
 	//	*Capability_RouteRefreshCisco
 	//	*Capability_Fqdn
 	//	*Capability_SoftwareVersion
+	//	*Capability_ExtendedMessage
 	Cap           isCapability_Cap `protobuf_oneof:"cap"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -270,6 +271,15 @@ func (x *Capability) GetSoftwareVersion() *SoftwareVersionCapability {
 	return nil
 }
 
+func (x *Capability) GetExtendedMessage() *ExtendedMessageCapability {
+	if x != nil {
+		if x, ok := x.Cap.(*Capability_ExtendedMessage); ok {
+			return x.ExtendedMessage
+		}
+	}
+	return nil
+}
+
 type isCapability_Cap interface {
 	isCapability_Cap()
 }
@@ -326,6 +336,10 @@ type Capability_SoftwareVersion struct {
 	SoftwareVersion *SoftwareVersionCapability `protobuf:"bytes,13,opt,name=software_version,json=softwareVersion,proto3,oneof"`
 }
 
+type Capability_ExtendedMessage struct {
+	ExtendedMessage *ExtendedMessageCapability `protobuf:"bytes,14,opt,name=extended_message,json=extendedMessage,proto3,oneof"`
+}
+
 func (*Capability_Unknown) isCapability_Cap() {}
 
 func (*Capability_MultiProtocol) isCapability_Cap() {}
@@ -351,6 +365,8 @@ func (*Capability_RouteRefreshCisco) isCapability_Cap() {}
 func (*Capability_Fqdn) isCapability_Cap() {}
 
 func (*Capability_SoftwareVersion) isCapability_Cap() {}
+
+func (*Capability_ExtendedMessage) isCapability_Cap() {}
 
 type MultiProtocolCapability struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -432,6 +448,46 @@ func (*RouteRefreshCapability) Descriptor() ([]byte, []int) {
 	return file_api_capability_proto_rawDescGZIP(), []int{2}
 }
 
+// ExtendedMessageCapability mirrors the empty TLV for the BGP
+// Extended Message Capability (Capability Code 6, Capability Length 0)
+// defined by RFC 8654. The presence of this oneof on a Capability
+// signals that the peer advertised it; there is no payload.
+type ExtendedMessageCapability struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExtendedMessageCapability) Reset() {
+	*x = ExtendedMessageCapability{}
+	mi := &file_api_capability_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExtendedMessageCapability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExtendedMessageCapability) ProtoMessage() {}
+
+func (x *ExtendedMessageCapability) ProtoReflect() protoreflect.Message {
+	mi := &file_api_capability_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExtendedMessageCapability.ProtoReflect.Descriptor instead.
+func (*ExtendedMessageCapability) Descriptor() ([]byte, []int) {
+	return file_api_capability_proto_rawDescGZIP(), []int{3}
+}
+
 type CarryingLabelInfoCapability struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -440,7 +496,7 @@ type CarryingLabelInfoCapability struct {
 
 func (x *CarryingLabelInfoCapability) Reset() {
 	*x = CarryingLabelInfoCapability{}
-	mi := &file_api_capability_proto_msgTypes[3]
+	mi := &file_api_capability_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -452,7 +508,7 @@ func (x *CarryingLabelInfoCapability) String() string {
 func (*CarryingLabelInfoCapability) ProtoMessage() {}
 
 func (x *CarryingLabelInfoCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[3]
+	mi := &file_api_capability_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -465,7 +521,7 @@ func (x *CarryingLabelInfoCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CarryingLabelInfoCapability.ProtoReflect.Descriptor instead.
 func (*CarryingLabelInfoCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{3}
+	return file_api_capability_proto_rawDescGZIP(), []int{4}
 }
 
 type ExtendedNexthopCapabilityTuple struct {
@@ -481,7 +537,7 @@ type ExtendedNexthopCapabilityTuple struct {
 
 func (x *ExtendedNexthopCapabilityTuple) Reset() {
 	*x = ExtendedNexthopCapabilityTuple{}
-	mi := &file_api_capability_proto_msgTypes[4]
+	mi := &file_api_capability_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -493,7 +549,7 @@ func (x *ExtendedNexthopCapabilityTuple) String() string {
 func (*ExtendedNexthopCapabilityTuple) ProtoMessage() {}
 
 func (x *ExtendedNexthopCapabilityTuple) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[4]
+	mi := &file_api_capability_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -506,7 +562,7 @@ func (x *ExtendedNexthopCapabilityTuple) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtendedNexthopCapabilityTuple.ProtoReflect.Descriptor instead.
 func (*ExtendedNexthopCapabilityTuple) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{4}
+	return file_api_capability_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ExtendedNexthopCapabilityTuple) GetNlriFamily() *Family {
@@ -532,7 +588,7 @@ type ExtendedNexthopCapability struct {
 
 func (x *ExtendedNexthopCapability) Reset() {
 	*x = ExtendedNexthopCapability{}
-	mi := &file_api_capability_proto_msgTypes[5]
+	mi := &file_api_capability_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -544,7 +600,7 @@ func (x *ExtendedNexthopCapability) String() string {
 func (*ExtendedNexthopCapability) ProtoMessage() {}
 
 func (x *ExtendedNexthopCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[5]
+	mi := &file_api_capability_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -557,7 +613,7 @@ func (x *ExtendedNexthopCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtendedNexthopCapability.ProtoReflect.Descriptor instead.
 func (*ExtendedNexthopCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{5}
+	return file_api_capability_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ExtendedNexthopCapability) GetTuples() []*ExtendedNexthopCapabilityTuple {
@@ -577,7 +633,7 @@ type GracefulRestartCapabilityTuple struct {
 
 func (x *GracefulRestartCapabilityTuple) Reset() {
 	*x = GracefulRestartCapabilityTuple{}
-	mi := &file_api_capability_proto_msgTypes[6]
+	mi := &file_api_capability_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -589,7 +645,7 @@ func (x *GracefulRestartCapabilityTuple) String() string {
 func (*GracefulRestartCapabilityTuple) ProtoMessage() {}
 
 func (x *GracefulRestartCapabilityTuple) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[6]
+	mi := &file_api_capability_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -602,7 +658,7 @@ func (x *GracefulRestartCapabilityTuple) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GracefulRestartCapabilityTuple.ProtoReflect.Descriptor instead.
 func (*GracefulRestartCapabilityTuple) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{6}
+	return file_api_capability_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GracefulRestartCapabilityTuple) GetFamily() *Family {
@@ -630,7 +686,7 @@ type GracefulRestartCapability struct {
 
 func (x *GracefulRestartCapability) Reset() {
 	*x = GracefulRestartCapability{}
-	mi := &file_api_capability_proto_msgTypes[7]
+	mi := &file_api_capability_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -642,7 +698,7 @@ func (x *GracefulRestartCapability) String() string {
 func (*GracefulRestartCapability) ProtoMessage() {}
 
 func (x *GracefulRestartCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[7]
+	mi := &file_api_capability_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -655,7 +711,7 @@ func (x *GracefulRestartCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GracefulRestartCapability.ProtoReflect.Descriptor instead.
 func (*GracefulRestartCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{7}
+	return file_api_capability_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GracefulRestartCapability) GetFlags() uint32 {
@@ -688,7 +744,7 @@ type FourOctetASNCapability struct {
 
 func (x *FourOctetASNCapability) Reset() {
 	*x = FourOctetASNCapability{}
-	mi := &file_api_capability_proto_msgTypes[8]
+	mi := &file_api_capability_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -700,7 +756,7 @@ func (x *FourOctetASNCapability) String() string {
 func (*FourOctetASNCapability) ProtoMessage() {}
 
 func (x *FourOctetASNCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[8]
+	mi := &file_api_capability_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -713,7 +769,7 @@ func (x *FourOctetASNCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FourOctetASNCapability.ProtoReflect.Descriptor instead.
 func (*FourOctetASNCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{8}
+	return file_api_capability_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *FourOctetASNCapability) GetAsn() uint32 {
@@ -733,7 +789,7 @@ type AddPathCapabilityTuple struct {
 
 func (x *AddPathCapabilityTuple) Reset() {
 	*x = AddPathCapabilityTuple{}
-	mi := &file_api_capability_proto_msgTypes[9]
+	mi := &file_api_capability_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -745,7 +801,7 @@ func (x *AddPathCapabilityTuple) String() string {
 func (*AddPathCapabilityTuple) ProtoMessage() {}
 
 func (x *AddPathCapabilityTuple) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[9]
+	mi := &file_api_capability_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -758,7 +814,7 @@ func (x *AddPathCapabilityTuple) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddPathCapabilityTuple.ProtoReflect.Descriptor instead.
 func (*AddPathCapabilityTuple) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{9}
+	return file_api_capability_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *AddPathCapabilityTuple) GetFamily() *Family {
@@ -784,7 +840,7 @@ type AddPathCapability struct {
 
 func (x *AddPathCapability) Reset() {
 	*x = AddPathCapability{}
-	mi := &file_api_capability_proto_msgTypes[10]
+	mi := &file_api_capability_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -796,7 +852,7 @@ func (x *AddPathCapability) String() string {
 func (*AddPathCapability) ProtoMessage() {}
 
 func (x *AddPathCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[10]
+	mi := &file_api_capability_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -809,7 +865,7 @@ func (x *AddPathCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddPathCapability.ProtoReflect.Descriptor instead.
 func (*AddPathCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{10}
+	return file_api_capability_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *AddPathCapability) GetTuples() []*AddPathCapabilityTuple {
@@ -827,7 +883,7 @@ type EnhancedRouteRefreshCapability struct {
 
 func (x *EnhancedRouteRefreshCapability) Reset() {
 	*x = EnhancedRouteRefreshCapability{}
-	mi := &file_api_capability_proto_msgTypes[11]
+	mi := &file_api_capability_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -839,7 +895,7 @@ func (x *EnhancedRouteRefreshCapability) String() string {
 func (*EnhancedRouteRefreshCapability) ProtoMessage() {}
 
 func (x *EnhancedRouteRefreshCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[11]
+	mi := &file_api_capability_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -852,7 +908,7 @@ func (x *EnhancedRouteRefreshCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnhancedRouteRefreshCapability.ProtoReflect.Descriptor instead.
 func (*EnhancedRouteRefreshCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{11}
+	return file_api_capability_proto_rawDescGZIP(), []int{12}
 }
 
 type LongLivedGracefulRestartCapabilityTuple struct {
@@ -866,7 +922,7 @@ type LongLivedGracefulRestartCapabilityTuple struct {
 
 func (x *LongLivedGracefulRestartCapabilityTuple) Reset() {
 	*x = LongLivedGracefulRestartCapabilityTuple{}
-	mi := &file_api_capability_proto_msgTypes[12]
+	mi := &file_api_capability_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -878,7 +934,7 @@ func (x *LongLivedGracefulRestartCapabilityTuple) String() string {
 func (*LongLivedGracefulRestartCapabilityTuple) ProtoMessage() {}
 
 func (x *LongLivedGracefulRestartCapabilityTuple) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[12]
+	mi := &file_api_capability_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -891,7 +947,7 @@ func (x *LongLivedGracefulRestartCapabilityTuple) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use LongLivedGracefulRestartCapabilityTuple.ProtoReflect.Descriptor instead.
 func (*LongLivedGracefulRestartCapabilityTuple) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{12}
+	return file_api_capability_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *LongLivedGracefulRestartCapabilityTuple) GetFamily() *Family {
@@ -924,7 +980,7 @@ type LongLivedGracefulRestartCapability struct {
 
 func (x *LongLivedGracefulRestartCapability) Reset() {
 	*x = LongLivedGracefulRestartCapability{}
-	mi := &file_api_capability_proto_msgTypes[13]
+	mi := &file_api_capability_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -936,7 +992,7 @@ func (x *LongLivedGracefulRestartCapability) String() string {
 func (*LongLivedGracefulRestartCapability) ProtoMessage() {}
 
 func (x *LongLivedGracefulRestartCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[13]
+	mi := &file_api_capability_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -949,7 +1005,7 @@ func (x *LongLivedGracefulRestartCapability) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use LongLivedGracefulRestartCapability.ProtoReflect.Descriptor instead.
 func (*LongLivedGracefulRestartCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{13}
+	return file_api_capability_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *LongLivedGracefulRestartCapability) GetTuples() []*LongLivedGracefulRestartCapabilityTuple {
@@ -967,7 +1023,7 @@ type RouteRefreshCiscoCapability struct {
 
 func (x *RouteRefreshCiscoCapability) Reset() {
 	*x = RouteRefreshCiscoCapability{}
-	mi := &file_api_capability_proto_msgTypes[14]
+	mi := &file_api_capability_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -979,7 +1035,7 @@ func (x *RouteRefreshCiscoCapability) String() string {
 func (*RouteRefreshCiscoCapability) ProtoMessage() {}
 
 func (x *RouteRefreshCiscoCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[14]
+	mi := &file_api_capability_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -992,7 +1048,7 @@ func (x *RouteRefreshCiscoCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteRefreshCiscoCapability.ProtoReflect.Descriptor instead.
 func (*RouteRefreshCiscoCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{14}
+	return file_api_capability_proto_rawDescGZIP(), []int{15}
 }
 
 type FqdnCapability struct {
@@ -1005,7 +1061,7 @@ type FqdnCapability struct {
 
 func (x *FqdnCapability) Reset() {
 	*x = FqdnCapability{}
-	mi := &file_api_capability_proto_msgTypes[15]
+	mi := &file_api_capability_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1017,7 +1073,7 @@ func (x *FqdnCapability) String() string {
 func (*FqdnCapability) ProtoMessage() {}
 
 func (x *FqdnCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[15]
+	mi := &file_api_capability_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1030,7 +1086,7 @@ func (x *FqdnCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FqdnCapability.ProtoReflect.Descriptor instead.
 func (*FqdnCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{15}
+	return file_api_capability_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *FqdnCapability) GetHostName() string {
@@ -1056,7 +1112,7 @@ type SoftwareVersionCapability struct {
 
 func (x *SoftwareVersionCapability) Reset() {
 	*x = SoftwareVersionCapability{}
-	mi := &file_api_capability_proto_msgTypes[16]
+	mi := &file_api_capability_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1068,7 +1124,7 @@ func (x *SoftwareVersionCapability) String() string {
 func (*SoftwareVersionCapability) ProtoMessage() {}
 
 func (x *SoftwareVersionCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[16]
+	mi := &file_api_capability_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1081,7 +1137,7 @@ func (x *SoftwareVersionCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SoftwareVersionCapability.ProtoReflect.Descriptor instead.
 func (*SoftwareVersionCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{16}
+	return file_api_capability_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SoftwareVersionCapability) GetSoftwareVersion() string {
@@ -1101,7 +1157,7 @@ type UnknownCapability struct {
 
 func (x *UnknownCapability) Reset() {
 	*x = UnknownCapability{}
-	mi := &file_api_capability_proto_msgTypes[17]
+	mi := &file_api_capability_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1113,7 +1169,7 @@ func (x *UnknownCapability) String() string {
 func (*UnknownCapability) ProtoMessage() {}
 
 func (x *UnknownCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[17]
+	mi := &file_api_capability_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1126,7 +1182,7 @@ func (x *UnknownCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnknownCapability.ProtoReflect.Descriptor instead.
 func (*UnknownCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{17}
+	return file_api_capability_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *UnknownCapability) GetCode() uint32 {
@@ -1147,7 +1203,7 @@ var File_api_capability_proto protoreflect.FileDescriptor
 
 const file_api_capability_proto_rawDesc = "" +
 	"\n" +
-	"\x14api/capability.proto\x12\x03api\x1a\x10api/common.proto\"\xcd\a\n" +
+	"\x14api/capability.proto\x12\x03api\x1a\x10api/common.proto\"\x9a\b\n" +
 	"\n" +
 	"Capability\x122\n" +
 	"\aunknown\x18\x01 \x01(\v2\x16.api.UnknownCapabilityH\x00R\aunknown\x12E\n" +
@@ -1163,11 +1219,13 @@ const file_api_capability_proto_rawDesc = "" +
 	" \x01(\v2'.api.LongLivedGracefulRestartCapabilityH\x00R\x18longLivedGracefulRestart\x12R\n" +
 	"\x13route_refresh_cisco\x18\v \x01(\v2 .api.RouteRefreshCiscoCapabilityH\x00R\x11routeRefreshCisco\x12)\n" +
 	"\x04fqdn\x18\f \x01(\v2\x13.api.FqdnCapabilityH\x00R\x04fqdn\x12K\n" +
-	"\x10software_version\x18\r \x01(\v2\x1e.api.SoftwareVersionCapabilityH\x00R\x0fsoftwareVersionB\x05\n" +
+	"\x10software_version\x18\r \x01(\v2\x1e.api.SoftwareVersionCapabilityH\x00R\x0fsoftwareVersion\x12K\n" +
+	"\x10extended_message\x18\x0e \x01(\v2\x1e.api.ExtendedMessageCapabilityH\x00R\x0fextendedMessageB\x05\n" +
 	"\x03cap\">\n" +
 	"\x17MultiProtocolCapability\x12#\n" +
 	"\x06family\x18\x01 \x01(\v2\v.api.FamilyR\x06family\"\x18\n" +
-	"\x16RouteRefreshCapability\"\x1d\n" +
+	"\x16RouteRefreshCapability\"\x1b\n" +
+	"\x19ExtendedMessageCapability\"\x1d\n" +
 	"\x1bCarryingLabelInfoCapability\"\x82\x01\n" +
 	"\x1eExtendedNexthopCapabilityTuple\x12,\n" +
 	"\vnlri_family\x18\x01 \x01(\v2\v.api.FamilyR\n" +
@@ -1225,59 +1283,61 @@ func file_api_capability_proto_rawDescGZIP() []byte {
 }
 
 var file_api_capability_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_api_capability_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_api_capability_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_api_capability_proto_goTypes = []any{
 	(AddPathCapabilityTuple_Mode)(0),                // 0: api.AddPathCapabilityTuple.Mode
 	(*Capability)(nil),                              // 1: api.Capability
 	(*MultiProtocolCapability)(nil),                 // 2: api.MultiProtocolCapability
 	(*RouteRefreshCapability)(nil),                  // 3: api.RouteRefreshCapability
-	(*CarryingLabelInfoCapability)(nil),             // 4: api.CarryingLabelInfoCapability
-	(*ExtendedNexthopCapabilityTuple)(nil),          // 5: api.ExtendedNexthopCapabilityTuple
-	(*ExtendedNexthopCapability)(nil),               // 6: api.ExtendedNexthopCapability
-	(*GracefulRestartCapabilityTuple)(nil),          // 7: api.GracefulRestartCapabilityTuple
-	(*GracefulRestartCapability)(nil),               // 8: api.GracefulRestartCapability
-	(*FourOctetASNCapability)(nil),                  // 9: api.FourOctetASNCapability
-	(*AddPathCapabilityTuple)(nil),                  // 10: api.AddPathCapabilityTuple
-	(*AddPathCapability)(nil),                       // 11: api.AddPathCapability
-	(*EnhancedRouteRefreshCapability)(nil),          // 12: api.EnhancedRouteRefreshCapability
-	(*LongLivedGracefulRestartCapabilityTuple)(nil), // 13: api.LongLivedGracefulRestartCapabilityTuple
-	(*LongLivedGracefulRestartCapability)(nil),      // 14: api.LongLivedGracefulRestartCapability
-	(*RouteRefreshCiscoCapability)(nil),             // 15: api.RouteRefreshCiscoCapability
-	(*FqdnCapability)(nil),                          // 16: api.FqdnCapability
-	(*SoftwareVersionCapability)(nil),               // 17: api.SoftwareVersionCapability
-	(*UnknownCapability)(nil),                       // 18: api.UnknownCapability
-	(*Family)(nil),                                  // 19: api.Family
+	(*ExtendedMessageCapability)(nil),               // 4: api.ExtendedMessageCapability
+	(*CarryingLabelInfoCapability)(nil),             // 5: api.CarryingLabelInfoCapability
+	(*ExtendedNexthopCapabilityTuple)(nil),          // 6: api.ExtendedNexthopCapabilityTuple
+	(*ExtendedNexthopCapability)(nil),               // 7: api.ExtendedNexthopCapability
+	(*GracefulRestartCapabilityTuple)(nil),          // 8: api.GracefulRestartCapabilityTuple
+	(*GracefulRestartCapability)(nil),               // 9: api.GracefulRestartCapability
+	(*FourOctetASNCapability)(nil),                  // 10: api.FourOctetASNCapability
+	(*AddPathCapabilityTuple)(nil),                  // 11: api.AddPathCapabilityTuple
+	(*AddPathCapability)(nil),                       // 12: api.AddPathCapability
+	(*EnhancedRouteRefreshCapability)(nil),          // 13: api.EnhancedRouteRefreshCapability
+	(*LongLivedGracefulRestartCapabilityTuple)(nil), // 14: api.LongLivedGracefulRestartCapabilityTuple
+	(*LongLivedGracefulRestartCapability)(nil),      // 15: api.LongLivedGracefulRestartCapability
+	(*RouteRefreshCiscoCapability)(nil),             // 16: api.RouteRefreshCiscoCapability
+	(*FqdnCapability)(nil),                          // 17: api.FqdnCapability
+	(*SoftwareVersionCapability)(nil),               // 18: api.SoftwareVersionCapability
+	(*UnknownCapability)(nil),                       // 19: api.UnknownCapability
+	(*Family)(nil),                                  // 20: api.Family
 }
 var file_api_capability_proto_depIdxs = []int32{
-	18, // 0: api.Capability.unknown:type_name -> api.UnknownCapability
+	19, // 0: api.Capability.unknown:type_name -> api.UnknownCapability
 	2,  // 1: api.Capability.multi_protocol:type_name -> api.MultiProtocolCapability
 	3,  // 2: api.Capability.route_refresh:type_name -> api.RouteRefreshCapability
-	4,  // 3: api.Capability.carrying_label_info:type_name -> api.CarryingLabelInfoCapability
-	6,  // 4: api.Capability.extended_nexthop:type_name -> api.ExtendedNexthopCapability
-	8,  // 5: api.Capability.graceful_restart:type_name -> api.GracefulRestartCapability
-	9,  // 6: api.Capability.four_octet_asn:type_name -> api.FourOctetASNCapability
-	11, // 7: api.Capability.add_path:type_name -> api.AddPathCapability
-	12, // 8: api.Capability.enhanced_route_refresh:type_name -> api.EnhancedRouteRefreshCapability
-	14, // 9: api.Capability.long_lived_graceful_restart:type_name -> api.LongLivedGracefulRestartCapability
-	15, // 10: api.Capability.route_refresh_cisco:type_name -> api.RouteRefreshCiscoCapability
-	16, // 11: api.Capability.fqdn:type_name -> api.FqdnCapability
-	17, // 12: api.Capability.software_version:type_name -> api.SoftwareVersionCapability
-	19, // 13: api.MultiProtocolCapability.family:type_name -> api.Family
-	19, // 14: api.ExtendedNexthopCapabilityTuple.nlri_family:type_name -> api.Family
-	19, // 15: api.ExtendedNexthopCapabilityTuple.nexthop_family:type_name -> api.Family
-	5,  // 16: api.ExtendedNexthopCapability.tuples:type_name -> api.ExtendedNexthopCapabilityTuple
-	19, // 17: api.GracefulRestartCapabilityTuple.family:type_name -> api.Family
-	7,  // 18: api.GracefulRestartCapability.tuples:type_name -> api.GracefulRestartCapabilityTuple
-	19, // 19: api.AddPathCapabilityTuple.family:type_name -> api.Family
-	0,  // 20: api.AddPathCapabilityTuple.mode:type_name -> api.AddPathCapabilityTuple.Mode
-	10, // 21: api.AddPathCapability.tuples:type_name -> api.AddPathCapabilityTuple
-	19, // 22: api.LongLivedGracefulRestartCapabilityTuple.family:type_name -> api.Family
-	13, // 23: api.LongLivedGracefulRestartCapability.tuples:type_name -> api.LongLivedGracefulRestartCapabilityTuple
-	24, // [24:24] is the sub-list for method output_type
-	24, // [24:24] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	5,  // 3: api.Capability.carrying_label_info:type_name -> api.CarryingLabelInfoCapability
+	7,  // 4: api.Capability.extended_nexthop:type_name -> api.ExtendedNexthopCapability
+	9,  // 5: api.Capability.graceful_restart:type_name -> api.GracefulRestartCapability
+	10, // 6: api.Capability.four_octet_asn:type_name -> api.FourOctetASNCapability
+	12, // 7: api.Capability.add_path:type_name -> api.AddPathCapability
+	13, // 8: api.Capability.enhanced_route_refresh:type_name -> api.EnhancedRouteRefreshCapability
+	15, // 9: api.Capability.long_lived_graceful_restart:type_name -> api.LongLivedGracefulRestartCapability
+	16, // 10: api.Capability.route_refresh_cisco:type_name -> api.RouteRefreshCiscoCapability
+	17, // 11: api.Capability.fqdn:type_name -> api.FqdnCapability
+	18, // 12: api.Capability.software_version:type_name -> api.SoftwareVersionCapability
+	4,  // 13: api.Capability.extended_message:type_name -> api.ExtendedMessageCapability
+	20, // 14: api.MultiProtocolCapability.family:type_name -> api.Family
+	20, // 15: api.ExtendedNexthopCapabilityTuple.nlri_family:type_name -> api.Family
+	20, // 16: api.ExtendedNexthopCapabilityTuple.nexthop_family:type_name -> api.Family
+	6,  // 17: api.ExtendedNexthopCapability.tuples:type_name -> api.ExtendedNexthopCapabilityTuple
+	20, // 18: api.GracefulRestartCapabilityTuple.family:type_name -> api.Family
+	8,  // 19: api.GracefulRestartCapability.tuples:type_name -> api.GracefulRestartCapabilityTuple
+	20, // 20: api.AddPathCapabilityTuple.family:type_name -> api.Family
+	0,  // 21: api.AddPathCapabilityTuple.mode:type_name -> api.AddPathCapabilityTuple.Mode
+	11, // 22: api.AddPathCapability.tuples:type_name -> api.AddPathCapabilityTuple
+	20, // 23: api.LongLivedGracefulRestartCapabilityTuple.family:type_name -> api.Family
+	14, // 24: api.LongLivedGracefulRestartCapability.tuples:type_name -> api.LongLivedGracefulRestartCapabilityTuple
+	25, // [25:25] is the sub-list for method output_type
+	25, // [25:25] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_api_capability_proto_init() }
@@ -1300,6 +1360,7 @@ func file_api_capability_proto_init() {
 		(*Capability_RouteRefreshCisco)(nil),
 		(*Capability_Fqdn)(nil),
 		(*Capability_SoftwareVersion)(nil),
+		(*Capability_ExtendedMessage)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -1307,7 +1368,7 @@ func file_api_capability_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_capability_proto_rawDesc), len(file_api_capability_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   18,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/pkg/table/message.go
+++ b/internal/pkg/table/message.go
@@ -26,6 +26,18 @@ import (
 	"github.com/segmentio/fasthash/fnv1a"
 )
 
+// maxUpdateMessageLength returns the per-UPDATE serialisation budget
+// the packer should fill before emitting a message. When the caller
+// signalled the RFC 8654 Extended Message Capability via a
+// MarshallingOption, the cap rises from 4096 to 65535 octets - UPDATE
+// is one of the message types Section 6 of the RFC explicitly extends.
+func maxUpdateMessageLength(options []*bgp.MarshallingOption) int {
+	if bgp.IsExtendedMessageSerialization(options) {
+		return bgp.BGP_MAX_EXTENDED_MESSAGE_LENGTH
+	}
+	return bgp.BGP_MAX_MESSAGE_LENGTH
+}
+
 func UpdatePathAttrs2ByteAs(msg *bgp.BGPUpdate) {
 	ps := msg.PathAttributes
 	msg.PathAttributes = make([]bgp.PathAttributeInterface, len(ps))
@@ -397,7 +409,7 @@ func (p *packerMP) pack(options ...*bgp.MarshallingOption) []*bgp.BGPMessage {
 			return
 		}
 
-		budget := bgp.BGP_MAX_MESSAGE_LENGTH - baseLen
+		budget := maxUpdateMessageLength(options) - baseLen
 		if budget <= 0 {
 			for _, path := range paths {
 				cb([]bgp.PathNLRI{{NLRI: path.GetNlri(), ID: path.localID}})
@@ -501,7 +513,7 @@ func (p *packerMP) pack(options ...*bgp.MarshallingOption) []*bgp.BGPMessage {
 			if sampleReach, err := bgp.NewPathAttributeMpReachNLRI(paths[0].GetFamily(), []bgp.PathNLRI{sampleNLRI}, nexthops...); err == nil {
 				baseReachLen += sampleReach.Len() + 1 - paths[0].GetNlri().Len(options...) // +1 for extended-length attr header
 			} else {
-				baseReachLen = bgp.BGP_MAX_MESSAGE_LENGTH
+				baseReachLen = maxUpdateMessageLength(options)
 			}
 			split(baseReachLen, paths, func(nlris []bgp.PathNLRI) {
 				msgs = append(msgs, createMPReachMessage(paths[0], nlris))
@@ -595,7 +607,7 @@ func (p *packerV4) pack(options ...*bgp.MarshallingOption) []*bgp.BGPMessage {
 	// TotalPathAttributeLen + attributes + maxlen of NLRI).
 	// the max size of NLRI is 5bytes (plus 4bytes with addpath enabled)
 	maxNLRIs := func(attrsLen int) int {
-		return (bgp.BGP_MAX_MESSAGE_LENGTH - (19 + 2 + 2 + attrsLen)) / (5 + addpathNLRILen)
+		return (maxUpdateMessageLength(options) - (19 + 2 + 2 + attrsLen)) / (5 + addpathNLRILen)
 	}
 
 	loop := func(attrsLen int, paths []*Path, cb func([]bgp.PathNLRI)) {

--- a/pkg/apiutil/capability.go
+++ b/pkg/apiutil/capability.go
@@ -32,6 +32,14 @@ func NewRouteRefreshCapability(a *bgp.CapRouteRefresh) *api.RouteRefreshCapabili
 	return &api.RouteRefreshCapability{}
 }
 
+// NewExtendedMessageCapability mirrors the empty-TLV shape RFC 8654
+// gives the BGP Extended Message capability. There is no payload to
+// project; the API consumer just needs to know the peer advertised
+// the capability.
+func NewExtendedMessageCapability(a *bgp.CapExtendedMessage) *api.ExtendedMessageCapability {
+	return &api.ExtendedMessageCapability{}
+}
+
 func NewCarryingLabelInfoCapability(a *bgp.CapCarryingLabelInfo) *api.CarryingLabelInfoCapability {
 	return &api.CarryingLabelInfoCapability{}
 }
@@ -152,6 +160,8 @@ func MarshalCapability(value bgp.ParameterCapabilityInterface) (*api.Capability,
 		m.Cap = &api.Capability_Fqdn{Fqdn: NewFQDNCapability(n)}
 	case *bgp.CapSoftwareVersion:
 		m.Cap = &api.Capability_SoftwareVersion{SoftwareVersion: NewSoftwareVersionCapability(n)}
+	case *bgp.CapExtendedMessage:
+		m.Cap = &api.Capability_ExtendedMessage{ExtendedMessage: NewExtendedMessageCapability(n)}
 	case *bgp.CapUnknown:
 		m.Cap = &api.Capability_Unknown{Unknown: NewUnknownCapability(n)}
 	default:
@@ -247,6 +257,8 @@ func unmarshalCapability(a *api.Capability) (bgp.ParameterCapabilityInterface, e
 	case *api.Capability_SoftwareVersion:
 		a := cap.SoftwareVersion
 		return bgp.NewCapSoftwareVersion(a.SoftwareVersion), nil
+	case *api.Capability_ExtendedMessage:
+		return bgp.NewCapExtendedMessage(), nil
 	case *api.Capability_Unknown:
 		a := cap.Unknown
 		return bgp.NewCapUnknown(bgp.BGPCapabilityCode(a.Code), a.Value), nil

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -37,8 +37,30 @@ type MarshallingOption struct {
 	AddPath    map[Family]BGPAddPathMode
 	MRT        bool
 	Use2ByteAS bool // true if peer does NOT support 4-byte AS capability
+	// ExtendedMessage signals that the BGP Extended Message Capability
+	// (RFC 8654) is negotiated on the session this serialisation is
+	// for. When true the per-message-type length cap rises from 4096
+	// to 65535 octets for UPDATE, NOTIFICATION and ROUTE-REFRESH;
+	// OPEN and KEEPALIVE keep the 4096-octet cap per RFC 8654 Section 6.
+	ExtendedMessage bool
 
 	attributes map[BGPAttrType]bool
+}
+
+// IsExtendedMessageSerialization reports whether any element of
+// options carries the RFC 8654 ExtendedMessage flag set. Used by
+// BGPMessage.Serialize to lift the length cap on the messages where
+// the RFC allows it.
+func IsExtendedMessageSerialization(options []*MarshallingOption) bool {
+	for _, opt := range options {
+		if opt == nil {
+			continue
+		}
+		if opt.ExtendedMessage {
+			return true
+		}
+	}
+	return false
 }
 
 func IsMRTSerialization(options []*MarshallingOption) bool {
@@ -373,6 +395,7 @@ const (
 	BGP_CAP_ROUTE_REFRESH               BGPCapabilityCode = 2
 	BGP_CAP_CARRYING_LABEL_INFO         BGPCapabilityCode = 4
 	BGP_CAP_EXTENDED_NEXTHOP            BGPCapabilityCode = 5
+	BGP_CAP_EXTENDED_MESSAGE            BGPCapabilityCode = 6
 	BGP_CAP_GRACEFUL_RESTART            BGPCapabilityCode = 64
 	BGP_CAP_FOUR_OCTET_AS_NUMBER        BGPCapabilityCode = 65
 	BGP_CAP_ADD_PATH                    BGPCapabilityCode = 69
@@ -389,6 +412,7 @@ var CapNameMap = map[BGPCapabilityCode]string{
 	BGP_CAP_CARRYING_LABEL_INFO:         "carrying-label-info",
 	BGP_CAP_GRACEFUL_RESTART:            "graceful-restart",
 	BGP_CAP_EXTENDED_NEXTHOP:            "extended-nexthop",
+	BGP_CAP_EXTENDED_MESSAGE:            "extended-message",
 	BGP_CAP_FOUR_OCTET_AS_NUMBER:        "4-octet-as",
 	BGP_CAP_ADD_PATH:                    "add-path",
 	BGP_CAP_ENHANCED_ROUTE_REFRESH:      "enhanced-route-refresh",
@@ -547,6 +571,24 @@ func NewCapRouteRefresh() *CapRouteRefresh {
 	return &CapRouteRefresh{
 		DefaultParameterCapability{
 			CapCode: BGP_CAP_ROUTE_REFRESH,
+		},
+	}
+}
+
+// CapExtendedMessage advertises the BGP Extended Message capability
+// from RFC 8654. The capability TLV is empty (Capability Code 6,
+// Capability Length 0). When both peers advertise it the maximum BGP
+// message size for UPDATE, NOTIFICATION and ROUTE-REFRESH grows from
+// 4096 to 65535 octets; OPEN and KEEPALIVE remain capped at 4096
+// (RFC 8654 Section 6).
+type CapExtendedMessage struct {
+	DefaultParameterCapability
+}
+
+func NewCapExtendedMessage() *CapExtendedMessage {
+	return &CapExtendedMessage{
+		DefaultParameterCapability{
+			CapCode: BGP_CAP_EXTENDED_MESSAGE,
 		},
 	}
 }
@@ -1175,6 +1217,8 @@ func DecodeCapability(data []byte) (ParameterCapabilityInterface, error) {
 		c = &CapCarryingLabelInfo{}
 	case BGP_CAP_EXTENDED_NEXTHOP:
 		c = &CapExtendedNexthop{}
+	case BGP_CAP_EXTENDED_MESSAGE:
+		c = &CapExtendedMessage{}
 	case BGP_CAP_GRACEFUL_RESTART:
 		c = &CapGracefulRestart{}
 	case BGP_CAP_FOUR_OCTET_AS_NUMBER:
@@ -16110,6 +16154,13 @@ type BGPBody interface {
 const (
 	BGP_HEADER_LENGTH      = 19
 	BGP_MAX_MESSAGE_LENGTH = 4096
+	// BGP_MAX_EXTENDED_MESSAGE_LENGTH is the largest BGP message a
+	// peer may exchange once both sides have advertised the RFC 8654
+	// Extended Message capability. RFC 8654 Section 2 fixes the cap
+	// at 65535 octets; Section 6 limits the relaxation to UPDATE,
+	// NOTIFICATION and ROUTE-REFRESH (OPEN and KEEPALIVE keep the
+	// 4096-octet ceiling).
+	BGP_MAX_EXTENDED_MESSAGE_LENGTH = 65535
 )
 
 type BGPHeader struct {
@@ -16201,7 +16252,21 @@ func (msg *BGPMessage) Serialize(options ...*MarshallingOption) ([]byte, error) 
 		return nil, err
 	}
 	if msg.Header.Len == 0 {
-		if BGP_HEADER_LENGTH+len(b) > BGP_MAX_MESSAGE_LENGTH {
+		// RFC 8654 Section 4 + Section 6: with the BGP Extended
+		// Message Capability negotiated the cap rises to 65535 for
+		// UPDATE, NOTIFICATION and ROUTE-REFRESH; OPEN and KEEPALIVE
+		// stay at 4096. The caller sets MarshallingOption.ExtendedMessage
+		// only when the session negotiated the capability, so an
+		// uncapped serialise on a peer that did not advertise the
+		// capability still hits the 4096-octet ceiling.
+		maxLen := BGP_MAX_MESSAGE_LENGTH
+		if IsExtendedMessageSerialization(options) {
+			switch msg.Header.Type {
+			case BGP_MSG_UPDATE, BGP_MSG_NOTIFICATION, BGP_MSG_ROUTE_REFRESH:
+				maxLen = BGP_MAX_EXTENDED_MESSAGE_LENGTH
+			}
+		}
+		if BGP_HEADER_LENGTH+len(b) > maxLen {
 			return nil, NewMessageError(0, 0, nil, fmt.Sprintf("too long message length %d", BGP_HEADER_LENGTH+len(b)))
 		}
 		msg.Header.Len = BGP_HEADER_LENGTH + uint16(len(b))

--- a/pkg/packet/bgp/extended_message_test.go
+++ b/pkg/packet/bgp/extended_message_test.go
@@ -1,0 +1,144 @@
+package bgp
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCapExtendedMessageRoundTrip exercises Serialize -> DecodeFromBytes
+// for the empty-TLV BGP Extended Message capability defined by
+// RFC 8654. Capability Code 6, Capability Length 0; nothing more on
+// the wire.
+func TestCapExtendedMessageRoundTrip(t *testing.T) {
+	cap := NewCapExtendedMessage()
+
+	buf, err := cap.Serialize()
+	require.NoError(t, err)
+	require.Equal(t, []byte{byte(BGP_CAP_EXTENDED_MESSAGE), 0x00}, buf,
+		"on-wire form is code=6 length=0")
+
+	decoded := &CapExtendedMessage{}
+	require.NoError(t, decoded.DecodeFromBytes(buf))
+	require.Equal(t, BGP_CAP_EXTENDED_MESSAGE, decoded.Code())
+}
+
+// TestDecodeCapabilityDispatchesExtendedMessage verifies that
+// DecodeCapability, the entry point the OPEN-message parser walks
+// through, returns a *CapExtendedMessage when handed the on-wire
+// form. Without the dispatch case a peer's advertisement would land
+// as *CapUnknown and the negotiation logic would never set the
+// negotiated flag.
+func TestDecodeCapabilityDispatchesExtendedMessage(t *testing.T) {
+	on := []byte{byte(BGP_CAP_EXTENDED_MESSAGE), 0x00}
+
+	got, err := DecodeCapability(on)
+	require.NoError(t, err)
+	_, ok := got.(*CapExtendedMessage)
+	require.True(t, ok, "expected *CapExtendedMessage, got %T", got)
+}
+
+// TestExtendedMessageNameMap pins the rendered name for the cap so
+// the gobgp CLI surface stays the same shape "extended-message"
+// other open-source implementations use (FRRouting, BIRD).
+func TestExtendedMessageNameMap(t *testing.T) {
+	require.Equal(t, "extended-message", CapNameMap[BGP_CAP_EXTENDED_MESSAGE])
+}
+
+// TestBGPMessageSerializeLengthCap covers the per-message-type
+// branching RFC 8654 Section 6 mandates: UPDATE, NOTIFICATION and
+// ROUTE-REFRESH may grow to 65535 octets when the negotiation flag
+// is on the MarshallingOption; OPEN and KEEPALIVE keep the legacy
+// 4096-octet ceiling regardless.
+func TestBGPMessageSerializeLengthCap(t *testing.T) {
+	// Build a UPDATE whose body is just shy of the extended cap.
+	// The body shape does not matter for the size check; we use a
+	// single ATTR_TYPE_UNKNOWN with a payload large enough to push
+	// the message past BGP_MAX_MESSAGE_LENGTH but still under
+	// BGP_MAX_EXTENDED_MESSAGE_LENGTH.
+	largePayload := bytes.Repeat([]byte{0xAA}, 5000)
+
+	mkLargeUpdate := func() *BGPMessage {
+		attr := &PathAttributeUnknown{
+			PathAttribute: PathAttribute{
+				Flags: BGP_ATTR_FLAG_OPTIONAL | BGP_ATTR_FLAG_EXTENDED_LENGTH,
+				Type:  0xFE, // a free experimental attribute code
+			},
+			Value: largePayload,
+		}
+		return NewBGPUpdateMessage(nil, []PathAttributeInterface{attr}, nil)
+	}
+
+	t.Run("UPDATE_over_4096_rejected_without_negotiation", func(t *testing.T) {
+		m := mkLargeUpdate()
+		_, err := m.Serialize()
+		require.Error(t, err, "must reject UPDATE > 4096 with no ExtendedMessage option")
+	})
+
+	t.Run("UPDATE_over_4096_accepted_with_negotiation", func(t *testing.T) {
+		m := mkLargeUpdate()
+		buf, err := m.Serialize(&MarshallingOption{ExtendedMessage: true})
+		require.NoError(t, err, "must accept UPDATE > 4096 once ExtendedMessage negotiated")
+		require.Greater(t, len(buf), BGP_MAX_MESSAGE_LENGTH,
+			"the serialised UPDATE actually exceeds the legacy 4096 cap")
+	})
+
+	t.Run("NOTIFICATION_uses_extended_cap", func(t *testing.T) {
+		// NOTIFICATION carries Code (1 byte) + Subcode (1 byte) +
+		// Data. Pad Data large enough to clear 4096 octets.
+		body := &BGPNotification{
+			ErrorCode:    BGP_ERROR_CEASE,
+			ErrorSubcode: 0,
+			Data:         bytes.Repeat([]byte{0xCC}, 5000),
+		}
+		m := &BGPMessage{
+			Header: BGPHeader{Type: BGP_MSG_NOTIFICATION},
+			Body:   body,
+		}
+		_, err := m.Serialize()
+		require.Error(t, err, "NOTIFICATION > 4096 without negotiation must reject")
+
+		// Reset the cached length the previous call wrote.
+		m.Header.Len = 0
+		_, err = m.Serialize(&MarshallingOption{ExtendedMessage: true})
+		require.NoError(t, err, "NOTIFICATION > 4096 with negotiation must serialise")
+	})
+
+	t.Run("OPEN_stays_at_legacy_cap_even_with_negotiation", func(t *testing.T) {
+		// OPEN carries an OptParamLen byte that limits OptParams to
+		// 255 octets in the non-extended form, so reaching a 4097-
+		// octet BGPOpen body requires RFC 9072 extended params or
+		// many capabilities. We compose a synthetic body via the
+		// BGPMessageHeader.Type case and a large notification-like
+		// body for the size check only - the Serialize cap fires on
+		// the body length the Body.Serialize call returns, which
+		// here we model by sending a BGPNotification body under an
+		// OPEN header. RFC 8654 Section 6: OPEN and KEEPALIVE keep
+		// the 4096-octet cap regardless of the option.
+		body := &BGPNotification{
+			ErrorCode:    BGP_ERROR_CEASE,
+			ErrorSubcode: 0,
+			Data:         bytes.Repeat([]byte{0xCC}, 5000),
+		}
+		m := &BGPMessage{
+			Header: BGPHeader{Type: BGP_MSG_OPEN},
+			Body:   body,
+		}
+		_, err := m.Serialize(&MarshallingOption{ExtendedMessage: true})
+		require.Error(t, err,
+			"OPEN > 4096 must reject even with ExtendedMessage negotiated")
+	})
+}
+
+// TestIsExtendedMessageSerialization documents the helper's
+// nil-safe walk: nil entries are skipped (so a callsite may pass a
+// half-populated option slice without panicking) and a true flag
+// anywhere in the slice flips the result.
+func TestIsExtendedMessageSerialization(t *testing.T) {
+	require.False(t, IsExtendedMessageSerialization(nil))
+	require.False(t, IsExtendedMessageSerialization([]*MarshallingOption{nil}))
+	require.False(t, IsExtendedMessageSerialization([]*MarshallingOption{{}}))
+	require.True(t, IsExtendedMessageSerialization([]*MarshallingOption{nil, {ExtendedMessage: true}}))
+	require.True(t, IsExtendedMessageSerialization([]*MarshallingOption{{ExtendedMessage: true}, {}}))
+}

--- a/pkg/server/extended_message_test.go
+++ b/pkg/server/extended_message_test.go
@@ -1,0 +1,105 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	"github.com/osrg/gobgp/v4/pkg/config/oc"
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// remoteAdvertisedExtendedMessage walks a peer's remote capability
+// list looking for *bgp.CapExtendedMessage. It is the on-wire
+// observation of what the peer sent in its OPEN message, which is
+// the only signal a test has of the negotiation outcome.
+func remoteAdvertisedExtendedMessage(p *api.Peer) bool {
+	if p == nil || p.State == nil {
+		return false
+	}
+	for _, c := range p.State.RemoteCap {
+		if c == nil {
+			continue
+		}
+		if c.GetExtendedMessage() != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// localAdvertisedExtendedMessage mirrors remoteAdvertisedExtendedMessage
+// on the local capability list, that is, what WE put in the OPEN.
+func localAdvertisedExtendedMessage(p *api.Peer) bool {
+	if p == nil || p.State == nil {
+		return false
+	}
+	for _, c := range p.State.LocalCap {
+		if c == nil {
+			continue
+		}
+		if c.GetExtendedMessage() != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// TestExtendedMessage_AdvertisedUnconditionally covers RFC 8654
+// Section 3 behaviour: each side always advertises the Extended
+// Message Capability in its OPEN, and once the peer also advertises
+// it the negotiation reaches "both peers carry the capability on
+// both their local and remote capability lists".
+func TestExtendedMessage_AdvertisedUnconditionally(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	s1 := runNewServer(t, 64512, "1.1.1.1", 10179)
+	defer s1.StopBgp(ctx, &api.StopBgpRequest{})
+	s2 := runNewServer(t, 64512, "2.2.2.2", 20179)
+	defer s2.StopBgp(ctx, &api.StopBgpRequest{})
+
+	require.NoError(t, peerServers(t, ctx, []*BgpServer{s1, s2},
+		[]oc.AfiSafiType{oc.AFI_SAFI_TYPE_IPV4_UNICAST}))
+
+	newPeerStateWaiter(s1, api.PeerState_SESSION_STATE_ESTABLISHED).Wait(t, 20*time.Second)
+
+	checked := false
+	require.NoError(t, s1.ListPeer(ctx, &api.ListPeerRequest{}, func(p *api.Peer) {
+		checked = true
+		assert.True(t, localAdvertisedExtendedMessage(p),
+			"s1 must advertise the capability unconditionally")
+		assert.True(t, remoteAdvertisedExtendedMessage(p),
+			"s2 must advertise the capability back")
+	}))
+	assert.True(t, checked, "ListPeer must have surfaced an established peer")
+}
+
+// TestExtendedMessage_CapMarshalRoundTripsThroughApi covers the
+// apiutil glue: a remote capability list containing
+// *bgp.CapExtendedMessage must serialise to api.Capability_ExtendedMessage
+// and back without losing identity. Without the dispatch case the
+// ListPeer plumbing (which is the only way an operator inspects
+// negotiated caps over gRPC) would surface the capability as
+// CapUnknown.
+func TestExtendedMessage_CapMarshalRoundTripsThroughApi(t *testing.T) {
+	caps := []bgp.ParameterCapabilityInterface{
+		bgp.NewCapExtendedMessage(),
+	}
+
+	apiCaps, err := apiutil.MarshalCapabilities(caps)
+	require.NoError(t, err)
+	require.Len(t, apiCaps, 1)
+	require.NotNil(t, apiCaps[0].GetExtendedMessage(),
+		"the api.Capability oneof must carry the ExtendedMessage variant")
+
+	roundTripped, err := apiutil.UnmarshalCapabilities(apiCaps)
+	require.NoError(t, err)
+	require.Len(t, roundTripped, 1)
+	_, ok := roundTripped[0].(*bgp.CapExtendedMessage)
+	require.True(t, ok, "round-trip must preserve the native cap type")
+}

--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -410,6 +410,12 @@ type fsm struct {
 	capMap   map[bgp.BGPCapabilityCode][]bgp.ParameterCapabilityInterface
 	recvOpen *bgp.BGPMessage
 
+	// extendedMessage is the RFC 8654 negotiation result: true iff
+	// both sides advertised the Extended Message Capability in OPEN.
+	// Read on the incoming-message hot path (read loop length gate),
+	// so atomic to keep the read lock-free without copying capMap.
+	extendedMessage atomic.Bool
+
 	// safe for concurrent access
 	state                    fsmState
 	familyMap                atomic.Value // map[bgp.Family]bgp.BGPAddPathMode
@@ -657,6 +663,16 @@ func (fsm *fsm) stateChange(nextState bgp.FSMState, reason *fsmStateReason) {
 
 		fsm.capMap = capmap
 		fsm.familyMap.Store(rfmap)
+
+		// RFC 8654 Section 4: a speaker MAY send a BGP Extended
+		// Message only if the peer advertised the BGP Extended
+		// Message Capability. We always advertise the capability
+		// (the OPEN-side advertisement is unconditional, like the
+		// 4-byte ASN capability), so the negotiated flag is simply
+		// whether the peer's capability map contains an entry for
+		// the Extended Message Capability.
+		_, peerExt := fsm.capMap[bgp.BGP_CAP_EXTENDED_MESSAGE]
+		fsm.extendedMessage.Store(peerExt)
 
 		// calculate HoldTime
 		// RFC 4271 P.13
@@ -1113,6 +1129,14 @@ func capabilitiesFromConfig(pConf *oc.Neighbor) []bgp.ParameterCapabilityInterfa
 		caps = append(caps, bgp.NewCapSoftwareVersion(softwareVersion))
 	}
 
+	// RFC 8654 Section 3: advertise the Extended Message Capability
+	// in OPEN unconditionally, mirroring how the 4-byte ASN capability
+	// is handled. The TLV is empty (Capability Code 6, Length 0);
+	// per Section 4 a side may only emit a message larger than 4096
+	// octets after both peers have advertised, so the actual length
+	// cap flip still depends on the negotiation result on the FSM.
+	caps = append(caps, bgp.NewCapExtendedMessage())
+
 	for _, af := range pConf.AfiSafis {
 		caps = append(caps, bgp.NewCapMultiProtocol(af.State.Family))
 	}
@@ -1279,9 +1303,24 @@ func (h *fsmHandler) recvMessageWithError(conn net.Conn, stateReasonCh chan<- fs
 
 	hd := &bgp.BGPHeader{}
 	err = hd.DecodeFromBytes(headerBuf)
-	// TODO: RFC 8654
-	if err == nil && hd.Len > bgp.BGP_MAX_MESSAGE_LENGTH {
-		err = bgp.NewMessageError(bgp.BGP_ERROR_MESSAGE_HEADER_ERROR, bgp.BGP_ERROR_SUB_BAD_MESSAGE_LENGTH, nil, "too large BGP message length")
+	// RFC 8654 Section 4 + Section 6: once both peers have advertised
+	// the Extended Message Capability the per-message-type cap rises
+	// from 4096 to 65535 octets, but OPEN and KEEPALIVE keep the
+	// legacy ceiling so the initial handshake stays interoperable
+	// with implementations that have not yet negotiated the
+	// capability (the handshake completes before the negotiation
+	// result is known).
+	if err == nil {
+		maxLen := uint16(bgp.BGP_MAX_MESSAGE_LENGTH)
+		if h.fsm.extendedMessage.Load() {
+			switch hd.Type {
+			case bgp.BGP_MSG_UPDATE, bgp.BGP_MSG_NOTIFICATION, bgp.BGP_MSG_ROUTE_REFRESH:
+				maxLen = uint16(bgp.BGP_MAX_EXTENDED_MESSAGE_LENGTH)
+			}
+		}
+		if hd.Len > maxLen {
+			err = bgp.NewMessageError(bgp.BGP_ERROR_MESSAGE_HEADER_ERROR, bgp.BGP_ERROR_SUB_BAD_MESSAGE_LENGTH, nil, "too large BGP message length")
+		}
 	}
 	if err != nil {
 		h.fsm.bgpMessageStateUpdate(0, true)
@@ -1310,8 +1349,9 @@ func (h *fsmHandler) recvMessageWithError(conn net.Conn, stateReasonCh chan<- fs
 	useRevisedError := h.fsm.isTreatAsWithdraw
 
 	m, err := bgp.ParseBGPBody(hd, bodyBuf, &bgp.MarshallingOption{
-		AddPath:    h.fsm.familyMap.Load().(map[bgp.Family]bgp.BGPAddPathMode),
-		Use2ByteAS: h.fsm.twoByteAsTrans, // true if peer does NOT support 4-byte AS
+		AddPath:         h.fsm.familyMap.Load().(map[bgp.Family]bgp.BGPAddPathMode),
+		Use2ByteAS:      h.fsm.twoByteAsTrans, // true if peer does NOT support 4-byte AS
+		ExtendedMessage: h.fsm.extendedMessage.Load(),
 	})
 	if err != nil {
 		if m == nil {
@@ -1726,7 +1766,10 @@ func (h *fsmHandler) sendMessageloop(ctx context.Context, conn net.Conn, stateRe
 			table.UpdatePathAggregator2ByteAs(m.Body.(*bgp.BGPUpdate))
 		}
 
-		b, err := m.Serialize(&bgp.MarshallingOption{AddPath: fsm.familyMap.Load().(map[bgp.Family]bgp.BGPAddPathMode)})
+		b, err := m.Serialize(&bgp.MarshallingOption{
+			AddPath:         fsm.familyMap.Load().(map[bgp.Family]bgp.BGPAddPathMode),
+			ExtendedMessage: fsm.extendedMessage.Load(),
+		})
 		if err != nil {
 			fsm.logger.Warn("failed to serialize",
 				slog.String("State", fsm.state.String()),
@@ -1800,7 +1843,10 @@ func (h *fsmHandler) sendMessageloop(ctx context.Context, conn net.Conn, stateRe
 					break
 				}
 
-				options := &bgp.MarshallingOption{AddPath: fsm.familyMap.Load().(map[bgp.Family]bgp.BGPAddPathMode)}
+				options := &bgp.MarshallingOption{
+					AddPath:         fsm.familyMap.Load().(map[bgp.Family]bgp.BGPAddPathMode),
+					ExtendedMessage: fsm.extendedMessage.Load(),
+				}
 				for _, msg := range table.CreateUpdateMsgFromPaths(paths, options) {
 					if err := send(msg); err != nil {
 						return nil

--- a/proto/api/capability.proto
+++ b/proto/api/capability.proto
@@ -42,6 +42,7 @@ message Capability {
     RouteRefreshCiscoCapability route_refresh_cisco = 11;
     FqdnCapability fqdn = 12;
     SoftwareVersionCapability software_version = 13;
+    ExtendedMessageCapability extended_message = 14;
   }
 }
 
@@ -50,6 +51,12 @@ message MultiProtocolCapability {
 }
 
 message RouteRefreshCapability {}
+
+// ExtendedMessageCapability mirrors the empty TLV for the BGP
+// Extended Message Capability (Capability Code 6, Capability Length 0)
+// defined by RFC 8654. The presence of this oneof on a Capability
+// signals that the peer advertised it; there is no payload.
+message ExtendedMessageCapability {}
 
 message CarryingLabelInfoCapability {}
 


### PR DESCRIPTION
Implements [RFC 8654 (Extended Message Support for BGP)](https://www.rfc-editor.org/rfc/rfc8654.html). The inbound length check in `pkg/server/fsm.go` has carried a `TODO: RFC 8654` since v4.0.0, and #2204 has tracked the work since 2019.

### What changes on the wire

A speaker advertises Capability Code 6 with a zero-length value inside its OPEN on every session. When the peer advertises the same capability, the FSM lifts the per-message length cap from 4096 to 65535 octets for UPDATE, NOTIFICATION and ROUTE-REFRESH (per Section 6); OPEN and KEEPALIVE keep the legacy 4096-octet ceiling. The negotiation result is the AND of both advertisements, as Section 4 requires.

### Always-on advertisement

Per maintainer review feedback, the capability is advertised unconditionally — no `disable-extended-message` knob, no YANG/proto config field, no surface area in `bgp_configs.go`. The shape follows the 4-byte AS Number capability: every session gets the cap in OPEN, and Section 4's "AND of both sides" rule on the receiver-side negotiation guarantees the safety property the operator-facing knob used to provide.

This also keeps the change YANG-clean: `bgp_configs.go` is untouched, `tools/pyang_plugins` does not need to learn a new openconfig path, and `oc.NeighborConfig` / `oc.PeerGroupConfig` keep their existing shape.

### Commit layout

Three logical commits:

1. `packet/bgp: add the BGP Extended Message capability (RFC 8654)`: capability code, struct, dispatch, the `BGP_MAX_EXTENDED_MESSAGE_LENGTH` constant, the `MarshallingOption.ExtendedMessage` flag, the serialise-side per-message-type length gate, and the packet-layer test matrix (round-trip, dispatch case, name map, length cap for each message type, helper nil-safety).
2. `api, apiutil: surface the BGP Extended Message capability`: `ExtendedMessageCapability` oneof entry on `api.Capability.cap` (field 14, mirroring `RouteRefreshCapability`), the regenerated `api/*.pb.go` from `buf generate`, and the `apiutil.MarshalCapability` / `unmarshalCapability` glue so `ListPeer` does not fall back to `CapUnknown`. No `bgp_configs.go` change, no proto field on `PeerConf`.
3. `server, table: advertise the cap, negotiate it, and gate the per-session length`: the `capabilitiesFromConfig` unconditional append (matching the `NewCapFourOctetASNumber` call site), the FSM `extendedMessage atomic.Bool`, the `handleOpen` AND'd negotiation, the read-loop length gate (removing the TODO that has sat in this code since v4.0.0), the `MarshallingOption.ExtendedMessage` plumbing on every FSM send-side call, the outbound UPDATE-packer budget in `internal/pkg/table/message.go`, and a server-package integration test covering the symmetric negotiation case and the apiutil round-trip.

### CI

On Go 1.25 (latest stable, matching the CI `setup-go@v6 stable` matrix):

- `go test -race -timeout 240s ./...`: green
- `golangci-lint run`: 0 issues
- `buf lint proto/` + `buf format --diff --exit-code`: green
- `buf generate --template proto/buf.gen.yaml proto` + `git diff --exit-code`: green. The `api/*.pb.go` output matches the byte-for-byte output of `buf generate` against the BSR plugins the upstream CI uses.
- `GOARCH=386 CGO_ENABLED=1 go test ./...`: green
- crossbuild `freebsd/openbsd/darwin/windows × amd64`: built
- `tools/spell-check/scspell.sh` and `tools/grep_avoided_functions.sh`: clean
- `markdownlint $(find . -name '*.md')`: clean

### Production exercise

The patch runs against a mixed-vendor BGP-LS lab built with containerlab: 42 FRR routers, 3 Nokia SR OS routers, 1 Juniper Junos router, and 3 GoBGP test peers, around 150 BGP sessions in total. Without the patch, every Nokia and Juniper BGP-LS UPDATE that crossed 4096 octets reset the session with NOTIFICATION code 1 / subcode 2, and the lab dropped 81 IS-IS links from its topology snapshot. With the patch in place, every established peer carries the capability on both its local and remote capability lists, no Bad-Message-Length notifications appear in a 24h run, and the link count holds at 81 against the same wire data v3.37.0 used to handle.

The rework you see here was also smoke-tested back on that same lab before the force-push: all 3 Nokia BGP-LS sessions established with the capability on both sides, 126 UPDATEs received on the busiest Nokia peer without any NOTIFICATION, and zero error/disconnect events in `pkg/server` logs across a fresh restart.

Closes #2204.