### PR TITLE
Use BindToDevice/Interface configurations for inbound/outbound BFD connections

### DIFF
--- a/pkg/server/bfd_peer.go
+++ b/pkg/server/bfd_peer.go
@@ -7,6 +7,7 @@ import (
 	"net/netip"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	api "github.com/osrg/gobgp/v4/api"
@@ -37,10 +38,11 @@ type bfdPeerStats struct {
 }
 
 type bfdPeer struct {
-	peerState   peerState
-	logger      *slog.Logger
-	peerAddress netip.Addr
-	peerPort    int
+	peerState     peerState
+	logger        *slog.Logger
+	peerAddress   netip.Addr
+	peerPort      int
+	bindInterface string
 
 	udpClient *net.UDPConn
 
@@ -65,17 +67,18 @@ type bfdPeer struct {
 	stats bfdPeerStats
 }
 
-func NewBfdPeer(ps peerState, logger *slog.Logger, peerAddress netip.Addr, config oc.BfdConfig) *bfdPeer {
+func NewBfdPeer(ps peerState, logger *slog.Logger, peerAddress netip.Addr, config oc.BfdConfig, bindInterface string) *bfdPeer {
 	peerPort := int(config.Port)
 	if peerPort == 0 {
 		peerPort = BfdServerPort
 	}
 
 	p := &bfdPeer{
-		peerState:   ps,
-		logger:      logger,
-		peerAddress: peerAddress,
-		peerPort:    peerPort,
+		peerState:     ps,
+		logger:        logger,
+		peerAddress:   peerAddress,
+		peerPort:      peerPort,
+		bindInterface: bindInterface,
 
 		myDiscriminator: randomBFDMyDiscriminator(),
 		multiplier:      defaultMultiplier,
@@ -206,7 +209,19 @@ func (p *bfdPeer) startClient() {
 	remoteAddress := p.remoteUDPAddr()
 
 	var err error
-	p.udpClient, err = net.DialUDP("udp", localAddress, remoteAddress)
+
+	dialer := net.Dialer{
+		LocalAddr: localAddress,
+		Control: func(network, address string, c syscall.RawConn) error {
+			if p.bindInterface != "" {
+				return netutils.SetBindToDevSockopt(c, p.bindInterface)
+			}
+
+			return nil
+		},
+	}
+
+	conn, err := dialer.Dial("udp", remoteAddress.String())
 	if err != nil {
 		p.logger.Warn("Can't dial UDP",
 			slog.String("Topic", "bfd"),
@@ -218,6 +233,21 @@ func (p *bfdPeer) startClient() {
 
 		return
 	}
+
+	udpConn, ok := conn.(*net.UDPConn)
+	if !ok {
+		p.logger.Warn("Can't dial UDP",
+			slog.String("Topic", "bfd"),
+			slog.String("Peer", p.peerAddress.String()),
+			slog.String("LocalAddress", localAddress.String()),
+			slog.String("RemoteAddress", remoteAddress.String()),
+			slog.Any("Error", "connection is not a UDP connection"),
+		)
+
+		return
+	}
+
+	p.udpClient = udpConn
 
 	// https://datatracker.ietf.org/doc/html/rfc5881
 	//   If BFD authentication is not in use on a session, all BFD Control

--- a/pkg/server/bfd_peer_test.go
+++ b/pkg/server/bfd_peer_test.go
@@ -24,7 +24,7 @@ func Test_NewBfdPeer(t *testing.T) {
 		DetectionMultiplier:      5,
 		RequiredMinimumReceive:   200000,
 		DesiredMinimumTxInterval: 200000,
-	})
+	}, "")
 	defer p.Stop()
 
 	assert.NotNil(p)
@@ -36,7 +36,7 @@ func Test_NewBfdPeerDefaultPort(t *testing.T) {
 	ps := &mockPeerState{}
 	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
 		Enabled: true,
-	})
+	}, "")
 	defer p.Stop()
 
 	assert.Equal(BfdServerPort, p.peerPort)
@@ -52,7 +52,7 @@ func Test_BfdPeerRemoteUDPAddrZone(t *testing.T) {
 	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("fe80::1%eth0"), oc.BfdConfig{
 		Port:    13784,
 		Enabled: true,
-	})
+	}, "")
 	defer p.Stop()
 
 	addr := p.remoteUDPAddr()
