### PR TITLE
table: fix ext-community-set match-set-options ALL and INVERT

### DIFF
--- a/internal/pkg/table/policy.go
+++ b/internal/pkg/table/policy.go
@@ -2298,14 +2298,14 @@ func (c *ExtCommunityCondition) Evaluate(path *Path, _ *PolicyOptions) bool {
 
 	// General path: loop over path ECs, try each matcher. Semantics preserved from original.
 	result := false
-	for _, x := range es {
+	for _, m := range c.set.matchers {
 		result = false
-		// match only with transitive community. see RFC7153
-		if !isTransitiveType(x) {
-			continue
-		}
-		var xStr string
-		for _, m := range c.set.matchers {
+		for _, x := range es {
+			// match only with transitive community. see RFC7153
+			if !isTransitiveType(x) {
+				continue
+			}
+			var xStr string
 			if m.matchesExtCommunity(x, &xStr) {
 				result = true
 				break
@@ -2314,7 +2314,7 @@ func (c *ExtCommunityCondition) Evaluate(path *Path, _ *PolicyOptions) bool {
 		if c.option == MATCH_OPTION_ALL && !result {
 			break
 		}
-		if c.option == MATCH_OPTION_ANY && result {
+		if (c.option == MATCH_OPTION_ANY || c.option == MATCH_OPTION_INVERT) && result {
 			break
 		}
 	}

--- a/internal/pkg/table/policy_test.go
+++ b/internal/pkg/table/policy_test.go
@@ -2696,11 +2696,24 @@ func TestExtCommunityConditionEvaluate(t *testing.T) {
 		ExtCommunitySetName: "ecomSet12",
 		ExtCommunityList:    []string{"LB:65001:125000"},
 	}
+	ecomSet13 := oc.ExtCommunitySet{
+		ExtCommunitySetName: "ecomSet13",
+		ExtCommunityList:    []string{"RT:65001:200", "SoO:65010:300"},
+	}
+	ecomSet14 := oc.ExtCommunitySet{
+		ExtCommunitySetName: "ecomSet14",
+		ExtCommunityList:    []string{"RT:65001:200", "RT:99999:999"},
+	}
+	ecomSet15 := oc.ExtCommunitySet{
+		ExtCommunitySetName: "ecomSet15",
+		ExtCommunityList:    []string{"RT:65001:200"},
+	}
 
 	m := make(map[string]DefinedSet)
 	for _, c := range []oc.ExtCommunitySet{
 		ecomSet1, ecomSet2, ecomSet3, ecomSet4, ecomSet5, ecomSet6, ecomSet7,
 		ecomSet8, ecomSet9, ecomSet10, ecomSet11, ecomSet12,
+		ecomSet13, ecomSet14, ecomSet15,
 	} {
 		s, _ := NewExtCommunitySet(c)
 		m[s.Name()] = s
@@ -2730,9 +2743,12 @@ func TestExtCommunityConditionEvaluate(t *testing.T) {
 
 	// ALL case
 	p10 := createExtCommunityC("ecomSet10", oc.MATCH_SET_OPTIONS_TYPE_ALL)
+	p13 := createExtCommunityC("ecomSet13", oc.MATCH_SET_OPTIONS_TYPE_ALL)
+	p14 := createExtCommunityC("ecomSet14", oc.MATCH_SET_OPTIONS_TYPE_ALL)
 
 	// INVERT case
 	p11 := createExtCommunityC("ecomSet11", oc.MATCH_SET_OPTIONS_TYPE_INVERT)
+	p15 := createExtCommunityC("ecomSet15", oc.MATCH_SET_OPTIONS_TYPE_INVERT)
 
 	// test
 	assert.Equal(t, true, p1.Evaluate(path1, nil))
@@ -2746,6 +2762,9 @@ func TestExtCommunityConditionEvaluate(t *testing.T) {
 	assert.Equal(t, true, p9.Evaluate(path1, nil))
 	assert.Equal(t, true, p10.Evaluate(path1, nil))
 	assert.Equal(t, true, p11.Evaluate(path1, nil))
+	assert.Equal(t, true, p13.Evaluate(path1, nil))
+	assert.Equal(t, false, p14.Evaluate(path1, nil))
+	assert.Equal(t, false, p15.Evaluate(path1, nil))
 }
 
 func TestExtCommunityConditionEvaluateWithOtherCondition(t *testing.T) {


### PR DESCRIPTION
ExtCommunityCondition.Evaluate iterated route extended communities in the outer loop and configured patterns in the inner loop. For MATCH_OPTION_ALL this gave the inverse of the OpenConfig semantics: "every route community matches some pattern" instead of "every configured pattern matches some route community". As a result, match-set-options: all rejected routes that carried extended communities not listed in the set.

MATCH_OPTION_INVERT was affected by the same nesting. The early break fired only for ANY, so result was reset on every outer iteration and the final value reflected only the last route community.

Swap the loop nesting and add INVERT to the early-break condition. Mirrors the community-set fix from #859 (commit e06bb04f).