### PR TITLE
Feature/fix bmp

### DIFF
--- a/internal/pkg/table/destination.go
+++ b/internal/pkg/table/destination.go
@@ -530,6 +530,41 @@ type Update struct {
 	OldKnownPathList []*Path
 }
 
+// GetMultiBestPathDiff returns multipath delta as update and withdraw lists.
+// update includes both newly added and changed paths.
+func (u *Update) GetMultiBestPathDiff(id string) (update []*Path, withdraw []*Path) {
+	oldM := getMultiBestPath(id, u.OldKnownPathList)
+	newM := getMultiBestPath(id, u.KnownPathList)
+	if len(oldM) == 0 && len(newM) == 0 {
+		return nil, nil
+	}
+
+	matchedOld := make([]bool, len(oldM))
+	for _, n := range newM {
+		match := -1
+		for idx, o := range oldM {
+			if n.EqualBySourceAndPathID(o) {
+				match = idx
+				break
+			}
+		}
+		if match == -1 {
+			update = append(update, n)
+			continue
+		}
+		matchedOld[match] = true
+		if !n.Equal(oldM[match]) {
+			update = append(update, n)
+		}
+	}
+	for idx, o := range oldM {
+		if !matchedOld[idx] {
+			withdraw = append(withdraw, o.Clone(true))
+		}
+	}
+	return update, withdraw
+}
+
 func getMultiBestPath(id string, pathList []*Path) []*Path {
 	// The path list of destinations in the global RIB are sorted
 	// in descending order. One of the criteria for being a better

--- a/internal/pkg/table/destination_test.go
+++ b/internal/pkg/table/destination_test.go
@@ -868,3 +868,51 @@ func TestNHT_NewPathWithInvalidNexthop(t *testing.T) {
 	assert.Nil(t, best, "invalid new path must not be advertised as best")
 	assert.Nil(t, old, "no old path expected")
 }
+
+func makeDeltaTestPath(t *testing.T, prefix, nexthop, src string, srcAS uint32, remoteID uint32) *Path {
+	t.Helper()
+
+	nlri, err := bgp.NewIPAddrPrefix(netip.MustParsePrefix(prefix))
+	assert.NoError(t, err)
+	nh, err := bgp.NewPathAttributeNextHop(netip.MustParseAddr(nexthop))
+	assert.NoError(t, err)
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{
+			bgp.NewAsPathParam(2, []uint16{uint16(srcAS)}),
+		}),
+		nh,
+	}
+	source := &PeerInfo{
+		AS:      srcAS,
+		ID:      netip.MustParseAddr(src),
+		Address: netip.MustParseAddr(src),
+	}
+	return NewPath(
+		bgp.RF_IPv4_UC,
+		source,
+		bgp.PathNLRI{NLRI: nlri, ID: remoteID},
+		false,
+		attrs,
+		time.Unix(100, 0),
+		false,
+	)
+}
+
+func TestUpdateGetMultiBestPathDiff(t *testing.T) {
+	oldA := makeDeltaTestPath(t, "10.10.0.0/24", "192.0.2.1", "198.51.100.1", 65001, 1)
+	oldB := makeDeltaTestPath(t, "10.10.0.0/24", "192.0.2.2", "198.51.100.2", 65002, 2)
+	newC := makeDeltaTestPath(t, "10.10.0.0/24", "192.0.2.3", "198.51.100.3", 65003, 3)
+
+	u := &Update{
+		OldKnownPathList: []*Path{oldA, oldB},
+		KnownPathList:    []*Path{oldB, newC},
+	}
+
+	update, withdraw := u.GetMultiBestPathDiff(GLOBAL_RIB_NAME)
+	assert.Len(t, update, 1)
+	assert.Len(t, withdraw, 1)
+	assert.Equal(t, newC.GetNexthop(), update[0].GetNexthop())
+	assert.Equal(t, oldA.GetNexthop(), withdraw[0].GetNexthop())
+	assert.True(t, withdraw[0].IsWithdraw)
+}

