### PR TITLE
Support BGP and BFD Listeners to Device

### DIFF
--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -12,6 +12,9 @@
     # listen address list (by default "0.0.0.0" and "::")
     local-address-list = ["192.168.10.1", "2001:db8::1"]
 
+    # bind BGP/BFD listeners to an interface
+    bind-interface = "eth0"
+
     [global.apply-policy.config]
         import-policy-list = ["policy1"]
         default-import-policy = "reject-route"
@@ -80,6 +83,7 @@
         local-address = "192.168.10.1"
         remote-port = 2016
         ip-tos = 192 #DSCP class CS6
+        bind-interface = "eth0" # Connect to BGP and BFD peers from this interface
     [neighbors.ebgp-multihop.config]
         enabled = true #directly connection should be set false，if not ，peer will be deleted after hold-time
         multihop-ttl = 100

--- a/pkg/config/oc/bgp_configs.go
+++ b/pkg/config/oc/bgp_configs.go
@@ -186,6 +186,7 @@ func (v MatchSetOptionsType) DefaultAsNeeded() MatchSetOptionsType {
 	}
 	return v
 }
+
 func (v MatchSetOptionsType) ToInt() int {
 	_v := v.DefaultAsNeeded()
 	i, ok := MatchSetOptionsTypeToIntMap[_v]
@@ -234,6 +235,7 @@ func (v MatchSetOptionsRestrictedType) DefaultAsNeeded() MatchSetOptionsRestrict
 	}
 	return v
 }
