### PR TITLE
packet/bgp, api, apiutil: implement RFC 9351 BGP-LS Flex-Algorithm Definition + multi-SID Prefix-SID

### DIFF
--- a/api/attribute.pb.go
+++ b/api/attribute.pb.go
@@ -3419,8 +3419,12 @@ type LsAttributeNode struct {
 	SrCapabilities  *LsSrCapabilities      `protobuf:"bytes,7,opt,name=sr_capabilities,json=srCapabilities,proto3" json:"sr_capabilities,omitempty"`
 	SrAlgorithms    []byte                 `protobuf:"bytes,8,opt,name=sr_algorithms,json=srAlgorithms,proto3" json:"sr_algorithms,omitempty"`
 	SrLocalBlock    *LsSrLocalBlock        `protobuf:"bytes,9,opt,name=sr_local_block,json=srLocalBlock,proto3" json:"sr_local_block,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// RFC 9351 Section 3 Flexible Algorithm Definition (FAD) TLVs
+	// observed for this Node NLRI. A node MAY advertise more than one
+	// FAD, one per algorithm in the [128, 255] Flex-Algorithm range.
+	FlexAlgoDefs  []*LsAttributeFlexAlgoDef `protobuf:"bytes,10,rep,name=flex_algo_defs,json=flexAlgoDefs,proto3" json:"flex_algo_defs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *LsAttributeNode) Reset() {
@@ -3516,6 +3520,133 @@ func (x *LsAttributeNode) GetSrLocalBlock() *LsSrLocalBlock {
 	return nil
 }
 
+func (x *LsAttributeNode) GetFlexAlgoDefs() []*LsAttributeFlexAlgoDef {
+	if x != nil {
+		return x.FlexAlgoDefs
+	}
+	return nil
+}
+
+// LsAttributeFlexAlgoDef is the structured projection of a single FAD
+// TLV (TLV 1039, RFC 9351 Section 3). Reserved Metric-Type values
+// (3..127) are passed through verbatim with metric_type_known=false
+// so consumers can render them without guessing semantics.
+type LsAttributeFlexAlgoDef struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Algorithm          uint32                 `protobuf:"varint,1,opt,name=algorithm,proto3" json:"algorithm,omitempty"`
+	MetricType         uint32                 `protobuf:"varint,2,opt,name=metric_type,json=metricType,proto3" json:"metric_type,omitempty"`
+	MetricTypeKnown    bool                   `protobuf:"varint,3,opt,name=metric_type_known,json=metricTypeKnown,proto3" json:"metric_type_known,omitempty"`
+	CalcType           uint32                 `protobuf:"varint,4,opt,name=calc_type,json=calcType,proto3" json:"calc_type,omitempty"`
+	Priority           uint32                 `protobuf:"varint,5,opt,name=priority,proto3" json:"priority,omitempty"`
+	ExcludeAnyAffinity []uint32               `protobuf:"varint,6,rep,packed,name=exclude_any_affinity,json=excludeAnyAffinity,proto3" json:"exclude_any_affinity,omitempty"`
+	IncludeAnyAffinity []uint32               `protobuf:"varint,7,rep,packed,name=include_any_affinity,json=includeAnyAffinity,proto3" json:"include_any_affinity,omitempty"`
+	IncludeAllAffinity []uint32               `protobuf:"varint,8,rep,packed,name=include_all_affinity,json=includeAllAffinity,proto3" json:"include_all_affinity,omitempty"`
+	DefinitionFlags    []byte                 `protobuf:"bytes,9,opt,name=definition_flags,json=definitionFlags,proto3" json:"definition_flags,omitempty"`
+	ExcludeSrlg        []uint32               `protobuf:"varint,10,rep,packed,name=exclude_srlg,json=excludeSrlg,proto3" json:"exclude_srlg,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *LsAttributeFlexAlgoDef) Reset() {
+	*x = LsAttributeFlexAlgoDef{}
+	mi := &file_api_attribute_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LsAttributeFlexAlgoDef) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LsAttributeFlexAlgoDef) ProtoMessage() {}
+
+func (x *LsAttributeFlexAlgoDef) ProtoReflect() protoreflect.Message {
+	mi := &file_api_attribute_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LsAttributeFlexAlgoDef.ProtoReflect.Descriptor instead.
+func (*LsAttributeFlexAlgoDef) Descriptor() ([]byte, []int) {
+	return file_api_attribute_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *LsAttributeFlexAlgoDef) GetAlgorithm() uint32 {
+	if x != nil {
+		return x.Algorithm
+	}
+	return 0
+}
+
+func (x *LsAttributeFlexAlgoDef) GetMetricType() uint32 {
+	if x != nil {
+		return x.MetricType
+	}
+	return 0
+}
+
+func (x *LsAttributeFlexAlgoDef) GetMetricTypeKnown() bool {
+	if x != nil {
+		return x.MetricTypeKnown
+	}
+	return false
+}
+
+func (x *LsAttributeFlexAlgoDef) GetCalcType() uint32 {
+	if x != nil {
+		return x.CalcType
+	}
+	return 0
+}
+
+func (x *LsAttributeFlexAlgoDef) GetPriority() uint32 {
+	if x != nil {
+		return x.Priority
+	}
+	return 0
+}
+
+func (x *LsAttributeFlexAlgoDef) GetExcludeAnyAffinity() []uint32 {
+	if x != nil {
+		return x.ExcludeAnyAffinity
+	}
+	return nil
+}
+
+func (x *LsAttributeFlexAlgoDef) GetIncludeAnyAffinity() []uint32 {
+	if x != nil {
+		return x.IncludeAnyAffinity
+	}
+	return nil
+}
+
+func (x *LsAttributeFlexAlgoDef) GetIncludeAllAffinity() []uint32 {
+	if x != nil {
+		return x.IncludeAllAffinity
+	}
+	return nil
+}
+
+func (x *LsAttributeFlexAlgoDef) GetDefinitionFlags() []byte {
+	if x != nil {
+		return x.DefinitionFlags
+	}
+	return nil
+}
+
+func (x *LsAttributeFlexAlgoDef) GetExcludeSrlg() []uint32 {
+	if x != nil {
+		return x.ExcludeSrlg
+	}
+	return nil
+}
+
 type LsAttributeLink struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	Name                string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -3546,7 +3677,7 @@ type LsAttributeLink struct {
 
 func (x *LsAttributeLink) Reset() {
 	*x = LsAttributeLink{}
-	mi := &file_api_attribute_proto_msgTypes[53]
+	mi := &file_api_attribute_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3558,7 +3689,7 @@ func (x *LsAttributeLink) String() string {
 func (*LsAttributeLink) ProtoMessage() {}
 
 func (x *LsAttributeLink) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[53]
+	mi := &file_api_attribute_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3571,7 +3702,7 @@ func (x *LsAttributeLink) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsAttributeLink.ProtoReflect.Descriptor instead.
 func (*LsAttributeLink) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{53}
+	return file_api_attribute_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *LsAttributeLink) GetName() string {
@@ -3722,17 +3853,30 @@ func (x *LsAttributeLink) GetUnidirectionalDelayVariation() uint32 {
 }
 
 type LsAttributePrefix struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	IgpFlags      *LsIGPFlags            `protobuf:"bytes,1,opt,name=igp_flags,json=igpFlags,proto3" json:"igp_flags,omitempty"`
-	Opaque        []byte                 `protobuf:"bytes,2,opt,name=opaque,proto3" json:"opaque,omitempty"`
-	SrPrefixSid   uint32                 `protobuf:"varint,3,opt,name=sr_prefix_sid,json=srPrefixSid,proto3" json:"sr_prefix_sid,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	IgpFlags *LsIGPFlags            `protobuf:"bytes,1,opt,name=igp_flags,json=igpFlags,proto3" json:"igp_flags,omitempty"`
+	Opaque   []byte                 `protobuf:"bytes,2,opt,name=opaque,proto3" json:"opaque,omitempty"`
+	// sr_prefix_sid is the SR-MPLS Prefix-SID label when the originator
+	// advertised it with Algorithm = 0 (default SPF). Kept for backward
+	// compatibility with the singular Algorithm-0 lookup callers used
+	// before multi-SID aggregation landed.
+	SrPrefixSid uint32 `protobuf:"varint,3,opt,name=sr_prefix_sid,json=srPrefixSid,proto3" json:"sr_prefix_sid,omitempty"`
+	// sr_prefix_sids carries every Prefix-SID TLV (RFC 9085
+	// Section 2.1.1) observed on this Prefix NLRI, including the
+	// Algorithm + Flags fields the singular sr_prefix_sid field drops.
+	// Algorithm 0 entries also populate sr_prefix_sid above.
+	SrPrefixSids []*LsAttributePrefixSID `protobuf:"bytes,4,rep,name=sr_prefix_sids,json=srPrefixSids,proto3" json:"sr_prefix_sids,omitempty"`
+	// fad_prefix_metrics carries every Flexible Algorithm Prefix Metric
+	// TLV (FAPM, TLV 1044, RFC 9351 Section 4) observed on this Prefix
+	// NLRI. One entry per Flex-Algorithm announced.
+	FadPrefixMetrics []*LsAttributeFADPrefixMetric `protobuf:"bytes,5,rep,name=fad_prefix_metrics,json=fadPrefixMetrics,proto3" json:"fad_prefix_metrics,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *LsAttributePrefix) Reset() {
 	*x = LsAttributePrefix{}
-	mi := &file_api_attribute_proto_msgTypes[54]
+	mi := &file_api_attribute_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3744,7 +3888,7 @@ func (x *LsAttributePrefix) String() string {
 func (*LsAttributePrefix) ProtoMessage() {}
 
 func (x *LsAttributePrefix) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[54]
+	mi := &file_api_attribute_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3757,7 +3901,7 @@ func (x *LsAttributePrefix) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsAttributePrefix.ProtoReflect.Descriptor instead.
 func (*LsAttributePrefix) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{54}
+	return file_api_attribute_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *LsAttributePrefix) GetIgpFlags() *LsIGPFlags {
@@ -3781,6 +3925,145 @@ func (x *LsAttributePrefix) GetSrPrefixSid() uint32 {
 	return 0
 }
 
+func (x *LsAttributePrefix) GetSrPrefixSids() []*LsAttributePrefixSID {
+	if x != nil {
+		return x.SrPrefixSids
+	}
+	return nil
+}
+
+func (x *LsAttributePrefix) GetFadPrefixMetrics() []*LsAttributeFADPrefixMetric {
+	if x != nil {
+		return x.FadPrefixMetrics
+	}
+	return nil
+}
+
+// LsAttributePrefixSID is one Prefix-SID TLV (RFC 9085 Section 2.1.1)
+// projected onto the LsAttribute surface so consumers can read the
+// Algorithm and Flags fields without re-parsing the wire bytes.
+type LsAttributePrefixSID struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Algorithm     uint32                 `protobuf:"varint,1,opt,name=algorithm,proto3" json:"algorithm,omitempty"`
+	Flags         uint32                 `protobuf:"varint,2,opt,name=flags,proto3" json:"flags,omitempty"`
+	Sid           uint32                 `protobuf:"varint,3,opt,name=sid,proto3" json:"sid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LsAttributePrefixSID) Reset() {
+	*x = LsAttributePrefixSID{}
+	mi := &file_api_attribute_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LsAttributePrefixSID) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LsAttributePrefixSID) ProtoMessage() {}
+
+func (x *LsAttributePrefixSID) ProtoReflect() protoreflect.Message {
+	mi := &file_api_attribute_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LsAttributePrefixSID.ProtoReflect.Descriptor instead.
+func (*LsAttributePrefixSID) Descriptor() ([]byte, []int) {
+	return file_api_attribute_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *LsAttributePrefixSID) GetAlgorithm() uint32 {
+	if x != nil {
+		return x.Algorithm
+	}
+	return 0
+}
+
+func (x *LsAttributePrefixSID) GetFlags() uint32 {
+	if x != nil {
+		return x.Flags
+	}
+	return 0
+}
+
+func (x *LsAttributePrefixSID) GetSid() uint32 {
+	if x != nil {
+		return x.Sid
+	}
+	return 0
+}
+
+// LsAttributeFADPrefixMetric is one FAPM TLV (RFC 9351 Section 4)
+// projected onto the LsAttribute surface.
+type LsAttributeFADPrefixMetric struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Algorithm     uint32                 `protobuf:"varint,1,opt,name=algorithm,proto3" json:"algorithm,omitempty"`
+	Flags         uint32                 `protobuf:"varint,2,opt,name=flags,proto3" json:"flags,omitempty"`
+	Metric        uint32                 `protobuf:"varint,3,opt,name=metric,proto3" json:"metric,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LsAttributeFADPrefixMetric) Reset() {
+	*x = LsAttributeFADPrefixMetric{}
+	mi := &file_api_attribute_proto_msgTypes[57]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LsAttributeFADPrefixMetric) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LsAttributeFADPrefixMetric) ProtoMessage() {}
+
+func (x *LsAttributeFADPrefixMetric) ProtoReflect() protoreflect.Message {
+	mi := &file_api_attribute_proto_msgTypes[57]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LsAttributeFADPrefixMetric.ProtoReflect.Descriptor instead.
+func (*LsAttributeFADPrefixMetric) Descriptor() ([]byte, []int) {
+	return file_api_attribute_proto_rawDescGZIP(), []int{57}
+}
+
+func (x *LsAttributeFADPrefixMetric) GetAlgorithm() uint32 {
+	if x != nil {
+		return x.Algorithm
+	}
+	return 0
+}
+
+func (x *LsAttributeFADPrefixMetric) GetFlags() uint32 {
+	if x != nil {
+		return x.Flags
+	}
+	return 0
+}
+
+func (x *LsAttributeFADPrefixMetric) GetMetric() uint32 {
+	if x != nil {
+		return x.Metric
+	}
+	return 0
+}
+
 type LsBgpPeerSegmentSIDFlags struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Value         bool                   `protobuf:"varint,1,opt,name=value,proto3" json:"value,omitempty"`
@@ -3793,7 +4076,7 @@ type LsBgpPeerSegmentSIDFlags struct {
 
 func (x *LsBgpPeerSegmentSIDFlags) Reset() {
 	*x = LsBgpPeerSegmentSIDFlags{}
-	mi := &file_api_attribute_proto_msgTypes[55]
+	mi := &file_api_attribute_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3805,7 +4088,7 @@ func (x *LsBgpPeerSegmentSIDFlags) String() string {
 func (*LsBgpPeerSegmentSIDFlags) ProtoMessage() {}
 
 func (x *LsBgpPeerSegmentSIDFlags) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[55]
+	mi := &file_api_attribute_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3818,7 +4101,7 @@ func (x *LsBgpPeerSegmentSIDFlags) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsBgpPeerSegmentSIDFlags.ProtoReflect.Descriptor instead.
 func (*LsBgpPeerSegmentSIDFlags) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{55}
+	return file_api_attribute_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *LsBgpPeerSegmentSIDFlags) GetValue() bool {
@@ -3860,7 +4143,7 @@ type LsBgpPeerSegmentSID struct {
 
 func (x *LsBgpPeerSegmentSID) Reset() {
 	*x = LsBgpPeerSegmentSID{}
-	mi := &file_api_attribute_proto_msgTypes[56]
+	mi := &file_api_attribute_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3872,7 +4155,7 @@ func (x *LsBgpPeerSegmentSID) String() string {
 func (*LsBgpPeerSegmentSID) ProtoMessage() {}
 
 func (x *LsBgpPeerSegmentSID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[56]
+	mi := &file_api_attribute_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3885,7 +4168,7 @@ func (x *LsBgpPeerSegmentSID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsBgpPeerSegmentSID.ProtoReflect.Descriptor instead.
 func (*LsBgpPeerSegmentSID) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{56}
+	return file_api_attribute_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *LsBgpPeerSegmentSID) GetFlags() *LsBgpPeerSegmentSIDFlags {
@@ -3920,7 +4203,7 @@ type LsAttributeBgpPeerSegment struct {
 
 func (x *LsAttributeBgpPeerSegment) Reset() {
 	*x = LsAttributeBgpPeerSegment{}
-	mi := &file_api_attribute_proto_msgTypes[57]
+	mi := &file_api_attribute_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3932,7 +4215,7 @@ func (x *LsAttributeBgpPeerSegment) String() string {
 func (*LsAttributeBgpPeerSegment) ProtoMessage() {}
 
 func (x *LsAttributeBgpPeerSegment) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[57]
+	mi := &file_api_attribute_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3945,7 +4228,7 @@ func (x *LsAttributeBgpPeerSegment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsAttributeBgpPeerSegment.ProtoReflect.Descriptor instead.
 func (*LsAttributeBgpPeerSegment) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{57}
+	return file_api_attribute_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *LsAttributeBgpPeerSegment) GetBgpPeerNodeSid() *LsBgpPeerSegmentSID {
@@ -3984,7 +4267,7 @@ type LsSrv6EndXSID struct {
 
 func (x *LsSrv6EndXSID) Reset() {
 	*x = LsSrv6EndXSID{}
-	mi := &file_api_attribute_proto_msgTypes[58]
+	mi := &file_api_attribute_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3996,7 +4279,7 @@ func (x *LsSrv6EndXSID) String() string {
 func (*LsSrv6EndXSID) ProtoMessage() {}
 
 func (x *LsSrv6EndXSID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[58]
+	mi := &file_api_attribute_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4009,7 +4292,7 @@ func (x *LsSrv6EndXSID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsSrv6EndXSID.ProtoReflect.Descriptor instead.
 func (*LsSrv6EndXSID) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{58}
+	return file_api_attribute_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *LsSrv6EndXSID) GetEndpointBehavior() uint32 {
@@ -4073,7 +4356,7 @@ type LsSrv6SIDStructure struct {
 
 func (x *LsSrv6SIDStructure) Reset() {
 	*x = LsSrv6SIDStructure{}
-	mi := &file_api_attribute_proto_msgTypes[59]
+	mi := &file_api_attribute_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4085,7 +4368,7 @@ func (x *LsSrv6SIDStructure) String() string {
 func (*LsSrv6SIDStructure) ProtoMessage() {}
 
 func (x *LsSrv6SIDStructure) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[59]
+	mi := &file_api_attribute_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4098,7 +4381,7 @@ func (x *LsSrv6SIDStructure) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsSrv6SIDStructure.ProtoReflect.Descriptor instead.
 func (*LsSrv6SIDStructure) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{59}
+	return file_api_attribute_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *LsSrv6SIDStructure) GetLocalBlock() uint32 {
@@ -4140,7 +4423,7 @@ type LsSrv6EndpointBehavior struct {
 
 func (x *LsSrv6EndpointBehavior) Reset() {
 	*x = LsSrv6EndpointBehavior{}
-	mi := &file_api_attribute_proto_msgTypes[60]
+	mi := &file_api_attribute_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4152,7 +4435,7 @@ func (x *LsSrv6EndpointBehavior) String() string {
 func (*LsSrv6EndpointBehavior) ProtoMessage() {}
 
 func (x *LsSrv6EndpointBehavior) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[60]
+	mi := &file_api_attribute_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4165,7 +4448,7 @@ func (x *LsSrv6EndpointBehavior) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsSrv6EndpointBehavior.ProtoReflect.Descriptor instead.
 func (*LsSrv6EndpointBehavior) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{60}
+	return file_api_attribute_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *LsSrv6EndpointBehavior) GetEndpointBehavior() uint32 {
@@ -4201,7 +4484,7 @@ type LsSrv6BgpPeerNodeSID struct {
 
 func (x *LsSrv6BgpPeerNodeSID) Reset() {
 	*x = LsSrv6BgpPeerNodeSID{}
-	mi := &file_api_attribute_proto_msgTypes[61]
+	mi := &file_api_attribute_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4213,7 +4496,7 @@ func (x *LsSrv6BgpPeerNodeSID) String() string {
 func (*LsSrv6BgpPeerNodeSID) ProtoMessage() {}
 
 func (x *LsSrv6BgpPeerNodeSID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[61]
+	mi := &file_api_attribute_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4226,7 +4509,7 @@ func (x *LsSrv6BgpPeerNodeSID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsSrv6BgpPeerNodeSID.ProtoReflect.Descriptor instead.
 func (*LsSrv6BgpPeerNodeSID) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{61}
+	return file_api_attribute_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *LsSrv6BgpPeerNodeSID) GetFlags() uint32 {
@@ -4268,7 +4551,7 @@ type LsAttributeSrv6SID struct {
 
 func (x *LsAttributeSrv6SID) Reset() {
 	*x = LsAttributeSrv6SID{}
-	mi := &file_api_attribute_proto_msgTypes[62]
+	mi := &file_api_attribute_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4280,7 +4563,7 @@ func (x *LsAttributeSrv6SID) String() string {
 func (*LsAttributeSrv6SID) ProtoMessage() {}
 
 func (x *LsAttributeSrv6SID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[62]
+	mi := &file_api_attribute_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4293,7 +4576,7 @@ func (x *LsAttributeSrv6SID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsAttributeSrv6SID.ProtoReflect.Descriptor instead.
 func (*LsAttributeSrv6SID) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{62}
+	return file_api_attribute_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *LsAttributeSrv6SID) GetSrv6SidStructure() *LsSrv6SIDStructure {
@@ -4330,7 +4613,7 @@ type LsAttribute struct {
 
 func (x *LsAttribute) Reset() {
 	*x = LsAttribute{}
-	mi := &file_api_attribute_proto_msgTypes[63]
+	mi := &file_api_attribute_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4342,7 +4625,7 @@ func (x *LsAttribute) String() string {
 func (*LsAttribute) ProtoMessage() {}
 
 func (x *LsAttribute) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[63]
+	mi := &file_api_attribute_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4355,7 +4638,7 @@ func (x *LsAttribute) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsAttribute.ProtoReflect.Descriptor instead.
 func (*LsAttribute) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{63}
+	return file_api_attribute_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *LsAttribute) GetNode() *LsAttributeNode {
@@ -4404,7 +4687,7 @@ type UnknownAttribute struct {
 
 func (x *UnknownAttribute) Reset() {
 	*x = UnknownAttribute{}
-	mi := &file_api_attribute_proto_msgTypes[64]
+	mi := &file_api_attribute_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4416,7 +4699,7 @@ func (x *UnknownAttribute) String() string {
 func (*UnknownAttribute) ProtoMessage() {}
 
 func (x *UnknownAttribute) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[64]
+	mi := &file_api_attribute_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4429,7 +4712,7 @@ func (x *UnknownAttribute) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnknownAttribute.ProtoReflect.Descriptor instead.
 func (*UnknownAttribute) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{64}
+	return file_api_attribute_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *UnknownAttribute) GetFlags() uint32 {
@@ -4468,7 +4751,7 @@ type SRv6StructureSubSubTLV struct {
 
 func (x *SRv6StructureSubSubTLV) Reset() {
 	*x = SRv6StructureSubSubTLV{}
-	mi := &file_api_attribute_proto_msgTypes[65]
+	mi := &file_api_attribute_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4480,7 +4763,7 @@ func (x *SRv6StructureSubSubTLV) String() string {
 func (*SRv6StructureSubSubTLV) ProtoMessage() {}
 
 func (x *SRv6StructureSubSubTLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[65]
+	mi := &file_api_attribute_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4493,7 +4776,7 @@ func (x *SRv6StructureSubSubTLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6StructureSubSubTLV.ProtoReflect.Descriptor instead.
 func (*SRv6StructureSubSubTLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{65}
+	return file_api_attribute_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *SRv6StructureSubSubTLV) GetLocatorBlockLength() uint32 {
@@ -4550,7 +4833,7 @@ type SRv6SubSubTLV struct {
 
 func (x *SRv6SubSubTLV) Reset() {
 	*x = SRv6SubSubTLV{}
-	mi := &file_api_attribute_proto_msgTypes[66]
+	mi := &file_api_attribute_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4562,7 +4845,7 @@ func (x *SRv6SubSubTLV) String() string {
 func (*SRv6SubSubTLV) ProtoMessage() {}
 
 func (x *SRv6SubSubTLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[66]
+	mi := &file_api_attribute_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4575,7 +4858,7 @@ func (x *SRv6SubSubTLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6SubSubTLV.ProtoReflect.Descriptor instead.
 func (*SRv6SubSubTLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{66}
+	return file_api_attribute_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *SRv6SubSubTLV) GetTlv() isSRv6SubSubTLV_Tlv {
@@ -4613,7 +4896,7 @@ type SRv6SubSubTLVs struct {
 
 func (x *SRv6SubSubTLVs) Reset() {
 	*x = SRv6SubSubTLVs{}
-	mi := &file_api_attribute_proto_msgTypes[67]
+	mi := &file_api_attribute_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4625,7 +4908,7 @@ func (x *SRv6SubSubTLVs) String() string {
 func (*SRv6SubSubTLVs) ProtoMessage() {}
 
 func (x *SRv6SubSubTLVs) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[67]
+	mi := &file_api_attribute_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4638,7 +4921,7 @@ func (x *SRv6SubSubTLVs) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6SubSubTLVs.ProtoReflect.Descriptor instead.
 func (*SRv6SubSubTLVs) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{67}
+	return file_api_attribute_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *SRv6SubSubTLVs) GetTlvs() []*SRv6SubSubTLV {
@@ -4658,7 +4941,7 @@ type SRv6SIDFlags struct {
 
 func (x *SRv6SIDFlags) Reset() {
 	*x = SRv6SIDFlags{}
-	mi := &file_api_attribute_proto_msgTypes[68]
+	mi := &file_api_attribute_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4670,7 +4953,7 @@ func (x *SRv6SIDFlags) String() string {
 func (*SRv6SIDFlags) ProtoMessage() {}
 
 func (x *SRv6SIDFlags) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[68]
+	mi := &file_api_attribute_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4683,7 +4966,7 @@ func (x *SRv6SIDFlags) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6SIDFlags.ProtoReflect.Descriptor instead.
 func (*SRv6SIDFlags) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{68}
+	return file_api_attribute_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *SRv6SIDFlags) GetFlag_1() bool {
@@ -4706,7 +4989,7 @@ type SRv6InformationSubTLV struct {
 
 func (x *SRv6InformationSubTLV) Reset() {
 	*x = SRv6InformationSubTLV{}
-	mi := &file_api_attribute_proto_msgTypes[69]
+	mi := &file_api_attribute_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4718,7 +5001,7 @@ func (x *SRv6InformationSubTLV) String() string {
 func (*SRv6InformationSubTLV) ProtoMessage() {}
 
 func (x *SRv6InformationSubTLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[69]
+	mi := &file_api_attribute_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4731,7 +5014,7 @@ func (x *SRv6InformationSubTLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6InformationSubTLV.ProtoReflect.Descriptor instead.
 func (*SRv6InformationSubTLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{69}
+	return file_api_attribute_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *SRv6InformationSubTLV) GetSid() []byte {
@@ -4774,7 +5057,7 @@ type SRv6SubTLV struct {
 
 func (x *SRv6SubTLV) Reset() {
 	*x = SRv6SubTLV{}
-	mi := &file_api_attribute_proto_msgTypes[70]
+	mi := &file_api_attribute_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4786,7 +5069,7 @@ func (x *SRv6SubTLV) String() string {
 func (*SRv6SubTLV) ProtoMessage() {}
 
 func (x *SRv6SubTLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[70]
+	mi := &file_api_attribute_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4799,7 +5082,7 @@ func (x *SRv6SubTLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6SubTLV.ProtoReflect.Descriptor instead.
 func (*SRv6SubTLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{70}
+	return file_api_attribute_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *SRv6SubTLV) GetTlv() isSRv6SubTLV_Tlv {
@@ -4837,7 +5120,7 @@ type SRv6SubTLVs struct {
 
 func (x *SRv6SubTLVs) Reset() {
 	*x = SRv6SubTLVs{}
-	mi := &file_api_attribute_proto_msgTypes[71]
+	mi := &file_api_attribute_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4849,7 +5132,7 @@ func (x *SRv6SubTLVs) String() string {
 func (*SRv6SubTLVs) ProtoMessage() {}
 
 func (x *SRv6SubTLVs) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[71]
+	mi := &file_api_attribute_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4862,7 +5145,7 @@ func (x *SRv6SubTLVs) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6SubTLVs.ProtoReflect.Descriptor instead.
 func (*SRv6SubTLVs) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{71}
+	return file_api_attribute_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *SRv6SubTLVs) GetTlvs() []*SRv6SubTLV {
@@ -4882,7 +5165,7 @@ type SRv6L3ServiceTLV struct {
 
 func (x *SRv6L3ServiceTLV) Reset() {
 	*x = SRv6L3ServiceTLV{}
-	mi := &file_api_attribute_proto_msgTypes[72]
+	mi := &file_api_attribute_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4894,7 +5177,7 @@ func (x *SRv6L3ServiceTLV) String() string {
 func (*SRv6L3ServiceTLV) ProtoMessage() {}
 
 func (x *SRv6L3ServiceTLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[72]
+	mi := &file_api_attribute_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4907,7 +5190,7 @@ func (x *SRv6L3ServiceTLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6L3ServiceTLV.ProtoReflect.Descriptor instead.
 func (*SRv6L3ServiceTLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{72}
+	return file_api_attribute_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *SRv6L3ServiceTLV) GetSubTlvs() map[uint32]*SRv6SubTLVs {
@@ -4927,7 +5210,7 @@ type SRv6L2ServiceTLV struct {
 
 func (x *SRv6L2ServiceTLV) Reset() {
 	*x = SRv6L2ServiceTLV{}
-	mi := &file_api_attribute_proto_msgTypes[73]
+	mi := &file_api_attribute_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4939,7 +5222,7 @@ func (x *SRv6L2ServiceTLV) String() string {
 func (*SRv6L2ServiceTLV) ProtoMessage() {}
 
 func (x *SRv6L2ServiceTLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[73]
+	mi := &file_api_attribute_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4952,7 +5235,7 @@ func (x *SRv6L2ServiceTLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6L2ServiceTLV.ProtoReflect.Descriptor instead.
 func (*SRv6L2ServiceTLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{73}
+	return file_api_attribute_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *SRv6L2ServiceTLV) GetSubTlvs() map[uint32]*SRv6SubTLVs {
@@ -4972,7 +5255,7 @@ type PrefixSID struct {
 
 func (x *PrefixSID) Reset() {
 	*x = PrefixSID{}
-	mi := &file_api_attribute_proto_msgTypes[74]
+	mi := &file_api_attribute_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4984,7 +5267,7 @@ func (x *PrefixSID) String() string {
 func (*PrefixSID) ProtoMessage() {}
 
 func (x *PrefixSID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[74]
+	mi := &file_api_attribute_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4997,7 +5280,7 @@ func (x *PrefixSID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrefixSID.ProtoReflect.Descriptor instead.
 func (*PrefixSID) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{74}
+	return file_api_attribute_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *PrefixSID) GetTlvs() []*PrefixSID_TLV {
@@ -5020,7 +5303,7 @@ type TunnelEncapSubTLVSRSegmentList_Segment struct {
 
 func (x *TunnelEncapSubTLVSRSegmentList_Segment) Reset() {
 	*x = TunnelEncapSubTLVSRSegmentList_Segment{}
-	mi := &file_api_attribute_proto_msgTypes[75]
+	mi := &file_api_attribute_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5032,7 +5315,7 @@ func (x *TunnelEncapSubTLVSRSegmentList_Segment) String() string {
 func (*TunnelEncapSubTLVSRSegmentList_Segment) ProtoMessage() {}
 
 func (x *TunnelEncapSubTLVSRSegmentList_Segment) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[75]
+	mi := &file_api_attribute_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5112,7 +5395,7 @@ type TunnelEncapTLV_TLV struct {
 
 func (x *TunnelEncapTLV_TLV) Reset() {
 	*x = TunnelEncapTLV_TLV{}
-	mi := &file_api_attribute_proto_msgTypes[76]
+	mi := &file_api_attribute_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5124,7 +5407,7 @@ func (x *TunnelEncapTLV_TLV) String() string {
 func (*TunnelEncapTLV_TLV) ProtoMessage() {}
 
 func (x *TunnelEncapTLV_TLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[76]
+	mi := &file_api_attribute_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5344,7 +5627,7 @@ type IP6ExtendedCommunitiesAttribute_Community struct {
 
 func (x *IP6ExtendedCommunitiesAttribute_Community) Reset() {
 	*x = IP6ExtendedCommunitiesAttribute_Community{}
-	mi := &file_api_attribute_proto_msgTypes[77]
+	mi := &file_api_attribute_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5356,7 +5639,7 @@ func (x *IP6ExtendedCommunitiesAttribute_Community) String() string {
 func (*IP6ExtendedCommunitiesAttribute_Community) ProtoMessage() {}
 
 func (x *IP6ExtendedCommunitiesAttribute_Community) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[77]
+	mi := &file_api_attribute_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5428,7 +5711,7 @@ type AigpAttribute_TLV struct {
 
 func (x *AigpAttribute_TLV) Reset() {
 	*x = AigpAttribute_TLV{}
-	mi := &file_api_attribute_proto_msgTypes[78]
+	mi := &file_api_attribute_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5440,7 +5723,7 @@ func (x *AigpAttribute_TLV) String() string {
 func (*AigpAttribute_TLV) ProtoMessage() {}
 
 func (x *AigpAttribute_TLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[78]
+	mi := &file_api_attribute_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5511,7 +5794,7 @@ type PrefixSID_TLV struct {
 
 func (x *PrefixSID_TLV) Reset() {
 	*x = PrefixSID_TLV{}
-	mi := &file_api_attribute_proto_msgTypes[82]
+	mi := &file_api_attribute_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5523,7 +5806,7 @@ func (x *PrefixSID_TLV) String() string {
 func (*PrefixSID_TLV) ProtoMessage() {}
 
 func (x *PrefixSID_TLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[82]
+	mi := &file_api_attribute_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5536,7 +5819,7 @@ func (x *PrefixSID_TLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrefixSID_TLV.ProtoReflect.Descriptor instead.
 func (*PrefixSID_TLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{74, 0}
+	return file_api_attribute_proto_rawDescGZIP(), []int{77, 0}
 }
 
 func (x *PrefixSID_TLV) GetTlv() isPrefixSID_TLV_Tlv {
@@ -5815,7 +6098,7 @@ const file_api_attribute_proto_rawDesc = "" +
 	"\x0eipv6_supported\x18\x02 \x01(\bR\ripv6Supported\x12&\n" +
 	"\x06ranges\x18\x03 \x03(\v2\x0e.api.LsSrRangeR\x06ranges\"8\n" +
 	"\x0eLsSrLocalBlock\x12&\n" +
-	"\x06ranges\x18\x01 \x03(\v2\x0e.api.LsSrRangeR\x06ranges\"\xf7\x02\n" +
+	"\x06ranges\x18\x01 \x03(\v2\x0e.api.LsSrRangeR\x06ranges\"\xba\x03\n" +
 	"\x0fLsAttributeNode\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12&\n" +
 	"\x05flags\x18\x02 \x01(\v2\x10.api.LsNodeFlagsR\x05flags\x12&\n" +
@@ -5825,7 +6108,22 @@ const file_api_attribute_proto_rawDesc = "" +
 	"\x06opaque\x18\x06 \x01(\fR\x06opaque\x12>\n" +
 	"\x0fsr_capabilities\x18\a \x01(\v2\x15.api.LsSrCapabilitiesR\x0esrCapabilities\x12#\n" +
 	"\rsr_algorithms\x18\b \x01(\fR\fsrAlgorithms\x129\n" +
-	"\x0esr_local_block\x18\t \x01(\v2\x13.api.LsSrLocalBlockR\fsrLocalBlock\"\x88\b\n" +
+	"\x0esr_local_block\x18\t \x01(\v2\x13.api.LsSrLocalBlockR\fsrLocalBlock\x12A\n" +
+	"\x0eflex_algo_defs\x18\n" +
+	" \x03(\v2\x1b.api.LsAttributeFlexAlgoDefR\fflexAlgoDefs\"\xa0\x03\n" +
+	"\x16LsAttributeFlexAlgoDef\x12\x1c\n" +
+	"\talgorithm\x18\x01 \x01(\rR\talgorithm\x12\x1f\n" +
+	"\vmetric_type\x18\x02 \x01(\rR\n" +
+	"metricType\x12*\n" +
+	"\x11metric_type_known\x18\x03 \x01(\bR\x0fmetricTypeKnown\x12\x1b\n" +
+	"\tcalc_type\x18\x04 \x01(\rR\bcalcType\x12\x1a\n" +
+	"\bpriority\x18\x05 \x01(\rR\bpriority\x120\n" +
+	"\x14exclude_any_affinity\x18\x06 \x03(\rR\x12excludeAnyAffinity\x120\n" +
+	"\x14include_any_affinity\x18\a \x03(\rR\x12includeAnyAffinity\x120\n" +
+	"\x14include_all_affinity\x18\b \x03(\rR\x12includeAllAffinity\x12)\n" +
+	"\x10definition_flags\x18\t \x01(\fR\x0fdefinitionFlags\x12!\n" +
+	"\fexclude_srlg\x18\n" +
+	" \x03(\rR\vexcludeSrlg\"\x88\b\n" +
 	"\x0fLsAttributeLink\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12&\n" +
 	"\x0flocal_router_id\x18\x02 \x01(\tR\rlocalRouterId\x12+\n" +
@@ -5850,11 +6148,21 @@ const file_api_attribute_proto_rawDesc = "" +
 	"+min_max_unidirectional_link_delay_anomalous\x18\x12 \x01(\bR&minMaxUnidirectionalLinkDelayAnomalous\x12A\n" +
 	"\x1dmin_unidirectional_link_delay\x18\x13 \x01(\rR\x1aminUnidirectionalLinkDelay\x12A\n" +
 	"\x1dmax_unidirectional_link_delay\x18\x14 \x01(\rR\x1amaxUnidirectionalLinkDelay\x12D\n" +
-	"\x1eunidirectional_delay_variation\x18\x15 \x01(\rR\x1cunidirectionalDelayVariation\"}\n" +
+	"\x1eunidirectional_delay_variation\x18\x15 \x01(\rR\x1cunidirectionalDelayVariation\"\x8d\x02\n" +
 	"\x11LsAttributePrefix\x12,\n" +
 	"\tigp_flags\x18\x01 \x01(\v2\x0f.api.LsIGPFlagsR\bigpFlags\x12\x16\n" +
 	"\x06opaque\x18\x02 \x01(\fR\x06opaque\x12\"\n" +
-	"\rsr_prefix_sid\x18\x03 \x01(\rR\vsrPrefixSid\"~\n" +
+	"\rsr_prefix_sid\x18\x03 \x01(\rR\vsrPrefixSid\x12?\n" +
+	"\x0esr_prefix_sids\x18\x04 \x03(\v2\x19.api.LsAttributePrefixSIDR\fsrPrefixSids\x12M\n" +
+	"\x12fad_prefix_metrics\x18\x05 \x03(\v2\x1f.api.LsAttributeFADPrefixMetricR\x10fadPrefixMetrics\"\\\n" +
+	"\x14LsAttributePrefixSID\x12\x1c\n" +
+	"\talgorithm\x18\x01 \x01(\rR\talgorithm\x12\x14\n" +
+	"\x05flags\x18\x02 \x01(\rR\x05flags\x12\x10\n" +
+	"\x03sid\x18\x03 \x01(\rR\x03sid\"h\n" +
+	"\x1aLsAttributeFADPrefixMetric\x12\x1c\n" +
+	"\talgorithm\x18\x01 \x01(\rR\talgorithm\x12\x14\n" +
+	"\x05flags\x18\x02 \x01(\rR\x05flags\x12\x16\n" +
+	"\x06metric\x18\x03 \x01(\rR\x06metric\"~\n" +
 	"\x18LsBgpPeerSegmentSIDFlags\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\bR\x05value\x12\x14\n" +
 	"\x05local\x18\x02 \x01(\bR\x05local\x12\x16\n" +
@@ -6020,7 +6328,7 @@ func file_api_attribute_proto_rawDescGZIP() []byte {
 }
 
 var file_api_attribute_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_api_attribute_proto_msgTypes = make([]protoimpl.MessageInfo, 83)
+var file_api_attribute_proto_msgTypes = make([]protoimpl.MessageInfo, 86)
 var file_api_attribute_proto_goTypes = []any{
 	(SRV6Behavior)(0),                                 // 0: api.SRV6Behavior
 	(ENLPType)(0),                                     // 1: api.ENLPType
@@ -6078,144 +6386,150 @@ var file_api_attribute_proto_goTypes = []any{
 	(*LsSrCapabilities)(nil),                          // 53: api.LsSrCapabilities
 	(*LsSrLocalBlock)(nil),                            // 54: api.LsSrLocalBlock
 	(*LsAttributeNode)(nil),                           // 55: api.LsAttributeNode
-	(*LsAttributeLink)(nil),                           // 56: api.LsAttributeLink
-	(*LsAttributePrefix)(nil),                         // 57: api.LsAttributePrefix
-	(*LsBgpPeerSegmentSIDFlags)(nil),                  // 58: api.LsBgpPeerSegmentSIDFlags
-	(*LsBgpPeerSegmentSID)(nil),                       // 59: api.LsBgpPeerSegmentSID
-	(*LsAttributeBgpPeerSegment)(nil),                 // 60: api.LsAttributeBgpPeerSegment
-	(*LsSrv6EndXSID)(nil),                             // 61: api.LsSrv6EndXSID
-	(*LsSrv6SIDStructure)(nil),                        // 62: api.LsSrv6SIDStructure
-	(*LsSrv6EndpointBehavior)(nil),                    // 63: api.LsSrv6EndpointBehavior
-	(*LsSrv6BgpPeerNodeSID)(nil),                      // 64: api.LsSrv6BgpPeerNodeSID
-	(*LsAttributeSrv6SID)(nil),                        // 65: api.LsAttributeSrv6SID
-	(*LsAttribute)(nil),                               // 66: api.LsAttribute
-	(*UnknownAttribute)(nil),                          // 67: api.UnknownAttribute
-	(*SRv6StructureSubSubTLV)(nil),                    // 68: api.SRv6StructureSubSubTLV
-	(*SRv6SubSubTLV)(nil),                             // 69: api.SRv6SubSubTLV
-	(*SRv6SubSubTLVs)(nil),                            // 70: api.SRv6SubSubTLVs
-	(*SRv6SIDFlags)(nil),                              // 71: api.SRv6SIDFlags
-	(*SRv6InformationSubTLV)(nil),                     // 72: api.SRv6InformationSubTLV
-	(*SRv6SubTLV)(nil),                                // 73: api.SRv6SubTLV
-	(*SRv6SubTLVs)(nil),                               // 74: api.SRv6SubTLVs
-	(*SRv6L3ServiceTLV)(nil),                          // 75: api.SRv6L3ServiceTLV
-	(*SRv6L2ServiceTLV)(nil),                          // 76: api.SRv6L2ServiceTLV
-	(*PrefixSID)(nil),                                 // 77: api.PrefixSID
-	(*TunnelEncapSubTLVSRSegmentList_Segment)(nil),    // 78: api.TunnelEncapSubTLVSRSegmentList.Segment
-	(*TunnelEncapTLV_TLV)(nil),                        // 79: api.TunnelEncapTLV.TLV
-	(*IP6ExtendedCommunitiesAttribute_Community)(nil), // 80: api.IP6ExtendedCommunitiesAttribute.Community
-	(*AigpAttribute_TLV)(nil),                         // 81: api.AigpAttribute.TLV
-	nil,                                               // 82: api.SRv6InformationSubTLV.SubSubTlvsEntry
-	nil,                                               // 83: api.SRv6L3ServiceTLV.SubTlvsEntry
-	nil,                                               // 84: api.SRv6L2ServiceTLV.SubTlvsEntry
-	(*PrefixSID_TLV)(nil),                             // 85: api.PrefixSID.TLV
-	(*Family)(nil),                                    // 86: api.Family
-	(*NLRI)(nil),                                      // 87: api.NLRI
-	(*ExtendedCommunity)(nil),                         // 88: api.ExtendedCommunity
+	(*LsAttributeFlexAlgoDef)(nil),                    // 56: api.LsAttributeFlexAlgoDef
+	(*LsAttributeLink)(nil),                           // 57: api.LsAttributeLink
+	(*LsAttributePrefix)(nil),                         // 58: api.LsAttributePrefix
+	(*LsAttributePrefixSID)(nil),                      // 59: api.LsAttributePrefixSID
+	(*LsAttributeFADPrefixMetric)(nil),                // 60: api.LsAttributeFADPrefixMetric
+	(*LsBgpPeerSegmentSIDFlags)(nil),                  // 61: api.LsBgpPeerSegmentSIDFlags
+	(*LsBgpPeerSegmentSID)(nil),                       // 62: api.LsBgpPeerSegmentSID
+	(*LsAttributeBgpPeerSegment)(nil),                 // 63: api.LsAttributeBgpPeerSegment
+	(*LsSrv6EndXSID)(nil),                             // 64: api.LsSrv6EndXSID
+	(*LsSrv6SIDStructure)(nil),                        // 65: api.LsSrv6SIDStructure
+	(*LsSrv6EndpointBehavior)(nil),                    // 66: api.LsSrv6EndpointBehavior
+	(*LsSrv6BgpPeerNodeSID)(nil),                      // 67: api.LsSrv6BgpPeerNodeSID
+	(*LsAttributeSrv6SID)(nil),                        // 68: api.LsAttributeSrv6SID
+	(*LsAttribute)(nil),                               // 69: api.LsAttribute
+	(*UnknownAttribute)(nil),                          // 70: api.UnknownAttribute
+	(*SRv6StructureSubSubTLV)(nil),                    // 71: api.SRv6StructureSubSubTLV
+	(*SRv6SubSubTLV)(nil),                             // 72: api.SRv6SubSubTLV
+	(*SRv6SubSubTLVs)(nil),                            // 73: api.SRv6SubSubTLVs
+	(*SRv6SIDFlags)(nil),                              // 74: api.SRv6SIDFlags
+	(*SRv6InformationSubTLV)(nil),                     // 75: api.SRv6InformationSubTLV
+	(*SRv6SubTLV)(nil),                                // 76: api.SRv6SubTLV
+	(*SRv6SubTLVs)(nil),                               // 77: api.SRv6SubTLVs
+	(*SRv6L3ServiceTLV)(nil),                          // 78: api.SRv6L3ServiceTLV
+	(*SRv6L2ServiceTLV)(nil),                          // 79: api.SRv6L2ServiceTLV
+	(*PrefixSID)(nil),                                 // 80: api.PrefixSID
+	(*TunnelEncapSubTLVSRSegmentList_Segment)(nil),    // 81: api.TunnelEncapSubTLVSRSegmentList.Segment
+	(*TunnelEncapTLV_TLV)(nil),                        // 82: api.TunnelEncapTLV.TLV
+	(*IP6ExtendedCommunitiesAttribute_Community)(nil), // 83: api.IP6ExtendedCommunitiesAttribute.Community
+	(*AigpAttribute_TLV)(nil),                         // 84: api.AigpAttribute.TLV
+	nil,                                               // 85: api.SRv6InformationSubTLV.SubSubTlvsEntry
+	nil,                                               // 86: api.SRv6L3ServiceTLV.SubTlvsEntry
+	nil,                                               // 87: api.SRv6L2ServiceTLV.SubTlvsEntry
+	(*PrefixSID_TLV)(nil),                             // 88: api.PrefixSID.TLV
+	(*Family)(nil),                                    // 89: api.Family
+	(*NLRI)(nil),                                      // 90: api.NLRI
+	(*ExtendedCommunity)(nil),                         // 91: api.ExtendedCommunity
 }
 var file_api_attribute_proto_depIdxs = []int32{
-	67, // 0: api.Attribute.unknown:type_name -> api.UnknownAttribute
-	4,  // 1: api.Attribute.origin:type_name -> api.OriginAttribute
-	6,  // 2: api.Attribute.as_path:type_name -> api.AsPathAttribute
-	7,  // 3: api.Attribute.next_hop:type_name -> api.NextHopAttribute
-	8,  // 4: api.Attribute.multi_exit_disc:type_name -> api.MultiExitDiscAttribute
-	9,  // 5: api.Attribute.local_pref:type_name -> api.LocalPrefAttribute
-	10, // 6: api.Attribute.atomic_aggregate:type_name -> api.AtomicAggregateAttribute
-	11, // 7: api.Attribute.aggregator:type_name -> api.AggregatorAttribute
-	12, // 8: api.Attribute.communities:type_name -> api.CommunitiesAttribute
-	13, // 9: api.Attribute.originator_id:type_name -> api.OriginatorIdAttribute
-	14, // 10: api.Attribute.cluster_list:type_name -> api.ClusterListAttribute
-	15, // 11: api.Attribute.mp_reach:type_name -> api.MpReachNLRIAttribute
-	16, // 12: api.Attribute.mp_unreach:type_name -> api.MpUnreachNLRIAttribute
-	17, // 13: api.Attribute.extended_communities:type_name -> api.ExtendedCommunitiesAttribute
-	18, // 14: api.Attribute.as4_path:type_name -> api.As4PathAttribute
-	19, // 15: api.Attribute.as4_aggregator:type_name -> api.As4AggregatorAttribute
-	20, // 16: api.Attribute.pmsi_tunnel:type_name -> api.PmsiTunnelAttribute
-	41, // 17: api.Attribute.tunnel_encap:type_name -> api.TunnelEncapAttribute
-	44, // 18: api.Attribute.ip6_extended_communities:type_name -> api.IP6ExtendedCommunitiesAttribute
-	47, // 19: api.Attribute.aigp:type_name -> api.AigpAttribute
-	49, // 20: api.Attribute.large_communities:type_name -> api.LargeCommunitiesAttribute
-	66, // 21: api.Attribute.ls:type_name -> api.LsAttribute
-	77, // 22: api.Attribute.prefix_sid:type_name -> api.PrefixSID
-	2,  // 23: api.AsSegment.type:type_name -> api.AsSegment.Type
-	5,  // 24: api.AsPathAttribute.segments:type_name -> api.AsSegment
-	86, // 25: api.MpReachNLRIAttribute.family:type_name -> api.Family
-	87, // 26: api.MpReachNLRIAttribute.nlris:type_name -> api.NLRI
-	86, // 27: api.MpUnreachNLRIAttribute.family:type_name -> api.Family
-	87, // 28: api.MpUnreachNLRIAttribute.nlris:type_name -> api.NLRI
-	88, // 29: api.ExtendedCommunitiesAttribute.communities:type_name -> api.ExtendedCommunity
-	5,  // 30: api.As4PathAttribute.segments:type_name -> api.AsSegment
-	28, // 31: api.TunnelEncapSubTLVSRBindingSID.sr_binding_sid:type_name -> api.SRBindingSID
-	30, // 32: api.TunnelEncapSubTLVSRBindingSID.srv6_binding_sid:type_name -> api.SRv6BindingSID
-	0,  // 33: api.SRv6EndPointBehavior.behavior:type_name -> api.SRV6Behavior
-	29, // 34: api.SRv6BindingSID.endpoint_behavior_structure:type_name -> api.SRv6EndPointBehavior
-	1,  // 35: api.TunnelEncapSubTLVSRENLP.enlp:type_name -> api.ENLPType
-	33, // 36: api.SegmentTypeA.flags:type_name -> api.SegmentFlags
-	33, // 37: api.SegmentTypeB.flags:type_name -> api.SegmentFlags
-	29, // 38: api.SegmentTypeB.endpoint_behavior_structure:type_name -> api.SRv6EndPointBehavior
-	32, // 39: api.TunnelEncapSubTLVSRSegmentList.weight:type_name -> api.SRWeight
-	78, // 40: api.TunnelEncapSubTLVSRSegmentList.segments:type_name -> api.TunnelEncapSubTLVSRSegmentList.Segment
-	79, // 41: api.TunnelEncapTLV.tlvs:type_name -> api.TunnelEncapTLV.TLV
-	40, // 42: api.TunnelEncapAttribute.tlvs:type_name -> api.TunnelEncapTLV
-	80, // 43: api.IP6ExtendedCommunitiesAttribute.communities:type_name -> api.IP6ExtendedCommunitiesAttribute.Community
-	81, // 44: api.AigpAttribute.tlvs:type_name -> api.AigpAttribute.TLV
-	48, // 45: api.LargeCommunitiesAttribute.communities:type_name -> api.LargeCommunity
-	52, // 46: api.LsSrCapabilities.ranges:type_name -> api.LsSrRange
-	52, // 47: api.LsSrLocalBlock.ranges:type_name -> api.LsSrRange
-	50, // 48: api.LsAttributeNode.flags:type_name -> api.LsNodeFlags
-	53, // 49: api.LsAttributeNode.sr_capabilities:type_name -> api.LsSrCapabilities
-	54, // 50: api.LsAttributeNode.sr_local_block:type_name -> api.LsSrLocalBlock
-	61, // 51: api.LsAttributeLink.srv6_end_x_sid:type_name -> api.LsSrv6EndXSID
-	51, // 52: api.LsAttributePrefix.igp_flags:type_name -> api.LsIGPFlags
-	58, // 53: api.LsBgpPeerSegmentSID.flags:type_name -> api.LsBgpPeerSegmentSIDFlags
-	59, // 54: api.LsAttributeBgpPeerSegment.bgp_peer_node_sid:type_name -> api.LsBgpPeerSegmentSID
-	59, // 55: api.LsAttributeBgpPeerSegment.bgp_peer_adjacency_sid:type_name -> api.LsBgpPeerSegmentSID
-	59, // 56: api.LsAttributeBgpPeerSegment.bgp_peer_set_sid:type_name -> api.LsBgpPeerSegmentSID
-	62, // 57: api.LsSrv6EndXSID.srv6_sid_structure:type_name -> api.LsSrv6SIDStructure
-	62, // 58: api.LsAttributeSrv6SID.srv6_sid_structure:type_name -> api.LsSrv6SIDStructure
-	63, // 59: api.LsAttributeSrv6SID.srv6_endpoint_behavior:type_name -> api.LsSrv6EndpointBehavior
-	64, // 60: api.LsAttributeSrv6SID.srv6_bgp_peer_node_sid:type_name -> api.LsSrv6BgpPeerNodeSID
-	55, // 61: api.LsAttribute.node:type_name -> api.LsAttributeNode
-	56, // 62: api.LsAttribute.link:type_name -> api.LsAttributeLink
-	57, // 63: api.LsAttribute.prefix:type_name -> api.LsAttributePrefix
-	60, // 64: api.LsAttribute.bgp_peer_segment:type_name -> api.LsAttributeBgpPeerSegment
-	65, // 65: api.LsAttribute.srv6_sid:type_name -> api.LsAttributeSrv6SID
-	68, // 66: api.SRv6SubSubTLV.structure:type_name -> api.SRv6StructureSubSubTLV
-	69, // 67: api.SRv6SubSubTLVs.tlvs:type_name -> api.SRv6SubSubTLV
-	71, // 68: api.SRv6InformationSubTLV.flags:type_name -> api.SRv6SIDFlags
-	82, // 69: api.SRv6InformationSubTLV.sub_sub_tlvs:type_name -> api.SRv6InformationSubTLV.SubSubTlvsEntry
-	72, // 70: api.SRv6SubTLV.information:type_name -> api.SRv6InformationSubTLV
-	73, // 71: api.SRv6SubTLVs.tlvs:type_name -> api.SRv6SubTLV
-	83, // 72: api.SRv6L3ServiceTLV.sub_tlvs:type_name -> api.SRv6L3ServiceTLV.SubTlvsEntry
-	84, // 73: api.SRv6L2ServiceTLV.sub_tlvs:type_name -> api.SRv6L2ServiceTLV.SubTlvsEntry
-	85, // 74: api.PrefixSID.tlvs:type_name -> api.PrefixSID.TLV
-	34, // 75: api.TunnelEncapSubTLVSRSegmentList.Segment.a:type_name -> api.SegmentTypeA
-	35, // 76: api.TunnelEncapSubTLVSRSegmentList.Segment.b:type_name -> api.SegmentTypeB
-	39, // 77: api.TunnelEncapTLV.TLV.unknown:type_name -> api.TunnelEncapSubTLVUnknown
-	21, // 78: api.TunnelEncapTLV.TLV.encapsulation:type_name -> api.TunnelEncapSubTLVEncapsulation
-	22, // 79: api.TunnelEncapTLV.TLV.protocol:type_name -> api.TunnelEncapSubTLVProtocol
-	23, // 80: api.TunnelEncapTLV.TLV.color:type_name -> api.TunnelEncapSubTLVColor
-	37, // 81: api.TunnelEncapTLV.TLV.egress_endpoint:type_name -> api.TunnelEncapSubTLVEgressEndpoint
-	38, // 82: api.TunnelEncapTLV.TLV.udp_dest_port:type_name -> api.TunnelEncapSubTLVUDPDestPort
-	24, // 83: api.TunnelEncapTLV.TLV.sr_preference:type_name -> api.TunnelEncapSubTLVSRPreference
-	26, // 84: api.TunnelEncapTLV.TLV.sr_priority:type_name -> api.TunnelEncapSubTLVSRPriority
-	25, // 85: api.TunnelEncapTLV.TLV.sr_candidate_path_name:type_name -> api.TunnelEncapSubTLVSRCandidatePathName
-	31, // 86: api.TunnelEncapTLV.TLV.sr_enlp:type_name -> api.TunnelEncapSubTLVSRENLP
-	27, // 87: api.TunnelEncapTLV.TLV.sr_binding_sid:type_name -> api.TunnelEncapSubTLVSRBindingSID
-	36, // 88: api.TunnelEncapTLV.TLV.sr_segment_list:type_name -> api.TunnelEncapSubTLVSRSegmentList
-	42, // 89: api.IP6ExtendedCommunitiesAttribute.Community.ipv6_address_specific:type_name -> api.IPv6AddressSpecificExtended
-	43, // 90: api.IP6ExtendedCommunitiesAttribute.Community.redirect_ipv6_address_specific:type_name -> api.RedirectIPv6AddressSpecificExtended
-	46, // 91: api.AigpAttribute.TLV.unknown:type_name -> api.AigpTLVUnknown
-	45, // 92: api.AigpAttribute.TLV.igp_metric:type_name -> api.AigpTLVIGPMetric
-	70, // 93: api.SRv6InformationSubTLV.SubSubTlvsEntry.value:type_name -> api.SRv6SubSubTLVs
-	74, // 94: api.SRv6L3ServiceTLV.SubTlvsEntry.value:type_name -> api.SRv6SubTLVs
-	74, // 95: api.SRv6L2ServiceTLV.SubTlvsEntry.value:type_name -> api.SRv6SubTLVs
-	75, // 96: api.PrefixSID.TLV.l3_service:type_name -> api.SRv6L3ServiceTLV
-	76, // 97: api.PrefixSID.TLV.l2_service:type_name -> api.SRv6L2ServiceTLV
-	98, // [98:98] is the sub-list for method output_type
-	98, // [98:98] is the sub-list for method input_type
-	98, // [98:98] is the sub-list for extension type_name
-	98, // [98:98] is the sub-list for extension extendee
-	0,  // [0:98] is the sub-list for field type_name
+	70,  // 0: api.Attribute.unknown:type_name -> api.UnknownAttribute
+	4,   // 1: api.Attribute.origin:type_name -> api.OriginAttribute
+	6,   // 2: api.Attribute.as_path:type_name -> api.AsPathAttribute
+	7,   // 3: api.Attribute.next_hop:type_name -> api.NextHopAttribute
+	8,   // 4: api.Attribute.multi_exit_disc:type_name -> api.MultiExitDiscAttribute
+	9,   // 5: api.Attribute.local_pref:type_name -> api.LocalPrefAttribute
+	10,  // 6: api.Attribute.atomic_aggregate:type_name -> api.AtomicAggregateAttribute
+	11,  // 7: api.Attribute.aggregator:type_name -> api.AggregatorAttribute
+	12,  // 8: api.Attribute.communities:type_name -> api.CommunitiesAttribute
+	13,  // 9: api.Attribute.originator_id:type_name -> api.OriginatorIdAttribute
+	14,  // 10: api.Attribute.cluster_list:type_name -> api.ClusterListAttribute
+	15,  // 11: api.Attribute.mp_reach:type_name -> api.MpReachNLRIAttribute
+	16,  // 12: api.Attribute.mp_unreach:type_name -> api.MpUnreachNLRIAttribute
+	17,  // 13: api.Attribute.extended_communities:type_name -> api.ExtendedCommunitiesAttribute
+	18,  // 14: api.Attribute.as4_path:type_name -> api.As4PathAttribute
+	19,  // 15: api.Attribute.as4_aggregator:type_name -> api.As4AggregatorAttribute
+	20,  // 16: api.Attribute.pmsi_tunnel:type_name -> api.PmsiTunnelAttribute
+	41,  // 17: api.Attribute.tunnel_encap:type_name -> api.TunnelEncapAttribute
+	44,  // 18: api.Attribute.ip6_extended_communities:type_name -> api.IP6ExtendedCommunitiesAttribute
+	47,  // 19: api.Attribute.aigp:type_name -> api.AigpAttribute
+	49,  // 20: api.Attribute.large_communities:type_name -> api.LargeCommunitiesAttribute
+	69,  // 21: api.Attribute.ls:type_name -> api.LsAttribute
+	80,  // 22: api.Attribute.prefix_sid:type_name -> api.PrefixSID
+	2,   // 23: api.AsSegment.type:type_name -> api.AsSegment.Type
+	5,   // 24: api.AsPathAttribute.segments:type_name -> api.AsSegment
+	89,  // 25: api.MpReachNLRIAttribute.family:type_name -> api.Family
+	90,  // 26: api.MpReachNLRIAttribute.nlris:type_name -> api.NLRI
+	89,  // 27: api.MpUnreachNLRIAttribute.family:type_name -> api.Family
+	90,  // 28: api.MpUnreachNLRIAttribute.nlris:type_name -> api.NLRI
+	91,  // 29: api.ExtendedCommunitiesAttribute.communities:type_name -> api.ExtendedCommunity
+	5,   // 30: api.As4PathAttribute.segments:type_name -> api.AsSegment
+	28,  // 31: api.TunnelEncapSubTLVSRBindingSID.sr_binding_sid:type_name -> api.SRBindingSID
+	30,  // 32: api.TunnelEncapSubTLVSRBindingSID.srv6_binding_sid:type_name -> api.SRv6BindingSID
+	0,   // 33: api.SRv6EndPointBehavior.behavior:type_name -> api.SRV6Behavior
+	29,  // 34: api.SRv6BindingSID.endpoint_behavior_structure:type_name -> api.SRv6EndPointBehavior
+	1,   // 35: api.TunnelEncapSubTLVSRENLP.enlp:type_name -> api.ENLPType
+	33,  // 36: api.SegmentTypeA.flags:type_name -> api.SegmentFlags
+	33,  // 37: api.SegmentTypeB.flags:type_name -> api.SegmentFlags
+	29,  // 38: api.SegmentTypeB.endpoint_behavior_structure:type_name -> api.SRv6EndPointBehavior
+	32,  // 39: api.TunnelEncapSubTLVSRSegmentList.weight:type_name -> api.SRWeight
+	81,  // 40: api.TunnelEncapSubTLVSRSegmentList.segments:type_name -> api.TunnelEncapSubTLVSRSegmentList.Segment
+	82,  // 41: api.TunnelEncapTLV.tlvs:type_name -> api.TunnelEncapTLV.TLV
+	40,  // 42: api.TunnelEncapAttribute.tlvs:type_name -> api.TunnelEncapTLV
+	83,  // 43: api.IP6ExtendedCommunitiesAttribute.communities:type_name -> api.IP6ExtendedCommunitiesAttribute.Community
+	84,  // 44: api.AigpAttribute.tlvs:type_name -> api.AigpAttribute.TLV
+	48,  // 45: api.LargeCommunitiesAttribute.communities:type_name -> api.LargeCommunity
+	52,  // 46: api.LsSrCapabilities.ranges:type_name -> api.LsSrRange
+	52,  // 47: api.LsSrLocalBlock.ranges:type_name -> api.LsSrRange
+	50,  // 48: api.LsAttributeNode.flags:type_name -> api.LsNodeFlags
+	53,  // 49: api.LsAttributeNode.sr_capabilities:type_name -> api.LsSrCapabilities
+	54,  // 50: api.LsAttributeNode.sr_local_block:type_name -> api.LsSrLocalBlock
+	56,  // 51: api.LsAttributeNode.flex_algo_defs:type_name -> api.LsAttributeFlexAlgoDef
+	64,  // 52: api.LsAttributeLink.srv6_end_x_sid:type_name -> api.LsSrv6EndXSID
+	51,  // 53: api.LsAttributePrefix.igp_flags:type_name -> api.LsIGPFlags
+	59,  // 54: api.LsAttributePrefix.sr_prefix_sids:type_name -> api.LsAttributePrefixSID
+	60,  // 55: api.LsAttributePrefix.fad_prefix_metrics:type_name -> api.LsAttributeFADPrefixMetric
+	61,  // 56: api.LsBgpPeerSegmentSID.flags:type_name -> api.LsBgpPeerSegmentSIDFlags
+	62,  // 57: api.LsAttributeBgpPeerSegment.bgp_peer_node_sid:type_name -> api.LsBgpPeerSegmentSID
+	62,  // 58: api.LsAttributeBgpPeerSegment.bgp_peer_adjacency_sid:type_name -> api.LsBgpPeerSegmentSID
+	62,  // 59: api.LsAttributeBgpPeerSegment.bgp_peer_set_sid:type_name -> api.LsBgpPeerSegmentSID
+	65,  // 60: api.LsSrv6EndXSID.srv6_sid_structure:type_name -> api.LsSrv6SIDStructure
+	65,  // 61: api.LsAttributeSrv6SID.srv6_sid_structure:type_name -> api.LsSrv6SIDStructure
+	66,  // 62: api.LsAttributeSrv6SID.srv6_endpoint_behavior:type_name -> api.LsSrv6EndpointBehavior
+	67,  // 63: api.LsAttributeSrv6SID.srv6_bgp_peer_node_sid:type_name -> api.LsSrv6BgpPeerNodeSID
+	55,  // 64: api.LsAttribute.node:type_name -> api.LsAttributeNode
+	57,  // 65: api.LsAttribute.link:type_name -> api.LsAttributeLink
+	58,  // 66: api.LsAttribute.prefix:type_name -> api.LsAttributePrefix
+	63,  // 67: api.LsAttribute.bgp_peer_segment:type_name -> api.LsAttributeBgpPeerSegment
+	68,  // 68: api.LsAttribute.srv6_sid:type_name -> api.LsAttributeSrv6SID
+	71,  // 69: api.SRv6SubSubTLV.structure:type_name -> api.SRv6StructureSubSubTLV
+	72,  // 70: api.SRv6SubSubTLVs.tlvs:type_name -> api.SRv6SubSubTLV
+	74,  // 71: api.SRv6InformationSubTLV.flags:type_name -> api.SRv6SIDFlags
+	85,  // 72: api.SRv6InformationSubTLV.sub_sub_tlvs:type_name -> api.SRv6InformationSubTLV.SubSubTlvsEntry
+	75,  // 73: api.SRv6SubTLV.information:type_name -> api.SRv6InformationSubTLV
+	76,  // 74: api.SRv6SubTLVs.tlvs:type_name -> api.SRv6SubTLV
+	86,  // 75: api.SRv6L3ServiceTLV.sub_tlvs:type_name -> api.SRv6L3ServiceTLV.SubTlvsEntry
+	87,  // 76: api.SRv6L2ServiceTLV.sub_tlvs:type_name -> api.SRv6L2ServiceTLV.SubTlvsEntry
+	88,  // 77: api.PrefixSID.tlvs:type_name -> api.PrefixSID.TLV
+	34,  // 78: api.TunnelEncapSubTLVSRSegmentList.Segment.a:type_name -> api.SegmentTypeA
+	35,  // 79: api.TunnelEncapSubTLVSRSegmentList.Segment.b:type_name -> api.SegmentTypeB
+	39,  // 80: api.TunnelEncapTLV.TLV.unknown:type_name -> api.TunnelEncapSubTLVUnknown
+	21,  // 81: api.TunnelEncapTLV.TLV.encapsulation:type_name -> api.TunnelEncapSubTLVEncapsulation
+	22,  // 82: api.TunnelEncapTLV.TLV.protocol:type_name -> api.TunnelEncapSubTLVProtocol
+	23,  // 83: api.TunnelEncapTLV.TLV.color:type_name -> api.TunnelEncapSubTLVColor
+	37,  // 84: api.TunnelEncapTLV.TLV.egress_endpoint:type_name -> api.TunnelEncapSubTLVEgressEndpoint
+	38,  // 85: api.TunnelEncapTLV.TLV.udp_dest_port:type_name -> api.TunnelEncapSubTLVUDPDestPort
+	24,  // 86: api.TunnelEncapTLV.TLV.sr_preference:type_name -> api.TunnelEncapSubTLVSRPreference
+	26,  // 87: api.TunnelEncapTLV.TLV.sr_priority:type_name -> api.TunnelEncapSubTLVSRPriority
+	25,  // 88: api.TunnelEncapTLV.TLV.sr_candidate_path_name:type_name -> api.TunnelEncapSubTLVSRCandidatePathName
+	31,  // 89: api.TunnelEncapTLV.TLV.sr_enlp:type_name -> api.TunnelEncapSubTLVSRENLP
+	27,  // 90: api.TunnelEncapTLV.TLV.sr_binding_sid:type_name -> api.TunnelEncapSubTLVSRBindingSID
+	36,  // 91: api.TunnelEncapTLV.TLV.sr_segment_list:type_name -> api.TunnelEncapSubTLVSRSegmentList
+	42,  // 92: api.IP6ExtendedCommunitiesAttribute.Community.ipv6_address_specific:type_name -> api.IPv6AddressSpecificExtended
+	43,  // 93: api.IP6ExtendedCommunitiesAttribute.Community.redirect_ipv6_address_specific:type_name -> api.RedirectIPv6AddressSpecificExtended
+	46,  // 94: api.AigpAttribute.TLV.unknown:type_name -> api.AigpTLVUnknown
+	45,  // 95: api.AigpAttribute.TLV.igp_metric:type_name -> api.AigpTLVIGPMetric
+	73,  // 96: api.SRv6InformationSubTLV.SubSubTlvsEntry.value:type_name -> api.SRv6SubSubTLVs
+	77,  // 97: api.SRv6L3ServiceTLV.SubTlvsEntry.value:type_name -> api.SRv6SubTLVs
+	77,  // 98: api.SRv6L2ServiceTLV.SubTlvsEntry.value:type_name -> api.SRv6SubTLVs
+	78,  // 99: api.PrefixSID.TLV.l3_service:type_name -> api.SRv6L3ServiceTLV
+	79,  // 100: api.PrefixSID.TLV.l2_service:type_name -> api.SRv6L2ServiceTLV
+	101, // [101:101] is the sub-list for method output_type
+	101, // [101:101] is the sub-list for method input_type
+	101, // [101:101] is the sub-list for extension type_name
+	101, // [101:101] is the sub-list for extension extendee
+	0,   // [0:101] is the sub-list for field type_name
 }
 
 func init() { file_api_attribute_proto_init() }
@@ -6255,17 +6569,17 @@ func file_api_attribute_proto_init() {
 		(*TunnelEncapSubTLVSRBindingSID_SrBindingSid)(nil),
 		(*TunnelEncapSubTLVSRBindingSID_Srv6BindingSid)(nil),
 	}
-	file_api_attribute_proto_msgTypes[66].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[69].OneofWrappers = []any{
 		(*SRv6SubSubTLV_Structure)(nil),
 	}
-	file_api_attribute_proto_msgTypes[70].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[73].OneofWrappers = []any{
 		(*SRv6SubTLV_Information)(nil),
 	}
-	file_api_attribute_proto_msgTypes[75].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[78].OneofWrappers = []any{
 		(*TunnelEncapSubTLVSRSegmentList_Segment_A)(nil),
 		(*TunnelEncapSubTLVSRSegmentList_Segment_B)(nil),
 	}
-	file_api_attribute_proto_msgTypes[76].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[79].OneofWrappers = []any{
 		(*TunnelEncapTLV_TLV_Unknown)(nil),
 		(*TunnelEncapTLV_TLV_Encapsulation)(nil),
 		(*TunnelEncapTLV_TLV_Protocol)(nil),
@@ -6279,15 +6593,15 @@ func file_api_attribute_proto_init() {
 		(*TunnelEncapTLV_TLV_SrBindingSid)(nil),
 		(*TunnelEncapTLV_TLV_SrSegmentList)(nil),
 	}
-	file_api_attribute_proto_msgTypes[77].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[80].OneofWrappers = []any{
 		(*IP6ExtendedCommunitiesAttribute_Community_Ipv6AddressSpecific)(nil),
 		(*IP6ExtendedCommunitiesAttribute_Community_RedirectIpv6AddressSpecific)(nil),
 	}
-	file_api_attribute_proto_msgTypes[78].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[81].OneofWrappers = []any{
 		(*AigpAttribute_TLV_Unknown)(nil),
 		(*AigpAttribute_TLV_IgpMetric)(nil),
 	}
-	file_api_attribute_proto_msgTypes[82].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[85].OneofWrappers = []any{
 		(*PrefixSID_TLV_L3Service)(nil),
 		(*PrefixSID_TLV_L2Service)(nil),
 	}
@@ -6297,7 +6611,7 @@ func file_api_attribute_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_attribute_proto_rawDesc), len(file_api_attribute_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   83,
+			NumMessages:   86,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -1075,6 +1075,23 @@ func UnmarshalLsAttribute(a *api.LsAttribute) (*bgp.LsAttribute, error) {
 			nodeSrAlgorithms = &a.Node.SrAlgorithms
 		}
 
+		// RFC 9351 Section 3: rehydrate FAD entries from the api side.
+		var nodeFlexAlgoDefs []bgp.LsAttributeFlexAlgoDef
+		for _, fad := range a.Node.FlexAlgoDefs {
+			nodeFlexAlgoDefs = append(nodeFlexAlgoDefs, bgp.LsAttributeFlexAlgoDef{
+				Algorithm:       uint8(fad.Algorithm),
+				MetricType:      uint8(fad.MetricType),
+				MetricTypeKnown: fad.MetricTypeKnown,
+				CalcType:        uint8(fad.CalcType),
+				Priority:        uint8(fad.Priority),
+				ExcludeAny:      append([]uint32(nil), fad.ExcludeAnyAffinity...),
+				IncludeAny:      append([]uint32(nil), fad.IncludeAnyAffinity...),
+				IncludeAll:      append([]uint32(nil), fad.IncludeAllAffinity...),
+				Flags:           append([]byte(nil), fad.DefinitionFlags...),
+				ExcludeSRLG:     append([]uint32(nil), fad.ExcludeSrlg...),
+			})
+		}
+
 		lsAttr.Node = bgp.LsAttributeNode{
 			Flags:           flags,
 			Opaque:          nodeOpaque,
@@ -1085,6 +1102,7 @@ func UnmarshalLsAttribute(a *api.LsAttribute) (*bgp.LsAttribute, error) {
 			SrCapabilties:   srCapabilities,
 			SrAlgorithms:    nodeSrAlgorithms,
 			SrLocalBlock:    lsSrLocalBlock,
+			FlexAlgoDefs:    nodeFlexAlgoDefs,
 		}
 	}
 
@@ -1224,6 +1242,28 @@ func UnmarshalLsAttribute(a *api.LsAttribute) (*bgp.LsAttribute, error) {
 
 	// For AttributePrefix
 	if a.Prefix != nil {
+		// RFC 9085 Section 2.1.1: rehydrate every Prefix-SID entry
+		// from the api side, plus the FAPM entries from RFC 9351
+		// Section 4. These are populated independently of IgpFlags
+		// because a Prefix NLRI can advertise SR or FAPM without
+		// carrying an IGP-Flags TLV.
+		var prefixSIDs []bgp.LsAttributePrefixSID
+		for _, sid := range a.Prefix.SrPrefixSids {
+			prefixSIDs = append(prefixSIDs, bgp.LsAttributePrefixSID{
+				Algorithm: uint8(sid.Algorithm),
+				Flags:     uint8(sid.Flags),
+				SID:       sid.Sid,
+			})
+		}
+		var fapms []bgp.LsAttributeFADPrefixMetric
+		for _, fapm := range a.Prefix.FadPrefixMetrics {
+			fapms = append(fapms, bgp.LsAttributeFADPrefixMetric{
+				Algorithm: uint8(fapm.Algorithm),
+				Flags:     uint8(fapm.Flags),
+				Metric:    fapm.Metric,
+			})
+		}
+
 		if a.Prefix.IgpFlags != nil {
 			lsAttr.Prefix = bgp.LsAttributePrefix{
 				IGPFlags: &bgp.LsIGPFlags{
@@ -1232,8 +1272,16 @@ func UnmarshalLsAttribute(a *api.LsAttribute) (*bgp.LsAttribute, error) {
 					LocalAddress:  a.Prefix.IgpFlags.LocalAddress,
 					PropagateNSSA: a.Prefix.IgpFlags.PropagateNssa,
 				},
-				Opaque:      &a.Prefix.Opaque,
-				SrPrefixSID: &a.Prefix.SrPrefixSid,
+				Opaque:           &a.Prefix.Opaque,
+				SrPrefixSID:      &a.Prefix.SrPrefixSid,
+				SrPrefixSIDs:     prefixSIDs,
+				FadPrefixMetrics: fapms,
+			}
+		} else if len(prefixSIDs) > 0 || len(fapms) > 0 {
+			// IgpFlags absent but SR / FAPM TLVs present.
+			lsAttr.Prefix = bgp.LsAttributePrefix{
+				SrPrefixSIDs:     prefixSIDs,
+				FadPrefixMetrics: fapms,
 			}
 		}
 	}
@@ -2825,6 +2873,45 @@ func NewLsAttributeFromNative(a *bgp.PathAttributeLs) (*api.LsAttribute, error) 
 			LocalAddress:  attr.Prefix.IGPFlags.LocalAddress,
 			PropagateNssa: attr.Prefix.IGPFlags.PropagateNSSA,
 		}
+	}
+
+	// RFC 9351 Section 3: surface every FAD observed for this Node
+	// NLRI. The packet layer keeps reserved Metric-Type values
+	// verbatim with MetricTypeKnown=false; pass that through.
+	for _, fad := range attr.Node.FlexAlgoDefs {
+		apiAttr.Node.FlexAlgoDefs = append(apiAttr.Node.FlexAlgoDefs, &api.LsAttributeFlexAlgoDef{
+			Algorithm:          uint32(fad.Algorithm),
+			MetricType:         uint32(fad.MetricType),
+			MetricTypeKnown:    fad.MetricTypeKnown,
+			CalcType:           uint32(fad.CalcType),
+			Priority:           uint32(fad.Priority),
+			ExcludeAnyAffinity: append([]uint32(nil), fad.ExcludeAny...),
+			IncludeAnyAffinity: append([]uint32(nil), fad.IncludeAny...),
+			IncludeAllAffinity: append([]uint32(nil), fad.IncludeAll...),
+			DefinitionFlags:    append([]byte(nil), fad.Flags...),
+			ExcludeSrlg:        append([]uint32(nil), fad.ExcludeSRLG...),
+		})
+	}
+
+	// RFC 9085 Section 2.1.1: surface every Prefix-SID TLV; the
+	// singular sr_prefix_sid field above is already populated for
+	// Algorithm-0 by the projection path.
+	for _, sid := range attr.Prefix.SrPrefixSIDs {
+		apiAttr.Prefix.SrPrefixSids = append(apiAttr.Prefix.SrPrefixSids, &api.LsAttributePrefixSID{
+			Algorithm: uint32(sid.Algorithm),
+			Flags:     uint32(sid.Flags),
+			Sid:       sid.SID,
+		})
+	}
+
+	// RFC 9351 Section 4: surface every FAPM TLV observed for this
+	// Prefix NLRI.
+	for _, fapm := range attr.Prefix.FadPrefixMetrics {
+		apiAttr.Prefix.FadPrefixMetrics = append(apiAttr.Prefix.FadPrefixMetrics, &api.LsAttributeFADPrefixMetric{
+			Algorithm: uint32(fapm.Algorithm),
+			Flags:     uint32(fapm.Flags),
+			Metric:    fapm.Metric,
+		})
 	}
 
 	return apiAttr, nil

--- a/pkg/apiutil/attribute_test.go
+++ b/pkg/apiutil/attribute_test.go
@@ -1810,12 +1810,12 @@ func TestFullCycleFlexAlgoDefAndFAPM(t *testing.T) {
 // TestFlexAlgo_FullWirePath drives the full RFC 9351 / RFC 9085
 // path end-to-end:
 //
-//   wire bytes -> PathAttributeLs.DecodeFromBytes
-//              -> Extract                 (structured fields)
-//              -> NewLsAttributeFromNative (api projection)
-//              -> proto.Marshal + proto.Unmarshal
-//              -> UnmarshalLsAttribute     (rehydrate bgp.LsAttribute)
-//              -> Serialize                (back to wire bytes)
+//	wire bytes -> PathAttributeLs.DecodeFromBytes
+//	           -> Extract                 (structured fields)
+//	           -> NewLsAttributeFromNative (api projection)
+//	           -> proto.Marshal + proto.Unmarshal
+//	           -> UnmarshalLsAttribute     (rehydrate bgp.LsAttribute)
+//	           -> Serialize                (back to wire bytes)
 //
 // The fixture is a hand-built BGP-LS Attribute (MP_REACH stripped, we
 // only test the attribute payload) carrying a Flex-Algo Definition

--- a/pkg/apiutil/attribute_test.go
+++ b/pkg/apiutil/attribute_test.go
@@ -1710,6 +1710,103 @@ func TestFullCycleSRv6SIDStructureSubSubTLV(t *testing.T) {
 	}
 }
 
+// TestFullCycleFlexAlgoDefAndFAPM exercises the api <-> packet
+// round-trip for the RFC 9351 Flex-Algorithm Definition (FAD) Node
+// Attribute TLV and the FAPM (Prefix Attribute TLV 1044). The packet
+// layer round-trip is covered in pkg/packet/bgp; here we confirm the
+// apiutil mapping preserves every field on the way from bgp.LsAttribute
+// down to api.LsAttribute and back.
+func TestFullCycleFlexAlgoDefAndFAPM(t *testing.T) {
+	srgbStart := uint32(16000)
+
+	// Build a synthetic PathAttributeLs whose Extract output already
+	// carries the FAD + multi-SID + FAPM fields we want to surface.
+	// We bypass the wire by hand-building the TLV slice; the goal is
+	// to drive NewLsAttributeFromNative and UnmarshalLsAttribute.
+	tlvs := []bgp.LsTLVInterface{
+		&bgp.LsTLVFlexAlgoDef{
+			LsTLV:       bgp.LsTLV{Type: bgp.LS_TLV_FLEX_ALGO_DEF},
+			Algorithm:   128,
+			MetricType:  1, // Min-Delay
+			CalcType:    0,
+			Priority:    200,
+			ExcludeAny:  []uint32{0x0F},
+			IncludeAny:  []uint32{0xF0},
+			IncludeAll:  []uint32{0xAA},
+			Flags:       []byte{0x80, 0x00, 0x00, 0x00},
+			ExcludeSRLG: []uint32{42, 43},
+		},
+		&bgp.LsTLVPrefixSID{
+			LsTLV:     bgp.LsTLV{Type: bgp.LS_TLV_PREFIX_SID},
+			Algorithm: 0,
+			Flags:     0,
+			SID:       srgbStart + 1,
+		},
+		&bgp.LsTLVPrefixSID{
+			LsTLV:     bgp.LsTLV{Type: bgp.LS_TLV_PREFIX_SID},
+			Algorithm: 128,
+			Flags:     0x08,
+			SID:       srgbStart + 128,
+		},
+		&bgp.LsTLVFADPrefixMetric{
+			LsTLV:     bgp.LsTLV{Type: bgp.LS_TLV_FAD_PREFIX_METRIC},
+			Algorithm: 128,
+			Flags:     0,
+			Metric:    10000,
+		},
+	}
+	pa := &bgp.PathAttributeLs{TLVs: tlvs}
+
+	apiAttr, err := NewLsAttributeFromNative(pa)
+	require.NoError(t, err)
+	require.NotNil(t, apiAttr)
+
+	require.Len(t, apiAttr.Node.FlexAlgoDefs, 1)
+	fad := apiAttr.Node.FlexAlgoDefs[0]
+	assert.Equal(t, uint32(128), fad.Algorithm)
+	assert.Equal(t, uint32(1), fad.MetricType)
+	assert.True(t, fad.MetricTypeKnown)
+	assert.Equal(t, uint32(200), fad.Priority)
+	assert.Equal(t, []uint32{0x0F}, fad.ExcludeAnyAffinity)
+	assert.Equal(t, []uint32{0xF0}, fad.IncludeAnyAffinity)
+	assert.Equal(t, []uint32{0xAA}, fad.IncludeAllAffinity)
+	assert.Equal(t, []byte{0x80, 0x00, 0x00, 0x00}, fad.DefinitionFlags)
+	assert.Equal(t, []uint32{42, 43}, fad.ExcludeSrlg)
+
+	require.Len(t, apiAttr.Prefix.SrPrefixSids, 2)
+	assert.Equal(t, uint32(0), apiAttr.Prefix.SrPrefixSids[0].Algorithm)
+	assert.Equal(t, srgbStart+1, apiAttr.Prefix.SrPrefixSids[0].Sid)
+	assert.Equal(t, uint32(128), apiAttr.Prefix.SrPrefixSids[1].Algorithm)
+	assert.Equal(t, uint32(0x08), apiAttr.Prefix.SrPrefixSids[1].Flags)
+	assert.Equal(t, srgbStart+128, apiAttr.Prefix.SrPrefixSids[1].Sid)
+	// Singular field still populated for the Algorithm-0 SID.
+	assert.Equal(t, srgbStart+1, apiAttr.Prefix.SrPrefixSid)
+
+	require.Len(t, apiAttr.Prefix.FadPrefixMetrics, 1)
+	assert.Equal(t, uint32(128), apiAttr.Prefix.FadPrefixMetrics[0].Algorithm)
+	assert.Equal(t, uint32(10000), apiAttr.Prefix.FadPrefixMetrics[0].Metric)
+
+	// proto round-trip: marshal + unmarshal must preserve byte-for-byte.
+	enc, err := proto.Marshal(apiAttr)
+	require.NoError(t, err)
+	clone := &api.LsAttribute{}
+	require.NoError(t, proto.Unmarshal(enc, clone))
+	assert.True(t, proto.Equal(apiAttr, clone))
+
+	// api -> bgp rehydration: every FAD / SID / FAPM field round-trips.
+	back, err := UnmarshalLsAttribute(clone)
+	require.NoError(t, err)
+	require.Len(t, back.Node.FlexAlgoDefs, 1)
+	assert.Equal(t, uint8(128), back.Node.FlexAlgoDefs[0].Algorithm)
+	assert.Equal(t, uint8(1), back.Node.FlexAlgoDefs[0].MetricType)
+	assert.Equal(t, []uint32{42, 43}, back.Node.FlexAlgoDefs[0].ExcludeSRLG)
+	require.Len(t, back.Prefix.SrPrefixSIDs, 2)
+	assert.Equal(t, uint8(128), back.Prefix.SrPrefixSIDs[1].Algorithm)
+	assert.Equal(t, srgbStart+128, back.Prefix.SrPrefixSIDs[1].SID)
+	require.Len(t, back.Prefix.FadPrefixMetrics, 1)
+	assert.Equal(t, uint32(10000), back.Prefix.FadPrefixMetrics[0].Metric)
+}
+
 func TestFullCycleSRv6InformationSubTLV(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/apiutil/attribute_test.go
+++ b/pkg/apiutil/attribute_test.go
@@ -1807,6 +1807,125 @@ func TestFullCycleFlexAlgoDefAndFAPM(t *testing.T) {
 	assert.Equal(t, uint32(10000), back.Prefix.FadPrefixMetrics[0].Metric)
 }
 
+// TestFlexAlgo_FullWirePath drives the full RFC 9351 / RFC 9085
+// path end-to-end:
+//
+//   wire bytes -> PathAttributeLs.DecodeFromBytes
+//              -> Extract                 (structured fields)
+//              -> NewLsAttributeFromNative (api projection)
+//              -> proto.Marshal + proto.Unmarshal
+//              -> UnmarshalLsAttribute     (rehydrate bgp.LsAttribute)
+//              -> Serialize                (back to wire bytes)
+//
+// The fixture is a hand-built BGP-LS Attribute (MP_REACH stripped, we
+// only test the attribute payload) carrying a Flex-Algo Definition
+// (TLV 1039 with three nested sub-TLVs), two Prefix-SID TLVs (algo 0
+// and algo 128) and one FAPM (TLV 1044). Every structured field on
+// the way out matches the wire bytes on the way in.
+func TestFlexAlgo_FullWirePath(t *testing.T) {
+	const (
+		srgbStart = uint32(16000)
+	)
+
+	// MP_REACH_NLRI is omitted; we test PathAttributeLs payload only.
+	// Outer wrapper: flags 0x80 (Optional, Non-Transitive,
+	// non-extended), type 41 (BGP_ATTR_TYPE_LS), 1-byte length.
+	body := []byte{
+		// TLV 1039 FAD, length 28 (4-byte fixed header + three
+		// 8-byte sub-TLVs):
+		//   algo=128 metric=0 (IGP) calc=0 (SPF) prio=200
+		//   sub-TLV 1040 Exclude-Any 0x0000000F
+		//   sub-TLV 1041 Include-Any 0x000000F0
+		//   sub-TLV 1043 Definition Flags 0x80000000
+		0x04, 0x0F, 0x00, 0x1C,
+		0x80, 0x00, 0x00, 0xC8,
+		0x04, 0x10, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0F,
+		0x04, 0x11, 0x00, 0x04, 0x00, 0x00, 0x00, 0xF0,
+		0x04, 0x13, 0x00, 0x04, 0x80, 0x00, 0x00, 0x00,
+
+		// TLV 1158 Prefix-SID algo 0 (default SPF), SID 16001 in
+		// 8-byte (4-byte SID) form: flags + algo + 2B reserved + 4B SID.
+		0x04, 0x86, 0x00, 0x08,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x3E, 0x81,
+
+		// TLV 1158 Prefix-SID algo 128, V-flag set (absolute label),
+		// SID 16128 in 8-byte form.
+		0x04, 0x86, 0x00, 0x08,
+		0x08, 0x80, 0x00, 0x00,
+		0x00, 0x00, 0x3F, 0x00,
+
+		// TLV 1044 FAPM (Flexible Algorithm Prefix Metric): algo 128
+		// metric 10000 (0x2710), flags 0, reserved 0.
+		0x04, 0x14, 0x00, 0x08,
+		0x80, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x27, 0x10,
+	}
+	hdr := []byte{0x80, 0x29, byte(len(body))}
+	wire := append([]byte{}, hdr...)
+	wire = append(wire, body...)
+
+	// Decode the wire bytes into the structured PathAttributeLs.
+	pa := &bgp.PathAttributeLs{}
+	require.NoError(t, pa.DecodeFromBytes(wire))
+
+	// Extract the structured LsAttribute and check every field.
+	ls := pa.Extract()
+	require.Len(t, ls.Node.FlexAlgoDefs, 1)
+	fad := ls.Node.FlexAlgoDefs[0]
+	assert.Equal(t, uint8(128), fad.Algorithm)
+	assert.Equal(t, uint8(0), fad.MetricType)
+	assert.True(t, fad.MetricTypeKnown)
+	assert.Equal(t, uint8(0), fad.CalcType)
+	assert.Equal(t, uint8(200), fad.Priority)
+	assert.Equal(t, []uint32{0x0F}, fad.ExcludeAny)
+	assert.Equal(t, []uint32{0xF0}, fad.IncludeAny)
+	assert.Equal(t, []byte{0x80, 0x00, 0x00, 0x00}, fad.Flags)
+
+	require.Len(t, ls.Prefix.SrPrefixSIDs, 2)
+	assert.Equal(t, uint8(0), ls.Prefix.SrPrefixSIDs[0].Algorithm)
+	assert.Equal(t, srgbStart+1, ls.Prefix.SrPrefixSIDs[0].SID)
+	assert.Equal(t, uint8(128), ls.Prefix.SrPrefixSIDs[1].Algorithm)
+	assert.Equal(t, uint8(0x08), ls.Prefix.SrPrefixSIDs[1].Flags)
+	assert.Equal(t, srgbStart+128, ls.Prefix.SrPrefixSIDs[1].SID)
+	require.NotNil(t, ls.Prefix.SrPrefixSID)
+	assert.Equal(t, srgbStart+1, *ls.Prefix.SrPrefixSID)
+
+	require.Len(t, ls.Prefix.FadPrefixMetrics, 1)
+	assert.Equal(t, uint8(128), ls.Prefix.FadPrefixMetrics[0].Algorithm)
+	assert.Equal(t, uint32(10000), ls.Prefix.FadPrefixMetrics[0].Metric)
+
+	// Cross the apiutil boundary in both directions.
+	apiAttr, err := NewLsAttributeFromNative(pa)
+	require.NoError(t, err)
+	require.Len(t, apiAttr.Node.FlexAlgoDefs, 1)
+	require.Len(t, apiAttr.Prefix.SrPrefixSids, 2)
+	require.Len(t, apiAttr.Prefix.FadPrefixMetrics, 1)
+
+	enc, err := proto.Marshal(apiAttr)
+	require.NoError(t, err)
+	clone := &api.LsAttribute{}
+	require.NoError(t, proto.Unmarshal(enc, clone))
+	assert.True(t, proto.Equal(apiAttr, clone))
+
+	back, err := UnmarshalLsAttribute(clone)
+	require.NoError(t, err)
+	require.Len(t, back.Node.FlexAlgoDefs, 1)
+	assert.Equal(t, uint8(128), back.Node.FlexAlgoDefs[0].Algorithm)
+	require.Len(t, back.Prefix.SrPrefixSIDs, 2)
+	assert.Equal(t, srgbStart+128, back.Prefix.SrPrefixSIDs[1].SID)
+	require.Len(t, back.Prefix.FadPrefixMetrics, 1)
+
+	// Re-serialise the original PathAttributeLs (its TLV slice still
+	// carries the original wire-shaped sub-TLVs) and confirm the
+	// byte sequence matches the input. This is the strongest
+	// regression signal against silent re-encoding drift.
+	out, err := pa.Serialize()
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(wire, out),
+		"wire bytes round-trip mismatch:\n  in: % x\n out: % x", wire, out)
+}
+
 func TestFullCycleSRv6InformationSubTLV(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -5909,6 +5909,19 @@ const (
 	LS_TLV_SR_LOCAL_BLOCK  = 1036 // draft-ietf-idr-bgp-ls-segment-routing-ext
 	LS_TLV_SRMS_PREFERENCE = 1037 // draft-ietf-idr-bgp-ls-segment-routing-ext, TODO
 
+	// Flexible Algorithm Definition (RFC9351 Section 3, IS-IS source RFC9350).
+	// TLV 1039 is a Node Attribute TLV. 1040, 1041, 1042, 1043, 1045 and 1046
+	// are sub-TLVs nested inside TLV 1039. TLV 1044 (FAPM) is a top-level
+	// Prefix Attribute TLV; see LS_TLV_FAD_PREFIX_METRIC below.
+	LS_TLV_FLEX_ALGO_DEF            = 1039 // RFC9351 Section 3
+	LS_TLV_FAD_EXCLUDE_ANY_AFFINITY = 1040 // RFC9351 Section 3.1
+	LS_TLV_FAD_INCLUDE_ANY_AFFINITY = 1041 // RFC9351 Section 3.2
+	LS_TLV_FAD_INCLUDE_ALL_AFFINITY = 1042 // RFC9351 Section 3.3
+	LS_TLV_FAD_DEFINITION_FLAGS     = 1043 // RFC9351 Section 3.4
+	LS_TLV_FAD_PREFIX_METRIC        = 1044 // RFC9351 Section 4 (FAPM, Prefix-side)
+	LS_TLV_FAD_EXCLUDE_SRLG         = 1045 // RFC9351 Section 3.5
+	LS_TLV_FAD_UNSUPPORTED          = 1046 // RFC9351 Section 3.6
+
 	LS_TLV_ADMIN_GROUP              = 1088
 	LS_TLV_MAX_LINK_BANDWIDTH       = 1089
 	LS_TLV_MAX_RESERVABLE_BANDWIDTH = 1090
@@ -8464,6 +8477,288 @@ func (l *LsTLVSrLocalBlock) GetLsTLV() LsTLV {
 	return l.LsTLV
 }
 
+// LsTLVFlexAlgoDef wire format (RFC 9351 Section 3):
+//
+//	byte 0     Flex Algo ID (128..255 per RFC 9350 Section 4)
+//	byte 1     Metric-Type (0=IGP, 1=Min-Delay, 2=TE per RFC 9350
+//	           Section 5.1)
+//	byte 2     Calc-Type (0=SPF per RFC 9350 Section 5.2)
+//	byte 3     Priority (RFC 9350 Section 5.3)
+//	bytes 4+   zero or more nested sub-TLVs in BGP-LS sub-TLV format
+//	           (Type 2B + Length 2B + Value), codepoints 1040, 1041,
+//	           1042, 1043, 1045, 1046.
+//
+// Sub-TLVs are decoded into typed fields below; unknown sub-TLV types
+// are preserved in the Unknown slice so a future caller can inspect
+// them without re-parsing the value bytes. Multiple FADs MAY be
+// advertised for the same Node NLRI (one per algorithm), so the
+// containing PathAttributeLs Extract aggregates them into a slice.
+
+// LsTLVFlexAlgoSubTLVRaw preserves a sub-TLV whose type is not one of
+// the codepoints RFC 9351 currently defines. Keeping the raw bytes
+// lets callers inspect or re-serialise the FAD without losing data
+// and matches the forward-compatibility requirement in RFC 9351
+// Section 3.
+type LsTLVFlexAlgoSubTLVRaw struct {
+	Type  LsTLVType
+	Value []byte
+}
+
+type LsTLVFlexAlgoDef struct {
+	LsTLV
+	Algorithm   uint8
+	MetricType  uint8
+	CalcType    uint8
+	Priority    uint8
+	ExcludeAny  []uint32                 // RFC9351 Section 3.1 (sub-TLV 1040)
+	IncludeAny  []uint32                 // RFC9351 Section 3.2 (sub-TLV 1041)
+	IncludeAll  []uint32                 // RFC9351 Section 3.3 (sub-TLV 1042)
+	Flags       []byte                   // RFC9351 Section 3.4 (sub-TLV 1043; bit ordering per RFC9350 Section 6.4)
+	ExcludeSRLG []uint32                 // RFC9351 Section 3.5 (sub-TLV 1045)
+	Unsupported *LsTLVFADUnsupported     // RFC9351 Section 3.6 (sub-TLV 1046)
+	Unknown     []LsTLVFlexAlgoSubTLVRaw // forward-compat for sub-TLVs not defined by RFC 9351
+}
+
+// LsTLVFADUnsupported records the Flex-Algorithm Unsupported sub-TLV
+// (RFC 9351 Section 3.6): a Protocol-ID byte plus the list of sub-TLV
+// type codes the originating node could not honour.
+type LsTLVFADUnsupported struct {
+	ProtocolID  uint8
+	SubTLVTypes []uint16
+}
+
+func (l *LsTLVFlexAlgoDef) DecodeFromBytes(data []byte) error {
+	value, err := l.LsTLV.DecodeFromBytes(data)
+	if err != nil {
+		return err
+	}
+	if l.Type != LS_TLV_FLEX_ALGO_DEF {
+		return malformedAttrListErr("Unexpected TLV type")
+	}
+	if len(value) < 4 {
+		return malformedAttrListErr("FAD TLV too short")
+	}
+	l.Algorithm = value[0]
+	l.MetricType = value[1]
+	l.CalcType = value[2]
+	l.Priority = value[3]
+	if l.Algorithm < 128 {
+		return malformedAttrListErr("FAD Algorithm reserved (must be 128..255)")
+	}
+
+	rem := value[4:]
+	for len(rem) >= 4 {
+		stype := binary.BigEndian.Uint16(rem[:2])
+		slen := int(binary.BigEndian.Uint16(rem[2:4]))
+		if 4+slen > len(rem) {
+			return malformedAttrListErr("FAD sub-TLV truncated")
+		}
+		sv := rem[4 : 4+slen]
+		switch LsTLVType(stype) {
+		case LS_TLV_FAD_EXCLUDE_ANY_AFFINITY:
+			if slen == 0 || slen%4 != 0 {
+				return malformedAttrListErr("FAD Exclude-Any length must be non-zero multiple of 4")
+			}
+			for i := 0; i+4 <= slen; i += 4 {
+				l.ExcludeAny = append(l.ExcludeAny, binary.BigEndian.Uint32(sv[i:i+4]))
+			}
+		case LS_TLV_FAD_INCLUDE_ANY_AFFINITY:
+			if slen == 0 || slen%4 != 0 {
+				return malformedAttrListErr("FAD Include-Any length must be non-zero multiple of 4")
+			}
+			for i := 0; i+4 <= slen; i += 4 {
+				l.IncludeAny = append(l.IncludeAny, binary.BigEndian.Uint32(sv[i:i+4]))
+			}
+		case LS_TLV_FAD_INCLUDE_ALL_AFFINITY:
+			if slen == 0 || slen%4 != 0 {
+				return malformedAttrListErr("FAD Include-All length must be non-zero multiple of 4")
+			}
+			for i := 0; i+4 <= slen; i += 4 {
+				l.IncludeAll = append(l.IncludeAll, binary.BigEndian.Uint32(sv[i:i+4]))
+			}
+		case LS_TLV_FAD_DEFINITION_FLAGS:
+			if slen == 0 || slen%4 != 0 {
+				return malformedAttrListErr("FAD Flags length must be non-zero multiple of 4")
+			}
+			l.Flags = append(l.Flags[:0], sv...)
+		case LS_TLV_FAD_EXCLUDE_SRLG:
+			if slen == 0 || slen%4 != 0 {
+				return malformedAttrListErr("FAD Exclude SRLG length must be non-zero multiple of 4")
+			}
+			for i := 0; i+4 <= slen; i += 4 {
+				l.ExcludeSRLG = append(l.ExcludeSRLG, binary.BigEndian.Uint32(sv[i:i+4]))
+			}
+		case LS_TLV_FAD_UNSUPPORTED:
+			if slen < 1 {
+				return malformedAttrListErr("FAD Unsupported sub-TLV must be at least 1 byte")
+			}
+			u := &LsTLVFADUnsupported{ProtocolID: sv[0]}
+			body := sv[1:]
+			if len(body)%2 != 0 {
+				return malformedAttrListErr("FAD Unsupported sub-TLV type list must be a multiple of 2")
+			}
+			for i := 0; i+2 <= len(body); i += 2 {
+				u.SubTLVTypes = append(u.SubTLVTypes, binary.BigEndian.Uint16(body[i:i+2]))
+			}
+			l.Unsupported = u
+		default:
+			cp := make([]byte, slen)
+			copy(cp, sv)
+			l.Unknown = append(l.Unknown, LsTLVFlexAlgoSubTLVRaw{Type: LsTLVType(stype), Value: cp})
+		}
+		rem = rem[4+slen:]
+	}
+	return nil
+}
+
+func (l *LsTLVFlexAlgoDef) Serialize() ([]byte, error) {
+	body := make([]byte, 0, 4)
+	body = append(body, l.Algorithm, l.MetricType, l.CalcType, l.Priority)
+
+	appendSub := func(t LsTLVType, v []byte) {
+		var hdr [4]byte
+		binary.BigEndian.PutUint16(hdr[:2], uint16(t))
+		binary.BigEndian.PutUint16(hdr[2:4], uint16(len(v)))
+		body = append(body, hdr[:]...)
+		body = append(body, v...)
+	}
+	u32slice := func(in []uint32) []byte {
+		out := make([]byte, 4*len(in))
+		for i, v := range in {
+			binary.BigEndian.PutUint32(out[4*i:4*i+4], v)
+		}
+		return out
+	}
+	if len(l.ExcludeAny) > 0 {
+		appendSub(LS_TLV_FAD_EXCLUDE_ANY_AFFINITY, u32slice(l.ExcludeAny))
+	}
+	if len(l.IncludeAny) > 0 {
+		appendSub(LS_TLV_FAD_INCLUDE_ANY_AFFINITY, u32slice(l.IncludeAny))
+	}
+	if len(l.IncludeAll) > 0 {
+		appendSub(LS_TLV_FAD_INCLUDE_ALL_AFFINITY, u32slice(l.IncludeAll))
+	}
+	if len(l.Flags) > 0 {
+		appendSub(LS_TLV_FAD_DEFINITION_FLAGS, l.Flags)
+	}
+	if len(l.ExcludeSRLG) > 0 {
+		appendSub(LS_TLV_FAD_EXCLUDE_SRLG, u32slice(l.ExcludeSRLG))
+	}
+	if l.Unsupported != nil {
+		buf := make([]byte, 1+2*len(l.Unsupported.SubTLVTypes))
+		buf[0] = l.Unsupported.ProtocolID
+		for i, t := range l.Unsupported.SubTLVTypes {
+			binary.BigEndian.PutUint16(buf[1+2*i:1+2*i+2], t)
+		}
+		appendSub(LS_TLV_FAD_UNSUPPORTED, buf)
+	}
+	for _, raw := range l.Unknown {
+		appendSub(raw.Type, raw.Value)
+	}
+	l.Length = uint16(len(body))
+	return l.LsTLV.Serialize(body)
+}
+
+func (l *LsTLVFlexAlgoDef) String() string {
+	return fmt.Sprintf("{Flex-Algo Def: %d (metric %d calc %d prio %d)}",
+		l.Algorithm, l.MetricType, l.CalcType, l.Priority)
+}
+
+func (l *LsTLVFlexAlgoDef) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type        LsTLVType `json:"type"`
+		Algorithm   uint8     `json:"algorithm"`
+		MetricType  uint8     `json:"metric_type"`
+		CalcType    uint8     `json:"calc_type"`
+		Priority    uint8     `json:"priority"`
+		ExcludeAny  []uint32  `json:"exclude_any_affinity,omitempty"`
+		IncludeAny  []uint32  `json:"include_any_affinity,omitempty"`
+		IncludeAll  []uint32  `json:"include_all_affinity,omitempty"`
+		Flags       []byte    `json:"definition_flags,omitempty"`
+		ExcludeSRLG []uint32  `json:"exclude_srlg,omitempty"`
+	}{
+		Type:        l.Type,
+		Algorithm:   l.Algorithm,
+		MetricType:  l.MetricType,
+		CalcType:    l.CalcType,
+		Priority:    l.Priority,
+		ExcludeAny:  l.ExcludeAny,
+		IncludeAny:  l.IncludeAny,
+		IncludeAll:  l.IncludeAll,
+		Flags:       l.Flags,
+		ExcludeSRLG: l.ExcludeSRLG,
+	})
+}
+
+func (l *LsTLVFlexAlgoDef) GetLsTLV() LsTLV {
+	return l.LsTLV
+}
+
+// LsTLVFADPrefixMetric carries the Flexible Algorithm Prefix Metric
+// (FAPM) Prefix Attribute TLV defined by RFC 9351 Section 4. The
+// codepoint sits in the same registry as the FAD sub-TLVs but the
+// TLV is a top-level Prefix Attribute, not nested inside TLV 1039.
+// Length is fixed at 8 octets.
+type LsTLVFADPrefixMetric struct {
+	LsTLV
+	Algorithm uint8
+	Flags     uint8 // OSPF-specific per RFC9351 Section 4; MUST be 0 for IS-IS
+	Metric    uint32
+}
+
+func (l *LsTLVFADPrefixMetric) DecodeFromBytes(data []byte) error {
+	value, err := l.LsTLV.DecodeFromBytes(data)
+	if err != nil {
+		return err
+	}
+	if l.Type != LS_TLV_FAD_PREFIX_METRIC {
+		return malformedAttrListErr("Unexpected TLV type")
+	}
+	if len(value) != 8 {
+		return malformedAttrListErr("FAPM Prefix Attribute TLV length must be 8")
+	}
+	l.Algorithm = value[0]
+	l.Flags = value[1]
+	// value[2:4] is Reserved per RFC9351 Section 4 and MUST be ignored.
+	l.Metric = binary.BigEndian.Uint32(value[4:8])
+	if l.Algorithm < 128 {
+		return malformedAttrListErr("FAPM Algorithm reserved (must be 128..255)")
+	}
+	return nil
+}
+
+func (l *LsTLVFADPrefixMetric) Serialize() ([]byte, error) {
+	buf := make([]byte, 8)
+	buf[0] = l.Algorithm
+	buf[1] = l.Flags
+	// bytes 2..3 are Reserved (RFC9351 Section 4) and stay zero.
+	binary.BigEndian.PutUint32(buf[4:8], l.Metric)
+	l.Length = 8
+	return l.LsTLV.Serialize(buf)
+}
+
+func (l *LsTLVFADPrefixMetric) String() string {
+	return fmt.Sprintf("{FAPM: algo %d metric %d}", l.Algorithm, l.Metric)
+}
+
+func (l *LsTLVFADPrefixMetric) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type      LsTLVType `json:"type"`
+		Algorithm uint8     `json:"algorithm"`
+		Flags     uint8     `json:"flags,omitempty"`
+		Metric    uint32    `json:"metric"`
+	}{
+		Type:      l.Type,
+		Algorithm: l.Algorithm,
+		Flags:     l.Flags,
+		Metric:    l.Metric,
+	})
+}
+
+func (l *LsTLVFADPrefixMetric) GetLsTLV() LsTLV {
+	return l.LsTLV
+}
+
 type LsTLVAdjacencySID struct {
 	LsTLV
 	Flags  uint8
@@ -10313,6 +10608,30 @@ type LsAttributeNode struct {
 	SrCapabilties *LsSrCapabilities `json:"sr_capabilities,omitempty"`
 	SrAlgorithms  *[]byte           `json:"sr_algorithms,omitempty"`
 	SrLocalBlock  *LsSrLocalBlock   `json:"sr_local_block,omitempty"`
+
+	// Flexible Algorithm (RFC9351 Section 3 / RFC9350 source).
+	// A node MAY advertise more than one FAD, one per algorithm in
+	// [128, 255]; the order is the order in which the TLVs appeared.
+	FlexAlgoDefs []LsAttributeFlexAlgoDef `json:"flex_algo_defs,omitempty"`
+}
+
+// LsAttributeFlexAlgoDef is the structured projection of a single
+// FAD TLV (TLV 1039, RFC 9351 Section 3) into the LsAttribute
+// surface. Per RFC 9350 Section 5.1 reserved Metric-Type values
+// (3..127) are kept verbatim with MetricTypeKnown=false so callers
+// can render them as "advertised but unknown" instead of guessing
+// semantics.
+type LsAttributeFlexAlgoDef struct {
+	Algorithm       uint8    `json:"algorithm"`
+	MetricType      uint8    `json:"metric_type"`
+	MetricTypeKnown bool     `json:"metric_type_known"`
+	CalcType        uint8    `json:"calc_type"`
+	Priority        uint8    `json:"priority"`
+	ExcludeAny      []uint32 `json:"exclude_any_affinity,omitempty"`
+	IncludeAny      []uint32 `json:"include_any_affinity,omitempty"`
+	IncludeAll      []uint32 `json:"include_all_affinity,omitempty"`
+	Flags           []byte   `json:"definition_flags,omitempty"`
+	ExcludeSRLG     []uint32 `json:"exclude_srlg,omitempty"`
 }
 
 type LsAttributeLink struct {
@@ -10345,7 +10664,37 @@ type LsAttributePrefix struct {
 	IGPFlags *LsIGPFlags `json:"igp_flags,omitempty"`
 	Opaque   *[]byte     `json:"opaque,omitempty"`
 
-	SrPrefixSID *uint32 `json:"sr_prefix_sid,omitempty"`
+	// SrPrefixSID holds the SR-MPLS Prefix-SID of the prefix when the
+	// originator advertised it with Algorithm = 0 (default SPF). RFC
+	// 9085 Section 2.1.1 permits several Prefix-SID TLVs on the same
+	// Prefix NLRI, one per algorithm, so SrPrefixSIDs below carries
+	// the full list (Algorithm + Flags + SID) without losing entries.
+	// SrPrefixSID stays for backward compatibility with the singular
+	// Algorithm-0 lookup callers already perform.
+	SrPrefixSID  *uint32                 `json:"sr_prefix_sid,omitempty"`
+	SrPrefixSIDs []LsAttributePrefixSID  `json:"sr_prefix_sids,omitempty"`
+
+	// FadPrefixMetrics carries any FAPM (Flexible Algorithm Prefix
+	// Metric) Prefix Attribute TLVs (TLV 1044, RFC 9351 Section 4)
+	// attached to the prefix. One entry per Flex-Algorithm announced.
+	FadPrefixMetrics []LsAttributeFADPrefixMetric `json:"fad_prefix_metrics,omitempty"`
+}
+
+// LsAttributePrefixSID projects one Prefix-SID TLV (RFC 9085
+// Section 2.1.1) into the LsAttribute surface so callers can read
+// Algorithm + Flags without re-parsing the wire bytes.
+type LsAttributePrefixSID struct {
+	Algorithm uint8  `json:"algorithm"`
+	Flags     uint8  `json:"flags"`
+	SID       uint32 `json:"sid"`
+}
+
+// LsAttributeFADPrefixMetric projects one FAPM TLV (RFC 9351
+// Section 4) into the LsAttribute surface.
+type LsAttributeFADPrefixMetric struct {
+	Algorithm uint8  `json:"algorithm"`
+	Flags     uint8  `json:"flags,omitempty"`
+	Metric    uint32 `json:"metric"`
 }
 
 type LsAttributeBgpPeerSegment struct {
@@ -10462,7 +10811,44 @@ func (p *PathAttributeLs) Extract() *LsAttribute {
 			l.Prefix.Opaque = &v.Attr
 
 		case *LsTLVPrefixSID:
-			l.Prefix.SrPrefixSID = &v.SID
+			// RFC 9085 Section 2.1.1 allows multiple Prefix-SID TLVs
+			// on the same Prefix NLRI (one per SR algorithm). Append
+			// every observation here so Algorithm 128..255 Flex-Algo
+			// SIDs survive; mirror the Algorithm-0 SID into
+			// SrPrefixSID for the singular legacy field.
+			l.Prefix.SrPrefixSIDs = append(l.Prefix.SrPrefixSIDs, LsAttributePrefixSID{
+				Algorithm: v.Algorithm,
+				Flags:     v.Flags,
+				SID:       v.SID,
+			})
+			if v.Algorithm == 0 && l.Prefix.SrPrefixSID == nil {
+				sid := v.SID
+				l.Prefix.SrPrefixSID = &sid
+			}
+
+		case *LsTLVFlexAlgoDef:
+			// RFC 9351 Section 3: one FAD per algorithm; aggregate
+			// every observation into the slice in the order they
+			// arrived on the wire.
+			l.Node.FlexAlgoDefs = append(l.Node.FlexAlgoDefs, LsAttributeFlexAlgoDef{
+				Algorithm:       v.Algorithm,
+				MetricType:      v.MetricType,
+				MetricTypeKnown: v.MetricType <= 2, // RFC 9350 Section 5.1 known set: 0=IGP, 1=MinDelay, 2=TE
+				CalcType:        v.CalcType,
+				Priority:        v.Priority,
+				ExcludeAny:      v.ExcludeAny,
+				IncludeAny:      v.IncludeAny,
+				IncludeAll:      v.IncludeAll,
+				Flags:           v.Flags,
+				ExcludeSRLG:     v.ExcludeSRLG,
+			})
+
+		case *LsTLVFADPrefixMetric:
+			l.Prefix.FadPrefixMetrics = append(l.Prefix.FadPrefixMetrics, LsAttributeFADPrefixMetric{
+				Algorithm: v.Algorithm,
+				Flags:     v.Flags,
+				Metric:    v.Metric,
+			})
 
 		case *LsTLVPeerNodeSID:
 			l.BgpPeerSegment.BgpPeerNodeSid = v.Extract()
@@ -10532,6 +10918,15 @@ func (p *PathAttributeLs) DecodeFromBytes(data []byte, options ...*MarshallingOp
 
 		case LS_TLV_SR_LOCAL_BLOCK:
 			tlv = &LsTLVSrLocalBlock{}
+
+		// Flex-Algorithm Definition (RFC 9351 Section 3).
+		case LS_TLV_FLEX_ALGO_DEF:
+			tlv = &LsTLVFlexAlgoDef{}
+
+		// Flex-Algorithm Prefix Metric (RFC 9351 Section 4).
+		// Top-level Prefix Attribute, not nested inside TLV 1039.
+		case LS_TLV_FAD_PREFIX_METRIC:
+			tlv = &LsTLVFADPrefixMetric{}
 
 		// Link NLRI-related TLVs (https://tools.ietf.org/html/rfc7752#section-3.3.2)
 		case LS_TLV_IPV4_REMOTE_ROUTER_ID:

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -8660,8 +8660,60 @@ func (l *LsTLVFlexAlgoDef) Serialize() ([]byte, error) {
 }
 
 func (l *LsTLVFlexAlgoDef) String() string {
-	return fmt.Sprintf("{Flex-Algo Def: %d (metric %d calc %d prio %d)}",
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "{Flex-Algo Def: %d metric:%d calc:%d prio:%d",
 		l.Algorithm, l.MetricType, l.CalcType, l.Priority)
+	if len(l.ExcludeAny) > 0 {
+		fmt.Fprintf(&buf, " exclude-any:%s", flexAlgoUint32SliceHex(l.ExcludeAny))
+	}
+	if len(l.IncludeAny) > 0 {
+		fmt.Fprintf(&buf, " include-any:%s", flexAlgoUint32SliceHex(l.IncludeAny))
+	}
+	if len(l.IncludeAll) > 0 {
+		fmt.Fprintf(&buf, " include-all:%s", flexAlgoUint32SliceHex(l.IncludeAll))
+	}
+	if len(l.Flags) > 0 {
+		fmt.Fprintf(&buf, " flags:%s", flexAlgoByteSliceHex(l.Flags))
+	}
+	if len(l.ExcludeSRLG) > 0 {
+		fmt.Fprintf(&buf, " exclude-srlg:%v", l.ExcludeSRLG)
+	}
+	if l.Unsupported != nil {
+		fmt.Fprintf(&buf, " unsupported:{proto:%d types:%v}",
+			l.Unsupported.ProtocolID, l.Unsupported.SubTLVTypes)
+	}
+	buf.WriteString("}")
+	return buf.String()
+}
+
+// flexAlgoUint32SliceHex formats a slice of 32-bit affinity bitmaps
+// as a comma-separated hex list, e.g. [0x0000000F 0x000000F0]. Used
+// by LsTLVFlexAlgoDef.String to keep the CLI render compact and easy
+// to compare against vendor "show isis flex-algorithm" output.
+func flexAlgoUint32SliceHex(in []uint32) string {
+	var buf bytes.Buffer
+	buf.WriteString("[")
+	for i, v := range in {
+		if i > 0 {
+			buf.WriteString(" ")
+		}
+		fmt.Fprintf(&buf, "0x%08x", v)
+	}
+	buf.WriteString("]")
+	return buf.String()
+}
+
+func flexAlgoByteSliceHex(in []byte) string {
+	var buf bytes.Buffer
+	buf.WriteString("[")
+	for i, v := range in {
+		if i > 0 {
+			buf.WriteString(" ")
+		}
+		fmt.Fprintf(&buf, "0x%02x", v)
+	}
+	buf.WriteString("]")
+	return buf.String()
 }
 
 func (l *LsTLVFlexAlgoDef) MarshalJSON() ([]byte, error) {

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -10723,8 +10723,8 @@ type LsAttributePrefix struct {
 	// the full list (Algorithm + Flags + SID) without losing entries.
 	// SrPrefixSID stays for backward compatibility with the singular
 	// Algorithm-0 lookup callers already perform.
-	SrPrefixSID  *uint32                 `json:"sr_prefix_sid,omitempty"`
-	SrPrefixSIDs []LsAttributePrefixSID  `json:"sr_prefix_sids,omitempty"`
+	SrPrefixSID  *uint32                `json:"sr_prefix_sid,omitempty"`
+	SrPrefixSIDs []LsAttributePrefixSID `json:"sr_prefix_sids,omitempty"`
 
 	// FadPrefixMetrics carries any FAPM (Flexible Algorithm Prefix
 	// Metric) Prefix Attribute TLVs (TLV 1044, RFC 9351 Section 4)

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -4485,7 +4485,13 @@ func Test_PathAttributeLs(t *testing.T) {
 				0x04, 0x86, 0x00, 0x07, 0x01, 0x01, 0x00, 0x00, 0x01, 0x88, 0x94, // Prefix SID: 100500
 			},
 			"{LsAttributes: {IGP Flags: XXXXPLND} {Prefix opaque attribute: [1 2 3]} {Prefix SID: 100500} }",
-			`{"type":41,"flags":128,"node":{},"link":{},"prefix":{"igp_flags":{"down":true,"no_unicast":true,"local_address":true,"propagate_nssa":true},"opaque":"AQID","sr_prefix_sid":100500},"bgp_peer_segment":{},"srv6_sid":{}}`,
+			// Per RFC 9085 Section 2.1.1 the Prefix-SID TLV carries
+			// a Flags + Algorithm header. The wire bytes above set
+			// Algorithm=1 / Flags=1 / SID=100500, so the projection
+			// puts the entry into sr_prefix_sids; the singular
+			// sr_prefix_sid is reserved for the Algorithm-0
+			// (default SPF) SID and stays unset here.
+			`{"type":41,"flags":128,"node":{},"link":{},"prefix":{"igp_flags":{"down":true,"no_unicast":true,"local_address":true,"propagate_nssa":true},"opaque":"AQID","sr_prefix_sids":[{"algorithm":1,"flags":1,"sid":100500}]},"bgp_peer_segment":{},"srv6_sid":{}}`,
 			true, false,
 		},
 	}
@@ -4544,6 +4550,202 @@ func Test_PathAttributeLsDelayMetricTLVs(t *testing.T) {
 	got, err := attr.Serialize()
 	assert.NoError(err)
 	assert.Equal(in, got)
+}
+
+// Test_LsTLVFlexAlgoDef exercises the RFC 9351 Section 3 wire decode
+// for the BGP-LS FAD TLV (1039) plus every defined nested sub-TLV
+// (1040 Exclude-Any, 1041 Include-Any, 1042 Include-All, 1043 Flags,
+// 1045 Exclude SRLG, 1046 Unsupported). Round-trip serialise/decode is
+// verified for each fixture so the IANA codepoints stay byte-stable.
+func Test_LsTLVFlexAlgoDef(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name string
+		in   []byte
+		want LsTLVFlexAlgoDef
+	}{
+		{
+			name: "fixed header only (algo 128, metric IGP, calc SPF, priority 100)",
+			// Type 1039 = 0x040F, Length 4, body: algo, metric, calc, prio.
+			in: []byte{0x04, 0x0F, 0x00, 0x04, 0x80, 0x00, 0x00, 0x64},
+			want: LsTLVFlexAlgoDef{
+				LsTLV:      LsTLV{Type: LS_TLV_FLEX_ALGO_DEF, Length: 4},
+				Algorithm:  128,
+				MetricType: 0,
+				CalcType:   0,
+				Priority:   100,
+			},
+		},
+		{
+			name: "algo 129 metric Min-Delay with Exclude-Any + Include-Any + Flags + Exclude-SRLG",
+			in: []byte{
+				0x04, 0x0F, 0x00, 0x24, // TLV 1039, length 36 (4-byte header + four 8-byte sub-TLVs)
+				0x81, 0x01, 0x00, 0xC8, // algo 129, metric 1 (Min-Delay), calc 0, prio 200
+				0x04, 0x10, 0x00, 0x04, 0x00, 0x00, 0x00, 0x0F, // sub-TLV 1040 Exclude-Any, EAG 0x0000000F
+				0x04, 0x11, 0x00, 0x04, 0x00, 0x00, 0x00, 0xF0, // sub-TLV 1041 Include-Any, EAG 0x000000F0
+				0x04, 0x13, 0x00, 0x04, 0x80, 0x00, 0x00, 0x00, // sub-TLV 1043 Flags, M-flag set
+				0x04, 0x15, 0x00, 0x04, 0x00, 0x00, 0x00, 0x2A, // sub-TLV 1045 Exclude SRLG = [42]
+			},
+			want: LsTLVFlexAlgoDef{
+				LsTLV:       LsTLV{Type: LS_TLV_FLEX_ALGO_DEF, Length: 36},
+				Algorithm:   129,
+				MetricType:  1,
+				CalcType:    0,
+				Priority:    200,
+				ExcludeAny:  []uint32{0x0F},
+				IncludeAny:  []uint32{0xF0},
+				Flags:       []byte{0x80, 0x00, 0x00, 0x00},
+				ExcludeSRLG: []uint32{42},
+			},
+		},
+		{
+			name: "algo 130 metric TE with Include-All + Unsupported",
+			in: []byte{
+				0x04, 0x0F, 0x00, 0x15, // TLV 1039, length 21
+				0x82, 0x02, 0x00, 0x32, // algo 130, metric 2 (TE), calc 0, prio 50
+				0x04, 0x12, 0x00, 0x04, 0x00, 0x00, 0x00, 0xAA, // sub-TLV 1042 Include-All, EAG 0xAA
+				0x04, 0x16, 0x00, 0x05, 0x02, 0x04, 0x10, 0x04, 0x11, // sub-TLV 1046 Unsupported, proto 2, types [1040 1041]
+			},
+			want: LsTLVFlexAlgoDef{
+				LsTLV:      LsTLV{Type: LS_TLV_FLEX_ALGO_DEF, Length: 21},
+				Algorithm:  130,
+				MetricType: 2,
+				CalcType:   0,
+				Priority:   50,
+				IncludeAll: []uint32{0xAA},
+				Unsupported: &LsTLVFADUnsupported{
+					ProtocolID:  2,
+					SubTLVTypes: []uint16{0x0410, 0x0411},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := LsTLVFlexAlgoDef{}
+			assert.NoError(got.DecodeFromBytes(tc.in))
+			assert.Equal(tc.want.Algorithm, got.Algorithm)
+			assert.Equal(tc.want.MetricType, got.MetricType)
+			assert.Equal(tc.want.CalcType, got.CalcType)
+			assert.Equal(tc.want.Priority, got.Priority)
+			assert.Equal(tc.want.ExcludeAny, got.ExcludeAny)
+			assert.Equal(tc.want.IncludeAny, got.IncludeAny)
+			assert.Equal(tc.want.IncludeAll, got.IncludeAll)
+			assert.Equal(tc.want.Flags, got.Flags)
+			assert.Equal(tc.want.ExcludeSRLG, got.ExcludeSRLG)
+			assert.Equal(tc.want.Unsupported, got.Unsupported)
+
+			out, err := got.Serialize()
+			assert.NoError(err)
+			assert.Equal(tc.in, out)
+		})
+	}
+}
+
+// Test_LsTLVFlexAlgoDef_Errors covers the malformed-input paths the
+// decoder must reject per RFC 9351 (truncated headers, reserved
+// algorithm IDs, sub-TLV length violations).
+func Test_LsTLVFlexAlgoDef_Errors(t *testing.T) {
+	assert := assert.New(t)
+
+	cases := []struct {
+		name string
+		in   []byte
+	}{
+		{
+			name: "value shorter than 4-byte fixed header",
+			in:   []byte{0x04, 0x0F, 0x00, 0x02, 0x80, 0x00},
+		},
+		{
+			name: "algorithm 127 is reserved (RFC 9350 Section 4)",
+			in:   []byte{0x04, 0x0F, 0x00, 0x04, 0x7F, 0x00, 0x00, 0x64},
+		},
+		{
+			name: "Exclude-Any length not a multiple of 4",
+			in: []byte{
+				0x04, 0x0F, 0x00, 0x09,
+				0x80, 0x00, 0x00, 0x64,
+				0x04, 0x10, 0x00, 0x01, 0x00,
+			},
+		},
+		{
+			name: "Exclude SRLG length zero is malformed",
+			in: []byte{
+				0x04, 0x0F, 0x00, 0x08,
+				0x80, 0x00, 0x00, 0x64,
+				0x04, 0x15, 0x00, 0x00,
+			},
+		},
+		{
+			name: "Unsupported sub-TLV body length 0 is malformed",
+			in: []byte{
+				0x04, 0x0F, 0x00, 0x08,
+				0x80, 0x00, 0x00, 0x64,
+				0x04, 0x16, 0x00, 0x00,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := LsTLVFlexAlgoDef{}
+			assert.Error(got.DecodeFromBytes(tc.in))
+		})
+	}
+}
+
+// Test_LsTLVFADPrefixMetric exercises the RFC 9351 Section 4 FAPM
+// wire format (TLV 1044, fixed 8-byte value).
+func Test_LsTLVFADPrefixMetric(t *testing.T) {
+	assert := assert.New(t)
+
+	in := []byte{
+		0x04, 0x14, 0x00, 0x08, // TLV 1044, length 8
+		0x80, 0x00, 0x00, 0x00, // algo 128, flags 0, reserved 0x0000
+		0x00, 0x00, 0x27, 0x10, // metric = 10000
+	}
+
+	got := LsTLVFADPrefixMetric{}
+	assert.NoError(got.DecodeFromBytes(in))
+	assert.Equal(uint8(128), got.Algorithm)
+	assert.Equal(uint8(0), got.Flags)
+	assert.Equal(uint32(10000), got.Metric)
+
+	out, err := got.Serialize()
+	assert.NoError(err)
+	assert.Equal(in, out)
+}
+
+// Test_PathAttributeLs_MultiPrefixSID confirms that the Extract path
+// aggregates every Prefix-SID TLV observed on the same Prefix NLRI
+// instead of overwriting earlier entries. Regression test for the
+// last-write-wins behaviour the legacy projection had.
+func Test_PathAttributeLs_MultiPrefixSID(t *testing.T) {
+	assert := assert.New(t)
+
+	in := []byte{
+		0x80, 0x29, 0x16, // Optional attribute, BGP_ATTR_TYPE_LS, length 22 (two 11-byte Prefix-SID TLVs)
+		0x04, 0x86, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x01, 0x88, 0x94, // Prefix-SID algo 0, SID 100500
+		0x04, 0x86, 0x00, 0x07, 0x40, 0x80, 0x00, 0x00, 0x01, 0x88, 0x95, // Prefix-SID algo 128, SID 100501
+	}
+
+	attr := PathAttributeLs{}
+	assert.NoError(attr.DecodeFromBytes(in))
+
+	ls := attr.Extract()
+	assert.NotNil(ls.Prefix.SrPrefixSID)
+	if ls.Prefix.SrPrefixSID != nil {
+		assert.Equal(uint32(100500), *ls.Prefix.SrPrefixSID)
+	}
+	assert.Len(ls.Prefix.SrPrefixSIDs, 2)
+	if len(ls.Prefix.SrPrefixSIDs) == 2 {
+		assert.Equal(uint8(0), ls.Prefix.SrPrefixSIDs[0].Algorithm)
+		assert.Equal(uint32(100500), ls.Prefix.SrPrefixSIDs[0].SID)
+		assert.Equal(uint8(128), ls.Prefix.SrPrefixSIDs[1].Algorithm)
+		assert.Equal(uint32(100501), ls.Prefix.SrPrefixSIDs[1].SID)
+	}
 }
 
 func Test_BGPOpenDecodeCapabilities(t *testing.T) {

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -4696,6 +4696,62 @@ func Test_LsTLVFlexAlgoDef_Errors(t *testing.T) {
 	}
 }
 
+// Test_LsTLVFlexAlgoDef_String covers the CLI render of the FAD TLV
+// so that operators see the affinity / SRLG / flags sub-TLVs and not
+// just the four fixed-header bytes.
+func Test_LsTLVFlexAlgoDef_String(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name string
+		def  LsTLVFlexAlgoDef
+		want string
+	}{
+		{
+			name: "fixed header only",
+			def: LsTLVFlexAlgoDef{
+				Algorithm: 128, MetricType: 0, CalcType: 0, Priority: 100,
+			},
+			want: "{Flex-Algo Def: 128 metric:0 calc:0 prio:100}",
+		},
+		{
+			name: "with all affinity bitmaps and SRLG",
+			def: LsTLVFlexAlgoDef{
+				Algorithm:   129,
+				MetricType:  1,
+				CalcType:    0,
+				Priority:    200,
+				ExcludeAny:  []uint32{0x0F},
+				IncludeAny:  []uint32{0xF0},
+				IncludeAll:  []uint32{0xAA},
+				Flags:       []byte{0x80, 0x00, 0x00, 0x00},
+				ExcludeSRLG: []uint32{42, 43},
+			},
+			want: "{Flex-Algo Def: 129 metric:1 calc:0 prio:200" +
+				" exclude-any:[0x0000000f] include-any:[0x000000f0]" +
+				" include-all:[0x000000aa] flags:[0x80 0x00 0x00 0x00]" +
+				" exclude-srlg:[42 43]}",
+		},
+		{
+			name: "with unsupported sub-TLV",
+			def: LsTLVFlexAlgoDef{
+				Algorithm: 130, MetricType: 2, CalcType: 0, Priority: 50,
+				Unsupported: &LsTLVFADUnsupported{
+					ProtocolID:  2,
+					SubTLVTypes: []uint16{1040, 1041},
+				},
+			},
+			want: "{Flex-Algo Def: 130 metric:2 calc:0 prio:50" +
+				" unsupported:{proto:2 types:[1040 1041]}}",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(tc.want, tc.def.String())
+		})
+	}
+}
+
 // Test_LsTLVFADPrefixMetric exercises the RFC 9351 Section 4 FAPM
 // wire format (TLV 1044, fixed 8-byte value).
 func Test_LsTLVFADPrefixMetric(t *testing.T) {

--- a/proto/api/attribute.proto
+++ b/proto/api/attribute.proto
@@ -418,6 +418,28 @@ message LsAttributeNode {
   LsSrCapabilities sr_capabilities = 7;
   bytes sr_algorithms = 8;
   LsSrLocalBlock sr_local_block = 9;
+
+  // RFC 9351 Section 3 Flexible Algorithm Definition (FAD) TLVs
+  // observed for this Node NLRI. A node MAY advertise more than one
+  // FAD, one per algorithm in the [128, 255] Flex-Algorithm range.
+  repeated LsAttributeFlexAlgoDef flex_algo_defs = 10;
+}
+
+// LsAttributeFlexAlgoDef is the structured projection of a single FAD
+// TLV (TLV 1039, RFC 9351 Section 3). Reserved Metric-Type values
+// (3..127) are passed through verbatim with metric_type_known=false
+// so consumers can render them without guessing semantics.
+message LsAttributeFlexAlgoDef {
+  uint32 algorithm = 1;
+  uint32 metric_type = 2;
+  bool metric_type_known = 3;
+  uint32 calc_type = 4;
+  uint32 priority = 5;
+  repeated uint32 exclude_any_affinity = 6;
+  repeated uint32 include_any_affinity = 7;
+  repeated uint32 include_all_affinity = 8;
+  bytes definition_flags = 9;
+  repeated uint32 exclude_srlg = 10;
 }
 
 message LsAttributeLink {
@@ -452,7 +474,39 @@ message LsAttributePrefix {
   LsIGPFlags igp_flags = 1;
   bytes opaque = 2;
 
+  // sr_prefix_sid is the SR-MPLS Prefix-SID label when the originator
+  // advertised it with Algorithm = 0 (default SPF). Kept for backward
+  // compatibility with the singular Algorithm-0 lookup callers used
+  // before multi-SID aggregation landed.
   uint32 sr_prefix_sid = 3;
+
+  // sr_prefix_sids carries every Prefix-SID TLV (RFC 9085
+  // Section 2.1.1) observed on this Prefix NLRI, including the
+  // Algorithm + Flags fields the singular sr_prefix_sid field drops.
+  // Algorithm 0 entries also populate sr_prefix_sid above.
+  repeated LsAttributePrefixSID sr_prefix_sids = 4;
+
+  // fad_prefix_metrics carries every Flexible Algorithm Prefix Metric
+  // TLV (FAPM, TLV 1044, RFC 9351 Section 4) observed on this Prefix
+  // NLRI. One entry per Flex-Algorithm announced.
+  repeated LsAttributeFADPrefixMetric fad_prefix_metrics = 5;
+}
+
+// LsAttributePrefixSID is one Prefix-SID TLV (RFC 9085 Section 2.1.1)
+// projected onto the LsAttribute surface so consumers can read the
+// Algorithm and Flags fields without re-parsing the wire bytes.
+message LsAttributePrefixSID {
+  uint32 algorithm = 1;
+  uint32 flags = 2;
+  uint32 sid = 3;
+}
+
+// LsAttributeFADPrefixMetric is one FAPM TLV (RFC 9351 Section 4)
+// projected onto the LsAttribute surface.
+message LsAttributeFADPrefixMetric {
+  uint32 algorithm = 1;
+  uint32 flags = 2;
+  uint32 metric = 3;
 }
 
 message LsBgpPeerSegmentSIDFlags {

--- a/tools/spell-check/dictionary.txt
+++ b/tools/spell-check/dictionary.txt
@@ -14,6 +14,7 @@ enlp
 ethernet
 etree
 evpn
+fapm
 flowspec
 gobgp
 gobgpd


### PR DESCRIPTION
Implements [RFC 9351 (BGP-LS Extensions for Flexible Algorithm Advertisement)](https://www.rfc-editor.org/rfc/rfc9351.html), tracked by issue #3440. Closes #3440.

The patch also closes an RFC 9085 Section 2.1.1 gap. When a Prefix NLRI carries Prefix-SIDs for several SR algorithms (the default SPF and one or more Flex-Algos), the existing `Extract()` projection of `LsTLVPrefixSID` overwrites prior entries because the singular `LsAttributePrefix.SrPrefixSID *uint32` only holds the last-decoded value. The new `SrPrefixSIDs []LsAttributePrefixSID` slice records every entry with its Algorithm, Flags and SID. The singular field stays populated from the first Algorithm-0 entry observed so existing consumers do not regress.

### What changes on the wire

The decoder gains support for the eight BGP-LS codepoints RFC 9351 Section 5 registers:

- TLV 1039 Flex-Algorithm Definition (Section 3): a Node Attribute TLV with a four-byte fixed header (Algorithm + Metric-Type + Calc-Type + Priority) followed by nested sub-TLVs in BGP-LS sub-TLV form (Type 2B + Length 2B + Value).
- Five FAD sub-TLVs nested inside TLV 1039: 1040 Exclude-Any Affinity (Section 3.1), 1041 Include-Any Affinity (Section 3.2), 1042 Include-All Affinity (Section 3.3), 1043 Definition Flags (Section 3.4), 1045 Exclude SRLG (Section 3.5), 1046 Flex-Algorithm Unsupported (Section 3.6).
- TLV 1044 Flexible Algorithm Prefix Metric (Section 4): a top-level Prefix Attribute TLV with an eight-octet fixed value (Algorithm + Flags + Reserved + 4B Metric).

Unknown sub-TLV types inside TLV 1039 are preserved verbatim in `LsTLVFlexAlgoDef.Unknown` so a future RFC 9351 sub-TLV registry addition does not lose bytes on re-serialise.

### Configuration and capabilities

No new knobs. The decode runs whenever a BGP-LS family session is up. Serialise stays symmetric so test peers and tools can originate the new TLVs.

### Commit layout

Five commits:

1. `packet/bgp: add RFC 9351 Flex-Algorithm Definition + multi-SID Prefix-SID`. New `LS_TLV_*` constants for 1039 and 1040..1046, the structured `LsTLVFlexAlgoDef` and `LsTLVFADPrefixMetric` types, the multi-SID `LsAttributePrefix.SrPrefixSIDs` slice, the FAPM `LsAttributePrefix.FadPrefixMetrics` slice. Tests cover round-trip serialise / decode for each sub-TLV, malformed-input rejection for reserved Algorithm IDs and out-of-spec sub-TLV lengths, and the multi-SID Prefix-SID aggregation regression.
2. `api, apiutil: surface RFC 9351 Flex-Algorithm Definition + multi-SID Prefix-SID`. The `api.LsAttributeFlexAlgoDef`, `api.LsAttributePrefixSID`, `api.LsAttributeFADPrefixMetric` proto messages, the repeated fields on `LsAttributeNode` and `LsAttributePrefix`, the regenerated `api/attribute.pb.go` (matches the byte-for-byte output of `buf generate` against the BSR plugins the upstream CI uses, so `git diff --exit-code` after CI regeneration stays clean), and the bidirectional `NewLsAttributeFromNative` / `UnmarshalLsAttribute` glue in `pkg/apiutil`.
3. `packet/bgp: render FAD sub-TLVs in LsTLVFlexAlgoDef.String for CLI output`. `gobgp global rib -a ls` now surfaces every affinity, SRLG and flags sub-TLV instead of just the four-byte fixed header.
4. `apiutil: end-to-end wire test for RFC 9351 FAD + multi-SID Prefix-SID + FAPM`. Drives the full chain (wire bytes, `DecodeFromBytes`, `Extract`, `NewLsAttributeFromNative`, `proto.Marshal / Unmarshal`, `UnmarshalLsAttribute`, `Serialize`) and asserts byte-stable round-trip.
5. `packet/bgp, apiutil: gofmt fixups in the RFC 9351 stack`.

### CI

On Go 1.25 (matching the CI `setup-go@v6 stable` matrix):

- `go test -race -timeout 240s ./pkg/packet/bgp/... ./pkg/apiutil/... ./cmd/gobgp/...`: green.
- `gofmt -l` on every touched file: clean.
- `go vet ./pkg/packet/bgp/... ./pkg/apiutil/... ./api/... ./cmd/gobgp/...`: clean.
- `buf generate --template proto/buf.gen.yaml proto` followed by `git diff --exit-code`: clean.
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go build ./pkg/packet/bgp/... ./pkg/apiutil/... ./api/...`: built.
- Crossbuild on `freebsd / openbsd / windows / amd64`: built.
- `tools/grep_avoided_functions.sh`: exit 0.

The `pkg/server` failures `TestEBGPRouteStuck` and `TestRTCDeferralTimerRaceCondition` reproduce on the unmodified `master` branch with a `127.0.0.201` bind error and are not caused by the patch.

### Production exercise

The patch runs against a mixed-vendor BGP-LS lab built with containerlab: 42 FRR routers, 3 Nokia SR OS 25.10.R1 routers, 1 Juniper Junos router and 3 GoBGP test peers, around 150 BGP sessions in total. The three Nokia routers each originate a Flex-Algorithm Definition with priority 200 (mad) or 150 (lis, bcn). Algorithm 128 uses metric-type delay and algorithm 129 uses metric-type IGP with `exclude admin-group "transit"` mapped to mask 0x00000004 on the backbone. Each Nokia loopback advertises three Prefix-SIDs (Algorithm 0 default SPF, Algorithm 128 Flex-Algo-delay, Algorithm 129 Flex-Algo-igp-no-transit) per RFC 9085 Section 2.1.1.

With the PR in place, the receiving gobgp instance surfaces every FAD entry through `LsAttributeNode.FlexAlgoDefs` and every per-algorithm Prefix-SID through `LsAttributePrefix.SrPrefixSIDs`. Mad wins the priority tie-break for both algorithms per RFC 9350 Section 5.3 and lis and bcn appear as challengers with priority 150. The per-algorithm prefix-SID labels match the index plan (mad/128=16129, mad/129=16257, lis/128=16165, lis/129=16293, bcn/128=16131, bcn/129=16259) against the SRGB base 16000. The same `LsAttributePrefix.SrPrefixSIDs` slice carries both the Algorithm-0 SPF SID and the Algorithm-128 / 129 Flex-Algo SIDs from a single Prefix NLRI, exercising the multi-SID aggregation regression fix end to end.

Closes #3440.