--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -188,7 +188,14 @@ func (b *bmpClient) loop() {
 			sentLocRIBPeerUp := false
 			if b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB || b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
 				// For now, use PD=0 and VRF/Table Name="global".
-				if err := write(bmpLocRIBPeerUp(b.s.bgpConfig.Global.Config.As, b.s.bgpConfig.Global.Config.RouterId, "global", 0, time.Now().Unix())); err != nil {
+				if err := write(bmpLocRIBPeerUp(
+					b.s.bgpConfig.Global.Config.As,
+					b.s.bgpConfig.Global.Config.RouterId,
+					"global",
+					0,
+					time.Now().Unix(),
+					table.UseMultiplePaths.Enabled,
+				)); err != nil {
 					return false
 				}
 				sentLocRIBPeerUp = true
@@ -297,7 +304,7 @@ func (b *bmpClient) loop() {
 	}
 }
 
-func bmpLocRIBPeerUp(localAS uint32, routerID netip.Addr, tableName string, peerDist uint64, timestamp int64) *bmp.BMPMessage {
+func bmpLocRIBPeerUp(localAS uint32, routerID netip.Addr, tableName string, peerDist uint64, timestamp int64, addPathEnabled bool) *bmp.BMPMessage {
 	const asTrans uint16 = 23456
 
 	myAS := asTrans
@@ -307,6 +314,14 @@ func bmpLocRIBPeerUp(localAS uint32, routerID netip.Addr, tableName string, peer
 	} else {
 		opts = append(opts, bgp.NewOptionParameterCapability([]bgp.ParameterCapabilityInterface{
 			bgp.NewCapFourOctetASNumber(localAS),
+		}))
+	}
+	if addPathEnabled {
+		opts = append(opts, bgp.NewOptionParameterCapability([]bgp.ParameterCapabilityInterface{
+			bgp.NewCapAddPath([]*bgp.CapAddPathTuple{
+				bgp.NewCapAddPathTuple(bgp.RF_IPv4_UC, bgp.BGP_ADD_PATH_BOTH),
+				bgp.NewCapAddPathTuple(bgp.RF_IPv6_UC, bgp.BGP_ADD_PATH_BOTH),
+			}),
 		}))
 	}
 

--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -83,6 +83,14 @@ func (r ribout) update(p *table.Path) bool {
 	return true
 }
 
+func bmpAddPathMarshallingOption(path *table.Path) *bgp.MarshallingOption {
+	return &bgp.MarshallingOption{
+		AddPath: map[bgp.Family]bgp.BGPAddPathMode{
+			path.GetFamily(): bgp.BGP_ADD_PATH_BOTH,
+		},
+	}
+}
+
 func (b *bmpClient) tryConnect() *net.TCPConn {
 	interval := 1
 	for {
@@ -224,9 +232,13 @@ func (b *bmpClient) loop() {
 							AS:      b.s.bgpConfig.Global.Config.As,
 							ID:      b.s.bgpConfig.Global.Config.RouterId,
 						}
-						for _, p := range msg.PathList {
-							u := table.CreateUpdateMsgFromPaths([]*table.Path{p})[0]
-							if payload, err := u.Serialize(); err != nil {
+						for _, p := range locRIBPathsForBMP(msg) {
+							if p == nil {
+								continue
+							}
+							options := bmpAddPathMarshallingOption(p)
+							u := table.CreateUpdateMsgFromPaths([]*table.Path{p}, options)[0]
+							if payload, err := u.Serialize(options); err != nil {
 								return false
 							} else if err = write(bmpPeerRoute(bmp.BMP_PEER_TYPE_LOCAL_RIB, false, 0, true, info, p.GetTimestamp().Unix(), payload)); err != nil {
 								return false

--- a/pkg/server/bmp_test.go
+++ b/pkg/server/bmp_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/osrg/gobgp/v4/internal/pkg/table"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	packetbmp "github.com/osrg/gobgp/v4/pkg/packet/bmp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,4 +94,49 @@ func TestBMPAddPathMarshallingOptionCarriesPathIDOnWithdraw(t *testing.T) {
 	// Loc-RIB sender-assigned path-id can be 0 for paths without local path-id assignment.
 	// We only assert Add-Path encoding is in use (checked above by withdrawn length).
 	_ = update.WithdrawnRoutes[0].ID
+}
+
+func localRIBPeerUpOpen(t *testing.T, addPathEnabled bool) *bgp.BGPOpen {
+	t.Helper()
+	msg := bmpLocRIBPeerUp(
+		65002,
+		netip.MustParseAddr("100.1.1.102"),
+		"global",
+		0,
+		time.Now().Unix(),
+		addPathEnabled,
+	)
+	up := msg.Body.(*packetbmp.BMPPeerUpNotification)
+	return up.SentOpenMsg.Body.(*bgp.BGPOpen)
+}
+
+func findAddPathCapability(open *bgp.BGPOpen) *bgp.CapAddPath {
+	for _, p := range open.OptParams {
+		param, ok := p.(*bgp.OptionParameterCapability)
+		if !ok {
+			continue
+		}
+		for _, c := range param.Capability {
+			if addPath, ok := c.(*bgp.CapAddPath); ok {
+				return addPath
+			}
+		}
+	}
+	return nil
+}
+
+func TestBMPLocRIBPeerUpOmitsAddPathCapabilityWhenDisabled(t *testing.T) {
+	open := localRIBPeerUpOpen(t, false)
+	require.Nil(t, findAddPathCapability(open))
+}
+
+func TestBMPLocRIBPeerUpCarriesAddPathCapabilityWhenEnabled(t *testing.T) {
+	open := localRIBPeerUpOpen(t, true)
+	addPath := findAddPathCapability(open)
+	require.NotNil(t, addPath)
+	require.Len(t, addPath.Tuples, 2)
+	require.Equal(t, bgp.RF_IPv4_UC, addPath.Tuples[0].Family)
+	require.Equal(t, bgp.BGP_ADD_PATH_BOTH, addPath.Tuples[0].Mode)
+	require.Equal(t, bgp.RF_IPv6_UC, addPath.Tuples[1].Family)
+	require.Equal(t, bgp.BGP_ADD_PATH_BOTH, addPath.Tuples[1].Mode)
 }

--- a/pkg/server/bmp_test.go
+++ b/pkg/server/bmp_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"encoding/binary"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/osrg/gobgp/v4/internal/pkg/table"
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	"github.com/stretchr/testify/require"
+)
+
+func makeIPv4Path(t *testing.T, prefix, nexthop, src string, srcAS uint32, remoteID uint32) *table.Path {
+	t.Helper()
+
+	nlri, err := bgp.NewIPAddrPrefix(netip.MustParsePrefix(prefix))
+	require.NoError(t, err)
+
+	nh, err := bgp.NewPathAttributeNextHop(netip.MustParseAddr(nexthop))
+	require.NoError(t, err)
+
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{
+			bgp.NewAsPathParam(2, []uint16{uint16(srcAS)}),
+		}),
+		nh,
+	}
+	source := &table.PeerInfo{
+		AS:      srcAS,
+		ID:      netip.MustParseAddr(src),
+		Address: netip.MustParseAddr(src),
+	}
+	return table.NewPath(
+		bgp.RF_IPv4_UC,
+		source,
+		bgp.PathNLRI{NLRI: nlri, ID: remoteID},
+		false,
+		attrs,
+		time.Unix(100, 0),
+		false,
+	)
+}
+
+func TestLocRIBPathsForBMPUsesDeltaListsFirst(t *testing.T) {
+	p1 := makeIPv4Path(t, "10.0.0.0/24", "192.0.2.1", "198.51.100.1", 65001, 1)
+	p2 := makeIPv4Path(t, "10.0.0.0/24", "192.0.2.2", "198.51.100.2", 65002, 2)
+	w := p1.Clone(true)
+	paths := locRIBPathsForBMP(&watchEventBestPath{
+		UpdatePathList:   []*table.Path{p2},
+		WithdrawPathList: []*table.Path{w},
+		// These are ignored when delta lists are present.
+		PathList:      []*table.Path{p1},
+		MultiPathList: [][]*table.Path{{p1, p2}},
+	})
+	require.Len(t, paths, 2)
+	require.True(t, paths[0].IsWithdraw)
+	require.False(t, paths[1].IsWithdraw)
+}
+
+func TestLocRIBPathsForBMPFallsBackToMultiPathList(t *testing.T) {
+	p1 := makeIPv4Path(t, "10.0.1.0/24", "192.0.2.11", "198.51.100.11", 65101, 11)
+	p2 := makeIPv4Path(t, "10.0.1.0/24", "192.0.2.12", "198.51.100.12", 65102, 12)
+
+	paths := locRIBPathsForBMP(&watchEventBestPath{
+		PathList:      []*table.Path{p1.Clone(true)},
+		MultiPathList: [][]*table.Path{{p1, p2}},
+	})
+	require.Len(t, paths, 2)
+}
+
+func TestBMPAddPathMarshallingOptionCarriesPathIDOnWithdraw(t *testing.T) {
+	p := makeIPv4Path(t, "10.0.2.0/24", "192.0.2.21", "198.51.100.21", 65201, 0)
+	w := p.Clone(true)
+
+	options := bmpAddPathMarshallingOption(w)
+	msg := table.CreateUpdateMsgFromPaths([]*table.Path{w}, options)[0]
+
+	payload, err := msg.Serialize(options)
+	require.NoError(t, err)
+
+	decoded, err := bgp.ParseBGPMessage(payload, options)
+	require.NoError(t, err)
+
+	// BGP header(19) + WithdrawnRoutesLen(2). For IPv4 /24 withdraw:
+	// with Add-Path => 4(path-id) + 1(prefix-len) + 3(prefix bytes) = 8.
+	require.GreaterOrEqual(t, len(payload), 21)
+	require.Equal(t, uint16(8), binary.BigEndian.Uint16(payload[19:21]))
+
+	update := decoded.Body.(*bgp.BGPUpdate)
+	require.Len(t, update.WithdrawnRoutes, 1)
+	// Loc-RIB sender-assigned path-id can be 0 for paths without local path-id assignment.
+	// We only assert Add-Path encoding is in use (checked above by withdrawn length).
+	_ = update.WithdrawnRoutes[0].ID
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -739,7 +739,7 @@ func (s *BgpServer) setPathVrfIdMap(paths []*table.Path, m map[uint32]bool) {
 
 // Note: the destination would be the same for all the paths passed here
 // The wather (only zapi) needs a unique list of vrf IDs
-func (s *BgpServer) notifyBestWatcher(best []*table.Path, multipath [][]*table.Path) {
+func (s *BgpServer) notifyBestWatcher(best []*table.Path, multipath [][]*table.Path, multipathUpdate []*table.Path, multipathWithdraw []*table.Path) {
 	if table.SelectionOptions.DisableBestPathSelection {
 		// Note: If best path selection disabled, no best path to notify.
 		return
@@ -753,10 +753,18 @@ func (s *BgpServer) notifyBestWatcher(best []*table.Path, multipath [][]*table.P
 		}
 	}
 	clonedB := clonePathList(best)
+	clonedU := clonePathList(multipathUpdate)
+	clonedW := clonePathList(multipathWithdraw)
 	if !table.UseMultiplePaths.Enabled {
 		s.setPathVrfIdMap(clonedB, m)
 	}
-	w := &watchEventBestPath{PathList: clonedB, MultiPathList: clonedM, Timestamp: time.Now()}
+	w := &watchEventBestPath{
+		PathList:         clonedB,
+		MultiPathList:    clonedM,
+		UpdatePathList:   clonedU,
+		WithdrawPathList: clonedW,
+		Timestamp:        time.Now(),
+	}
 	if len(m) > 0 {
 		w.Vrf = m
 	}
@@ -1349,10 +1357,12 @@ func (s *BgpServer) rtcVPNCandidates(peer *peer, isWithdraw bool, rt bgp.Extende
 	fn(nil, s.globalRib.GetBestPathList(peer.TableID(), 0, fs))
 }
 
-func dstsToPaths(id string, as uint32, dsts []*table.Update) ([]*table.Path, []*table.Path, [][]*table.Path) {
+func dstsToPaths(id string, as uint32, dsts []*table.Update) ([]*table.Path, []*table.Path, [][]*table.Path, []*table.Path, []*table.Path) {
 	bestList := make([]*table.Path, 0, len(dsts))
 	oldList := make([]*table.Path, 0, len(dsts))
 	mpathList := make([][]*table.Path, 0, len(dsts))
+	multipathUpdate := make([]*table.Path, 0, len(dsts))
+	multipathWithdraw := make([]*table.Path, 0, len(dsts))
 
 	for _, dst := range dsts {
 		best, old, mpath := dst.GetChanges(id, as, false)
@@ -1361,8 +1371,13 @@ func dstsToPaths(id string, as uint32, dsts []*table.Update) ([]*table.Path, []*
 		if mpath != nil {
 			mpathList = append(mpathList, mpath)
 		}
+		if id == table.GLOBAL_RIB_NAME && table.UseMultiplePaths.Enabled {
+			u, w := dst.GetMultiBestPathDiff(id)
+			multipathUpdate = append(multipathUpdate, u...)
+			multipathWithdraw = append(multipathWithdraw, w...)
+		}
 	}
-	return bestList, oldList, mpathList
+	return bestList, oldList, mpathList, multipathUpdate, multipathWithdraw
 }
 
 func (s *BgpServer) propagateUpdateToNeighbors(rib *table.TableManager, source *peer, newPath *table.Path, dsts []*table.Update, needOld bool) {
@@ -1371,9 +1386,10 @@ func (s *BgpServer) propagateUpdateToNeighbors(rib *table.TableManager, source *
 	}
 	var gBestList, gOldList []*table.Path
 	var mpathList [][]*table.Path
+	var multipathUpdate, multipathWithdraw []*table.Path
 	if source == nil || !source.isRouteServerClient() {
-		gBestList, gOldList, mpathList = dstsToPaths(table.GLOBAL_RIB_NAME, 0, dsts)
-		s.notifyBestWatcher(gBestList, mpathList)
+		gBestList, gOldList, mpathList, multipathUpdate, multipathWithdraw = dstsToPaths(table.GLOBAL_RIB_NAME, 0, dsts)
+		s.notifyBestWatcher(gBestList, mpathList, multipathUpdate, multipathWithdraw)
 	}
 	family := newPath.GetFamily()
 	for _, targetPeer := range s.neighborMap {
@@ -1495,7 +1511,7 @@ func (s *BgpServer) propagateUpdateToNeighbors(rib *table.TableManager, source *
 						}
 						return
 					}
-					bestList, oldList, _ = dstsToPaths(targetPeer.TableID(), targetPeer.AS(), dsts)
+					bestList, oldList, _, _, _ = dstsToPaths(targetPeer.TableID(), targetPeer.AS(), dsts)
 				} else {
 					bestList = gBestList
 					oldList = gOldList
@@ -4596,24 +4612,7 @@ func (s *BgpServer) WatchEvent(ctx context.Context, callbacks WatchEventMessageC
 							}
 							callbacks.OnBestPath(p, msg.Timestamp)
 						}
-
-						if len(msg.MultiPathList) > 0 {
-							plen := 0
-							for _, pa := range msg.MultiPathList {
-								plen += len(pa)
-							}
-							paths := make([]*table.Path, plen)
-							i := 0
-							for _, pa := range msg.MultiPathList {
-								for _, path := range pa {
-									paths[i] = path
-									i++
-								}
-							}
-							callback(paths)
-						} else {
-							callback(msg.PathList)
-						}
+						callback(locRIBPathsForBMP(msg))
 					}
 
 				case *watchEventEor:
@@ -4767,10 +4766,35 @@ type watchEventPeer struct {
 }
 
 type watchEventBestPath struct {
-	PathList      []*table.Path
-	MultiPathList [][]*table.Path
-	Vrf           map[uint32]bool
-	Timestamp     time.Time
+	PathList         []*table.Path
+	MultiPathList    [][]*table.Path
+	UpdatePathList   []*table.Path
+	WithdrawPathList []*table.Path
+	Vrf              map[uint32]bool
+	Timestamp        time.Time
+}
+
+func locRIBPathsForBMP(msg *watchEventBestPath) []*table.Path {
+	// Prefer update/withdraw delta when present.
+	if len(msg.UpdatePathList) > 0 || len(msg.WithdrawPathList) > 0 {
+		paths := make([]*table.Path, 0, len(msg.WithdrawPathList)+len(msg.UpdatePathList))
+		paths = append(paths, msg.WithdrawPathList...)
+		paths = append(paths, msg.UpdatePathList...)
+		return paths
+	}
+	// Fallback for non-multipath and init snapshot behavior.
+	if len(msg.MultiPathList) > 0 {
+		plen := 0
+		for _, pa := range msg.MultiPathList {
+			plen += len(pa)
+		}
+		paths := make([]*table.Path, 0, plen)
+		for _, pa := range msg.MultiPathList {
+			paths = append(paths, pa...)
+		}
+		return paths
+	}
+	return msg.PathList
 }
 
 type watchEventMessage struct {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1463,7 +1463,7 @@ func process(rib *table.TableManager, l []*table.Path) (*table.Path, *table.Path
 	for _, path := range l {
 		dsts = append(dsts, rib.Update(path)...)
 	}
-	news, olds, _ := dstsToPaths(table.GLOBAL_RIB_NAME, 0, dsts)
+	news, olds, _, _, _ := dstsToPaths(table.GLOBAL_RIB_NAME, 0, dsts)
 	if len(news) != 1 {
 		panic("can't handle multiple paths")
 	}


### PR DESCRIPTION
## Problem
In multipath scenarios, BMP Local-RIB monitoring did not clearly show per-path changes (which path was updated vs withdrawn).
## Changes
- Added multipath delta fields to bestpath events:
  - `UpdatePathList` (new or changed paths)
  - `WithdrawPathList` (removed paths)
- Kept existing fields (`PathList`, `MultiPathList`) for backward compatibility.
- Generated multipath deltas at the update source (`table.Update`) .
- Unified path selection logic for BMP and WatchEvent/monitor:
  1. use `UpdatePathList`/`WithdrawPathList` first  
  2. fallback to `MultiPathList`  
  3. fallback to `PathList`
- Enabled Add-Path serialization for Local-RIB BMP messages.
- Added Local-RIB Peer Up Add-Path capability advertisement(only when multipath is enabled).
## Impact
- Multipath changes are now visible as explicit update/withdraw events.
- Non-multipath behavior remains unchanged.
- Zebra path is not affected.

by the way:  There still has a minor issue with the gobgp monitor: when the path-id does not change when route update, only a single "update" message is generated, making it impossible to distinguish whether it is a "replace" or an "add." To resolve this issue, the monitor's output needs to be modified. Maybe need a new word replace.