+
 func (v MatchSetOptionsRestrictedType) ToInt() int {
 	_v := v.DefaultAsNeeded()
 	i, ok := MatchSetOptionsRestrictedTypeToIntMap[_v]
@@ -2186,6 +2188,8 @@ type BfdConfig struct {
 	// original -> gobgp:detection-multiplier
 	// Detection time multiplier.
 	DetectionMultiplier uint8 `mapstructure:"detection-multiplier" json:"detection-multiplier,omitempty"`
+	// BindInterface selects the device to bind to
+	BindInterface string `mapstructure:"bind-interface" json:"bind-to-device,omitempty"`
 }
 
 func (lhs *BfdConfig) Equal(rhs *BfdConfig) bool {
@@ -5110,6 +5114,8 @@ type GlobalConfig struct {
 	// original -> gobgp:local-address
 	// original type is list of inet:ip-address
 	LocalAddressList []netip.Addr `mapstructure:"local-address-list" json:"local-address-list,omitempty"`
+	// BindInterface is the interface to bind BGP listeners to.
+	BindInterface string `mapstructure:"bind-interface" json:"bind-interface,omitempty"`
 }
 
 func (lhs *GlobalConfig) Equal(rhs *GlobalConfig) bool {
@@ -5891,8 +5897,7 @@ func (lhs *BgpConditions) Equal(rhs *BgpConditions) bool {
 
 // struct for container rpol:igp-conditions.
 // Policy conditions for IGP attributes.
-type IgpConditions struct {
-}
+type IgpConditions struct{}
 
 func (lhs *IgpConditions) Equal(rhs *IgpConditions) bool {
 	if lhs == nil || rhs == nil {

--- a/pkg/config/oc/util.go
+++ b/pkg/config/oc/util.go
@@ -795,6 +795,7 @@ func NewGlobalFromConfigStruct(c *Global) *api.Global {
 			NotificationEnabled: c.GracefulRestart.Config.NotificationEnabled,
 			LonglivedEnabled:    c.GracefulRestart.Config.LongLivedEnabled,
 		},
+		BindToDevice: c.Config.BindInterface,
 	}
 }
 

--- a/pkg/server/bfd_peer.go
+++ b/pkg/server/bfd_peer.go
@@ -7,6 +7,7 @@ import (
 	"net/netip"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	api "github.com/osrg/gobgp/v4/api"
@@ -37,10 +38,11 @@ type bfdPeerStats struct {
 }
 
 type bfdPeer struct {
-	peerState   peerState
-	logger      *slog.Logger
-	peerAddress netip.Addr
-	peerPort    int
+	peerState     peerState
+	logger        *slog.Logger
+	peerAddress   netip.Addr
+	peerPort      int
+	bindInterface string
 
 	udpClient *net.UDPConn
 
@@ -72,10 +74,11 @@ func NewBfdPeer(ps peerState, logger *slog.Logger, peerAddress netip.Addr, confi
 	}
 
 	p := &bfdPeer{
-		peerState:   ps,
-		logger:      logger,
-		peerAddress: peerAddress,
-		peerPort:    peerPort,
+		peerState:     ps,
+		logger:        logger,
+		peerAddress:   peerAddress,
+		peerPort:      peerPort,
+		bindInterface: config.BindInterface,
 
 		myDiscriminator: randomBFDMyDiscriminator(),
 		multiplier:      defaultMultiplier,
@@ -198,7 +201,19 @@ func (p *bfdPeer) startClient() {
 	}
 
 	var err error
-	p.udpClient, err = net.DialUDP("udp", localAddress, remoteAddress)
+
+	dialer := net.Dialer{
+		LocalAddr: localAddress,
+		Control: func(network, address string, c syscall.RawConn) error {
+			if p.bindInterface != "" {
+				return netutils.SetBindToDevSockopt(c, p.bindInterface)
+			}
+
+			return nil
+		},
+	}
+
+	conn, err := dialer.Dial("udp", remoteAddress.String())
 	if err != nil {
 		p.logger.Warn("Can't dial UDP",
 			slog.String("Topic", "bfd"),
@@ -207,9 +222,23 @@ func (p *bfdPeer) startClient() {
 			slog.String("RemoteAddress", remoteAddress.String()),
 			slog.Any("Error", err),
 		)
-
 		return
 	}
+
+	// Assert the connection to *net.UDPConn if you need UDP-specific methods
+	udpConn, ok := conn.(*net.UDPConn)
+	if !ok {
+		p.logger.Warn("Can't dial UDP",
+			slog.String("Topic", "bfd"),
+			slog.String("Peer", p.peerAddress.String()),
+			slog.String("LocalAddress", localAddress.String()),
+			slog.String("RemoteAddress", remoteAddress.String()),
+			slog.Any("Error", "connection is not a UDP connection"),
+		)
+		return
+	}
+
+	p.udpClient = udpConn
 
 	// https://datatracker.ietf.org/doc/html/rfc5881
 	//   If BFD authentication is not in use on a session, all BFD Control

--- a/pkg/server/bfd_server.go
+++ b/pkg/server/bfd_server.go
@@ -234,6 +234,14 @@ func (s *bfdServer) startServer() {
 
 	var lc net.ListenConfig
 	lc.Control = func(network, address string, sc syscall.RawConn) error {
+		s.logger.Info("configuring BFD listener", slog.Any("config", s.config))
+		if s.config.BindInterface != "" {
+			s.logger.Info("binding bfd listener to interface", slog.String("interface", s.config.BindInterface))
+			if err := netutils.SetBindToDevSockopt(sc, s.config.BindInterface); err != nil {
+				return err
+			}
+		}
+
 		return netutils.SetReuseAddrSockopt(sc)
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2602,7 +2602,7 @@ func (s *BgpServer) StartBgp(ctx context.Context, r *api.StartBgpRequest) error 
 		table.SelectionOptions = c.RouteSelectionOptions.Config
 		table.UseMultiplePaths = c.UseMultiplePaths.Config
 		if s.bfdServer != nil {
-			if err := s.bfdServer.Start(ctx, oc.BfdConfig{Port: BfdServerPort}); err != nil {
+			if err := s.bfdServer.Start(ctx, oc.BfdConfig{Port: BfdServerPort, BindInterface: g.BindToDevice}); err != nil {
 				return err
 			}
 		}
@@ -3452,6 +3452,11 @@ func (s *BgpServer) addNeighbor(c *oc.Neighbor) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse IP address: %v", err)
 		}
+
+		if c.Transport.Config.BindInterface != "" && c.Bfd.Config.BindInterface == "" {
+			c.Bfd.Config.BindInterface = c.Transport.Config.BindInterface
+		}
+
 		if err := s.bfdServer.AddPeer(context.Background(), ipAddr, c.Bfd.Config); err != nil {
 			s.logger.Warn("failed to add BFD peer",
 				slog.String("Topic", "Peer"),


### PR DESCRIPTION
Connect the existing `StartBgpRequest.Global.BindToDevice`, to a new corresponding option in the configuration file.  This allows for the **listeners** for BGP and BFD to bind to a device.

Similarly, apply the `BgpConfigSet.Neighbor.Transport.Config.BindInterface`, when set, to the neighbor's corresponding outbound BFD connection.