### PR TITLE
packet/bgp: keep Link Local/Remote Identifier in LsLinkDescriptor.String when addresses are also present

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -5051,9 +5051,26 @@ func (l *LsLinkDescriptor) String() string {
 	default:
 		base = "UNKNOWN"
 	}
-	// MT-ID participates in the destination key (RFC 7752 §3.2.1.5).
-	// Two ISIS-MT advertisements of the same physical link must not
-	// collide in the RIB.
+
+	// The Link Local/Remote Identifier sub-TLV (Type 258, RFC 7752
+	// Table 5) coexists with the interface/neighbor address sub-TLVs
+	// in some NLRI shapes. RFC 9086 Section 5.2 mandates Type 258 on
+	// PeerAdj-SID Link NLRIs and lets the producer also include the
+	// IPv4 or IPv6 address sub-TLVs alongside. PeerNode-SID Link
+	// NLRIs for the same eBGP session may share the addresses but
+	// omit Type 258. The two NLRIs are distinct prefixes in
+	// adj-RIB-in because of Type 258's presence, so the String form
+	// must show the identifier whenever it is set or two distinct
+	// prefixes collide in any caller keyed on this output.
+	if l.LinkLocalID != nil && l.LinkRemoteID != nil &&
+		(l.InterfaceAddrIPv4 != nil || l.NeighborAddrIPv4 != nil ||
+			l.InterfaceAddrIPv6 != nil || l.NeighborAddrIPv6 != nil) {
+		base += fmt.Sprintf("(L:%d,R:%d)", *l.LinkLocalID, *l.LinkRemoteID)
+	}
+
+	// MT-ID participates in the destination key (RFC 7752 Section
+	// 3.2.1.5). Two ISIS-MT advertisements of the same physical link
+	// must not collide in the RIB.
 	return base + multiTopoIDsToString(l.MultiTopoIDs)
 }
 

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -5280,6 +5280,112 @@ func mtTLVBytes(ids ...uint16) []byte {
 	return out
 }
 
+// linkIDTLVBytes builds an LS Link Local/Remote Identifier sub-TLV
+// (RFC 7752 Table 5, type 258, length 8) carrying the supplied
+// 32-bit values. Used by the table-driven test below to compose
+// NLRI payloads that exercise the coexistence of the identifier
+// sub-TLV with the IPv4 interface/neighbor address sub-TLVs (the
+// shape RFC 9086 Section 5.2 PeerAdj-SID Link NLRI mandates).
+func linkIDTLVBytes(local, remote uint32) []byte {
+	return []byte{
+		0x01, 0x02, 0x00, 0x08,
+		byte(local >> 24), byte(local >> 16), byte(local >> 8), byte(local),
+		byte(remote >> 24), byte(remote >> 16), byte(remote >> 8), byte(remote),
+	}
+}
+
+// Test_LsLinkDescriptor_StringIncludesLinkID verifies that
+// LsLinkDescriptor.String folds the Link Local/Remote Identifier
+// sub-TLV (RFC 7752 Table 5, type 258) into its output when the
+// identifier is present alongside the IPv4 interface/neighbor
+// address sub-TLVs (types 259/260). RFC 9086 Section 5.2 mandates
+// the identifier on PeerAdj-SID Link NLRIs and lets the producer
+// also include the addresses. The two NLRI shapes (PeerNode-SID
+// with addresses only vs PeerAdj-SID with addresses plus
+// identifier) reuse the addresses but are distinct prefixes in
+// adj-RIB-in. Any caller keyed on this String form (table-layer
+// dedup, RIB walkers, log correlation) collapses the two prefixes
+// into one unless the identifier surfaces too.
+func Test_LsLinkDescriptor_StringIncludesLinkID(t *testing.T) {
+	commonHeader := []byte{
+		0x02,                                           // Protocol: ISIS L2
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Identifier
+		// Local Node Descriptor, value length=18
+		0x01, 0x00, 0x00, 0x12,
+		0x02, 0x00, 0x00, 0x04, 0x07, 0x07, 0x07, 0x07,
+		0x02, 0x03, 0x00, 0x06, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+		// Remote Node Descriptor, value length=18
+		0x01, 0x01, 0x00, 0x12,
+		0x02, 0x00, 0x00, 0x04, 0x07, 0x07, 0x07, 0x07,
+		0x02, 0x03, 0x00, 0x06, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		// IPv4 Interface Address: 10.0.0.1
+		0x01, 0x03, 0x00, 0x04, 0x0a, 0x00, 0x00, 0x01,
+		// IPv4 Neighbor Address: 10.0.0.2
+		0x01, 0x04, 0x00, 0x04, 0x0a, 0x00, 0x00, 0x02,
+	}
+
+	tests := []struct {
+		name         string
+		extraTLV     []byte
+		wantContains string // expected substring in String()
+		wantNoLinkID bool   // String() must NOT contain "(L:" suffix
+	}{
+		{
+			name:         "addresses only (PeerNode-SID NLRI shape)",
+			extraTLV:     nil,
+			wantContains: "10.0.0.1->10.0.0.2",
+			wantNoLinkID: true,
+		},
+		{
+			name:         "addresses + Link ID 3/0 (PeerAdj-SID NLRI shape)",
+			extraTLV:     linkIDTLVBytes(3, 0),
+			wantContains: "10.0.0.1->10.0.0.2(L:3,R:0)",
+		},
+		{
+			name:         "addresses + Link ID 1/1",
+			extraTLV:     linkIDTLVBytes(1, 1),
+			wantContains: "10.0.0.1->10.0.0.2(L:1,R:1)",
+		},
+	}
+
+	keys := make(map[string]string, len(tests))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			data := append(append([]byte{}, commonHeader...), tt.extraTLV...)
+			nlri := &LsLinkNLRI{}
+			nlri.Length = uint16(len(data))
+			assert.NoError(nlri.DecodeFromBytes(data))
+
+			desc := &LsLinkDescriptor{}
+			desc.ParseTLVs(nlri.LinkDesc)
+
+			s := desc.String()
+			assert.Contains(s, tt.wantContains)
+			if tt.wantNoLinkID {
+				assert.NotContains(s, "(L:",
+					"NLRI without Link Local/Remote Identifier must not gain (L:..,R:..) suffix")
+			}
+			keys[tt.name] = s
+		})
+	}
+
+	// Cross-case regression: every distinct NLRI shape must produce a
+	// distinct String(), or callers keyed on the human-readable form
+	// will collapse two adj-RIB-in prefixes into one.
+	t.Run("distinct Link ID sub-TLV presence yields distinct keys", func(t *testing.T) {
+		seen := make(map[string]string, len(keys))
+		for name, key := range keys {
+			if other, ok := seen[key]; ok {
+				t.Fatalf("key collision: %q and %q both produced %q", name, other, key)
+			}
+			seen[key] = name
+		}
+	})
+}
+
 // Test_LsLinkNLRI_MultiTopoID verifies that the Multi-Topology ID sub-TLV
 // (RFC 7752 §3.2.1.5, type 263) is parsed into LinkDesc, that
 // LsLinkDescriptor.String() emits the MT-ID suffix, and that two