@@ -64,7 +64,7 @@ func Test_BfdPeerRemoteUDPAddrZone(t *testing.T) {
 	g := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("10.0.0.1"), oc.BfdConfig{
 		Port:    13784,
 		Enabled: true,
-	})
+	}, "")
 	defer g.Stop()
 
 	assert.Empty(g.remoteUDPAddr().Zone)
@@ -77,7 +77,7 @@ func Test_BfdPeerStopIdempotent(t *testing.T) {
 	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
 		Port:    13784,
 		Enabled: true,
-	})
+	}, "")
 
 	p.Stop()
 	p.Stop()
@@ -95,7 +95,7 @@ func Test_RxPacket(t *testing.T) {
 		DetectionMultiplier:      5,
 		RequiredMinimumReceive:   200000,
 		DesiredMinimumTxInterval: 200000,
-	})
+	}, "")
 
 	assert.Equal(p.stats.rxPacket.Load(), uint64(0))
 
@@ -117,7 +117,7 @@ func Test_RxPacketRemoteDownResetsPeer(t *testing.T) {
 		DetectionMultiplier:      5,
 		RequiredMinimumReceive:   200000,
 		DesiredMinimumTxInterval: 200000,
-	})
+	}, "")
 	defer p.Stop()
 
 	p.state.Store(int32(api.BfdSessionState_BFD_SESSION_STATE_UP))
@@ -143,7 +143,7 @@ func Test_RxPacketRFCStateTransitions(t *testing.T) {
 		DetectionMultiplier:      5,
 		RequiredMinimumReceive:   200000,
 		DesiredMinimumTxInterval: 200000,
-	})
+	}, "")
 	defer p.Stop()
 
 	p.rxPacket(&bfd.BFDHeader{
@@ -182,7 +182,7 @@ func Test_TxPacket(t *testing.T) {
 		DetectionMultiplier:      5,
 		RequiredMinimumReceive:   200000,
 		DesiredMinimumTxInterval: 200000,
-	})
+	}, "")
 
 	err := eventually(4*time.Second, func() error {
 		if p.stats.txPacket.Load() > 3 {

--- a/pkg/server/bfd_server.go
+++ b/pkg/server/bfd_server.go
@@ -29,9 +29,10 @@ type bfdServerStats struct {
 }
 
 type bfdEventPeerUpdate struct {
-	isAdd       bool
-	peerAddress netip.Addr
-	config      oc.BfdConfig
+	isAdd         bool
+	peerAddress   netip.Addr
+	config        oc.BfdConfig
+	bindInterface string
 }
 
 type bfdPeerState struct {
@@ -49,7 +50,8 @@ type bfdServer struct {
 
 	config *oc.BfdConfig
 
-	udpServer *net.UDPConn
+	udpServer       *net.UDPConn
+	listenInterface string
 
 	peersMutex sync.RWMutex
 	peers      map[netip.Addr]*bfdPeer
@@ -114,7 +116,7 @@ func (s *bfdServer) Stop() {
 	})
 }
 
-func (s *bfdServer) AddPeer(ctx context.Context, peerAddress netip.Addr, config oc.BfdConfig) error {
+func (s *bfdServer) AddPeer(ctx context.Context, peerAddress netip.Addr, config oc.BfdConfig, bindInterface string) error {
 	if s.stopped.Load() {
 		return errors.New("bfd server stopped")
 	}
@@ -124,7 +126,7 @@ func (s *bfdServer) AddPeer(ctx context.Context, peerAddress netip.Addr, config 
 	}
 
 	select {
-	case s.eventPeerUpdate <- &bfdEventPeerUpdate{isAdd: true, peerAddress: peerAddress, config: config}:
+	case s.eventPeerUpdate <- &bfdEventPeerUpdate{isAdd: true, peerAddress: peerAddress, config: config, bindInterface: bindInterface}:
 		if s.stopped.Load() {
 			return errors.New("bfd server stopped")
 		}
@@ -203,7 +205,7 @@ func (s *bfdServer) loop() {
 			s.config = ev
 		case ev := <-s.eventPeerUpdate:
 			if ev.isAdd {
-				s.addBfdPeer(ev.peerAddress, ev.config)
+				s.addBfdPeer(ev.peerAddress, ev.config, ev.bindInterface)
 			} else {
 				s.deleteBfdPeer(ev.peerAddress)
 			}
@@ -234,6 +236,13 @@ func (s *bfdServer) startServer() {
 
 	var lc net.ListenConfig
 	lc.Control = func(network, address string, sc syscall.RawConn) error {
+		if s.listenInterface != "" {
+			s.logger.Info("binding bfd listener to interface", slog.String("interface", s.listenInterface))
+			if err := netutils.SetBindToDevSockopt(sc, s.listenInterface); err != nil {
+				return err
+			}
+		}
+
 		return netutils.SetReuseAddrSockopt(sc)
 	}
 
@@ -283,7 +292,7 @@ func (s *bfdServer) stop() {
 	)
 }
 
-func (s *bfdServer) addBfdPeer(peerAddress netip.Addr, config oc.BfdConfig) {
+func (s *bfdServer) addBfdPeer(peerAddress netip.Addr, config oc.BfdConfig, bindInterface string) {
 	s.peersMutex.RLock()
 	_, ok := s.peers[peerAddress]
 	s.peersMutex.RUnlock()
@@ -297,7 +306,7 @@ func (s *bfdServer) addBfdPeer(peerAddress netip.Addr, config oc.BfdConfig) {
 		return
 	}
 
-	bfdPeer := NewBfdPeer(s.peerState, s.logger, peerAddress, config)
+	bfdPeer := NewBfdPeer(s.peerState, s.logger, peerAddress, config, bindInterface)
 	if bfdPeer != nil {
 		s.logger.Info("Insert BFD peer",
 			slog.String("Topic", "bfd"),

--- a/pkg/server/bfd_server_test.go
+++ b/pkg/server/bfd_server_test.go
@@ -85,7 +85,7 @@ func Test_BfdServerStopIdempotentAndPublicMethodsAfterStop(t *testing.T) {
 	assert.Error(s.AddPeer(context.Background(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
 		Port:    23784,
 		Enabled: true,
-	}))
+	}, ""))
 	assert.Error(s.DeletePeer(context.Background(), netip.MustParseAddr("127.0.0.1")))
 }
 
@@ -143,7 +143,7 @@ func addPeer(s *bfdServer, port uint16) error {
 		DetectionMultiplier:      5,
 		RequiredMinimumReceive:   200000,
 		DesiredMinimumTxInterval: 200000,
-	})
+	}, "")
 }
 
 func Test_AddDeletePeer(t *testing.T) {
@@ -578,7 +578,7 @@ func Test_BfdServer_NoGoroutineLeakAfterStop(t *testing.T) {
 		DetectionMultiplier:      5,
 		RequiredMinimumReceive:   200000,
 		DesiredMinimumTxInterval: 200000,
-	})
+	}, "")
 	assert.NoError(err)
 
 	time.Sleep(500 * time.Millisecond)
@@ -601,7 +601,7 @@ func Test_BfdServer_RepeatedLifecycleNoGoroutineLeak(t *testing.T) {
 			DetectionMultiplier:      5,
 			RequiredMinimumReceive:   200000,
 			DesiredMinimumTxInterval: 200000,
-		})
+		}, "")
 		assert.NoError(err)
 		time.Sleep(80 * time.Millisecond)
 		s.Stop()