### PR DESCRIPTION
## Summary

`LsLinkDescriptor.String` falls through to the IPv4 or IPv6 address form whenever the interface and neighbor address sub-TLVs (RFC 7752 Table 5, types 259/260 or 261/262) are populated, and never appends the Link Local/Remote Identifier sub-TLV (RFC 7752 Table 5, type 258) even when the descriptor carries it.

That fall-through is correct under a strict reading of RFC 7752 Section 3.2.2, which calls the two shapes mutually exclusive. RFC 9086 Section 5.2 relaxes that for the BGP Egress Peer Engineering case. A PeerAdj-SID Link NLRI MUST include the Link Local/Remote Identifier sub-TLV and MAY also include the interface/neighbor address sub-TLVs alongside it. The companion PeerNode-SID Link NLRI for the same eBGP session reuses the same addresses but omits type 258, so the two NLRIs are distinct prefixes in adj-RIB-in because of the identifier sub-TLV.

When both shapes appear together the existing String form collapses the two prefixes to the same human-readable key. Callers that key on String (table-layer dedup, RIB walkers, log correlation loops) see one prefix where the wire carries two and silently drop the second flavour.

## Fix

Append `(L:<local>,R:<remote>)` to the address form whenever the Link Local/Remote Identifier sub-TLV is set alongside an address sub-TLV. The standalone identifier-only case is untouched, the all-UNKNOWN fallback is untouched, and the MT-ID suffix still appends at the end.

## Reproduction

Verified live against a Nokia SR OS 25.10 producer that emits both a PeerNode-SID Link NLRI (addresses only) and a PeerAdj-SID Link NLRI (addresses + Link Local/Remote Identifier 3/0) on the same eBGP session.

Before the patch both NLRIs collapse to `192.0.2.1->192.0.2.2`. The receiver's String-keyed cache stores only the last-seen flavour and a periodic reconcile silently withdraws the other. After the patch the PeerAdj NLRI renders as `192.0.2.1->192.0.2.2(L:3,R:0)`.

## Tests

`Test_LsLinkDescriptor_StringIncludesLinkID` covers three NLRI shapes:

- addresses only (PeerNode-SID NLRI shape)
- addresses + Link ID 3/0 (PeerAdj-SID NLRI shape Nokia emits)
- addresses + Link ID 1/1 (distinct identifier values)

Same shape as `Test_LsLinkNLRI_MultiTopoID`: every distinct sub-TLV combination must produce a distinct String. The addresses-only case asserts backward compatibility (no `(L:` suffix appears).

## References

- RFC 7752 Table 5 (Link Descriptor sub-TLVs)
- RFC 7752 Section 3.2.2 (IGP Link Descriptors)
- RFC 9086 Section 5.2 (PeerAdj-SID Link NLRI format)