@@ -655,7 +655,7 @@ func Test_BfdServer_ConcurrentPublicMethods(t *testing.T) {
 					DetectionMultiplier:      cfg.DetectionMultiplier,
 					RequiredMinimumReceive:   cfg.RequiredMinimumReceive,
 					DesiredMinimumTxInterval: cfg.DesiredMinimumTxInterval,
-				}))
+				}, ""))
 				_, _ = s.GetPeerState(peerAddr)
 				list := s.GetPeerStateList()
 				_ = list

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -372,7 +372,7 @@ func (s *BgpServer) passConnToPeer(conn net.Conn) {
 		// register BFD for the dynamic neighbor too (explicit neighbors do this in addNeighbor): the
 		// BFD config is inherited from the peer group. Without this, BFD never runs for dynamic peers.
 		if s.bfdServer != nil && conf.Bfd.Config.Enabled {
-			if err := s.bfdServer.AddPeer(context.Background(), addr, conf.Bfd.Config, ""); err != nil {
+			if err := s.bfdServer.AddPeer(context.Background(), addr, conf.Bfd.Config, s.bgpConfig.Global.Config.BindToDevice); err != nil {
 				s.logger.Warn("failed to add BFD peer for dynamic neighbor",
 					slog.String("Topic", "Peer"),
 					slog.String("Key", addr.String()),
@@ -3805,6 +3805,11 @@ func (s *BgpServer) updateNeighbor(c *oc.Neighbor) (needsSoftResetIn bool, err e
 	if bfdConfigChanged {
 		peer.fsm.logger.Info("Update BFD configuration")
 		conf.Bfd.Config = c.Bfd.Config
+	}
+
+	if original.Transport.Config.BindInterface != c.Transport.Config.BindInterface {
+		peer.fsm.logger.Info("Update BFD interface binding")
+		bfdConfigChanged = true
 	}
 
 	if original.NeedsResendOpenMessage(c) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -372,7 +372,7 @@ func (s *BgpServer) passConnToPeer(conn net.Conn) {
 		// register BFD for the dynamic neighbor too (explicit neighbors do this in addNeighbor): the
 		// BFD config is inherited from the peer group. Without this, BFD never runs for dynamic peers.
 		if s.bfdServer != nil && conf.Bfd.Config.Enabled {
-			if err := s.bfdServer.AddPeer(context.Background(), addr, conf.Bfd.Config); err != nil {
+			if err := s.bfdServer.AddPeer(context.Background(), addr, conf.Bfd.Config, ""); err != nil {
 				s.logger.Warn("failed to add BFD peer for dynamic neighbor",
 					slog.String("Topic", "Peer"),
 					slog.String("Key", addr.String()),
@@ -2632,6 +2632,7 @@ func (s *BgpServer) StartBgp(ctx context.Context, r *api.StartBgpRequest) error 
 		table.SelectionOptions = c.RouteSelectionOptions.Config
 		table.UseMultiplePaths = c.UseMultiplePaths.Config
 		if s.bfdServer != nil {
+			s.bfdServer.listenInterface = g.BindToDevice
 			if err := s.bfdServer.Start(ctx, oc.BfdConfig{Port: BfdServerPort}); err != nil {
 				return err
 			}
@@ -3482,7 +3483,7 @@ func (s *BgpServer) addNeighbor(c *oc.Neighbor) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse IP address: %v", err)
 		}
-		if err := s.bfdServer.AddPeer(context.Background(), ipAddr, c.Bfd.Config); err != nil {
+		if err := s.bfdServer.AddPeer(context.Background(), ipAddr, c.Bfd.Config, c.Transport.Config.BindInterface); err != nil {
 			s.logger.Warn("failed to add BFD peer",
 				slog.String("Topic", "Peer"),
 				slog.String("Key", addr),
@@ -3508,8 +3509,12 @@ func apiBfdSessionStateToOC(state api.BfdSessionState) oc.BfdSessionState {
 	}
 }
 
-func (s *BgpServer) updateBfdPeer(addr string, oldConfig, newConfig oc.BfdConfig) error {
-	if s.bfdServer == nil || oldConfig.Equal(&newConfig) {
+func (s *BgpServer) updateBfdPeer(
+	addr string,
+	oldConfig, newConfig oc.BfdConfig,
+	oldBindInterface, newBindInterface string,
+) error {
+	if s.bfdServer == nil || oldConfig.Equal(&newConfig) && oldBindInterface == newBindInterface {
 		return nil
 	}
 
@@ -3525,7 +3530,7 @@ func (s *BgpServer) updateBfdPeer(addr string, oldConfig, newConfig oc.BfdConfig
 	}
 
 	if newConfig.Enabled {
-		if err := s.bfdServer.AddPeer(context.Background(), ipAddr, newConfig); err != nil {
+		if err := s.bfdServer.AddPeer(context.Background(), ipAddr, newConfig, newBindInterface); err != nil {
 			return err
 		}
 	}
@@ -3846,7 +3851,11 @@ func (s *BgpServer) updateNeighbor(c *oc.Neighbor) (needsSoftResetIn bool, err e
 		peer.fsm.pConf.Update(&conf)
 		peer.fsm.lock.Unlock()
 		if bfdConfigChanged {
-			err = s.updateBfdPeer(addr, original.Bfd.Config, c.Bfd.Config)
+			err = s.updateBfdPeer(
+				addr,
+				original.Bfd.Config, c.Bfd.Config,
+				original.Transport.Config.BindInterface, c.Transport.Config.BindInterface,
+			)
 		}
 		if isLimit {
 			if err == nil {


### PR DESCRIPTION
This PR contains 2 commits:

1. Exposes the API.Global.BindInterface option via the configuration file providing the ability to configure the BGP listener sockets for incomming BGP connections to a specific (likely VRF interface).  For BGP, this was already in the code base, just not accessible from the configuration file.  For BFD, additional functionality has been added such that if BGP listeners are interface bound, BFD listeners will be too.
2. If a neighbors configuration includes a Transport.Config.BindInterface, in addition to binding the interface for outbound BGP connections for that neighbor, use it for outbound BFD connections as well.