### PR TITLE
Add BGP route aggregation

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -12774,6 +12774,374 @@ func (x *BfdState) GetUnknownPeer() uint64 {
 	return 0
 }
 
+type AggregateAddress struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Prefix        string                 `protobuf:"bytes,1,opt,name=prefix,proto3" json:"prefix,omitempty"`
+	SummaryOnly   bool                   `protobuf:"varint,2,opt,name=summary_only,json=summaryOnly,proto3" json:"summary_only,omitempty"`
+	PolicyName    string                 `protobuf:"bytes,3,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
+	AsSet         bool                   `protobuf:"varint,4,opt,name=as_set,json=asSet,proto3" json:"as_set,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AggregateAddress) Reset() {
+	*x = AggregateAddress{}
+	mi := &file_api_gobgp_proto_msgTypes[193]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AggregateAddress) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AggregateAddress) ProtoMessage() {}
+
+func (x *AggregateAddress) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[193]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AggregateAddress.ProtoReflect.Descriptor instead.
+func (*AggregateAddress) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{193}
+}
+
+func (x *AggregateAddress) GetPrefix() string {
+	if x != nil {
+		return x.Prefix
+	}
+	return ""
+}
+
+func (x *AggregateAddress) GetSummaryOnly() bool {
+	if x != nil {
+		return x.SummaryOnly
+	}
+	return false
+}
+
+func (x *AggregateAddress) GetPolicyName() string {
+	if x != nil {
+		return x.PolicyName
+	}
+	return ""
+}
+
+func (x *AggregateAddress) GetAsSet() bool {
+	if x != nil {
+		return x.AsSet
+	}
+	return false
+}
+
+type AggregateAddressInfo struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Aggregate       *AggregateAddress      `protobuf:"bytes,1,opt,name=aggregate,proto3" json:"aggregate,omitempty"`
+	NumContributors uint32                 `protobuf:"varint,2,opt,name=num_contributors,json=numContributors,proto3" json:"num_contributors,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *AggregateAddressInfo) Reset() {
+	*x = AggregateAddressInfo{}
+	mi := &file_api_gobgp_proto_msgTypes[194]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AggregateAddressInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AggregateAddressInfo) ProtoMessage() {}
+
+func (x *AggregateAddressInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[194]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AggregateAddressInfo.ProtoReflect.Descriptor instead.
+func (*AggregateAddressInfo) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{194}
+}
+
+func (x *AggregateAddressInfo) GetAggregate() *AggregateAddress {
+	if x != nil {
+		return x.Aggregate
+	}
+	return nil
+}
+
+func (x *AggregateAddressInfo) GetNumContributors() uint32 {
+	if x != nil {
+		return x.NumContributors
+	}
+	return 0
+}
+
+type AddAggregateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Aggregate     *AggregateAddress      `protobuf:"bytes,1,opt,name=aggregate,proto3" json:"aggregate,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddAggregateRequest) Reset() {
+	*x = AddAggregateRequest{}
+	mi := &file_api_gobgp_proto_msgTypes[195]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddAggregateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddAggregateRequest) ProtoMessage() {}
+
+func (x *AddAggregateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[195]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddAggregateRequest.ProtoReflect.Descriptor instead.
+func (*AddAggregateRequest) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{195}
+}
+
+func (x *AddAggregateRequest) GetAggregate() *AggregateAddress {
+	if x != nil {
+		return x.Aggregate
+	}
+	return nil
+}
+
+type AddAggregateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddAggregateResponse) Reset() {
+	*x = AddAggregateResponse{}
+	mi := &file_api_gobgp_proto_msgTypes[196]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddAggregateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddAggregateResponse) ProtoMessage() {}
+
+func (x *AddAggregateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[196]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddAggregateResponse.ProtoReflect.Descriptor instead.
+func (*AddAggregateResponse) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{196}
+}
+
+type DeleteAggregateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Prefix        string                 `protobuf:"bytes,1,opt,name=prefix,proto3" json:"prefix,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteAggregateRequest) Reset() {
+	*x = DeleteAggregateRequest{}
+	mi := &file_api_gobgp_proto_msgTypes[197]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteAggregateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteAggregateRequest) ProtoMessage() {}
+
+func (x *DeleteAggregateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[197]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteAggregateRequest.ProtoReflect.Descriptor instead.
+func (*DeleteAggregateRequest) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{197}
+}
+
+func (x *DeleteAggregateRequest) GetPrefix() string {
+	if x != nil {
+		return x.Prefix
+	}
+	return ""
+}
+
+type DeleteAggregateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteAggregateResponse) Reset() {
+	*x = DeleteAggregateResponse{}
+	mi := &file_api_gobgp_proto_msgTypes[198]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteAggregateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteAggregateResponse) ProtoMessage() {}
+
+func (x *DeleteAggregateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[198]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteAggregateResponse.ProtoReflect.Descriptor instead.
+func (*DeleteAggregateResponse) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{198}
+}
+
+type ListAggregateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Family        *Family                `protobuf:"bytes,1,opt,name=family,proto3" json:"family,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAggregateRequest) Reset() {
+	*x = ListAggregateRequest{}
+	mi := &file_api_gobgp_proto_msgTypes[199]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAggregateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAggregateRequest) ProtoMessage() {}
+
+func (x *ListAggregateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[199]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAggregateRequest.ProtoReflect.Descriptor instead.
+func (*ListAggregateRequest) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{199}
+}
+
+func (x *ListAggregateRequest) GetFamily() *Family {
+	if x != nil {
+		return x.Family
+	}
+	return nil
+}
+
+type ListAggregateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Aggregate     *AggregateAddressInfo  `protobuf:"bytes,1,opt,name=aggregate,proto3" json:"aggregate,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAggregateResponse) Reset() {
+	*x = ListAggregateResponse{}
+	mi := &file_api_gobgp_proto_msgTypes[200]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAggregateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAggregateResponse) ProtoMessage() {}
+
+func (x *ListAggregateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[200]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAggregateResponse.ProtoReflect.Descriptor instead.
+func (*ListAggregateResponse) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{200}
+}
+
+func (x *ListAggregateResponse) GetAggregate() *AggregateAddressInfo {
+	if x != nil {
+		return x.Aggregate
+	}
+	return nil
+}
+
 type WatchEventRequest_Peer struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -12782,7 +13150,7 @@ type WatchEventRequest_Peer struct {
 
 func (x *WatchEventRequest_Peer) Reset() {
 	*x = WatchEventRequest_Peer{}
-	mi := &file_api_gobgp_proto_msgTypes[193]
+	mi := &file_api_gobgp_proto_msgTypes[201]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12794,7 +13162,7 @@ func (x *WatchEventRequest_Peer) String() string {
 func (*WatchEventRequest_Peer) ProtoMessage() {}
 
 func (x *WatchEventRequest_Peer) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[193]
+	mi := &file_api_gobgp_proto_msgTypes[201]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12819,7 +13187,7 @@ type WatchEventRequest_Table struct {
 
 func (x *WatchEventRequest_Table) Reset() {
 	*x = WatchEventRequest_Table{}
-	mi := &file_api_gobgp_proto_msgTypes[194]
+	mi := &file_api_gobgp_proto_msgTypes[202]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12831,7 +13199,7 @@ func (x *WatchEventRequest_Table) String() string {
 func (*WatchEventRequest_Table) ProtoMessage() {}
 
 func (x *WatchEventRequest_Table) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[194]
+	mi := &file_api_gobgp_proto_msgTypes[202]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12866,7 +13234,7 @@ type WatchEventRequest_Table_Filter struct {
 
 func (x *WatchEventRequest_Table_Filter) Reset() {
 	*x = WatchEventRequest_Table_Filter{}
-	mi := &file_api_gobgp_proto_msgTypes[195]
+	mi := &file_api_gobgp_proto_msgTypes[203]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12878,7 +13246,7 @@ func (x *WatchEventRequest_Table_Filter) String() string {
 func (*WatchEventRequest_Table_Filter) ProtoMessage() {}
 
 func (x *WatchEventRequest_Table_Filter) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[195]
+	mi := &file_api_gobgp_proto_msgTypes[203]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12932,7 +13300,7 @@ type WatchEventResponse_PeerEvent struct {
 
 func (x *WatchEventResponse_PeerEvent) Reset() {
 	*x = WatchEventResponse_PeerEvent{}
-	mi := &file_api_gobgp_proto_msgTypes[196]
+	mi := &file_api_gobgp_proto_msgTypes[204]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12944,7 +13312,7 @@ func (x *WatchEventResponse_PeerEvent) String() string {
 func (*WatchEventResponse_PeerEvent) ProtoMessage() {}
 
 func (x *WatchEventResponse_PeerEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[196]
+	mi := &file_api_gobgp_proto_msgTypes[204]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12983,7 +13351,7 @@ type WatchEventResponse_TableEvent struct {
 
 func (x *WatchEventResponse_TableEvent) Reset() {
 	*x = WatchEventResponse_TableEvent{}
-	mi := &file_api_gobgp_proto_msgTypes[197]
+	mi := &file_api_gobgp_proto_msgTypes[205]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12995,7 +13363,7 @@ func (x *WatchEventResponse_TableEvent) String() string {
 func (*WatchEventResponse_TableEvent) ProtoMessage() {}
 
 func (x *WatchEventResponse_TableEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[197]
+	mi := &file_api_gobgp_proto_msgTypes[205]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13028,7 +13396,7 @@ type ListBmpResponse_BmpStation struct {
 
 func (x *ListBmpResponse_BmpStation) Reset() {
 	*x = ListBmpResponse_BmpStation{}
-	mi := &file_api_gobgp_proto_msgTypes[198]
+	mi := &file_api_gobgp_proto_msgTypes[206]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13040,7 +13408,7 @@ func (x *ListBmpResponse_BmpStation) String() string {
 func (*ListBmpResponse_BmpStation) ProtoMessage() {}
 
 func (x *ListBmpResponse_BmpStation) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[198]
+	mi := &file_api_gobgp_proto_msgTypes[206]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13080,7 +13448,7 @@ type ListBmpResponse_BmpStation_Conf struct {
 
 func (x *ListBmpResponse_BmpStation_Conf) Reset() {
 	*x = ListBmpResponse_BmpStation_Conf{}
-	mi := &file_api_gobgp_proto_msgTypes[199]
+	mi := &file_api_gobgp_proto_msgTypes[207]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13092,7 +13460,7 @@ func (x *ListBmpResponse_BmpStation_Conf) String() string {
 func (*ListBmpResponse_BmpStation_Conf) ProtoMessage() {}
 
 func (x *ListBmpResponse_BmpStation_Conf) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[199]
+	mi := &file_api_gobgp_proto_msgTypes[207]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13132,7 +13500,7 @@ type ListBmpResponse_BmpStation_State struct {
 
 func (x *ListBmpResponse_BmpStation_State) Reset() {
 	*x = ListBmpResponse_BmpStation_State{}
-	mi := &file_api_gobgp_proto_msgTypes[200]
+	mi := &file_api_gobgp_proto_msgTypes[208]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13144,7 +13512,7 @@ func (x *ListBmpResponse_BmpStation_State) String() string {
 func (*ListBmpResponse_BmpStation_State) ProtoMessage() {}
 
 func (x *ListBmpResponse_BmpStation_State) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[200]
+	mi := &file_api_gobgp_proto_msgTypes[208]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14120,7 +14488,26 @@ const file_api_gobgp_proto_rawDesc = "" +
 	"\rreceived_drop\x18\x02 \x01(\x04R\freceivedDrop\x12%\n" +
 	"\x0ereceived_error\x18\x03 \x01(\x04R\rreceivedError\x12%\n" +
 	"\x0einvalid_packet\x18\x04 \x01(\x04R\rinvalidPacket\x12!\n" +
-	"\funknown_peer\x18\x05 \x01(\x04R\vunknownPeer*\x97\x01\n" +
+	"\funknown_peer\x18\x05 \x01(\x04R\vunknownPeer\"\x85\x01\n" +
+	"\x10AggregateAddress\x12\x16\n" +
+	"\x06prefix\x18\x01 \x01(\tR\x06prefix\x12!\n" +
+	"\fsummary_only\x18\x02 \x01(\bR\vsummaryOnly\x12\x1f\n" +
+	"\vpolicy_name\x18\x03 \x01(\tR\n" +
+	"policyName\x12\x15\n" +
+	"\x06as_set\x18\x04 \x01(\bR\x05asSet\"v\n" +
+	"\x14AggregateAddressInfo\x123\n" +
+	"\taggregate\x18\x01 \x01(\v2\x15.api.AggregateAddressR\taggregate\x12)\n" +
+	"\x10num_contributors\x18\x02 \x01(\rR\x0fnumContributors\"J\n" +
+	"\x13AddAggregateRequest\x123\n" +
+	"\taggregate\x18\x01 \x01(\v2\x15.api.AggregateAddressR\taggregate\"\x16\n" +
+	"\x14AddAggregateResponse\"0\n" +
+	"\x16DeleteAggregateRequest\x12\x16\n" +
+	"\x06prefix\x18\x01 \x01(\tR\x06prefix\"\x19\n" +
+	"\x17DeleteAggregateResponse\";\n" +
+	"\x14ListAggregateRequest\x12#\n" +
+	"\x06family\x18\x01 \x01(\v2\v.api.FamilyR\x06family\"P\n" +
+	"\x15ListAggregateResponse\x127\n" +
+	"\taggregate\x18\x01 \x01(\v2\x19.api.AggregateAddressInfoR\taggregate*\x97\x01\n" +
 	"\tTableType\x12\x1a\n" +
 	"\x16TABLE_TYPE_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11TABLE_TYPE_GLOBAL\x10\x01\x12\x14\n" +
@@ -14187,7 +14574,7 @@ const file_api_gobgp_proto_rawDesc = "" +
 	"\x1dBFD_DIAGNOSTIC_CODE_PATH_DOWN\x10\x05\x12.\n" +
 	"*BFD_DIAGNOSTIC_CODE_CONCATENATED_PATH_DOWN\x10\x06\x12-\n" +
 	")BFD_DIAGNOSTIC_CODE_ADMINISTRATIVELY_DOWN\x10\a\x126\n" +
-	"2BFD_DIAGNOSTIC_CODE_REVERSE_CONCATENATED_PATH_DOWN\x10\b2\x94\x1d\n" +
+	"2BFD_DIAGNOSTIC_CODE_REVERSE_CONCATENATED_PATH_DOWN\x10\b2\xf1\x1e\n" +
 	"\fGoBgpService\x127\n" +
 	"\bStartBgp\x12\x14.api.StartBgpRequest\x1a\x15.api.StartBgpResponse\x124\n" +
 	"\aStopBgp\x12\x13.api.StopBgpRequest\x1a\x14.api.StopBgpResponse\x121\n" +
@@ -14220,7 +14607,10 @@ const file_api_gobgp_proto_rawDesc = "" +
 	"\bGetTable\x12\x14.api.GetTableRequest\x1a\x15.api.GetTableResponse\x121\n" +
 	"\x06AddVrf\x12\x12.api.AddVrfRequest\x1a\x13.api.AddVrfResponse\x12:\n" +
 	"\tDeleteVrf\x12\x15.api.DeleteVrfRequest\x1a\x16.api.DeleteVrfResponse\x126\n" +
-	"\aListVrf\x12\x13.api.ListVrfRequest\x1a\x14.api.ListVrfResponse0\x01\x12:\n" +
+	"\aListVrf\x12\x13.api.ListVrfRequest\x1a\x14.api.ListVrfResponse0\x01\x12C\n" +
+	"\fAddAggregate\x12\x18.api.AddAggregateRequest\x1a\x19.api.AddAggregateResponse\x12L\n" +
+	"\x0fDeleteAggregate\x12\x1b.api.DeleteAggregateRequest\x1a\x1c.api.DeleteAggregateResponse\x12H\n" +
+	"\rListAggregate\x12\x19.api.ListAggregateRequest\x1a\x1a.api.ListAggregateResponse0\x01\x12:\n" +
 	"\tAddPolicy\x12\x15.api.AddPolicyRequest\x1a\x16.api.AddPolicyResponse\x12C\n" +
 	"\fDeletePolicy\x12\x18.api.DeletePolicyRequest\x1a\x19.api.DeletePolicyResponse\x12?\n" +
 	"\n" +
@@ -14267,7 +14657,7 @@ func file_api_gobgp_proto_rawDescGZIP() []byte {
 }
 
 var file_api_gobgp_proto_enumTypes = make([]protoimpl.EnumInfo, 27)
-var file_api_gobgp_proto_msgTypes = make([]protoimpl.MessageInfo, 201)
+var file_api_gobgp_proto_msgTypes = make([]protoimpl.MessageInfo, 209)
 var file_api_gobgp_proto_goTypes = []any{
 	(TableType)(0),                           // 0: api.TableType
 	(ValidationState)(0),                     // 1: api.ValidationState
@@ -14489,29 +14879,37 @@ var file_api_gobgp_proto_goTypes = []any{
 	(*BfdPeerState)(nil),                     // 217: api.BfdPeerState
 	(*BfdPeerConfig)(nil),                    // 218: api.BfdPeerConfig
 	(*BfdState)(nil),                         // 219: api.BfdState
-	(*WatchEventRequest_Peer)(nil),           // 220: api.WatchEventRequest.Peer
-	(*WatchEventRequest_Table)(nil),          // 221: api.WatchEventRequest.Table
-	(*WatchEventRequest_Table_Filter)(nil),   // 222: api.WatchEventRequest.Table.Filter
-	(*WatchEventResponse_PeerEvent)(nil),     // 223: api.WatchEventResponse.PeerEvent
-	(*WatchEventResponse_TableEvent)(nil),    // 224: api.WatchEventResponse.TableEvent
-	(*ListBmpResponse_BmpStation)(nil),       // 225: api.ListBmpResponse.BmpStation
-	(*ListBmpResponse_BmpStation_Conf)(nil),  // 226: api.ListBmpResponse.BmpStation.Conf
-	(*ListBmpResponse_BmpStation_State)(nil), // 227: api.ListBmpResponse.BmpStation.State
-	(*Family)(nil),                           // 228: api.Family
-	(*NLRI)(nil),                             // 229: api.NLRI
-	(*Attribute)(nil),                        // 230: api.Attribute
-	(*timestamppb.Timestamp)(nil),            // 231: google.protobuf.Timestamp
-	(*Capability)(nil),                       // 232: api.Capability
-	(*RouteDistinguisher)(nil),               // 233: api.RouteDistinguisher
-	(*RouteTarget)(nil),                      // 234: api.RouteTarget
+	(*AggregateAddress)(nil),                 // 220: api.AggregateAddress
+	(*AggregateAddressInfo)(nil),             // 221: api.AggregateAddressInfo
+	(*AddAggregateRequest)(nil),              // 222: api.AddAggregateRequest
+	(*AddAggregateResponse)(nil),             // 223: api.AddAggregateResponse
+	(*DeleteAggregateRequest)(nil),           // 224: api.DeleteAggregateRequest
+	(*DeleteAggregateResponse)(nil),          // 225: api.DeleteAggregateResponse
+	(*ListAggregateRequest)(nil),             // 226: api.ListAggregateRequest
+	(*ListAggregateResponse)(nil),            // 227: api.ListAggregateResponse
+	(*WatchEventRequest_Peer)(nil),           // 228: api.WatchEventRequest.Peer
+	(*WatchEventRequest_Table)(nil),          // 229: api.WatchEventRequest.Table
+	(*WatchEventRequest_Table_Filter)(nil),   // 230: api.WatchEventRequest.Table.Filter
+	(*WatchEventResponse_PeerEvent)(nil),     // 231: api.WatchEventResponse.PeerEvent
+	(*WatchEventResponse_TableEvent)(nil),    // 232: api.WatchEventResponse.TableEvent
+	(*ListBmpResponse_BmpStation)(nil),       // 233: api.ListBmpResponse.BmpStation
+	(*ListBmpResponse_BmpStation_Conf)(nil),  // 234: api.ListBmpResponse.BmpStation.Conf
+	(*ListBmpResponse_BmpStation_State)(nil), // 235: api.ListBmpResponse.BmpStation.State
+	(*Family)(nil),                           // 236: api.Family
+	(*NLRI)(nil),                             // 237: api.NLRI
+	(*Attribute)(nil),                        // 238: api.Attribute
+	(*timestamppb.Timestamp)(nil),            // 239: google.protobuf.Timestamp
+	(*Capability)(nil),                       // 240: api.Capability
+	(*RouteDistinguisher)(nil),               // 241: api.RouteDistinguisher
+	(*RouteTarget)(nil),                      // 242: api.RouteTarget
 }
 var file_api_gobgp_proto_depIdxs = []int32{
 	209, // 0: api.StartBgpRequest.global:type_name -> api.Global
 	209, // 1: api.GetBgpResponse.global:type_name -> api.Global
-	220, // 2: api.WatchEventRequest.peer:type_name -> api.WatchEventRequest.Peer
-	221, // 3: api.WatchEventRequest.table:type_name -> api.WatchEventRequest.Table
-	223, // 4: api.WatchEventResponse.peer:type_name -> api.WatchEventResponse.PeerEvent
-	224, // 5: api.WatchEventResponse.table:type_name -> api.WatchEventResponse.TableEvent
+	228, // 2: api.WatchEventRequest.peer:type_name -> api.WatchEventRequest.Peer
+	229, // 3: api.WatchEventRequest.table:type_name -> api.WatchEventRequest.Table
+	231, // 4: api.WatchEventResponse.peer:type_name -> api.WatchEventResponse.PeerEvent
+	232, // 5: api.WatchEventResponse.table:type_name -> api.WatchEventResponse.TableEvent
 	139, // 6: api.AddPeerRequest.peer:type_name -> api.Peer
 	139, // 7: api.ListPeerResponse.peer:type_name -> api.Peer
 	139, // 8: api.UpdatePeerRequest.peer:type_name -> api.Peer
@@ -14524,18 +14922,18 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	0,   // 15: api.AddPathRequest.table_type:type_name -> api.TableType
 	137, // 16: api.AddPathRequest.path:type_name -> api.Path
 	0,   // 17: api.DeletePathRequest.table_type:type_name -> api.TableType
-	228, // 18: api.DeletePathRequest.family:type_name -> api.Family
+	236, // 18: api.DeletePathRequest.family:type_name -> api.Family
 	137, // 19: api.DeletePathRequest.path:type_name -> api.Path
 	14,  // 20: api.TableLookupPrefix.type:type_name -> api.TableLookupPrefix.Type
 	0,   // 21: api.ListPathRequest.table_type:type_name -> api.TableType
-	228, // 22: api.ListPathRequest.family:type_name -> api.Family
+	236, // 22: api.ListPathRequest.family:type_name -> api.Family
 	69,  // 23: api.ListPathRequest.prefixes:type_name -> api.TableLookupPrefix
 	15,  // 24: api.ListPathRequest.sort_type:type_name -> api.ListPathRequest.SortType
 	138, // 25: api.ListPathResponse.destination:type_name -> api.Destination
 	0,   // 26: api.AddPathStreamRequest.table_type:type_name -> api.TableType
 	137, // 27: api.AddPathStreamRequest.paths:type_name -> api.Path
 	0,   // 28: api.GetTableRequest.table_type:type_name -> api.TableType
-	228, // 29: api.GetTableRequest.family:type_name -> api.Family
+	236, // 29: api.GetTableRequest.family:type_name -> api.Family
 	207, // 30: api.AddVrfRequest.vrf:type_name -> api.Vrf
 	207, // 31: api.ListVrfResponse.vrf:type_name -> api.Vrf
 	203, // 32: api.AddPolicyRequest.policy:type_name -> api.Policy
@@ -14556,23 +14954,23 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	8,   // 47: api.ListPolicyAssignmentRequest.direction:type_name -> api.PolicyDirection
 	204, // 48: api.ListPolicyAssignmentResponse.assignment:type_name -> api.PolicyAssignment
 	204, // 49: api.SetPolicyAssignmentRequest.assignment:type_name -> api.PolicyAssignment
-	228, // 50: api.ListRpkiRequest.family:type_name -> api.Family
+	236, // 50: api.ListRpkiRequest.family:type_name -> api.Family
 	213, // 51: api.ListRpkiResponse.server:type_name -> api.Rpki
-	228, // 52: api.ListRpkiTableRequest.family:type_name -> api.Family
+	236, // 52: api.ListRpkiTableRequest.family:type_name -> api.Family
 	206, // 53: api.ListRpkiTableResponse.roa:type_name -> api.Roa
 	16,  // 54: api.EnableMrtRequest.dump_type:type_name -> api.EnableMrtRequest.DumpType
 	17,  // 55: api.AddBmpRequest.policy:type_name -> api.AddBmpRequest.MonitoringPolicy
-	225, // 56: api.ListBmpResponse.station:type_name -> api.ListBmpResponse.BmpStation
+	233, // 56: api.ListBmpResponse.station:type_name -> api.ListBmpResponse.BmpStation
 	1,   // 57: api.Validation.state:type_name -> api.ValidationState
 	18,  // 58: api.Validation.reason:type_name -> api.Validation.Reason
 	206, // 59: api.Validation.matched:type_name -> api.Roa
 	206, // 60: api.Validation.unmatched_asn:type_name -> api.Roa
 	206, // 61: api.Validation.unmatched_length:type_name -> api.Roa
-	229, // 62: api.Path.nlri:type_name -> api.NLRI
-	230, // 63: api.Path.pattrs:type_name -> api.Attribute
-	231, // 64: api.Path.age:type_name -> google.protobuf.Timestamp
+	237, // 62: api.Path.nlri:type_name -> api.NLRI
+	238, // 63: api.Path.pattrs:type_name -> api.Attribute
+	239, // 64: api.Path.age:type_name -> google.protobuf.Timestamp
 	136, // 65: api.Path.validation:type_name -> api.Validation
-	228, // 66: api.Path.family:type_name -> api.Family
+	236, // 66: api.Path.family:type_name -> api.Family
 	137, // 67: api.Destination.paths:type_name -> api.Path
 	142, // 68: api.Peer.apply_policy:type_name -> api.ApplyPolicy
 	144, // 69: api.Peer.conf:type_name -> api.PeerConf
@@ -14600,7 +14998,7 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	218, // 91: api.PeerGroup.bfd:type_name -> api.BfdPeerConfig
 	204, // 92: api.ApplyPolicy.export_policy:type_name -> api.PolicyAssignment
 	204, // 93: api.ApplyPolicy.import_policy:type_name -> api.PolicyAssignment
-	228, // 94: api.PrefixLimit.family:type_name -> api.Family
+	236, // 94: api.PrefixLimit.family:type_name -> api.Family
 	2,   // 95: api.PeerConf.type:type_name -> api.PeerType
 	3,   // 96: api.PeerConf.remove_private:type_name -> api.RemovePrivate
 	2,   // 97: api.PeerGroupConf.type:type_name -> api.PeerType
@@ -14613,20 +15011,20 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	3,   // 104: api.PeerState.remove_private:type_name -> api.RemovePrivate
 	19,  // 105: api.PeerState.session_state:type_name -> api.PeerState.SessionState
 	20,  // 106: api.PeerState.admin_state:type_name -> api.PeerState.AdminState
-	232, // 107: api.PeerState.remote_cap:type_name -> api.Capability
-	232, // 108: api.PeerState.local_cap:type_name -> api.Capability
+	240, // 107: api.PeerState.remote_cap:type_name -> api.Capability
+	240, // 108: api.PeerState.local_cap:type_name -> api.Capability
 	21,  // 109: api.PeerState.disconnect_reason:type_name -> api.PeerState.DisconnectReason
 	217, // 110: api.PeerState.bfd_state:type_name -> api.BfdPeerState
 	152, // 111: api.Messages.received:type_name -> api.Message
 	152, // 112: api.Messages.sent:type_name -> api.Message
 	155, // 113: api.Timers.config:type_name -> api.TimersConfig
 	156, // 114: api.Timers.state:type_name -> api.TimersState
-	231, // 115: api.TimersState.uptime:type_name -> google.protobuf.Timestamp
-	231, // 116: api.TimersState.downtime:type_name -> google.protobuf.Timestamp
+	239, // 115: api.TimersState.uptime:type_name -> google.protobuf.Timestamp
+	239, // 116: api.TimersState.downtime:type_name -> google.protobuf.Timestamp
 	160, // 117: api.MpGracefulRestart.config:type_name -> api.MpGracefulRestartConfig
 	161, // 118: api.MpGracefulRestart.state:type_name -> api.MpGracefulRestartState
-	228, // 119: api.AfiSafiConfig.family:type_name -> api.Family
-	228, // 120: api.AfiSafiState.family:type_name -> api.Family
+	236, // 119: api.AfiSafiConfig.family:type_name -> api.Family
+	236, // 120: api.AfiSafiState.family:type_name -> api.Family
 	165, // 121: api.RouteSelectionOptions.config:type_name -> api.RouteSelectionOptionsConfig
 	166, // 122: api.RouteSelectionOptions.state:type_name -> api.RouteSelectionOptionsState
 	170, // 123: api.Ebgp.config:type_name -> api.EbgpConfig
@@ -14667,7 +15065,7 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	1,   // 158: api.Conditions.rpki_result:type_name -> api.ValidationState
 	23,  // 159: api.Conditions.route_type:type_name -> api.Conditions.RouteType
 	189, // 160: api.Conditions.large_community_set:type_name -> api.MatchSet
-	228, // 161: api.Conditions.afi_safi_in:type_name -> api.Family
+	236, // 161: api.Conditions.afi_safi_in:type_name -> api.Family
 	191, // 162: api.Conditions.community_count:type_name -> api.CommunityCount
 	6,   // 163: api.Conditions.origin:type_name -> api.OriginType
 	192, // 164: api.Conditions.local_pref_eq:type_name -> api.LocalPrefEq
@@ -14693,15 +15091,15 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	188, // 184: api.RoutingPolicy.defined_sets:type_name -> api.DefinedSet
 	203, // 185: api.RoutingPolicy.policies:type_name -> api.Policy
 	211, // 186: api.Roa.conf:type_name -> api.RPKIConf
-	233, // 187: api.Vrf.rd:type_name -> api.RouteDistinguisher
-	234, // 188: api.Vrf.import_rt:type_name -> api.RouteTarget
-	234, // 189: api.Vrf.export_rt:type_name -> api.RouteTarget
+	241, // 187: api.Vrf.rd:type_name -> api.RouteDistinguisher
+	242, // 188: api.Vrf.import_rt:type_name -> api.RouteTarget
+	242, // 189: api.Vrf.export_rt:type_name -> api.RouteTarget
 	165, // 190: api.Global.route_selection_options:type_name -> api.RouteSelectionOptionsConfig
 	208, // 191: api.Global.default_route_distance:type_name -> api.DefaultRouteDistance
 	210, // 192: api.Global.confederation:type_name -> api.Confederation
 	159, // 193: api.Global.graceful_restart:type_name -> api.GracefulRestart
-	231, // 194: api.RPKIState.uptime:type_name -> google.protobuf.Timestamp
-	231, // 195: api.RPKIState.downtime:type_name -> google.protobuf.Timestamp
+	239, // 194: api.RPKIState.uptime:type_name -> google.protobuf.Timestamp
+	239, // 195: api.RPKIState.downtime:type_name -> google.protobuf.Timestamp
 	211, // 196: api.Rpki.conf:type_name -> api.RPKIConf
 	212, // 197: api.Rpki.state:type_name -> api.RPKIState
 	26,  // 198: api.SetLogLevelRequest.level:type_name -> api.SetLogLevelRequest.Level
@@ -14710,130 +15108,140 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	10,  // 201: api.BfdPeerState.local_diagnostic_code:type_name -> api.BfdDiagnosticCode
 	10,  // 202: api.BfdPeerState.remote_diagnostic_code:type_name -> api.BfdDiagnosticCode
 	216, // 203: api.BfdPeerState.bfd_async:type_name -> api.BfdAsyncCounters
-	222, // 204: api.WatchEventRequest.Table.filters:type_name -> api.WatchEventRequest.Table.Filter
-	11,  // 205: api.WatchEventRequest.Table.Filter.type:type_name -> api.WatchEventRequest.Table.Filter.Type
-	12,  // 206: api.WatchEventResponse.PeerEvent.type:type_name -> api.WatchEventResponse.PeerEvent.Type
-	139, // 207: api.WatchEventResponse.PeerEvent.peer:type_name -> api.Peer
-	137, // 208: api.WatchEventResponse.TableEvent.paths:type_name -> api.Path
-	226, // 209: api.ListBmpResponse.BmpStation.conf:type_name -> api.ListBmpResponse.BmpStation.Conf
-	227, // 210: api.ListBmpResponse.BmpStation.state:type_name -> api.ListBmpResponse.BmpStation.State
-	231, // 211: api.ListBmpResponse.BmpStation.State.uptime:type_name -> google.protobuf.Timestamp
-	231, // 212: api.ListBmpResponse.BmpStation.State.downtime:type_name -> google.protobuf.Timestamp
-	27,  // 213: api.GoBgpService.StartBgp:input_type -> api.StartBgpRequest
-	29,  // 214: api.GoBgpService.StopBgp:input_type -> api.StopBgpRequest
-	31,  // 215: api.GoBgpService.GetBgp:input_type -> api.GetBgpRequest
-	33,  // 216: api.GoBgpService.WatchEvent:input_type -> api.WatchEventRequest
-	35,  // 217: api.GoBgpService.AddPeer:input_type -> api.AddPeerRequest
-	37,  // 218: api.GoBgpService.DeletePeer:input_type -> api.DeletePeerRequest
-	39,  // 219: api.GoBgpService.ListPeer:input_type -> api.ListPeerRequest
-	41,  // 220: api.GoBgpService.UpdatePeer:input_type -> api.UpdatePeerRequest
-	43,  // 221: api.GoBgpService.ResetPeer:input_type -> api.ResetPeerRequest
-	45,  // 222: api.GoBgpService.ShutdownPeer:input_type -> api.ShutdownPeerRequest
-	47,  // 223: api.GoBgpService.EnablePeer:input_type -> api.EnablePeerRequest
-	49,  // 224: api.GoBgpService.DisablePeer:input_type -> api.DisablePeerRequest
-	51,  // 225: api.GoBgpService.AddPeerGroup:input_type -> api.AddPeerGroupRequest
-	53,  // 226: api.GoBgpService.DeletePeerGroup:input_type -> api.DeletePeerGroupRequest
-	57,  // 227: api.GoBgpService.ListPeerGroup:input_type -> api.ListPeerGroupRequest
-	55,  // 228: api.GoBgpService.UpdatePeerGroup:input_type -> api.UpdatePeerGroupRequest
-	59,  // 229: api.GoBgpService.AddDynamicNeighbor:input_type -> api.AddDynamicNeighborRequest
-	63,  // 230: api.GoBgpService.ListDynamicNeighbor:input_type -> api.ListDynamicNeighborRequest
-	61,  // 231: api.GoBgpService.DeleteDynamicNeighbor:input_type -> api.DeleteDynamicNeighborRequest
-	65,  // 232: api.GoBgpService.AddPath:input_type -> api.AddPathRequest
-	67,  // 233: api.GoBgpService.DeletePath:input_type -> api.DeletePathRequest
-	70,  // 234: api.GoBgpService.ListPath:input_type -> api.ListPathRequest
-	72,  // 235: api.GoBgpService.AddPathStream:input_type -> api.AddPathStreamRequest
-	74,  // 236: api.GoBgpService.GetTable:input_type -> api.GetTableRequest
-	76,  // 237: api.GoBgpService.AddVrf:input_type -> api.AddVrfRequest
-	78,  // 238: api.GoBgpService.DeleteVrf:input_type -> api.DeleteVrfRequest
-	80,  // 239: api.GoBgpService.ListVrf:input_type -> api.ListVrfRequest
-	82,  // 240: api.GoBgpService.AddPolicy:input_type -> api.AddPolicyRequest
-	84,  // 241: api.GoBgpService.DeletePolicy:input_type -> api.DeletePolicyRequest
-	86,  // 242: api.GoBgpService.ListPolicy:input_type -> api.ListPolicyRequest
-	88,  // 243: api.GoBgpService.SetPolicies:input_type -> api.SetPoliciesRequest
-	90,  // 244: api.GoBgpService.AddDefinedSet:input_type -> api.AddDefinedSetRequest
-	92,  // 245: api.GoBgpService.DeleteDefinedSet:input_type -> api.DeleteDefinedSetRequest
-	94,  // 246: api.GoBgpService.ListDefinedSet:input_type -> api.ListDefinedSetRequest
-	96,  // 247: api.GoBgpService.AddStatement:input_type -> api.AddStatementRequest
-	98,  // 248: api.GoBgpService.DeleteStatement:input_type -> api.DeleteStatementRequest
-	100, // 249: api.GoBgpService.ListStatement:input_type -> api.ListStatementRequest
-	102, // 250: api.GoBgpService.AddPolicyAssignment:input_type -> api.AddPolicyAssignmentRequest
-	104, // 251: api.GoBgpService.DeletePolicyAssignment:input_type -> api.DeletePolicyAssignmentRequest
-	106, // 252: api.GoBgpService.ListPolicyAssignment:input_type -> api.ListPolicyAssignmentRequest
-	108, // 253: api.GoBgpService.SetPolicyAssignment:input_type -> api.SetPolicyAssignmentRequest
-	110, // 254: api.GoBgpService.AddRpki:input_type -> api.AddRpkiRequest
-	112, // 255: api.GoBgpService.DeleteRpki:input_type -> api.DeleteRpkiRequest
-	114, // 256: api.GoBgpService.ListRpki:input_type -> api.ListRpkiRequest
-	116, // 257: api.GoBgpService.EnableRpki:input_type -> api.EnableRpkiRequest
-	118, // 258: api.GoBgpService.DisableRpki:input_type -> api.DisableRpkiRequest
-	120, // 259: api.GoBgpService.ResetRpki:input_type -> api.ResetRpkiRequest
-	122, // 260: api.GoBgpService.ListRpkiTable:input_type -> api.ListRpkiTableRequest
-	124, // 261: api.GoBgpService.EnableZebra:input_type -> api.EnableZebraRequest
-	126, // 262: api.GoBgpService.EnableMrt:input_type -> api.EnableMrtRequest
-	128, // 263: api.GoBgpService.DisableMrt:input_type -> api.DisableMrtRequest
-	130, // 264: api.GoBgpService.AddBmp:input_type -> api.AddBmpRequest
-	132, // 265: api.GoBgpService.DeleteBmp:input_type -> api.DeleteBmpRequest
-	134, // 266: api.GoBgpService.ListBmp:input_type -> api.ListBmpRequest
-	214, // 267: api.GoBgpService.SetLogLevel:input_type -> api.SetLogLevelRequest
-	28,  // 268: api.GoBgpService.StartBgp:output_type -> api.StartBgpResponse
-	30,  // 269: api.GoBgpService.StopBgp:output_type -> api.StopBgpResponse
-	32,  // 270: api.GoBgpService.GetBgp:output_type -> api.GetBgpResponse
-	34,  // 271: api.GoBgpService.WatchEvent:output_type -> api.WatchEventResponse
-	36,  // 272: api.GoBgpService.AddPeer:output_type -> api.AddPeerResponse
-	38,  // 273: api.GoBgpService.DeletePeer:output_type -> api.DeletePeerResponse
-	40,  // 274: api.GoBgpService.ListPeer:output_type -> api.ListPeerResponse
-	42,  // 275: api.GoBgpService.UpdatePeer:output_type -> api.UpdatePeerResponse
-	44,  // 276: api.GoBgpService.ResetPeer:output_type -> api.ResetPeerResponse
-	46,  // 277: api.GoBgpService.ShutdownPeer:output_type -> api.ShutdownPeerResponse
-	48,  // 278: api.GoBgpService.EnablePeer:output_type -> api.EnablePeerResponse
-	50,  // 279: api.GoBgpService.DisablePeer:output_type -> api.DisablePeerResponse
-	52,  // 280: api.GoBgpService.AddPeerGroup:output_type -> api.AddPeerGroupResponse
-	54,  // 281: api.GoBgpService.DeletePeerGroup:output_type -> api.DeletePeerGroupResponse
-	58,  // 282: api.GoBgpService.ListPeerGroup:output_type -> api.ListPeerGroupResponse
-	56,  // 283: api.GoBgpService.UpdatePeerGroup:output_type -> api.UpdatePeerGroupResponse
-	60,  // 284: api.GoBgpService.AddDynamicNeighbor:output_type -> api.AddDynamicNeighborResponse
-	64,  // 285: api.GoBgpService.ListDynamicNeighbor:output_type -> api.ListDynamicNeighborResponse
-	62,  // 286: api.GoBgpService.DeleteDynamicNeighbor:output_type -> api.DeleteDynamicNeighborResponse
-	66,  // 287: api.GoBgpService.AddPath:output_type -> api.AddPathResponse
-	68,  // 288: api.GoBgpService.DeletePath:output_type -> api.DeletePathResponse
-	71,  // 289: api.GoBgpService.ListPath:output_type -> api.ListPathResponse
-	73,  // 290: api.GoBgpService.AddPathStream:output_type -> api.AddPathStreamResponse
-	75,  // 291: api.GoBgpService.GetTable:output_type -> api.GetTableResponse
-	77,  // 292: api.GoBgpService.AddVrf:output_type -> api.AddVrfResponse
-	79,  // 293: api.GoBgpService.DeleteVrf:output_type -> api.DeleteVrfResponse
-	81,  // 294: api.GoBgpService.ListVrf:output_type -> api.ListVrfResponse
-	83,  // 295: api.GoBgpService.AddPolicy:output_type -> api.AddPolicyResponse
-	85,  // 296: api.GoBgpService.DeletePolicy:output_type -> api.DeletePolicyResponse
-	87,  // 297: api.GoBgpService.ListPolicy:output_type -> api.ListPolicyResponse
-	89,  // 298: api.GoBgpService.SetPolicies:output_type -> api.SetPoliciesResponse
-	91,  // 299: api.GoBgpService.AddDefinedSet:output_type -> api.AddDefinedSetResponse
-	93,  // 300: api.GoBgpService.DeleteDefinedSet:output_type -> api.DeleteDefinedSetResponse
-	95,  // 301: api.GoBgpService.ListDefinedSet:output_type -> api.ListDefinedSetResponse
-	97,  // 302: api.GoBgpService.AddStatement:output_type -> api.AddStatementResponse
-	99,  // 303: api.GoBgpService.DeleteStatement:output_type -> api.DeleteStatementResponse
-	101, // 304: api.GoBgpService.ListStatement:output_type -> api.ListStatementResponse
-	103, // 305: api.GoBgpService.AddPolicyAssignment:output_type -> api.AddPolicyAssignmentResponse
-	105, // 306: api.GoBgpService.DeletePolicyAssignment:output_type -> api.DeletePolicyAssignmentResponse
-	107, // 307: api.GoBgpService.ListPolicyAssignment:output_type -> api.ListPolicyAssignmentResponse
-	109, // 308: api.GoBgpService.SetPolicyAssignment:output_type -> api.SetPolicyAssignmentResponse
-	111, // 309: api.GoBgpService.AddRpki:output_type -> api.AddRpkiResponse
-	113, // 310: api.GoBgpService.DeleteRpki:output_type -> api.DeleteRpkiResponse
-	115, // 311: api.GoBgpService.ListRpki:output_type -> api.ListRpkiResponse
-	117, // 312: api.GoBgpService.EnableRpki:output_type -> api.EnableRpkiResponse
-	119, // 313: api.GoBgpService.DisableRpki:output_type -> api.DisableRpkiResponse
-	121, // 314: api.GoBgpService.ResetRpki:output_type -> api.ResetRpkiResponse
-	123, // 315: api.GoBgpService.ListRpkiTable:output_type -> api.ListRpkiTableResponse
-	125, // 316: api.GoBgpService.EnableZebra:output_type -> api.EnableZebraResponse
-	127, // 317: api.GoBgpService.EnableMrt:output_type -> api.EnableMrtResponse
-	129, // 318: api.GoBgpService.DisableMrt:output_type -> api.DisableMrtResponse
-	131, // 319: api.GoBgpService.AddBmp:output_type -> api.AddBmpResponse
-	133, // 320: api.GoBgpService.DeleteBmp:output_type -> api.DeleteBmpResponse
-	135, // 321: api.GoBgpService.ListBmp:output_type -> api.ListBmpResponse
-	215, // 322: api.GoBgpService.SetLogLevel:output_type -> api.SetLogLevelResponse
-	268, // [268:323] is the sub-list for method output_type
-	213, // [213:268] is the sub-list for method input_type
-	213, // [213:213] is the sub-list for extension type_name
-	213, // [213:213] is the sub-list for extension extendee
-	0,   // [0:213] is the sub-list for field type_name
+	220, // 204: api.AggregateAddressInfo.aggregate:type_name -> api.AggregateAddress
+	220, // 205: api.AddAggregateRequest.aggregate:type_name -> api.AggregateAddress
+	236, // 206: api.ListAggregateRequest.family:type_name -> api.Family
+	221, // 207: api.ListAggregateResponse.aggregate:type_name -> api.AggregateAddressInfo
+	230, // 208: api.WatchEventRequest.Table.filters:type_name -> api.WatchEventRequest.Table.Filter
+	11,  // 209: api.WatchEventRequest.Table.Filter.type:type_name -> api.WatchEventRequest.Table.Filter.Type
+	12,  // 210: api.WatchEventResponse.PeerEvent.type:type_name -> api.WatchEventResponse.PeerEvent.Type
+	139, // 211: api.WatchEventResponse.PeerEvent.peer:type_name -> api.Peer
+	137, // 212: api.WatchEventResponse.TableEvent.paths:type_name -> api.Path
+	234, // 213: api.ListBmpResponse.BmpStation.conf:type_name -> api.ListBmpResponse.BmpStation.Conf
+	235, // 214: api.ListBmpResponse.BmpStation.state:type_name -> api.ListBmpResponse.BmpStation.State
+	239, // 215: api.ListBmpResponse.BmpStation.State.uptime:type_name -> google.protobuf.Timestamp
+	239, // 216: api.ListBmpResponse.BmpStation.State.downtime:type_name -> google.protobuf.Timestamp
+	27,  // 217: api.GoBgpService.StartBgp:input_type -> api.StartBgpRequest
+	29,  // 218: api.GoBgpService.StopBgp:input_type -> api.StopBgpRequest
+	31,  // 219: api.GoBgpService.GetBgp:input_type -> api.GetBgpRequest
+	33,  // 220: api.GoBgpService.WatchEvent:input_type -> api.WatchEventRequest
+	35,  // 221: api.GoBgpService.AddPeer:input_type -> api.AddPeerRequest
+	37,  // 222: api.GoBgpService.DeletePeer:input_type -> api.DeletePeerRequest
+	39,  // 223: api.GoBgpService.ListPeer:input_type -> api.ListPeerRequest
+	41,  // 224: api.GoBgpService.UpdatePeer:input_type -> api.UpdatePeerRequest
+	43,  // 225: api.GoBgpService.ResetPeer:input_type -> api.ResetPeerRequest
+	45,  // 226: api.GoBgpService.ShutdownPeer:input_type -> api.ShutdownPeerRequest
+	47,  // 227: api.GoBgpService.EnablePeer:input_type -> api.EnablePeerRequest
+	49,  // 228: api.GoBgpService.DisablePeer:input_type -> api.DisablePeerRequest
+	51,  // 229: api.GoBgpService.AddPeerGroup:input_type -> api.AddPeerGroupRequest
+	53,  // 230: api.GoBgpService.DeletePeerGroup:input_type -> api.DeletePeerGroupRequest
+	57,  // 231: api.GoBgpService.ListPeerGroup:input_type -> api.ListPeerGroupRequest
+	55,  // 232: api.GoBgpService.UpdatePeerGroup:input_type -> api.UpdatePeerGroupRequest
+	59,  // 233: api.GoBgpService.AddDynamicNeighbor:input_type -> api.AddDynamicNeighborRequest
+	63,  // 234: api.GoBgpService.ListDynamicNeighbor:input_type -> api.ListDynamicNeighborRequest
+	61,  // 235: api.GoBgpService.DeleteDynamicNeighbor:input_type -> api.DeleteDynamicNeighborRequest
+	65,  // 236: api.GoBgpService.AddPath:input_type -> api.AddPathRequest
+	67,  // 237: api.GoBgpService.DeletePath:input_type -> api.DeletePathRequest
+	70,  // 238: api.GoBgpService.ListPath:input_type -> api.ListPathRequest
+	72,  // 239: api.GoBgpService.AddPathStream:input_type -> api.AddPathStreamRequest
+	74,  // 240: api.GoBgpService.GetTable:input_type -> api.GetTableRequest
+	76,  // 241: api.GoBgpService.AddVrf:input_type -> api.AddVrfRequest
+	78,  // 242: api.GoBgpService.DeleteVrf:input_type -> api.DeleteVrfRequest
+	80,  // 243: api.GoBgpService.ListVrf:input_type -> api.ListVrfRequest
+	222, // 244: api.GoBgpService.AddAggregate:input_type -> api.AddAggregateRequest
+	224, // 245: api.GoBgpService.DeleteAggregate:input_type -> api.DeleteAggregateRequest
+	226, // 246: api.GoBgpService.ListAggregate:input_type -> api.ListAggregateRequest
+	82,  // 247: api.GoBgpService.AddPolicy:input_type -> api.AddPolicyRequest
+	84,  // 248: api.GoBgpService.DeletePolicy:input_type -> api.DeletePolicyRequest
+	86,  // 249: api.GoBgpService.ListPolicy:input_type -> api.ListPolicyRequest
+	88,  // 250: api.GoBgpService.SetPolicies:input_type -> api.SetPoliciesRequest
+	90,  // 251: api.GoBgpService.AddDefinedSet:input_type -> api.AddDefinedSetRequest
+	92,  // 252: api.GoBgpService.DeleteDefinedSet:input_type -> api.DeleteDefinedSetRequest
+	94,  // 253: api.GoBgpService.ListDefinedSet:input_type -> api.ListDefinedSetRequest
+	96,  // 254: api.GoBgpService.AddStatement:input_type -> api.AddStatementRequest
+	98,  // 255: api.GoBgpService.DeleteStatement:input_type -> api.DeleteStatementRequest
+	100, // 256: api.GoBgpService.ListStatement:input_type -> api.ListStatementRequest
+	102, // 257: api.GoBgpService.AddPolicyAssignment:input_type -> api.AddPolicyAssignmentRequest
+	104, // 258: api.GoBgpService.DeletePolicyAssignment:input_type -> api.DeletePolicyAssignmentRequest
+	106, // 259: api.GoBgpService.ListPolicyAssignment:input_type -> api.ListPolicyAssignmentRequest
+	108, // 260: api.GoBgpService.SetPolicyAssignment:input_type -> api.SetPolicyAssignmentRequest
+	110, // 261: api.GoBgpService.AddRpki:input_type -> api.AddRpkiRequest
+	112, // 262: api.GoBgpService.DeleteRpki:input_type -> api.DeleteRpkiRequest
+	114, // 263: api.GoBgpService.ListRpki:input_type -> api.ListRpkiRequest
+	116, // 264: api.GoBgpService.EnableRpki:input_type -> api.EnableRpkiRequest
+	118, // 265: api.GoBgpService.DisableRpki:input_type -> api.DisableRpkiRequest
+	120, // 266: api.GoBgpService.ResetRpki:input_type -> api.ResetRpkiRequest
+	122, // 267: api.GoBgpService.ListRpkiTable:input_type -> api.ListRpkiTableRequest
+	124, // 268: api.GoBgpService.EnableZebra:input_type -> api.EnableZebraRequest
+	126, // 269: api.GoBgpService.EnableMrt:input_type -> api.EnableMrtRequest
+	128, // 270: api.GoBgpService.DisableMrt:input_type -> api.DisableMrtRequest
+	130, // 271: api.GoBgpService.AddBmp:input_type -> api.AddBmpRequest
+	132, // 272: api.GoBgpService.DeleteBmp:input_type -> api.DeleteBmpRequest
+	134, // 273: api.GoBgpService.ListBmp:input_type -> api.ListBmpRequest
+	214, // 274: api.GoBgpService.SetLogLevel:input_type -> api.SetLogLevelRequest
+	28,  // 275: api.GoBgpService.StartBgp:output_type -> api.StartBgpResponse
+	30,  // 276: api.GoBgpService.StopBgp:output_type -> api.StopBgpResponse
+	32,  // 277: api.GoBgpService.GetBgp:output_type -> api.GetBgpResponse
+	34,  // 278: api.GoBgpService.WatchEvent:output_type -> api.WatchEventResponse
+	36,  // 279: api.GoBgpService.AddPeer:output_type -> api.AddPeerResponse
+	38,  // 280: api.GoBgpService.DeletePeer:output_type -> api.DeletePeerResponse
+	40,  // 281: api.GoBgpService.ListPeer:output_type -> api.ListPeerResponse
+	42,  // 282: api.GoBgpService.UpdatePeer:output_type -> api.UpdatePeerResponse
+	44,  // 283: api.GoBgpService.ResetPeer:output_type -> api.ResetPeerResponse
+	46,  // 284: api.GoBgpService.ShutdownPeer:output_type -> api.ShutdownPeerResponse
+	48,  // 285: api.GoBgpService.EnablePeer:output_type -> api.EnablePeerResponse
+	50,  // 286: api.GoBgpService.DisablePeer:output_type -> api.DisablePeerResponse
+	52,  // 287: api.GoBgpService.AddPeerGroup:output_type -> api.AddPeerGroupResponse
+	54,  // 288: api.GoBgpService.DeletePeerGroup:output_type -> api.DeletePeerGroupResponse
+	58,  // 289: api.GoBgpService.ListPeerGroup:output_type -> api.ListPeerGroupResponse
+	56,  // 290: api.GoBgpService.UpdatePeerGroup:output_type -> api.UpdatePeerGroupResponse
+	60,  // 291: api.GoBgpService.AddDynamicNeighbor:output_type -> api.AddDynamicNeighborResponse
+	64,  // 292: api.GoBgpService.ListDynamicNeighbor:output_type -> api.ListDynamicNeighborResponse
+	62,  // 293: api.GoBgpService.DeleteDynamicNeighbor:output_type -> api.DeleteDynamicNeighborResponse
+	66,  // 294: api.GoBgpService.AddPath:output_type -> api.AddPathResponse
+	68,  // 295: api.GoBgpService.DeletePath:output_type -> api.DeletePathResponse
+	71,  // 296: api.GoBgpService.ListPath:output_type -> api.ListPathResponse
+	73,  // 297: api.GoBgpService.AddPathStream:output_type -> api.AddPathStreamResponse
+	75,  // 298: api.GoBgpService.GetTable:output_type -> api.GetTableResponse
+	77,  // 299: api.GoBgpService.AddVrf:output_type -> api.AddVrfResponse
+	79,  // 300: api.GoBgpService.DeleteVrf:output_type -> api.DeleteVrfResponse
+	81,  // 301: api.GoBgpService.ListVrf:output_type -> api.ListVrfResponse
+	223, // 302: api.GoBgpService.AddAggregate:output_type -> api.AddAggregateResponse
+	225, // 303: api.GoBgpService.DeleteAggregate:output_type -> api.DeleteAggregateResponse
+	227, // 304: api.GoBgpService.ListAggregate:output_type -> api.ListAggregateResponse
+	83,  // 305: api.GoBgpService.AddPolicy:output_type -> api.AddPolicyResponse
+	85,  // 306: api.GoBgpService.DeletePolicy:output_type -> api.DeletePolicyResponse
+	87,  // 307: api.GoBgpService.ListPolicy:output_type -> api.ListPolicyResponse
+	89,  // 308: api.GoBgpService.SetPolicies:output_type -> api.SetPoliciesResponse
+	91,  // 309: api.GoBgpService.AddDefinedSet:output_type -> api.AddDefinedSetResponse
+	93,  // 310: api.GoBgpService.DeleteDefinedSet:output_type -> api.DeleteDefinedSetResponse
+	95,  // 311: api.GoBgpService.ListDefinedSet:output_type -> api.ListDefinedSetResponse
+	97,  // 312: api.GoBgpService.AddStatement:output_type -> api.AddStatementResponse
+	99,  // 313: api.GoBgpService.DeleteStatement:output_type -> api.DeleteStatementResponse
+	101, // 314: api.GoBgpService.ListStatement:output_type -> api.ListStatementResponse
+	103, // 315: api.GoBgpService.AddPolicyAssignment:output_type -> api.AddPolicyAssignmentResponse
+	105, // 316: api.GoBgpService.DeletePolicyAssignment:output_type -> api.DeletePolicyAssignmentResponse
+	107, // 317: api.GoBgpService.ListPolicyAssignment:output_type -> api.ListPolicyAssignmentResponse
+	109, // 318: api.GoBgpService.SetPolicyAssignment:output_type -> api.SetPolicyAssignmentResponse
+	111, // 319: api.GoBgpService.AddRpki:output_type -> api.AddRpkiResponse
+	113, // 320: api.GoBgpService.DeleteRpki:output_type -> api.DeleteRpkiResponse
+	115, // 321: api.GoBgpService.ListRpki:output_type -> api.ListRpkiResponse
+	117, // 322: api.GoBgpService.EnableRpki:output_type -> api.EnableRpkiResponse
+	119, // 323: api.GoBgpService.DisableRpki:output_type -> api.DisableRpkiResponse
+	121, // 324: api.GoBgpService.ResetRpki:output_type -> api.ResetRpkiResponse
+	123, // 325: api.GoBgpService.ListRpkiTable:output_type -> api.ListRpkiTableResponse
+	125, // 326: api.GoBgpService.EnableZebra:output_type -> api.EnableZebraResponse
+	127, // 327: api.GoBgpService.EnableMrt:output_type -> api.EnableMrtResponse
+	129, // 328: api.GoBgpService.DisableMrt:output_type -> api.DisableMrtResponse
+	131, // 329: api.GoBgpService.AddBmp:output_type -> api.AddBmpResponse
+	133, // 330: api.GoBgpService.DeleteBmp:output_type -> api.DeleteBmpResponse
+	135, // 331: api.GoBgpService.ListBmp:output_type -> api.ListBmpResponse
+	215, // 332: api.GoBgpService.SetLogLevel:output_type -> api.SetLogLevelResponse
+	275, // [275:333] is the sub-list for method output_type
+	217, // [217:275] is the sub-list for method input_type
+	217, // [217:217] is the sub-list for extension type_name
+	217, // [217:217] is the sub-list for extension extendee
+	0,   // [0:217] is the sub-list for field type_name
 }
 
 func init() { file_api_gobgp_proto_init() }
@@ -14856,7 +15264,7 @@ func file_api_gobgp_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_gobgp_proto_rawDesc), len(file_api_gobgp_proto_rawDesc)),
 			NumEnums:      27,
-			NumMessages:   201,
+			NumMessages:   209,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -13317,6 +13317,374 @@ func (x *ListTcpAoKeychainResponse) GetKeychain() *TcpAoKeychain {
 	return nil
 }
 
+type AggregateAddress struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Prefix        string                 `protobuf:"bytes,1,opt,name=prefix,proto3" json:"prefix,omitempty"`
+	SummaryOnly   bool                   `protobuf:"varint,2,opt,name=summary_only,json=summaryOnly,proto3" json:"summary_only,omitempty"`
+	PolicyName    string                 `protobuf:"bytes,3,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
+	AsSet         bool                   `protobuf:"varint,4,opt,name=as_set,json=asSet,proto3" json:"as_set,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AggregateAddress) Reset() {
+	*x = AggregateAddress{}
+	mi := &file_api_gobgp_proto_msgTypes[203]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AggregateAddress) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AggregateAddress) ProtoMessage() {}
+
+func (x *AggregateAddress) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[203]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AggregateAddress.ProtoReflect.Descriptor instead.
+func (*AggregateAddress) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{203}
+}
+
+func (x *AggregateAddress) GetPrefix() string {
+	if x != nil {
+		return x.Prefix
+	}
+	return ""
+}
+
+func (x *AggregateAddress) GetSummaryOnly() bool {
+	if x != nil {
+		return x.SummaryOnly
+	}
+	return false
+}
+
+func (x *AggregateAddress) GetPolicyName() string {
+	if x != nil {
+		return x.PolicyName
+	}
+	return ""
+}
+
+func (x *AggregateAddress) GetAsSet() bool {
+	if x != nil {
+		return x.AsSet
+	}
+	return false
+}
+
+type AggregateAddressInfo struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Aggregate       *AggregateAddress      `protobuf:"bytes,1,opt,name=aggregate,proto3" json:"aggregate,omitempty"`
+	NumContributors uint32                 `protobuf:"varint,2,opt,name=num_contributors,json=numContributors,proto3" json:"num_contributors,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *AggregateAddressInfo) Reset() {
+	*x = AggregateAddressInfo{}
+	mi := &file_api_gobgp_proto_msgTypes[204]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AggregateAddressInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AggregateAddressInfo) ProtoMessage() {}
+
+func (x *AggregateAddressInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[204]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AggregateAddressInfo.ProtoReflect.Descriptor instead.
+func (*AggregateAddressInfo) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{204}
+}
+
+func (x *AggregateAddressInfo) GetAggregate() *AggregateAddress {
+	if x != nil {
+		return x.Aggregate
+	}
+	return nil
+}
+
+func (x *AggregateAddressInfo) GetNumContributors() uint32 {
+	if x != nil {
+		return x.NumContributors
+	}
+	return 0
+}
+
+type AddAggregateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Aggregate     *AggregateAddress      `protobuf:"bytes,1,opt,name=aggregate,proto3" json:"aggregate,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddAggregateRequest) Reset() {
+	*x = AddAggregateRequest{}
+	mi := &file_api_gobgp_proto_msgTypes[205]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddAggregateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddAggregateRequest) ProtoMessage() {}
+
+func (x *AddAggregateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[205]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddAggregateRequest.ProtoReflect.Descriptor instead.
+func (*AddAggregateRequest) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{205}
+}
+
+func (x *AddAggregateRequest) GetAggregate() *AggregateAddress {
+	if x != nil {
+		return x.Aggregate
+	}
+	return nil
+}
+
+type AddAggregateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddAggregateResponse) Reset() {
+	*x = AddAggregateResponse{}
+	mi := &file_api_gobgp_proto_msgTypes[206]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddAggregateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddAggregateResponse) ProtoMessage() {}
+
+func (x *AddAggregateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[206]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddAggregateResponse.ProtoReflect.Descriptor instead.
+func (*AddAggregateResponse) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{206}
+}
+
+type DeleteAggregateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Prefix        string                 `protobuf:"bytes,1,opt,name=prefix,proto3" json:"prefix,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteAggregateRequest) Reset() {
+	*x = DeleteAggregateRequest{}
+	mi := &file_api_gobgp_proto_msgTypes[207]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteAggregateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteAggregateRequest) ProtoMessage() {}
+
+func (x *DeleteAggregateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[207]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteAggregateRequest.ProtoReflect.Descriptor instead.
+func (*DeleteAggregateRequest) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{207}
+}
+
+func (x *DeleteAggregateRequest) GetPrefix() string {
+	if x != nil {
+		return x.Prefix
+	}
+	return ""
+}
+
+type DeleteAggregateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteAggregateResponse) Reset() {
+	*x = DeleteAggregateResponse{}
+	mi := &file_api_gobgp_proto_msgTypes[208]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteAggregateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteAggregateResponse) ProtoMessage() {}
+
+func (x *DeleteAggregateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[208]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteAggregateResponse.ProtoReflect.Descriptor instead.
+func (*DeleteAggregateResponse) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{208}
+}
+
+type ListAggregateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Family        *Family                `protobuf:"bytes,1,opt,name=family,proto3" json:"family,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAggregateRequest) Reset() {
+	*x = ListAggregateRequest{}
+	mi := &file_api_gobgp_proto_msgTypes[209]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAggregateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAggregateRequest) ProtoMessage() {}
+
+func (x *ListAggregateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[209]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAggregateRequest.ProtoReflect.Descriptor instead.
+func (*ListAggregateRequest) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{209}
+}
+
+func (x *ListAggregateRequest) GetFamily() *Family {
+	if x != nil {
+		return x.Family
+	}
+	return nil
+}
+
+type ListAggregateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Aggregate     *AggregateAddressInfo  `protobuf:"bytes,1,opt,name=aggregate,proto3" json:"aggregate,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAggregateResponse) Reset() {
+	*x = ListAggregateResponse{}
+	mi := &file_api_gobgp_proto_msgTypes[210]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAggregateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAggregateResponse) ProtoMessage() {}
+
+func (x *ListAggregateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[210]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAggregateResponse.ProtoReflect.Descriptor instead.
+func (*ListAggregateResponse) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{210}
+}
+
+func (x *ListAggregateResponse) GetAggregate() *AggregateAddressInfo {
+	if x != nil {
+		return x.Aggregate
+	}
+	return nil
+}
+
 type WatchEventRequest_Peer struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -13325,7 +13693,7 @@ type WatchEventRequest_Peer struct {
 
 func (x *WatchEventRequest_Peer) Reset() {
 	*x = WatchEventRequest_Peer{}
-	mi := &file_api_gobgp_proto_msgTypes[203]
+	mi := &file_api_gobgp_proto_msgTypes[211]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13337,7 +13705,7 @@ func (x *WatchEventRequest_Peer) String() string {
 func (*WatchEventRequest_Peer) ProtoMessage() {}
 
 func (x *WatchEventRequest_Peer) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[203]
+	mi := &file_api_gobgp_proto_msgTypes[211]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13362,7 +13730,7 @@ type WatchEventRequest_Table struct {
 
 func (x *WatchEventRequest_Table) Reset() {
 	*x = WatchEventRequest_Table{}
-	mi := &file_api_gobgp_proto_msgTypes[204]
+	mi := &file_api_gobgp_proto_msgTypes[212]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13374,7 +13742,7 @@ func (x *WatchEventRequest_Table) String() string {
 func (*WatchEventRequest_Table) ProtoMessage() {}
 
 func (x *WatchEventRequest_Table) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[204]
+	mi := &file_api_gobgp_proto_msgTypes[212]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13409,7 +13777,7 @@ type WatchEventRequest_Table_Filter struct {
 
 func (x *WatchEventRequest_Table_Filter) Reset() {
 	*x = WatchEventRequest_Table_Filter{}
-	mi := &file_api_gobgp_proto_msgTypes[205]
+	mi := &file_api_gobgp_proto_msgTypes[213]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13421,7 +13789,7 @@ func (x *WatchEventRequest_Table_Filter) String() string {
 func (*WatchEventRequest_Table_Filter) ProtoMessage() {}
 
 func (x *WatchEventRequest_Table_Filter) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[205]
+	mi := &file_api_gobgp_proto_msgTypes[213]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13475,7 +13843,7 @@ type WatchEventResponse_PeerEvent struct {
 
 func (x *WatchEventResponse_PeerEvent) Reset() {
 	*x = WatchEventResponse_PeerEvent{}
-	mi := &file_api_gobgp_proto_msgTypes[206]
+	mi := &file_api_gobgp_proto_msgTypes[214]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13487,7 +13855,7 @@ func (x *WatchEventResponse_PeerEvent) String() string {
 func (*WatchEventResponse_PeerEvent) ProtoMessage() {}
 
 func (x *WatchEventResponse_PeerEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[206]
+	mi := &file_api_gobgp_proto_msgTypes[214]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13526,7 +13894,7 @@ type WatchEventResponse_TableEvent struct {
 
 func (x *WatchEventResponse_TableEvent) Reset() {
 	*x = WatchEventResponse_TableEvent{}
-	mi := &file_api_gobgp_proto_msgTypes[207]
+	mi := &file_api_gobgp_proto_msgTypes[215]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13538,7 +13906,7 @@ func (x *WatchEventResponse_TableEvent) String() string {
 func (*WatchEventResponse_TableEvent) ProtoMessage() {}
 
 func (x *WatchEventResponse_TableEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[207]
+	mi := &file_api_gobgp_proto_msgTypes[215]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13571,7 +13939,7 @@ type ListBmpResponse_BmpStation struct {
 
 func (x *ListBmpResponse_BmpStation) Reset() {
 	*x = ListBmpResponse_BmpStation{}
-	mi := &file_api_gobgp_proto_msgTypes[208]
+	mi := &file_api_gobgp_proto_msgTypes[216]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13583,7 +13951,7 @@ func (x *ListBmpResponse_BmpStation) String() string {
 func (*ListBmpResponse_BmpStation) ProtoMessage() {}
 
 func (x *ListBmpResponse_BmpStation) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[208]
+	mi := &file_api_gobgp_proto_msgTypes[216]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13623,7 +13991,7 @@ type ListBmpResponse_BmpStation_Conf struct {
 
 func (x *ListBmpResponse_BmpStation_Conf) Reset() {
 	*x = ListBmpResponse_BmpStation_Conf{}
-	mi := &file_api_gobgp_proto_msgTypes[209]
+	mi := &file_api_gobgp_proto_msgTypes[217]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13635,7 +14003,7 @@ func (x *ListBmpResponse_BmpStation_Conf) String() string {
 func (*ListBmpResponse_BmpStation_Conf) ProtoMessage() {}
 
 func (x *ListBmpResponse_BmpStation_Conf) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[209]
+	mi := &file_api_gobgp_proto_msgTypes[217]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13675,7 +14043,7 @@ type ListBmpResponse_BmpStation_State struct {
 
 func (x *ListBmpResponse_BmpStation_State) Reset() {
 	*x = ListBmpResponse_BmpStation_State{}
-	mi := &file_api_gobgp_proto_msgTypes[210]
+	mi := &file_api_gobgp_proto_msgTypes[218]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13687,7 +14055,7 @@ func (x *ListBmpResponse_BmpStation_State) String() string {
 func (*ListBmpResponse_BmpStation_State) ProtoMessage() {}
 
 func (x *ListBmpResponse_BmpStation_State) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[210]
+	mi := &file_api_gobgp_proto_msgTypes[218]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14693,7 +15061,26 @@ const file_api_gobgp_proto_rawDesc = "" +
 	"\x18ListTcpAoKeychainRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"K\n" +
 	"\x19ListTcpAoKeychainResponse\x12.\n" +
-	"\bkeychain\x18\x01 \x01(\v2\x12.api.TcpAoKeychainR\bkeychain*\x97\x01\n" +
+	"\bkeychain\x18\x01 \x01(\v2\x12.api.TcpAoKeychainR\bkeychain\"\x85\x01\n" +
+	"\x10AggregateAddress\x12\x16\n" +
+	"\x06prefix\x18\x01 \x01(\tR\x06prefix\x12!\n" +
+	"\fsummary_only\x18\x02 \x01(\bR\vsummaryOnly\x12\x1f\n" +
+	"\vpolicy_name\x18\x03 \x01(\tR\n" +
+	"policyName\x12\x15\n" +
+	"\x06as_set\x18\x04 \x01(\bR\x05asSet\"v\n" +
+	"\x14AggregateAddressInfo\x123\n" +
+	"\taggregate\x18\x01 \x01(\v2\x15.api.AggregateAddressR\taggregate\x12)\n" +
+	"\x10num_contributors\x18\x02 \x01(\rR\x0fnumContributors\"J\n" +
+	"\x13AddAggregateRequest\x123\n" +
+	"\taggregate\x18\x01 \x01(\v2\x15.api.AggregateAddressR\taggregate\"\x16\n" +
+	"\x14AddAggregateResponse\"0\n" +
+	"\x16DeleteAggregateRequest\x12\x16\n" +
+	"\x06prefix\x18\x01 \x01(\tR\x06prefix\"\x19\n" +
+	"\x17DeleteAggregateResponse\";\n" +
+	"\x14ListAggregateRequest\x12#\n" +
+	"\x06family\x18\x01 \x01(\v2\v.api.FamilyR\x06family\"P\n" +
+	"\x15ListAggregateResponse\x127\n" +
+	"\taggregate\x18\x01 \x01(\v2\x19.api.AggregateAddressInfoR\taggregate*\x97\x01\n" +
 	"\tTableType\x12\x1a\n" +
 	"\x16TABLE_TYPE_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11TABLE_TYPE_GLOBAL\x10\x01\x12\x14\n" +
@@ -14766,7 +15153,7 @@ const file_api_gobgp_proto_rawDesc = "" +
 	"\x1dTCP_AO_ALGORITHM_HMAC_SHA1_96\x10\x01\x12$\n" +
 	" TCP_AO_ALGORITHM_AES_128_CMAC_96\x10\x02\x12#\n" +
 	"\x1fTCP_AO_ALGORITHM_HMAC_SHA256_96\x10\x03\x12$\n" +
-	" TCP_AO_ALGORITHM_HMAC_SHA256_128\x10\x042\xef\x1f\n" +
+	" TCP_AO_ALGORITHM_HMAC_SHA256_128\x10\x042\xcc!\n" +
 	"\fGoBgpService\x127\n" +
 	"\bStartBgp\x12\x14.api.StartBgpRequest\x1a\x15.api.StartBgpResponse\x124\n" +
 	"\aStopBgp\x12\x13.api.StopBgpRequest\x1a\x14.api.StopBgpResponse\x121\n" +
@@ -14799,7 +15186,10 @@ const file_api_gobgp_proto_rawDesc = "" +
 	"\bGetTable\x12\x14.api.GetTableRequest\x1a\x15.api.GetTableResponse\x121\n" +
 	"\x06AddVrf\x12\x12.api.AddVrfRequest\x1a\x13.api.AddVrfResponse\x12:\n" +
 	"\tDeleteVrf\x12\x15.api.DeleteVrfRequest\x1a\x16.api.DeleteVrfResponse\x126\n" +
-	"\aListVrf\x12\x13.api.ListVrfRequest\x1a\x14.api.ListVrfResponse0\x01\x12:\n" +
+	"\aListVrf\x12\x13.api.ListVrfRequest\x1a\x14.api.ListVrfResponse0\x01\x12C\n" +
+	"\fAddAggregate\x12\x18.api.AddAggregateRequest\x1a\x19.api.AddAggregateResponse\x12L\n" +
+	"\x0fDeleteAggregate\x12\x1b.api.DeleteAggregateRequest\x1a\x1c.api.DeleteAggregateResponse\x12H\n" +
+	"\rListAggregate\x12\x19.api.ListAggregateRequest\x1a\x1a.api.ListAggregateResponse0\x01\x12:\n" +
 	"\tAddPolicy\x12\x15.api.AddPolicyRequest\x1a\x16.api.AddPolicyResponse\x12C\n" +
 	"\fDeletePolicy\x12\x18.api.DeletePolicyRequest\x1a\x19.api.DeletePolicyResponse\x12?\n" +
 	"\n" +
@@ -14850,7 +15240,7 @@ func file_api_gobgp_proto_rawDescGZIP() []byte {
 }
 
 var file_api_gobgp_proto_enumTypes = make([]protoimpl.EnumInfo, 28)
-var file_api_gobgp_proto_msgTypes = make([]protoimpl.MessageInfo, 211)
+var file_api_gobgp_proto_msgTypes = make([]protoimpl.MessageInfo, 219)
 var file_api_gobgp_proto_goTypes = []any{
 	(TableType)(0),                           // 0: api.TableType
 	(ValidationState)(0),                     // 1: api.ValidationState
@@ -15083,29 +15473,37 @@ var file_api_gobgp_proto_goTypes = []any{
 	(*DeleteTcpAoKeychainResponse)(nil),      // 228: api.DeleteTcpAoKeychainResponse
 	(*ListTcpAoKeychainRequest)(nil),         // 229: api.ListTcpAoKeychainRequest
 	(*ListTcpAoKeychainResponse)(nil),        // 230: api.ListTcpAoKeychainResponse
-	(*WatchEventRequest_Peer)(nil),           // 231: api.WatchEventRequest.Peer
-	(*WatchEventRequest_Table)(nil),          // 232: api.WatchEventRequest.Table
-	(*WatchEventRequest_Table_Filter)(nil),   // 233: api.WatchEventRequest.Table.Filter
-	(*WatchEventResponse_PeerEvent)(nil),     // 234: api.WatchEventResponse.PeerEvent
-	(*WatchEventResponse_TableEvent)(nil),    // 235: api.WatchEventResponse.TableEvent
-	(*ListBmpResponse_BmpStation)(nil),       // 236: api.ListBmpResponse.BmpStation
-	(*ListBmpResponse_BmpStation_Conf)(nil),  // 237: api.ListBmpResponse.BmpStation.Conf
-	(*ListBmpResponse_BmpStation_State)(nil), // 238: api.ListBmpResponse.BmpStation.State
-	(*Family)(nil),                           // 239: api.Family
-	(*NLRI)(nil),                             // 240: api.NLRI
-	(*Attribute)(nil),                        // 241: api.Attribute
-	(*timestamppb.Timestamp)(nil),            // 242: google.protobuf.Timestamp
-	(*Capability)(nil),                       // 243: api.Capability
-	(*RouteDistinguisher)(nil),               // 244: api.RouteDistinguisher
-	(*RouteTarget)(nil),                      // 245: api.RouteTarget
+	(*AggregateAddress)(nil),                 // 231: api.AggregateAddress
+	(*AggregateAddressInfo)(nil),             // 232: api.AggregateAddressInfo
+	(*AddAggregateRequest)(nil),              // 233: api.AddAggregateRequest
+	(*AddAggregateResponse)(nil),             // 234: api.AddAggregateResponse
+	(*DeleteAggregateRequest)(nil),           // 235: api.DeleteAggregateRequest
+	(*DeleteAggregateResponse)(nil),          // 236: api.DeleteAggregateResponse
+	(*ListAggregateRequest)(nil),             // 237: api.ListAggregateRequest
+	(*ListAggregateResponse)(nil),            // 238: api.ListAggregateResponse
+	(*WatchEventRequest_Peer)(nil),           // 239: api.WatchEventRequest.Peer
+	(*WatchEventRequest_Table)(nil),          // 240: api.WatchEventRequest.Table
+	(*WatchEventRequest_Table_Filter)(nil),   // 241: api.WatchEventRequest.Table.Filter
+	(*WatchEventResponse_PeerEvent)(nil),     // 242: api.WatchEventResponse.PeerEvent
+	(*WatchEventResponse_TableEvent)(nil),    // 243: api.WatchEventResponse.TableEvent
+	(*ListBmpResponse_BmpStation)(nil),       // 244: api.ListBmpResponse.BmpStation
+	(*ListBmpResponse_BmpStation_Conf)(nil),  // 245: api.ListBmpResponse.BmpStation.Conf
+	(*ListBmpResponse_BmpStation_State)(nil), // 246: api.ListBmpResponse.BmpStation.State
+	(*Family)(nil),                           // 247: api.Family
+	(*NLRI)(nil),                             // 248: api.NLRI
+	(*Attribute)(nil),                        // 249: api.Attribute
+	(*timestamppb.Timestamp)(nil),            // 250: google.protobuf.Timestamp
+	(*Capability)(nil),                       // 251: api.Capability
+	(*RouteDistinguisher)(nil),               // 252: api.RouteDistinguisher
+	(*RouteTarget)(nil),                      // 253: api.RouteTarget
 }
 var file_api_gobgp_proto_depIdxs = []int32{
 	210, // 0: api.StartBgpRequest.global:type_name -> api.Global
 	210, // 1: api.GetBgpResponse.global:type_name -> api.Global
-	231, // 2: api.WatchEventRequest.peer:type_name -> api.WatchEventRequest.Peer
-	232, // 3: api.WatchEventRequest.table:type_name -> api.WatchEventRequest.Table
-	234, // 4: api.WatchEventResponse.peer:type_name -> api.WatchEventResponse.PeerEvent
-	235, // 5: api.WatchEventResponse.table:type_name -> api.WatchEventResponse.TableEvent
+	239, // 2: api.WatchEventRequest.peer:type_name -> api.WatchEventRequest.Peer
+	240, // 3: api.WatchEventRequest.table:type_name -> api.WatchEventRequest.Table
+	242, // 4: api.WatchEventResponse.peer:type_name -> api.WatchEventResponse.PeerEvent
+	243, // 5: api.WatchEventResponse.table:type_name -> api.WatchEventResponse.TableEvent
 	140, // 6: api.AddPeerRequest.peer:type_name -> api.Peer
 	140, // 7: api.ListPeerResponse.peer:type_name -> api.Peer
 	140, // 8: api.UpdatePeerRequest.peer:type_name -> api.Peer
@@ -15118,18 +15516,18 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	0,   // 15: api.AddPathRequest.table_type:type_name -> api.TableType
 	138, // 16: api.AddPathRequest.path:type_name -> api.Path
 	0,   // 17: api.DeletePathRequest.table_type:type_name -> api.TableType
-	239, // 18: api.DeletePathRequest.family:type_name -> api.Family
+	247, // 18: api.DeletePathRequest.family:type_name -> api.Family
 	138, // 19: api.DeletePathRequest.path:type_name -> api.Path
 	15,  // 20: api.TableLookupPrefix.type:type_name -> api.TableLookupPrefix.Type
 	0,   // 21: api.ListPathRequest.table_type:type_name -> api.TableType
-	239, // 22: api.ListPathRequest.family:type_name -> api.Family
+	247, // 22: api.ListPathRequest.family:type_name -> api.Family
 	70,  // 23: api.ListPathRequest.prefixes:type_name -> api.TableLookupPrefix
 	16,  // 24: api.ListPathRequest.sort_type:type_name -> api.ListPathRequest.SortType
 	139, // 25: api.ListPathResponse.destination:type_name -> api.Destination
 	0,   // 26: api.AddPathStreamRequest.table_type:type_name -> api.TableType
 	138, // 27: api.AddPathStreamRequest.paths:type_name -> api.Path
 	0,   // 28: api.GetTableRequest.table_type:type_name -> api.TableType
-	239, // 29: api.GetTableRequest.family:type_name -> api.Family
+	247, // 29: api.GetTableRequest.family:type_name -> api.Family
 	208, // 30: api.AddVrfRequest.vrf:type_name -> api.Vrf
 	208, // 31: api.ListVrfResponse.vrf:type_name -> api.Vrf
 	204, // 32: api.AddPolicyRequest.policy:type_name -> api.Policy
@@ -15150,23 +15548,23 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	8,   // 47: api.ListPolicyAssignmentRequest.direction:type_name -> api.PolicyDirection
 	205, // 48: api.ListPolicyAssignmentResponse.assignment:type_name -> api.PolicyAssignment
 	205, // 49: api.SetPolicyAssignmentRequest.assignment:type_name -> api.PolicyAssignment
-	239, // 50: api.ListRpkiRequest.family:type_name -> api.Family
+	247, // 50: api.ListRpkiRequest.family:type_name -> api.Family
 	214, // 51: api.ListRpkiResponse.server:type_name -> api.Rpki
-	239, // 52: api.ListRpkiTableRequest.family:type_name -> api.Family
+	247, // 52: api.ListRpkiTableRequest.family:type_name -> api.Family
 	207, // 53: api.ListRpkiTableResponse.roa:type_name -> api.Roa
 	17,  // 54: api.EnableMrtRequest.dump_type:type_name -> api.EnableMrtRequest.DumpType
 	18,  // 55: api.AddBmpRequest.policy:type_name -> api.AddBmpRequest.MonitoringPolicy
-	236, // 56: api.ListBmpResponse.station:type_name -> api.ListBmpResponse.BmpStation
+	244, // 56: api.ListBmpResponse.station:type_name -> api.ListBmpResponse.BmpStation
 	1,   // 57: api.Validation.state:type_name -> api.ValidationState
 	19,  // 58: api.Validation.reason:type_name -> api.Validation.Reason
 	207, // 59: api.Validation.matched:type_name -> api.Roa
 	207, // 60: api.Validation.unmatched_asn:type_name -> api.Roa
 	207, // 61: api.Validation.unmatched_length:type_name -> api.Roa
-	240, // 62: api.Path.nlri:type_name -> api.NLRI
-	241, // 63: api.Path.pattrs:type_name -> api.Attribute
-	242, // 64: api.Path.age:type_name -> google.protobuf.Timestamp
+	248, // 62: api.Path.nlri:type_name -> api.NLRI
+	249, // 63: api.Path.pattrs:type_name -> api.Attribute
+	250, // 64: api.Path.age:type_name -> google.protobuf.Timestamp
 	137, // 65: api.Path.validation:type_name -> api.Validation
-	239, // 66: api.Path.family:type_name -> api.Family
+	247, // 66: api.Path.family:type_name -> api.Family
 	138, // 67: api.Destination.paths:type_name -> api.Path
 	143, // 68: api.Peer.apply_policy:type_name -> api.ApplyPolicy
 	145, // 69: api.Peer.conf:type_name -> api.PeerConf
@@ -15194,7 +15592,7 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	219, // 91: api.PeerGroup.bfd:type_name -> api.BfdPeerConfig
 	205, // 92: api.ApplyPolicy.export_policy:type_name -> api.PolicyAssignment
 	205, // 93: api.ApplyPolicy.import_policy:type_name -> api.PolicyAssignment
-	239, // 94: api.PrefixLimit.family:type_name -> api.Family
+	247, // 94: api.PrefixLimit.family:type_name -> api.Family
 	2,   // 95: api.PeerConf.type:type_name -> api.PeerType
 	3,   // 96: api.PeerConf.remove_private:type_name -> api.RemovePrivate
 	2,   // 97: api.PeerGroupConf.type:type_name -> api.PeerType
@@ -15207,20 +15605,20 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	3,   // 104: api.PeerState.remove_private:type_name -> api.RemovePrivate
 	20,  // 105: api.PeerState.session_state:type_name -> api.PeerState.SessionState
 	21,  // 106: api.PeerState.admin_state:type_name -> api.PeerState.AdminState
-	243, // 107: api.PeerState.remote_cap:type_name -> api.Capability
-	243, // 108: api.PeerState.local_cap:type_name -> api.Capability
+	251, // 107: api.PeerState.remote_cap:type_name -> api.Capability
+	251, // 108: api.PeerState.local_cap:type_name -> api.Capability
 	22,  // 109: api.PeerState.disconnect_reason:type_name -> api.PeerState.DisconnectReason
 	218, // 110: api.PeerState.bfd_state:type_name -> api.BfdPeerState
 	153, // 111: api.Messages.received:type_name -> api.Message
 	153, // 112: api.Messages.sent:type_name -> api.Message
 	156, // 113: api.Timers.config:type_name -> api.TimersConfig
 	157, // 114: api.Timers.state:type_name -> api.TimersState
-	242, // 115: api.TimersState.uptime:type_name -> google.protobuf.Timestamp
-	242, // 116: api.TimersState.downtime:type_name -> google.protobuf.Timestamp
+	250, // 115: api.TimersState.uptime:type_name -> google.protobuf.Timestamp
+	250, // 116: api.TimersState.downtime:type_name -> google.protobuf.Timestamp
 	161, // 117: api.MpGracefulRestart.config:type_name -> api.MpGracefulRestartConfig
 	162, // 118: api.MpGracefulRestart.state:type_name -> api.MpGracefulRestartState
-	239, // 119: api.AfiSafiConfig.family:type_name -> api.Family
-	239, // 120: api.AfiSafiState.family:type_name -> api.Family
+	247, // 119: api.AfiSafiConfig.family:type_name -> api.Family
+	247, // 120: api.AfiSafiState.family:type_name -> api.Family
 	166, // 121: api.RouteSelectionOptions.config:type_name -> api.RouteSelectionOptionsConfig
 	167, // 122: api.RouteSelectionOptions.state:type_name -> api.RouteSelectionOptionsState
 	171, // 123: api.Ebgp.config:type_name -> api.EbgpConfig
@@ -15261,7 +15659,7 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	1,   // 158: api.Conditions.rpki_result:type_name -> api.ValidationState
 	24,  // 159: api.Conditions.route_type:type_name -> api.Conditions.RouteType
 	190, // 160: api.Conditions.large_community_set:type_name -> api.MatchSet
-	239, // 161: api.Conditions.afi_safi_in:type_name -> api.Family
+	247, // 161: api.Conditions.afi_safi_in:type_name -> api.Family
 	192, // 162: api.Conditions.community_count:type_name -> api.CommunityCount
 	6,   // 163: api.Conditions.origin:type_name -> api.OriginType
 	193, // 164: api.Conditions.local_pref_eq:type_name -> api.LocalPrefEq
@@ -15287,15 +15685,15 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	189, // 184: api.RoutingPolicy.defined_sets:type_name -> api.DefinedSet
 	204, // 185: api.RoutingPolicy.policies:type_name -> api.Policy
 	212, // 186: api.Roa.conf:type_name -> api.RPKIConf
-	244, // 187: api.Vrf.rd:type_name -> api.RouteDistinguisher
-	245, // 188: api.Vrf.import_rt:type_name -> api.RouteTarget
-	245, // 189: api.Vrf.export_rt:type_name -> api.RouteTarget
+	252, // 187: api.Vrf.rd:type_name -> api.RouteDistinguisher
+	253, // 188: api.Vrf.import_rt:type_name -> api.RouteTarget
+	253, // 189: api.Vrf.export_rt:type_name -> api.RouteTarget
 	166, // 190: api.Global.route_selection_options:type_name -> api.RouteSelectionOptionsConfig
 	209, // 191: api.Global.default_route_distance:type_name -> api.DefaultRouteDistance
 	211, // 192: api.Global.confederation:type_name -> api.Confederation
 	160, // 193: api.Global.graceful_restart:type_name -> api.GracefulRestart
-	242, // 194: api.RPKIState.uptime:type_name -> google.protobuf.Timestamp
-	242, // 195: api.RPKIState.downtime:type_name -> google.protobuf.Timestamp
+	250, // 194: api.RPKIState.uptime:type_name -> google.protobuf.Timestamp
+	250, // 195: api.RPKIState.downtime:type_name -> google.protobuf.Timestamp
 	212, // 196: api.Rpki.conf:type_name -> api.RPKIConf
 	213, // 197: api.Rpki.state:type_name -> api.RPKIState
 	27,  // 198: api.SetLogLevelRequest.level:type_name -> api.SetLogLevelRequest.Level
@@ -15311,138 +15709,148 @@ var file_api_gobgp_proto_depIdxs = []int32{
 	221, // 208: api.UpdateTcpAoKeychainRequest.delete_keys:type_name -> api.TcpAoKey
 	222, // 209: api.UpdateTcpAoKeychainResponse.keychain:type_name -> api.TcpAoKeychain
 	222, // 210: api.ListTcpAoKeychainResponse.keychain:type_name -> api.TcpAoKeychain
-	233, // 211: api.WatchEventRequest.Table.filters:type_name -> api.WatchEventRequest.Table.Filter
-	12,  // 212: api.WatchEventRequest.Table.Filter.type:type_name -> api.WatchEventRequest.Table.Filter.Type
-	13,  // 213: api.WatchEventResponse.PeerEvent.type:type_name -> api.WatchEventResponse.PeerEvent.Type
-	140, // 214: api.WatchEventResponse.PeerEvent.peer:type_name -> api.Peer
-	138, // 215: api.WatchEventResponse.TableEvent.paths:type_name -> api.Path
-	237, // 216: api.ListBmpResponse.BmpStation.conf:type_name -> api.ListBmpResponse.BmpStation.Conf
-	238, // 217: api.ListBmpResponse.BmpStation.state:type_name -> api.ListBmpResponse.BmpStation.State
-	242, // 218: api.ListBmpResponse.BmpStation.State.uptime:type_name -> google.protobuf.Timestamp
-	242, // 219: api.ListBmpResponse.BmpStation.State.downtime:type_name -> google.protobuf.Timestamp
-	28,  // 220: api.GoBgpService.StartBgp:input_type -> api.StartBgpRequest
-	30,  // 221: api.GoBgpService.StopBgp:input_type -> api.StopBgpRequest
-	32,  // 222: api.GoBgpService.GetBgp:input_type -> api.GetBgpRequest
-	34,  // 223: api.GoBgpService.WatchEvent:input_type -> api.WatchEventRequest
-	36,  // 224: api.GoBgpService.AddPeer:input_type -> api.AddPeerRequest
-	38,  // 225: api.GoBgpService.DeletePeer:input_type -> api.DeletePeerRequest
-	40,  // 226: api.GoBgpService.ListPeer:input_type -> api.ListPeerRequest
-	42,  // 227: api.GoBgpService.UpdatePeer:input_type -> api.UpdatePeerRequest
-	44,  // 228: api.GoBgpService.ResetPeer:input_type -> api.ResetPeerRequest
-	46,  // 229: api.GoBgpService.ShutdownPeer:input_type -> api.ShutdownPeerRequest
-	48,  // 230: api.GoBgpService.EnablePeer:input_type -> api.EnablePeerRequest
-	50,  // 231: api.GoBgpService.DisablePeer:input_type -> api.DisablePeerRequest
-	52,  // 232: api.GoBgpService.AddPeerGroup:input_type -> api.AddPeerGroupRequest
-	54,  // 233: api.GoBgpService.DeletePeerGroup:input_type -> api.DeletePeerGroupRequest
-	58,  // 234: api.GoBgpService.ListPeerGroup:input_type -> api.ListPeerGroupRequest
-	56,  // 235: api.GoBgpService.UpdatePeerGroup:input_type -> api.UpdatePeerGroupRequest
-	60,  // 236: api.GoBgpService.AddDynamicNeighbor:input_type -> api.AddDynamicNeighborRequest
-	64,  // 237: api.GoBgpService.ListDynamicNeighbor:input_type -> api.ListDynamicNeighborRequest
-	62,  // 238: api.GoBgpService.DeleteDynamicNeighbor:input_type -> api.DeleteDynamicNeighborRequest
-	66,  // 239: api.GoBgpService.AddPath:input_type -> api.AddPathRequest
-	68,  // 240: api.GoBgpService.DeletePath:input_type -> api.DeletePathRequest
-	71,  // 241: api.GoBgpService.ListPath:input_type -> api.ListPathRequest
-	73,  // 242: api.GoBgpService.AddPathStream:input_type -> api.AddPathStreamRequest
-	75,  // 243: api.GoBgpService.GetTable:input_type -> api.GetTableRequest
-	77,  // 244: api.GoBgpService.AddVrf:input_type -> api.AddVrfRequest
-	79,  // 245: api.GoBgpService.DeleteVrf:input_type -> api.DeleteVrfRequest
-	81,  // 246: api.GoBgpService.ListVrf:input_type -> api.ListVrfRequest
-	83,  // 247: api.GoBgpService.AddPolicy:input_type -> api.AddPolicyRequest
-	85,  // 248: api.GoBgpService.DeletePolicy:input_type -> api.DeletePolicyRequest
-	87,  // 249: api.GoBgpService.ListPolicy:input_type -> api.ListPolicyRequest
-	89,  // 250: api.GoBgpService.SetPolicies:input_type -> api.SetPoliciesRequest
-	91,  // 251: api.GoBgpService.AddDefinedSet:input_type -> api.AddDefinedSetRequest
-	93,  // 252: api.GoBgpService.DeleteDefinedSet:input_type -> api.DeleteDefinedSetRequest
-	95,  // 253: api.GoBgpService.ListDefinedSet:input_type -> api.ListDefinedSetRequest
-	97,  // 254: api.GoBgpService.AddStatement:input_type -> api.AddStatementRequest
-	99,  // 255: api.GoBgpService.DeleteStatement:input_type -> api.DeleteStatementRequest
-	101, // 256: api.GoBgpService.ListStatement:input_type -> api.ListStatementRequest
-	103, // 257: api.GoBgpService.AddPolicyAssignment:input_type -> api.AddPolicyAssignmentRequest
-	105, // 258: api.GoBgpService.DeletePolicyAssignment:input_type -> api.DeletePolicyAssignmentRequest
-	107, // 259: api.GoBgpService.ListPolicyAssignment:input_type -> api.ListPolicyAssignmentRequest
-	109, // 260: api.GoBgpService.SetPolicyAssignment:input_type -> api.SetPolicyAssignmentRequest
-	111, // 261: api.GoBgpService.AddRpki:input_type -> api.AddRpkiRequest
-	113, // 262: api.GoBgpService.DeleteRpki:input_type -> api.DeleteRpkiRequest
-	115, // 263: api.GoBgpService.ListRpki:input_type -> api.ListRpkiRequest
-	117, // 264: api.GoBgpService.EnableRpki:input_type -> api.EnableRpkiRequest
-	119, // 265: api.GoBgpService.DisableRpki:input_type -> api.DisableRpkiRequest
-	121, // 266: api.GoBgpService.ResetRpki:input_type -> api.ResetRpkiRequest
-	123, // 267: api.GoBgpService.ListRpkiTable:input_type -> api.ListRpkiTableRequest
-	125, // 268: api.GoBgpService.EnableZebra:input_type -> api.EnableZebraRequest
-	127, // 269: api.GoBgpService.EnableMrt:input_type -> api.EnableMrtRequest
-	129, // 270: api.GoBgpService.DisableMrt:input_type -> api.DisableMrtRequest
-	131, // 271: api.GoBgpService.AddBmp:input_type -> api.AddBmpRequest
-	133, // 272: api.GoBgpService.DeleteBmp:input_type -> api.DeleteBmpRequest
-	135, // 273: api.GoBgpService.ListBmp:input_type -> api.ListBmpRequest
-	215, // 274: api.GoBgpService.SetLogLevel:input_type -> api.SetLogLevelRequest
-	223, // 275: api.GoBgpService.AddTcpAoKeychain:input_type -> api.AddTcpAoKeychainRequest
-	225, // 276: api.GoBgpService.UpdateTcpAoKeychain:input_type -> api.UpdateTcpAoKeychainRequest
-	227, // 277: api.GoBgpService.DeleteTcpAoKeychain:input_type -> api.DeleteTcpAoKeychainRequest
-	229, // 278: api.GoBgpService.ListTcpAoKeychain:input_type -> api.ListTcpAoKeychainRequest
-	29,  // 279: api.GoBgpService.StartBgp:output_type -> api.StartBgpResponse
-	31,  // 280: api.GoBgpService.StopBgp:output_type -> api.StopBgpResponse
-	33,  // 281: api.GoBgpService.GetBgp:output_type -> api.GetBgpResponse
-	35,  // 282: api.GoBgpService.WatchEvent:output_type -> api.WatchEventResponse
-	37,  // 283: api.GoBgpService.AddPeer:output_type -> api.AddPeerResponse
-	39,  // 284: api.GoBgpService.DeletePeer:output_type -> api.DeletePeerResponse
-	41,  // 285: api.GoBgpService.ListPeer:output_type -> api.ListPeerResponse
-	43,  // 286: api.GoBgpService.UpdatePeer:output_type -> api.UpdatePeerResponse
-	45,  // 287: api.GoBgpService.ResetPeer:output_type -> api.ResetPeerResponse
-	47,  // 288: api.GoBgpService.ShutdownPeer:output_type -> api.ShutdownPeerResponse
-	49,  // 289: api.GoBgpService.EnablePeer:output_type -> api.EnablePeerResponse
-	51,  // 290: api.GoBgpService.DisablePeer:output_type -> api.DisablePeerResponse
-	53,  // 291: api.GoBgpService.AddPeerGroup:output_type -> api.AddPeerGroupResponse
-	55,  // 292: api.GoBgpService.DeletePeerGroup:output_type -> api.DeletePeerGroupResponse
-	59,  // 293: api.GoBgpService.ListPeerGroup:output_type -> api.ListPeerGroupResponse
-	57,  // 294: api.GoBgpService.UpdatePeerGroup:output_type -> api.UpdatePeerGroupResponse
-	61,  // 295: api.GoBgpService.AddDynamicNeighbor:output_type -> api.AddDynamicNeighborResponse
-	65,  // 296: api.GoBgpService.ListDynamicNeighbor:output_type -> api.ListDynamicNeighborResponse
-	63,  // 297: api.GoBgpService.DeleteDynamicNeighbor:output_type -> api.DeleteDynamicNeighborResponse
-	67,  // 298: api.GoBgpService.AddPath:output_type -> api.AddPathResponse
-	69,  // 299: api.GoBgpService.DeletePath:output_type -> api.DeletePathResponse
-	72,  // 300: api.GoBgpService.ListPath:output_type -> api.ListPathResponse
-	74,  // 301: api.GoBgpService.AddPathStream:output_type -> api.AddPathStreamResponse
-	76,  // 302: api.GoBgpService.GetTable:output_type -> api.GetTableResponse
-	78,  // 303: api.GoBgpService.AddVrf:output_type -> api.AddVrfResponse
-	80,  // 304: api.GoBgpService.DeleteVrf:output_type -> api.DeleteVrfResponse
-	82,  // 305: api.GoBgpService.ListVrf:output_type -> api.ListVrfResponse
-	84,  // 306: api.GoBgpService.AddPolicy:output_type -> api.AddPolicyResponse
-	86,  // 307: api.GoBgpService.DeletePolicy:output_type -> api.DeletePolicyResponse
-	88,  // 308: api.GoBgpService.ListPolicy:output_type -> api.ListPolicyResponse
-	90,  // 309: api.GoBgpService.SetPolicies:output_type -> api.SetPoliciesResponse
-	92,  // 310: api.GoBgpService.AddDefinedSet:output_type -> api.AddDefinedSetResponse
-	94,  // 311: api.GoBgpService.DeleteDefinedSet:output_type -> api.DeleteDefinedSetResponse
-	96,  // 312: api.GoBgpService.ListDefinedSet:output_type -> api.ListDefinedSetResponse
-	98,  // 313: api.GoBgpService.AddStatement:output_type -> api.AddStatementResponse
-	100, // 314: api.GoBgpService.DeleteStatement:output_type -> api.DeleteStatementResponse
-	102, // 315: api.GoBgpService.ListStatement:output_type -> api.ListStatementResponse
-	104, // 316: api.GoBgpService.AddPolicyAssignment:output_type -> api.AddPolicyAssignmentResponse
-	106, // 317: api.GoBgpService.DeletePolicyAssignment:output_type -> api.DeletePolicyAssignmentResponse
-	108, // 318: api.GoBgpService.ListPolicyAssignment:output_type -> api.ListPolicyAssignmentResponse
-	110, // 319: api.GoBgpService.SetPolicyAssignment:output_type -> api.SetPolicyAssignmentResponse
-	112, // 320: api.GoBgpService.AddRpki:output_type -> api.AddRpkiResponse
-	114, // 321: api.GoBgpService.DeleteRpki:output_type -> api.DeleteRpkiResponse
-	116, // 322: api.GoBgpService.ListRpki:output_type -> api.ListRpkiResponse
-	118, // 323: api.GoBgpService.EnableRpki:output_type -> api.EnableRpkiResponse
-	120, // 324: api.GoBgpService.DisableRpki:output_type -> api.DisableRpkiResponse
-	122, // 325: api.GoBgpService.ResetRpki:output_type -> api.ResetRpkiResponse
-	124, // 326: api.GoBgpService.ListRpkiTable:output_type -> api.ListRpkiTableResponse
-	126, // 327: api.GoBgpService.EnableZebra:output_type -> api.EnableZebraResponse
-	128, // 328: api.GoBgpService.EnableMrt:output_type -> api.EnableMrtResponse
-	130, // 329: api.GoBgpService.DisableMrt:output_type -> api.DisableMrtResponse
-	132, // 330: api.GoBgpService.AddBmp:output_type -> api.AddBmpResponse
-	134, // 331: api.GoBgpService.DeleteBmp:output_type -> api.DeleteBmpResponse
-	136, // 332: api.GoBgpService.ListBmp:output_type -> api.ListBmpResponse
-	216, // 333: api.GoBgpService.SetLogLevel:output_type -> api.SetLogLevelResponse
-	224, // 334: api.GoBgpService.AddTcpAoKeychain:output_type -> api.AddTcpAoKeychainResponse
-	226, // 335: api.GoBgpService.UpdateTcpAoKeychain:output_type -> api.UpdateTcpAoKeychainResponse
-	228, // 336: api.GoBgpService.DeleteTcpAoKeychain:output_type -> api.DeleteTcpAoKeychainResponse
-	230, // 337: api.GoBgpService.ListTcpAoKeychain:output_type -> api.ListTcpAoKeychainResponse
-	279, // [279:338] is the sub-list for method output_type
-	220, // [220:279] is the sub-list for method input_type
-	220, // [220:220] is the sub-list for extension type_name
-	220, // [220:220] is the sub-list for extension extendee
-	0,   // [0:220] is the sub-list for field type_name
+	231, // 211: api.AggregateAddressInfo.aggregate:type_name -> api.AggregateAddress
+	231, // 212: api.AddAggregateRequest.aggregate:type_name -> api.AggregateAddress
+	247, // 213: api.ListAggregateRequest.family:type_name -> api.Family
+	232, // 214: api.ListAggregateResponse.aggregate:type_name -> api.AggregateAddressInfo
+	241, // 215: api.WatchEventRequest.Table.filters:type_name -> api.WatchEventRequest.Table.Filter
+	12,  // 216: api.WatchEventRequest.Table.Filter.type:type_name -> api.WatchEventRequest.Table.Filter.Type
+	13,  // 217: api.WatchEventResponse.PeerEvent.type:type_name -> api.WatchEventResponse.PeerEvent.Type
+	140, // 218: api.WatchEventResponse.PeerEvent.peer:type_name -> api.Peer
+	138, // 219: api.WatchEventResponse.TableEvent.paths:type_name -> api.Path
+	245, // 220: api.ListBmpResponse.BmpStation.conf:type_name -> api.ListBmpResponse.BmpStation.Conf
+	246, // 221: api.ListBmpResponse.BmpStation.state:type_name -> api.ListBmpResponse.BmpStation.State
+	250, // 222: api.ListBmpResponse.BmpStation.State.uptime:type_name -> google.protobuf.Timestamp
+	250, // 223: api.ListBmpResponse.BmpStation.State.downtime:type_name -> google.protobuf.Timestamp
+	28,  // 224: api.GoBgpService.StartBgp:input_type -> api.StartBgpRequest
+	30,  // 225: api.GoBgpService.StopBgp:input_type -> api.StopBgpRequest
+	32,  // 226: api.GoBgpService.GetBgp:input_type -> api.GetBgpRequest
+	34,  // 227: api.GoBgpService.WatchEvent:input_type -> api.WatchEventRequest
+	36,  // 228: api.GoBgpService.AddPeer:input_type -> api.AddPeerRequest
+	38,  // 229: api.GoBgpService.DeletePeer:input_type -> api.DeletePeerRequest
+	40,  // 230: api.GoBgpService.ListPeer:input_type -> api.ListPeerRequest
+	42,  // 231: api.GoBgpService.UpdatePeer:input_type -> api.UpdatePeerRequest
+	44,  // 232: api.GoBgpService.ResetPeer:input_type -> api.ResetPeerRequest
+	46,  // 233: api.GoBgpService.ShutdownPeer:input_type -> api.ShutdownPeerRequest
+	48,  // 234: api.GoBgpService.EnablePeer:input_type -> api.EnablePeerRequest
+	50,  // 235: api.GoBgpService.DisablePeer:input_type -> api.DisablePeerRequest
+	52,  // 236: api.GoBgpService.AddPeerGroup:input_type -> api.AddPeerGroupRequest
+	54,  // 237: api.GoBgpService.DeletePeerGroup:input_type -> api.DeletePeerGroupRequest
+	58,  // 238: api.GoBgpService.ListPeerGroup:input_type -> api.ListPeerGroupRequest
+	56,  // 239: api.GoBgpService.UpdatePeerGroup:input_type -> api.UpdatePeerGroupRequest
+	60,  // 240: api.GoBgpService.AddDynamicNeighbor:input_type -> api.AddDynamicNeighborRequest
+	64,  // 241: api.GoBgpService.ListDynamicNeighbor:input_type -> api.ListDynamicNeighborRequest
+	62,  // 242: api.GoBgpService.DeleteDynamicNeighbor:input_type -> api.DeleteDynamicNeighborRequest
+	66,  // 243: api.GoBgpService.AddPath:input_type -> api.AddPathRequest
+	68,  // 244: api.GoBgpService.DeletePath:input_type -> api.DeletePathRequest
+	71,  // 245: api.GoBgpService.ListPath:input_type -> api.ListPathRequest
+	73,  // 246: api.GoBgpService.AddPathStream:input_type -> api.AddPathStreamRequest
+	75,  // 247: api.GoBgpService.GetTable:input_type -> api.GetTableRequest
+	77,  // 248: api.GoBgpService.AddVrf:input_type -> api.AddVrfRequest
+	79,  // 249: api.GoBgpService.DeleteVrf:input_type -> api.DeleteVrfRequest
+	81,  // 250: api.GoBgpService.ListVrf:input_type -> api.ListVrfRequest
+	233, // 251: api.GoBgpService.AddAggregate:input_type -> api.AddAggregateRequest
+	235, // 252: api.GoBgpService.DeleteAggregate:input_type -> api.DeleteAggregateRequest
+	237, // 253: api.GoBgpService.ListAggregate:input_type -> api.ListAggregateRequest
+	83,  // 254: api.GoBgpService.AddPolicy:input_type -> api.AddPolicyRequest
+	85,  // 255: api.GoBgpService.DeletePolicy:input_type -> api.DeletePolicyRequest
+	87,  // 256: api.GoBgpService.ListPolicy:input_type -> api.ListPolicyRequest
+	89,  // 257: api.GoBgpService.SetPolicies:input_type -> api.SetPoliciesRequest
+	91,  // 258: api.GoBgpService.AddDefinedSet:input_type -> api.AddDefinedSetRequest
+	93,  // 259: api.GoBgpService.DeleteDefinedSet:input_type -> api.DeleteDefinedSetRequest
+	95,  // 260: api.GoBgpService.ListDefinedSet:input_type -> api.ListDefinedSetRequest
+	97,  // 261: api.GoBgpService.AddStatement:input_type -> api.AddStatementRequest
+	99,  // 262: api.GoBgpService.DeleteStatement:input_type -> api.DeleteStatementRequest
+	101, // 263: api.GoBgpService.ListStatement:input_type -> api.ListStatementRequest
+	103, // 264: api.GoBgpService.AddPolicyAssignment:input_type -> api.AddPolicyAssignmentRequest
+	105, // 265: api.GoBgpService.DeletePolicyAssignment:input_type -> api.DeletePolicyAssignmentRequest
+	107, // 266: api.GoBgpService.ListPolicyAssignment:input_type -> api.ListPolicyAssignmentRequest
+	109, // 267: api.GoBgpService.SetPolicyAssignment:input_type -> api.SetPolicyAssignmentRequest
+	111, // 268: api.GoBgpService.AddRpki:input_type -> api.AddRpkiRequest
+	113, // 269: api.GoBgpService.DeleteRpki:input_type -> api.DeleteRpkiRequest
+	115, // 270: api.GoBgpService.ListRpki:input_type -> api.ListRpkiRequest
+	117, // 271: api.GoBgpService.EnableRpki:input_type -> api.EnableRpkiRequest
+	119, // 272: api.GoBgpService.DisableRpki:input_type -> api.DisableRpkiRequest
+	121, // 273: api.GoBgpService.ResetRpki:input_type -> api.ResetRpkiRequest
+	123, // 274: api.GoBgpService.ListRpkiTable:input_type -> api.ListRpkiTableRequest
+	125, // 275: api.GoBgpService.EnableZebra:input_type -> api.EnableZebraRequest
+	127, // 276: api.GoBgpService.EnableMrt:input_type -> api.EnableMrtRequest
+	129, // 277: api.GoBgpService.DisableMrt:input_type -> api.DisableMrtRequest
+	131, // 278: api.GoBgpService.AddBmp:input_type -> api.AddBmpRequest
+	133, // 279: api.GoBgpService.DeleteBmp:input_type -> api.DeleteBmpRequest
+	135, // 280: api.GoBgpService.ListBmp:input_type -> api.ListBmpRequest
+	215, // 281: api.GoBgpService.SetLogLevel:input_type -> api.SetLogLevelRequest
+	223, // 282: api.GoBgpService.AddTcpAoKeychain:input_type -> api.AddTcpAoKeychainRequest
+	225, // 283: api.GoBgpService.UpdateTcpAoKeychain:input_type -> api.UpdateTcpAoKeychainRequest
+	227, // 284: api.GoBgpService.DeleteTcpAoKeychain:input_type -> api.DeleteTcpAoKeychainRequest
+	229, // 285: api.GoBgpService.ListTcpAoKeychain:input_type -> api.ListTcpAoKeychainRequest
+	29,  // 286: api.GoBgpService.StartBgp:output_type -> api.StartBgpResponse
+	31,  // 287: api.GoBgpService.StopBgp:output_type -> api.StopBgpResponse
+	33,  // 288: api.GoBgpService.GetBgp:output_type -> api.GetBgpResponse
+	35,  // 289: api.GoBgpService.WatchEvent:output_type -> api.WatchEventResponse
+	37,  // 290: api.GoBgpService.AddPeer:output_type -> api.AddPeerResponse
+	39,  // 291: api.GoBgpService.DeletePeer:output_type -> api.DeletePeerResponse
+	41,  // 292: api.GoBgpService.ListPeer:output_type -> api.ListPeerResponse
+	43,  // 293: api.GoBgpService.UpdatePeer:output_type -> api.UpdatePeerResponse
+	45,  // 294: api.GoBgpService.ResetPeer:output_type -> api.ResetPeerResponse
+	47,  // 295: api.GoBgpService.ShutdownPeer:output_type -> api.ShutdownPeerResponse
+	49,  // 296: api.GoBgpService.EnablePeer:output_type -> api.EnablePeerResponse
+	51,  // 297: api.GoBgpService.DisablePeer:output_type -> api.DisablePeerResponse
+	53,  // 298: api.GoBgpService.AddPeerGroup:output_type -> api.AddPeerGroupResponse
+	55,  // 299: api.GoBgpService.DeletePeerGroup:output_type -> api.DeletePeerGroupResponse
+	59,  // 300: api.GoBgpService.ListPeerGroup:output_type -> api.ListPeerGroupResponse
+	57,  // 301: api.GoBgpService.UpdatePeerGroup:output_type -> api.UpdatePeerGroupResponse
+	61,  // 302: api.GoBgpService.AddDynamicNeighbor:output_type -> api.AddDynamicNeighborResponse
+	65,  // 303: api.GoBgpService.ListDynamicNeighbor:output_type -> api.ListDynamicNeighborResponse
+	63,  // 304: api.GoBgpService.DeleteDynamicNeighbor:output_type -> api.DeleteDynamicNeighborResponse
+	67,  // 305: api.GoBgpService.AddPath:output_type -> api.AddPathResponse
+	69,  // 306: api.GoBgpService.DeletePath:output_type -> api.DeletePathResponse
+	72,  // 307: api.GoBgpService.ListPath:output_type -> api.ListPathResponse
+	74,  // 308: api.GoBgpService.AddPathStream:output_type -> api.AddPathStreamResponse
+	76,  // 309: api.GoBgpService.GetTable:output_type -> api.GetTableResponse
+	78,  // 310: api.GoBgpService.AddVrf:output_type -> api.AddVrfResponse
+	80,  // 311: api.GoBgpService.DeleteVrf:output_type -> api.DeleteVrfResponse
+	82,  // 312: api.GoBgpService.ListVrf:output_type -> api.ListVrfResponse
+	234, // 313: api.GoBgpService.AddAggregate:output_type -> api.AddAggregateResponse
+	236, // 314: api.GoBgpService.DeleteAggregate:output_type -> api.DeleteAggregateResponse
+	238, // 315: api.GoBgpService.ListAggregate:output_type -> api.ListAggregateResponse
+	84,  // 316: api.GoBgpService.AddPolicy:output_type -> api.AddPolicyResponse
+	86,  // 317: api.GoBgpService.DeletePolicy:output_type -> api.DeletePolicyResponse
+	88,  // 318: api.GoBgpService.ListPolicy:output_type -> api.ListPolicyResponse
+	90,  // 319: api.GoBgpService.SetPolicies:output_type -> api.SetPoliciesResponse
+	92,  // 320: api.GoBgpService.AddDefinedSet:output_type -> api.AddDefinedSetResponse
+	94,  // 321: api.GoBgpService.DeleteDefinedSet:output_type -> api.DeleteDefinedSetResponse
+	96,  // 322: api.GoBgpService.ListDefinedSet:output_type -> api.ListDefinedSetResponse
+	98,  // 323: api.GoBgpService.AddStatement:output_type -> api.AddStatementResponse
+	100, // 324: api.GoBgpService.DeleteStatement:output_type -> api.DeleteStatementResponse
+	102, // 325: api.GoBgpService.ListStatement:output_type -> api.ListStatementResponse
+	104, // 326: api.GoBgpService.AddPolicyAssignment:output_type -> api.AddPolicyAssignmentResponse
+	106, // 327: api.GoBgpService.DeletePolicyAssignment:output_type -> api.DeletePolicyAssignmentResponse
+	108, // 328: api.GoBgpService.ListPolicyAssignment:output_type -> api.ListPolicyAssignmentResponse
+	110, // 329: api.GoBgpService.SetPolicyAssignment:output_type -> api.SetPolicyAssignmentResponse
+	112, // 330: api.GoBgpService.AddRpki:output_type -> api.AddRpkiResponse
+	114, // 331: api.GoBgpService.DeleteRpki:output_type -> api.DeleteRpkiResponse
+	116, // 332: api.GoBgpService.ListRpki:output_type -> api.ListRpkiResponse
+	118, // 333: api.GoBgpService.EnableRpki:output_type -> api.EnableRpkiResponse
+	120, // 334: api.GoBgpService.DisableRpki:output_type -> api.DisableRpkiResponse
+	122, // 335: api.GoBgpService.ResetRpki:output_type -> api.ResetRpkiResponse
+	124, // 336: api.GoBgpService.ListRpkiTable:output_type -> api.ListRpkiTableResponse
+	126, // 337: api.GoBgpService.EnableZebra:output_type -> api.EnableZebraResponse
+	128, // 338: api.GoBgpService.EnableMrt:output_type -> api.EnableMrtResponse
+	130, // 339: api.GoBgpService.DisableMrt:output_type -> api.DisableMrtResponse
+	132, // 340: api.GoBgpService.AddBmp:output_type -> api.AddBmpResponse
+	134, // 341: api.GoBgpService.DeleteBmp:output_type -> api.DeleteBmpResponse
+	136, // 342: api.GoBgpService.ListBmp:output_type -> api.ListBmpResponse
+	216, // 343: api.GoBgpService.SetLogLevel:output_type -> api.SetLogLevelResponse
+	224, // 344: api.GoBgpService.AddTcpAoKeychain:output_type -> api.AddTcpAoKeychainResponse
+	226, // 345: api.GoBgpService.UpdateTcpAoKeychain:output_type -> api.UpdateTcpAoKeychainResponse
+	228, // 346: api.GoBgpService.DeleteTcpAoKeychain:output_type -> api.DeleteTcpAoKeychainResponse
+	230, // 347: api.GoBgpService.ListTcpAoKeychain:output_type -> api.ListTcpAoKeychainResponse
+	286, // [286:348] is the sub-list for method output_type
+	224, // [224:286] is the sub-list for method input_type
+	224, // [224:224] is the sub-list for extension type_name
+	224, // [224:224] is the sub-list for extension extendee
+	0,   // [0:224] is the sub-list for field type_name
 }
 
 func init() { file_api_gobgp_proto_init() }
@@ -15465,7 +15873,7 @@ func file_api_gobgp_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_gobgp_proto_rawDesc), len(file_api_gobgp_proto_rawDesc)),
 			NumEnums:      28,
-			NumMessages:   211,
+			NumMessages:   219,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gobgp_grpc.pb.go
+++ b/api/gobgp_grpc.pb.go
@@ -67,6 +67,9 @@ const (
 	GoBgpService_AddVrf_FullMethodName                 = "/api.GoBgpService/AddVrf"
 	GoBgpService_DeleteVrf_FullMethodName              = "/api.GoBgpService/DeleteVrf"
 	GoBgpService_ListVrf_FullMethodName                = "/api.GoBgpService/ListVrf"
+	GoBgpService_AddAggregate_FullMethodName           = "/api.GoBgpService/AddAggregate"
+	GoBgpService_DeleteAggregate_FullMethodName        = "/api.GoBgpService/DeleteAggregate"
+	GoBgpService_ListAggregate_FullMethodName          = "/api.GoBgpService/ListAggregate"
 	GoBgpService_AddPolicy_FullMethodName              = "/api.GoBgpService/AddPolicy"
 	GoBgpService_DeletePolicy_FullMethodName           = "/api.GoBgpService/DeletePolicy"
 	GoBgpService_ListPolicy_FullMethodName             = "/api.GoBgpService/ListPolicy"
@@ -130,6 +133,9 @@ type GoBgpServiceClient interface {
 	AddVrf(ctx context.Context, in *AddVrfRequest, opts ...grpc.CallOption) (*AddVrfResponse, error)
 	DeleteVrf(ctx context.Context, in *DeleteVrfRequest, opts ...grpc.CallOption) (*DeleteVrfResponse, error)
 	ListVrf(ctx context.Context, in *ListVrfRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListVrfResponse], error)
+	AddAggregate(ctx context.Context, in *AddAggregateRequest, opts ...grpc.CallOption) (*AddAggregateResponse, error)
+	DeleteAggregate(ctx context.Context, in *DeleteAggregateRequest, opts ...grpc.CallOption) (*DeleteAggregateResponse, error)
+	ListAggregate(ctx context.Context, in *ListAggregateRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListAggregateResponse], error)
 	AddPolicy(ctx context.Context, in *AddPolicyRequest, opts ...grpc.CallOption) (*AddPolicyResponse, error)
 	DeletePolicy(ctx context.Context, in *DeletePolicyRequest, opts ...grpc.CallOption) (*DeletePolicyResponse, error)
 	ListPolicy(ctx context.Context, in *ListPolicyRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListPolicyResponse], error)
@@ -495,6 +501,45 @@ func (c *goBgpServiceClient) ListVrf(ctx context.Context, in *ListVrfRequest, op
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type GoBgpService_ListVrfClient = grpc.ServerStreamingClient[ListVrfResponse]
 
+func (c *goBgpServiceClient) AddAggregate(ctx context.Context, in *AddAggregateRequest, opts ...grpc.CallOption) (*AddAggregateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AddAggregateResponse)
+	err := c.cc.Invoke(ctx, GoBgpService_AddAggregate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *goBgpServiceClient) DeleteAggregate(ctx context.Context, in *DeleteAggregateRequest, opts ...grpc.CallOption) (*DeleteAggregateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteAggregateResponse)
+	err := c.cc.Invoke(ctx, GoBgpService_DeleteAggregate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *goBgpServiceClient) ListAggregate(ctx context.Context, in *ListAggregateRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListAggregateResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[7], GoBgpService_ListAggregate_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[ListAggregateRequest, ListAggregateResponse]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type GoBgpService_ListAggregateClient = grpc.ServerStreamingClient[ListAggregateResponse]
+
 func (c *goBgpServiceClient) AddPolicy(ctx context.Context, in *AddPolicyRequest, opts ...grpc.CallOption) (*AddPolicyResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(AddPolicyResponse)
@@ -517,7 +562,7 @@ func (c *goBgpServiceClient) DeletePolicy(ctx context.Context, in *DeletePolicyR
 
 func (c *goBgpServiceClient) ListPolicy(ctx context.Context, in *ListPolicyRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListPolicyResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[7], GoBgpService_ListPolicy_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[8], GoBgpService_ListPolicy_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -566,7 +611,7 @@ func (c *goBgpServiceClient) DeleteDefinedSet(ctx context.Context, in *DeleteDef
 
 func (c *goBgpServiceClient) ListDefinedSet(ctx context.Context, in *ListDefinedSetRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListDefinedSetResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[8], GoBgpService_ListDefinedSet_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[9], GoBgpService_ListDefinedSet_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -605,7 +650,7 @@ func (c *goBgpServiceClient) DeleteStatement(ctx context.Context, in *DeleteStat
 
 func (c *goBgpServiceClient) ListStatement(ctx context.Context, in *ListStatementRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListStatementResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[9], GoBgpService_ListStatement_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[10], GoBgpService_ListStatement_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -644,7 +689,7 @@ func (c *goBgpServiceClient) DeletePolicyAssignment(ctx context.Context, in *Del
 
 func (c *goBgpServiceClient) ListPolicyAssignment(ctx context.Context, in *ListPolicyAssignmentRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListPolicyAssignmentResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[10], GoBgpService_ListPolicyAssignment_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[11], GoBgpService_ListPolicyAssignment_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -693,7 +738,7 @@ func (c *goBgpServiceClient) DeleteRpki(ctx context.Context, in *DeleteRpkiReque
 
 func (c *goBgpServiceClient) ListRpki(ctx context.Context, in *ListRpkiRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListRpkiResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[11], GoBgpService_ListRpki_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[12], GoBgpService_ListRpki_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -742,7 +787,7 @@ func (c *goBgpServiceClient) ResetRpki(ctx context.Context, in *ResetRpkiRequest
 
 func (c *goBgpServiceClient) ListRpkiTable(ctx context.Context, in *ListRpkiTableRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListRpkiTableResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[12], GoBgpService_ListRpkiTable_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[13], GoBgpService_ListRpkiTable_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -811,7 +856,7 @@ func (c *goBgpServiceClient) DeleteBmp(ctx context.Context, in *DeleteBmpRequest
 
 func (c *goBgpServiceClient) ListBmp(ctx context.Context, in *ListBmpRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListBmpResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[13], GoBgpService_ListBmp_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[14], GoBgpService_ListBmp_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -871,6 +916,9 @@ type GoBgpServiceServer interface {
 	AddVrf(context.Context, *AddVrfRequest) (*AddVrfResponse, error)
 	DeleteVrf(context.Context, *DeleteVrfRequest) (*DeleteVrfResponse, error)
 	ListVrf(*ListVrfRequest, grpc.ServerStreamingServer[ListVrfResponse]) error
+	AddAggregate(context.Context, *AddAggregateRequest) (*AddAggregateResponse, error)
+	DeleteAggregate(context.Context, *DeleteAggregateRequest) (*DeleteAggregateResponse, error)
+	ListAggregate(*ListAggregateRequest, grpc.ServerStreamingServer[ListAggregateResponse]) error
 	AddPolicy(context.Context, *AddPolicyRequest) (*AddPolicyResponse, error)
 	DeletePolicy(context.Context, *DeletePolicyRequest) (*DeletePolicyResponse, error)
 	ListPolicy(*ListPolicyRequest, grpc.ServerStreamingServer[ListPolicyResponse]) error
@@ -989,6 +1037,15 @@ func (UnimplementedGoBgpServiceServer) DeleteVrf(context.Context, *DeleteVrfRequ
 }
 func (UnimplementedGoBgpServiceServer) ListVrf(*ListVrfRequest, grpc.ServerStreamingServer[ListVrfResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method ListVrf not implemented")
+}
+func (UnimplementedGoBgpServiceServer) AddAggregate(context.Context, *AddAggregateRequest) (*AddAggregateResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddAggregate not implemented")
+}
+func (UnimplementedGoBgpServiceServer) DeleteAggregate(context.Context, *DeleteAggregateRequest) (*DeleteAggregateResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteAggregate not implemented")
+}
+func (UnimplementedGoBgpServiceServer) ListAggregate(*ListAggregateRequest, grpc.ServerStreamingServer[ListAggregateResponse]) error {
+	return status.Errorf(codes.Unimplemented, "method ListAggregate not implemented")
 }
 func (UnimplementedGoBgpServiceServer) AddPolicy(context.Context, *AddPolicyRequest) (*AddPolicyResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AddPolicy not implemented")
@@ -1527,6 +1584,53 @@ func _GoBgpService_ListVrf_Handler(srv interface{}, stream grpc.ServerStream) er
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type GoBgpService_ListVrfServer = grpc.ServerStreamingServer[ListVrfResponse]
+
+func _GoBgpService_AddAggregate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AddAggregateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GoBgpServiceServer).AddAggregate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GoBgpService_AddAggregate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GoBgpServiceServer).AddAggregate(ctx, req.(*AddAggregateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _GoBgpService_DeleteAggregate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteAggregateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GoBgpServiceServer).DeleteAggregate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GoBgpService_DeleteAggregate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GoBgpServiceServer).DeleteAggregate(ctx, req.(*DeleteAggregateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _GoBgpService_ListAggregate_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(ListAggregateRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(GoBgpServiceServer).ListAggregate(m, &grpc.GenericServerStream[ListAggregateRequest, ListAggregateResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type GoBgpService_ListAggregateServer = grpc.ServerStreamingServer[ListAggregateResponse]
 
 func _GoBgpService_AddPolicy_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(AddPolicyRequest)
@@ -2071,6 +2175,14 @@ var GoBgpService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _GoBgpService_DeleteVrf_Handler,
 		},
 		{
+			MethodName: "AddAggregate",
+			Handler:    _GoBgpService_AddAggregate_Handler,
+		},
+		{
+			MethodName: "DeleteAggregate",
+			Handler:    _GoBgpService_DeleteAggregate_Handler,
+		},
+		{
 			MethodName: "AddPolicy",
 			Handler:    _GoBgpService_AddPolicy_Handler,
 		},
@@ -2189,6 +2301,11 @@ var GoBgpService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "ListVrf",
 			Handler:       _GoBgpService_ListVrf_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "ListAggregate",
+			Handler:       _GoBgpService_ListAggregate_Handler,
 			ServerStreams: true,
 		},
 		{

--- a/api/gobgp_grpc.pb.go
+++ b/api/gobgp_grpc.pb.go
@@ -67,6 +67,9 @@ const (
 	GoBgpService_AddVrf_FullMethodName                 = "/api.GoBgpService/AddVrf"
 	GoBgpService_DeleteVrf_FullMethodName              = "/api.GoBgpService/DeleteVrf"
 	GoBgpService_ListVrf_FullMethodName                = "/api.GoBgpService/ListVrf"
+	GoBgpService_AddAggregate_FullMethodName           = "/api.GoBgpService/AddAggregate"
+	GoBgpService_DeleteAggregate_FullMethodName        = "/api.GoBgpService/DeleteAggregate"
+	GoBgpService_ListAggregate_FullMethodName          = "/api.GoBgpService/ListAggregate"
 	GoBgpService_AddPolicy_FullMethodName              = "/api.GoBgpService/AddPolicy"
 	GoBgpService_DeletePolicy_FullMethodName           = "/api.GoBgpService/DeletePolicy"
 	GoBgpService_ListPolicy_FullMethodName             = "/api.GoBgpService/ListPolicy"
@@ -134,6 +137,9 @@ type GoBgpServiceClient interface {
 	AddVrf(ctx context.Context, in *AddVrfRequest, opts ...grpc.CallOption) (*AddVrfResponse, error)
 	DeleteVrf(ctx context.Context, in *DeleteVrfRequest, opts ...grpc.CallOption) (*DeleteVrfResponse, error)
 	ListVrf(ctx context.Context, in *ListVrfRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListVrfResponse], error)
+	AddAggregate(ctx context.Context, in *AddAggregateRequest, opts ...grpc.CallOption) (*AddAggregateResponse, error)
+	DeleteAggregate(ctx context.Context, in *DeleteAggregateRequest, opts ...grpc.CallOption) (*DeleteAggregateResponse, error)
+	ListAggregate(ctx context.Context, in *ListAggregateRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListAggregateResponse], error)
 	AddPolicy(ctx context.Context, in *AddPolicyRequest, opts ...grpc.CallOption) (*AddPolicyResponse, error)
 	DeletePolicy(ctx context.Context, in *DeletePolicyRequest, opts ...grpc.CallOption) (*DeletePolicyResponse, error)
 	ListPolicy(ctx context.Context, in *ListPolicyRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListPolicyResponse], error)
@@ -503,6 +509,45 @@ func (c *goBgpServiceClient) ListVrf(ctx context.Context, in *ListVrfRequest, op
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type GoBgpService_ListVrfClient = grpc.ServerStreamingClient[ListVrfResponse]
 
+func (c *goBgpServiceClient) AddAggregate(ctx context.Context, in *AddAggregateRequest, opts ...grpc.CallOption) (*AddAggregateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AddAggregateResponse)
+	err := c.cc.Invoke(ctx, GoBgpService_AddAggregate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *goBgpServiceClient) DeleteAggregate(ctx context.Context, in *DeleteAggregateRequest, opts ...grpc.CallOption) (*DeleteAggregateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteAggregateResponse)
+	err := c.cc.Invoke(ctx, GoBgpService_DeleteAggregate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *goBgpServiceClient) ListAggregate(ctx context.Context, in *ListAggregateRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListAggregateResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[7], GoBgpService_ListAggregate_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[ListAggregateRequest, ListAggregateResponse]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type GoBgpService_ListAggregateClient = grpc.ServerStreamingClient[ListAggregateResponse]
+
 func (c *goBgpServiceClient) AddPolicy(ctx context.Context, in *AddPolicyRequest, opts ...grpc.CallOption) (*AddPolicyResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(AddPolicyResponse)
@@ -525,7 +570,7 @@ func (c *goBgpServiceClient) DeletePolicy(ctx context.Context, in *DeletePolicyR
 
 func (c *goBgpServiceClient) ListPolicy(ctx context.Context, in *ListPolicyRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListPolicyResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[7], GoBgpService_ListPolicy_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[8], GoBgpService_ListPolicy_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -574,7 +619,7 @@ func (c *goBgpServiceClient) DeleteDefinedSet(ctx context.Context, in *DeleteDef
 
 func (c *goBgpServiceClient) ListDefinedSet(ctx context.Context, in *ListDefinedSetRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListDefinedSetResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[8], GoBgpService_ListDefinedSet_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[9], GoBgpService_ListDefinedSet_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -613,7 +658,7 @@ func (c *goBgpServiceClient) DeleteStatement(ctx context.Context, in *DeleteStat
 
 func (c *goBgpServiceClient) ListStatement(ctx context.Context, in *ListStatementRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListStatementResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[9], GoBgpService_ListStatement_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[10], GoBgpService_ListStatement_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -652,7 +697,7 @@ func (c *goBgpServiceClient) DeletePolicyAssignment(ctx context.Context, in *Del
 
 func (c *goBgpServiceClient) ListPolicyAssignment(ctx context.Context, in *ListPolicyAssignmentRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListPolicyAssignmentResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[10], GoBgpService_ListPolicyAssignment_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[11], GoBgpService_ListPolicyAssignment_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -701,7 +746,7 @@ func (c *goBgpServiceClient) DeleteRpki(ctx context.Context, in *DeleteRpkiReque
 
 func (c *goBgpServiceClient) ListRpki(ctx context.Context, in *ListRpkiRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListRpkiResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[11], GoBgpService_ListRpki_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[12], GoBgpService_ListRpki_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -750,7 +795,7 @@ func (c *goBgpServiceClient) ResetRpki(ctx context.Context, in *ResetRpkiRequest
 
 func (c *goBgpServiceClient) ListRpkiTable(ctx context.Context, in *ListRpkiTableRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListRpkiTableResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[12], GoBgpService_ListRpkiTable_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[13], GoBgpService_ListRpkiTable_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -819,7 +864,7 @@ func (c *goBgpServiceClient) DeleteBmp(ctx context.Context, in *DeleteBmpRequest
 
 func (c *goBgpServiceClient) ListBmp(ctx context.Context, in *ListBmpRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListBmpResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[13], GoBgpService_ListBmp_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[14], GoBgpService_ListBmp_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -878,7 +923,7 @@ func (c *goBgpServiceClient) DeleteTcpAoKeychain(ctx context.Context, in *Delete
 
 func (c *goBgpServiceClient) ListTcpAoKeychain(ctx context.Context, in *ListTcpAoKeychainRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListTcpAoKeychainResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[14], GoBgpService_ListTcpAoKeychain_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[15], GoBgpService_ListTcpAoKeychain_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -928,6 +973,9 @@ type GoBgpServiceServer interface {
 	AddVrf(context.Context, *AddVrfRequest) (*AddVrfResponse, error)
 	DeleteVrf(context.Context, *DeleteVrfRequest) (*DeleteVrfResponse, error)
 	ListVrf(*ListVrfRequest, grpc.ServerStreamingServer[ListVrfResponse]) error
+	AddAggregate(context.Context, *AddAggregateRequest) (*AddAggregateResponse, error)
+	DeleteAggregate(context.Context, *DeleteAggregateRequest) (*DeleteAggregateResponse, error)
+	ListAggregate(*ListAggregateRequest, grpc.ServerStreamingServer[ListAggregateResponse]) error
 	AddPolicy(context.Context, *AddPolicyRequest) (*AddPolicyResponse, error)
 	DeletePolicy(context.Context, *DeletePolicyRequest) (*DeletePolicyResponse, error)
 	ListPolicy(*ListPolicyRequest, grpc.ServerStreamingServer[ListPolicyResponse]) error
@@ -1050,6 +1098,15 @@ func (UnimplementedGoBgpServiceServer) DeleteVrf(context.Context, *DeleteVrfRequ
 }
 func (UnimplementedGoBgpServiceServer) ListVrf(*ListVrfRequest, grpc.ServerStreamingServer[ListVrfResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method ListVrf not implemented")
+}
+func (UnimplementedGoBgpServiceServer) AddAggregate(context.Context, *AddAggregateRequest) (*AddAggregateResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddAggregate not implemented")
+}
+func (UnimplementedGoBgpServiceServer) DeleteAggregate(context.Context, *DeleteAggregateRequest) (*DeleteAggregateResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteAggregate not implemented")
+}
+func (UnimplementedGoBgpServiceServer) ListAggregate(*ListAggregateRequest, grpc.ServerStreamingServer[ListAggregateResponse]) error {
+	return status.Errorf(codes.Unimplemented, "method ListAggregate not implemented")
 }
 func (UnimplementedGoBgpServiceServer) AddPolicy(context.Context, *AddPolicyRequest) (*AddPolicyResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AddPolicy not implemented")
@@ -1600,6 +1657,53 @@ func _GoBgpService_ListVrf_Handler(srv interface{}, stream grpc.ServerStream) er
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type GoBgpService_ListVrfServer = grpc.ServerStreamingServer[ListVrfResponse]
+
+func _GoBgpService_AddAggregate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AddAggregateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GoBgpServiceServer).AddAggregate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GoBgpService_AddAggregate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GoBgpServiceServer).AddAggregate(ctx, req.(*AddAggregateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _GoBgpService_DeleteAggregate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteAggregateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GoBgpServiceServer).DeleteAggregate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GoBgpService_DeleteAggregate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GoBgpServiceServer).DeleteAggregate(ctx, req.(*DeleteAggregateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _GoBgpService_ListAggregate_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(ListAggregateRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(GoBgpServiceServer).ListAggregate(m, &grpc.GenericServerStream[ListAggregateRequest, ListAggregateResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type GoBgpService_ListAggregateServer = grpc.ServerStreamingServer[ListAggregateResponse]
 
 func _GoBgpService_AddPolicy_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(AddPolicyRequest)
@@ -2209,6 +2313,14 @@ var GoBgpService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _GoBgpService_DeleteVrf_Handler,
 		},
 		{
+			MethodName: "AddAggregate",
+			Handler:    _GoBgpService_AddAggregate_Handler,
+		},
+		{
+			MethodName: "DeleteAggregate",
+			Handler:    _GoBgpService_DeleteAggregate_Handler,
+		},
+		{
 			MethodName: "AddPolicy",
 			Handler:    _GoBgpService_AddPolicy_Handler,
 		},
@@ -2339,6 +2451,11 @@ var GoBgpService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "ListVrf",
 			Handler:       _GoBgpService_ListVrf_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "ListAggregate",
+			Handler:       _GoBgpService_ListAggregate_Handler,
 			ServerStreams: true,
 		},
 		{

--- a/cmd/gobgp/common.go
+++ b/cmd/gobgp/common.go
@@ -87,6 +87,8 @@ const (
 	cmdInfo           = "info"
 	cmdDebug          = "debug"
 	cmdTrace          = "trace"
+	cmdList           = "list"
+	cmdAggregate      = "aggregate"
 )
 
 const (
@@ -98,6 +100,9 @@ const (
 var subOpts struct {
 	AddressFamily string `short:"a" long:"address-family" description:"specifying an address family"`
 	BatchSize     uint64 `short:"b" long:"batch-size" description:"Size of the temporary buffer in the server memory. Zero is unlimited (default)"`
+	SummaryOnly   bool   `short:"s" long:"summary-only" description:"suppress more-specific contributing routes"`
+	AsSet         bool   `long:"as-set" description:"generate an AS_SET from contributing routes"`
+	Policy        string `long:"policy" description:"policy a contributing route must pass"`
 }
 
 var neighborsOpts struct {

--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/netip"
 	"regexp"
@@ -3447,6 +3448,64 @@ func modGlobalConfig(args []string) error {
 	return err
 }
 
+func showAggregates(_ []string) error {
+	stream, err := client.ListAggregate(ctx, &api.ListAggregateRequest{})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%-40s %-13s %-8s %-7s %s\n", "Prefix", "Contributors", "Summary", "AS-Set", "Policy")
+	for {
+		r, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		a := r.Aggregate
+		policy := a.Aggregate.PolicyName
+		if policy == "" {
+			policy = "-"
+		}
+		fmt.Printf("%-40s %-13d %-8t %-7t %s\n",
+			a.Aggregate.Prefix, a.NumContributors, a.Aggregate.SummaryOnly, a.Aggregate.AsSet, policy)
+	}
+	return nil
+}
+
+func addAggregate(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: gobgp global aggregate add <prefix> [--summary-only] [--as-set] [--policy <name>]")
+	}
+	prefix, err := netip.ParsePrefix(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid prefix: %w", err)
+	}
+	_, err = client.AddAggregate(ctx, &api.AddAggregateRequest{
+		Aggregate: &api.AggregateAddress{
+			Prefix:      prefix.String(),
+			SummaryOnly: subOpts.SummaryOnly,
+			AsSet:       subOpts.AsSet,
+			PolicyName:  subOpts.Policy,
+		},
+	})
+	return err
+}
+
+func deleteAggregate(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: gobgp global aggregate del <prefix>")
+	}
+	prefix, err := netip.ParsePrefix(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid prefix: %w", err)
+	}
+	_, err = client.DeleteAggregate(ctx, &api.DeleteAggregateRequest{
+		Prefix: prefix.String(),
+	})
+	return err
+}
+
 func newGlobalCmd() *cobra.Command {
 	globalCmd := &cobra.Command{
 		Use: cmdGlobal,
@@ -3571,6 +3630,46 @@ func newGlobalCmd() *cobra.Command {
 	}
 	delCmd.AddCommand(allCmd)
 
-	globalCmd.AddCommand(ribCmd, policyCmd, delCmd)
+	aggregateCmd := &cobra.Command{
+		Use: cmdAggregate,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := showAggregates(args); err != nil {
+				exitWithError(err)
+			}
+		},
+	}
+
+	listAggregateCmd := &cobra.Command{
+		Use: cmdList,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := showAggregates(args); err != nil {
+				exitWithError(err)
+			}
+		},
+	}
+
+	addAggregateCmd := &cobra.Command{
+		Use: cmdAdd,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := addAggregate(args); err != nil {
+				exitWithError(err)
+			}
+		},
+	}
+	addAggregateCmd.Flags().BoolVarP(&subOpts.SummaryOnly, "summary-only", "s", false, "suppress more-specific contributing routes")
+	addAggregateCmd.Flags().BoolVar(&subOpts.AsSet, "as-set", false, "generate an AS_SET from contributing routes")
+	addAggregateCmd.Flags().StringVar(&subOpts.Policy, "policy", "", "policy a contributing route must pass")
+
+	delAggregateCmd := &cobra.Command{
+		Use: cmdDel,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := deleteAggregate(args); err != nil {
+				exitWithError(err)
+			}
+		},
+	}
+
+	aggregateCmd.AddCommand(listAggregateCmd, addAggregateCmd, delAggregateCmd)
+	globalCmd.AddCommand(ribCmd, policyCmd, delCmd, aggregateCmd)
 	return globalCmd
 }

--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/netip"
 	"regexp"
@@ -3595,6 +3596,64 @@ func modGlobalConfig(args []string) error {
 	return err
 }
 
+func showAggregates(_ []string) error {
+	stream, err := client.ListAggregate(ctx, &api.ListAggregateRequest{})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%-40s %-13s %-8s %-7s %s\n", "Prefix", "Contributors", "Summary", "AS-Set", "Policy")
+	for {
+		r, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		a := r.Aggregate
+		policy := a.Aggregate.PolicyName
+		if policy == "" {
+			policy = "-"
+		}
+		fmt.Printf("%-40s %-13d %-8t %-7t %s\n",
+			a.Aggregate.Prefix, a.NumContributors, a.Aggregate.SummaryOnly, a.Aggregate.AsSet, policy)
+	}
+	return nil
+}
+
+func addAggregate(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: gobgp global aggregate add <prefix> [--summary-only] [--as-set] [--policy <name>]")
+	}
+	prefix, err := netip.ParsePrefix(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid prefix: %w", err)
+	}
+	_, err = client.AddAggregate(ctx, &api.AddAggregateRequest{
+		Aggregate: &api.AggregateAddress{
+			Prefix:      prefix.String(),
+			SummaryOnly: subOpts.SummaryOnly,
+			AsSet:       subOpts.AsSet,
+			PolicyName:  subOpts.Policy,
+		},
+	})
+	return err
+}
+
+func deleteAggregate(args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: gobgp global aggregate del <prefix>")
+	}
+	prefix, err := netip.ParsePrefix(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid prefix: %w", err)
+	}
+	_, err = client.DeleteAggregate(ctx, &api.DeleteAggregateRequest{
+		Prefix: prefix.String(),
+	})
+	return err
+}
+
 func newGlobalCmd() *cobra.Command {
 	globalCmd := &cobra.Command{
 		Use: cmdGlobal,
@@ -3719,6 +3778,46 @@ func newGlobalCmd() *cobra.Command {
 	}
 	delCmd.AddCommand(allCmd)
 
-	globalCmd.AddCommand(ribCmd, policyCmd, delCmd)
+	aggregateCmd := &cobra.Command{
+		Use: cmdAggregate,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := showAggregates(args); err != nil {
+				exitWithError(err)
+			}
+		},
+	}
+
+	listAggregateCmd := &cobra.Command{
+		Use: cmdList,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := showAggregates(args); err != nil {
+				exitWithError(err)
+			}
+		},
+	}
+
+	addAggregateCmd := &cobra.Command{
+		Use: cmdAdd,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := addAggregate(args); err != nil {
+				exitWithError(err)
+			}
+		},
+	}
+	addAggregateCmd.Flags().BoolVarP(&subOpts.SummaryOnly, "summary-only", "s", false, "suppress more-specific contributing routes")
+	addAggregateCmd.Flags().BoolVar(&subOpts.AsSet, "as-set", false, "generate an AS_SET from contributing routes")
+	addAggregateCmd.Flags().StringVar(&subOpts.Policy, "policy", "", "policy a contributing route must pass")
+
+	delAggregateCmd := &cobra.Command{
+		Use: cmdDel,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := deleteAggregate(args); err != nil {
+				exitWithError(err)
+			}
+		},
+	}
+
+	aggregateCmd.AddCommand(listAggregateCmd, addAggregateCmd, delAggregateCmd)
+	globalCmd.AddCommand(ribCmd, policyCmd, delCmd, aggregateCmd)
 	return globalCmd
 }

--- a/docs/sources/aggregate.md
+++ b/docs/sources/aggregate.md
@@ -1,0 +1,50 @@
+# Route Aggregation
+
+This page explains how to configure route aggregation.
+Aggregation advertises a single, less-specific route in place of the more-specific
+routes it covers, reducing the number of routes propagated to peers.
+
+## Contents
+
+- [Configuration](#configuration)
+- [CLI](#cli)
+
+## Configuration
+
+Aggregates are declared under the global configuration. Each aggregate generates a
+locally-originated route for its prefix once at least one more-specific route exists in
+the global RIB.
+
+```toml
+[global.config]
+  as = 65001
+  router-id = "172.40.1.2"
+
+[[global.aggregates]]
+  [global.aggregates.config]
+    prefix = "10.0.0.0/8"
+    summary-only = true
+    as-set = true
+    policy-name = "contributors"
+```
+
+- `summary-only` suppresses advertisement of the more-specific contributing routes.
+- `as-set` builds an `AS_SET` from the contributing routes' AS paths; otherwise the
+  aggregate carries `ATOMIC_AGGREGATE`.
+- `policy-name` references a policy a route must pass to contribute to the aggregate.
+
+## CLI
+
+Aggregates can also be managed at runtime.
+
+```shell
+$ gobgp global aggregate add 10.0.0.0/8 --summary-only --as-set --policy contributors
+$ gobgp global aggregate add 2001:db8::/32
+
+$ gobgp global aggregate
+Prefix                                   Contributors  Summary  AS-Set  Policy
+10.0.0.0/8                               3             true     true    contributors
+2001:db8::/32                            1             false    false   -
+
+$ gobgp global aggregate del 10.0.0.0/8
+```

--- a/internal/pkg/table/aggregate.go
+++ b/internal/pkg/table/aggregate.go
@@ -1,0 +1,326 @@
+// Copyright (C) 2024 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+)
+
+type aggregateRoute struct {
+	prefix       netip.Prefix
+	family       bgp.Family
+	summaryOnly  bool
+	asSet        bool
+	policyName   string
+	policy       *Policy
+	contributors map[string]*Path
+	advertised   *Path
+}
+
+type AggregateInfo struct {
+	Family       bgp.Family
+	Prefix       netip.Prefix
+	SummaryOnly  bool
+	AsSet        bool
+	PolicyName   string
+	Contributors int
+}
+
+// AggregateManager tracks configured aggregate routes and originates/withdraws
+// them event-driven as contributor prefixes appear and disappear.
+type AggregateManager struct {
+	mu            sync.Mutex
+	hasAggregates atomic.Bool
+	aggregates    map[bgp.Family]map[string]*aggregateRoute
+	policy        *RoutingPolicy
+	peerInfo      *PeerInfo
+	logger        *slog.Logger
+}
+
+func NewAggregateManager(logger *slog.Logger, policy *RoutingPolicy, peerInfo *PeerInfo) *AggregateManager {
+	return &AggregateManager{
+		aggregates: make(map[bgp.Family]map[string]*aggregateRoute),
+		policy:     policy,
+		peerInfo:   peerInfo,
+		logger:     logger,
+	}
+}
+
+// Active reports whether any aggregates are configured; safe to call without mu.
+func (m *AggregateManager) Active() bool {
+	return m.hasAggregates.Load()
+}
+
+func (m *AggregateManager) AddAggregate(family bgp.Family, prefix netip.Prefix, summaryOnly, asSet bool, policyName string) error {
+	var pol *Policy
+	if policyName != "" {
+		defs := m.policy.GetPolicy(policyName)
+		if len(defs) == 0 {
+			return fmt.Errorf("policy %s not found", policyName)
+		}
+		var err error
+		pol, err = NewPolicy(*defs[0])
+		if err != nil {
+			return err
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.aggregates[family]; !ok {
+		m.aggregates[family] = make(map[string]*aggregateRoute)
+	}
+	key := prefix.String()
+	if _, exists := m.aggregates[family][key]; exists {
+		return fmt.Errorf("aggregate %s already exists", key)
+	}
+	m.aggregates[family][key] = &aggregateRoute{
+		prefix:       prefix,
+		family:       family,
+		summaryOnly:  summaryOnly,
+		asSet:        asSet,
+		policyName:   policyName,
+		policy:       pol,
+		contributors: make(map[string]*Path),
+	}
+	m.hasAggregates.Store(true)
+	return nil
+}
+
+func (m *AggregateManager) DeleteAggregate(family bgp.Family, prefix netip.Prefix) (*Path, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fmap, ok := m.aggregates[family]
+	if !ok {
+		return nil, fmt.Errorf("aggregate %s not found", prefix)
+	}
+	key := prefix.String()
+	agg, ok := fmap[key]
+	if !ok {
+		return nil, fmt.Errorf("aggregate %s not found", prefix)
+	}
+	delete(fmap, key)
+
+	total := 0
+	for _, fm := range m.aggregates {
+		total += len(fm)
+	}
+	m.hasAggregates.Store(total > 0)
+
+	if agg.advertised != nil {
+		return agg.advertised.Clone(true), nil
+	}
+	return nil, nil
+}
+
+func (m *AggregateManager) isAggregatePrefix(family bgp.Family, prefix netip.Prefix) bool {
+	fam, ok := m.aggregates[family]
+	if !ok {
+		return false
+	}
+	_, ok = fam[prefix.String()]
+	return ok
+}
+
+func (m *AggregateManager) contributes(agg *aggregateRoute, prefix netip.Prefix, path *Path) bool {
+	if path == nil || path.IsWithdraw {
+		return false
+	}
+	if prefix.Bits() <= agg.prefix.Bits() || !agg.prefix.Contains(prefix.Addr()) {
+		return false
+	}
+	if path.IsLocal() && m.isAggregatePrefix(path.GetFamily(), prefix) {
+		return false
+	}
+	if agg.policy != nil {
+		rt, _ := agg.policy.Apply(m.logger, path, nil)
+		return rt == ROUTE_TYPE_ACCEPT
+	}
+	return true
+}
+
+func (m *AggregateManager) evaluate(family bgp.Family, prefix netip.Prefix, best *Path) []*Path {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fmap, ok := m.aggregates[family]
+	if !ok {
+		return nil
+	}
+
+	var results []*Path
+	for _, agg := range fmap {
+		if !agg.prefix.Contains(prefix.Addr()) || prefix.Bits() <= agg.prefix.Bits() {
+			continue
+		}
+		key := prefix.String()
+		if m.contributes(agg, prefix, best) {
+			agg.contributors[key] = best
+		} else {
+			delete(agg.contributors, key)
+		}
+		if p := m.reconcile(agg); p != nil {
+			results = append(results, p)
+		}
+	}
+	return results
+}
+
+func (m *AggregateManager) reconcile(agg *aggregateRoute) *Path {
+	if len(agg.contributors) == 0 {
+		if agg.advertised == nil {
+			return nil
+		}
+		withdraw := agg.advertised.Clone(true)
+		agg.advertised = nil
+		return withdraw
+	}
+
+	generated := m.generate(agg)
+	if agg.advertised != nil {
+		if !agg.asSet {
+			return nil
+		}
+		if asSetEqual(agg.advertised, generated) {
+			return nil
+		}
+	}
+	agg.advertised = generated
+	return generated
+}
+
+func (m *AggregateManager) generate(agg *aggregateRoute) *Path {
+	nlri, err := bgp.NewIPAddrPrefix(agg.prefix)
+	if err != nil {
+		m.logger.Error("aggregate: failed to create NLRI", slog.Any("prefix", agg.prefix), slog.Any("err", err))
+		return nil
+	}
+
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP),
+	}
+
+	if agg.asSet {
+		ases := m.contributorASes(agg)
+		var params []bgp.AsPathParamInterface
+		if len(ases) > 0 {
+			params = []bgp.AsPathParamInterface{bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SET, ases)}
+		}
+		attrs = append(attrs, bgp.NewPathAttributeAsPath(params))
+	} else {
+		attrs = append(attrs, bgp.NewPathAttributeAsPath(nil))
+		attrs = append(attrs, bgp.NewPathAttributeAtomicAggregate())
+	}
+
+	if agg.family == bgp.RF_IPv6_UC {
+		mpAttr, _ := bgp.NewPathAttributeMpReachNLRI(agg.family, []bgp.PathNLRI{{NLRI: nlri}}, netip.IPv6Unspecified())
+		attrs = append(attrs, mpAttr)
+	} else {
+		nhAttr, _ := bgp.NewPathAttributeNextHop(netip.IPv4Unspecified())
+		attrs = append(attrs, nhAttr)
+	}
+
+	attrs = append(attrs, bgp.NewPathAttributeLocalPref(DEFAULT_LOCAL_PREF))
+
+	if m.peerInfo.LocalID.IsValid() && m.peerInfo.LocalID.Is4() {
+		aggAttr, err := bgp.NewPathAttributeAggregator(m.peerInfo.LocalAS, m.peerInfo.LocalID)
+		if err == nil {
+			attrs = append(attrs, aggAttr)
+		}
+	}
+
+	return NewPath(agg.family, m.peerInfo, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
+}
+
+func (m *AggregateManager) contributorASes(agg *aggregateRoute) []uint32 {
+	seen := make(map[uint32]struct{})
+	for _, p := range agg.contributors {
+		for _, as := range p.GetAsList() {
+			// GetAsList returns 0 for confederation segments; exclude them.
+			if as != 0 {
+				seen[as] = struct{}{}
+			}
+		}
+	}
+	result := make([]uint32, 0, len(seen))
+	for as := range seen {
+		result = append(result, as)
+	}
+	slices.Sort(result)
+	return result
+}
+
+// Suppressed returns true if prefix is covered by a summary-only aggregate that is currently advertised.
+func (m *AggregateManager) Suppressed(family bgp.Family, prefix netip.Prefix) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fmap, ok := m.aggregates[family]
+	if !ok {
+		return false
+	}
+	for _, agg := range fmap {
+		if agg.summaryOnly && agg.advertised != nil &&
+			agg.prefix.Contains(prefix.Addr()) && prefix.Bits() > agg.prefix.Bits() {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *AggregateManager) List(family *bgp.Family) []AggregateInfo {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var result []AggregateInfo
+	for fam, fmap := range m.aggregates {
+		if family != nil && fam != *family {
+			continue
+		}
+		for _, agg := range fmap {
+			result = append(result, AggregateInfo{
+				Family:       agg.family,
+				Prefix:       agg.prefix,
+				SummaryOnly:  agg.summaryOnly,
+				AsSet:        agg.asSet,
+				PolicyName:   agg.policyName,
+				Contributors: len(agg.contributors),
+			})
+		}
+	}
+	return result
+}
+
+func prefixOf(p *Path) netip.Prefix {
+	if nlri, ok := p.GetNlri().(*bgp.IPAddrPrefix); ok {
+		return nlri.Prefix
+	}
+	return netip.Prefix{}
+}
+
+func asSetEqual(a, b *Path) bool {
+	return slices.Equal(a.GetAsList(), b.GetAsList())
+}

--- a/internal/pkg/table/aggregate_test.go
+++ b/internal/pkg/table/aggregate_test.go
@@ -1,0 +1,171 @@
+// Copyright (C) 2024 Nippon Telegraph and Telephone Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	"github.com/stretchr/testify/assert"
+)
+
+func (m *AggregateManager) contributorCount(family bgp.Family, aggPrefix string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	fmap, ok := m.aggregates[family]
+	if !ok {
+		return 0
+	}
+	agg, ok := fmap[aggPrefix]
+	if !ok {
+		return 0
+	}
+	return len(agg.contributors)
+}
+
+func localPath(t *testing.T, prefix string, asList []uint32) *Path {
+	t.Helper()
+	p := netip.MustParsePrefix(prefix)
+	nlri, err := bgp.NewIPAddrPrefix(p)
+	assert.NoError(t, err)
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP)}
+	if len(asList) > 0 {
+		attrs = append(attrs, bgp.NewPathAttributeAsPath(
+			[]bgp.AsPathParamInterface{bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, asList)}))
+	}
+	pi := &PeerInfo{AS: 65000, LocalAS: 65000, LocalID: netip.MustParseAddr("10.0.0.1")}
+	fam := bgp.RF_IPv4_UC
+	if p.Addr().Is6() {
+		fam = bgp.RF_IPv6_UC
+	}
+	return NewPath(fam, pi, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Time{}, false)
+}
+
+func newTestAggMgr() *AggregateManager {
+	pi := &PeerInfo{AS: 65000, LocalAS: 65000, LocalID: netip.MustParseAddr("10.0.0.1")}
+	return NewAggregateManager(slog.Default(), NewRoutingPolicy(slog.Default()), pi)
+}
+
+func TestAggregateOriginatesWhenContributorAppears(t *testing.T) {
+	m := newTestAggMgr()
+	agg := netip.MustParsePrefix("10.1.0.0/16")
+	assert.NoError(t, m.AddAggregate(bgp.RF_IPv4_UC, agg, false, false, ""))
+	out := m.evaluate(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.1.1.0/24"), localPath(t, "10.1.1.0/24", []uint32{65001}))
+	assert.Len(t, out, 1)
+	assert.False(t, out[0].IsWithdraw)
+	assert.Equal(t, agg.String(), out[0].GetNlri().String())
+}
+
+func TestAggregateWithdrawsWhenLastContributorLeaves(t *testing.T) {
+	m := newTestAggMgr()
+	agg := netip.MustParsePrefix("10.1.0.0/16")
+	assert.NoError(t, m.AddAggregate(bgp.RF_IPv4_UC, agg, false, false, ""))
+	m.evaluate(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.1.1.0/24"), localPath(t, "10.1.1.0/24", []uint32{65001}))
+	out := m.evaluate(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.1.1.0/24"), nil)
+	assert.Len(t, out, 1)
+	assert.True(t, out[0].IsWithdraw)
+}
+
+func TestAggregateAsSetCollectsContributorASes(t *testing.T) {
+	m := newTestAggMgr()
+	agg := netip.MustParsePrefix("10.1.0.0/16")
+	assert.NoError(t, m.AddAggregate(bgp.RF_IPv4_UC, agg, false, true, ""))
+	m.evaluate(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.1.1.0/24"), localPath(t, "10.1.1.0/24", []uint32{65001}))
+	out := m.evaluate(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.1.2.0/24"), localPath(t, "10.1.2.0/24", []uint32{65002}))
+	assert.Len(t, out, 1)
+	assert.Equal(t, []uint32{65001, 65002}, out[0].GetAsList())
+}
+
+func TestSummaryOnlySuppressesMoreSpecifics(t *testing.T) {
+	m := newTestAggMgr()
+	agg := netip.MustParsePrefix("10.1.0.0/16")
+	assert.NoError(t, m.AddAggregate(bgp.RF_IPv4_UC, agg, true, false, ""))
+	m.evaluate(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.1.1.0/24"), localPath(t, "10.1.1.0/24", []uint32{65001}))
+	assert.True(t, m.Suppressed(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.1.1.0/24")))
+	assert.False(t, m.Suppressed(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.2.0.0/24")))
+}
+
+func TestIPv6AggregateOriginates(t *testing.T) {
+	m := newTestAggMgr()
+	agg := netip.MustParsePrefix("2001:db8::/32")
+	assert.NoError(t, m.AddAggregate(bgp.RF_IPv6_UC, agg, false, false, ""))
+	out := m.evaluate(bgp.RF_IPv6_UC, netip.MustParsePrefix("2001:db8:1::/48"), localPath(t, "2001:db8:1::/48", []uint32{65001}))
+	assert.Len(t, out, 1)
+	assert.Equal(t, agg.String(), out[0].GetNlri().String())
+}
+
+func TestAggregateConcurrentEvaluate(t *testing.T) {
+	m := newTestAggMgr()
+	aggPrefix := netip.MustParsePrefix("10.1.0.0/16")
+	assert.NoError(t, m.AddAggregate(bgp.RF_IPv4_UC, aggPrefix, false, false, ""))
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		go func() {
+			defer wg.Done()
+			pfx := netip.MustParsePrefix(fmt.Sprintf("10.1.%d.0/24", i))
+			m.evaluate(bgp.RF_IPv4_UC, pfx, localPath(t, pfx.String(), []uint32{uint32(65001 + i)}))
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, n, m.contributorCount(bgp.RF_IPv4_UC, aggPrefix.String()))
+}
+
+func TestOverlappingAsSetAggregateNotSelfContributing(t *testing.T) {
+	m := newTestAggMgr()
+	assert.NoError(t, m.AddAggregate(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.0.0.0/8"), false, true, ""))
+	assert.NoError(t, m.AddAggregate(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.1.0.0/16"), false, true, ""))
+
+	contributor := localPath(t, "10.1.5.0/24", []uint32{65001})
+	m.evaluate(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.1.5.0/24"), contributor)
+
+	m.mu.Lock()
+	agg16 := m.aggregates[bgp.RF_IPv4_UC]["10.1.0.0/16"]
+	agg8 := m.aggregates[bgp.RF_IPv4_UC]["10.0.0.0/8"]
+	m.mu.Unlock()
+	assert.NotNil(t, agg16.advertised, "/16 aggregate must be advertised")
+	assert.NotNil(t, agg8.advertised, "/8 aggregate must be advertised")
+
+	// Re-evaluate against /8 with the /16 aggregate path as the candidate.
+	m.evaluate(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.1.0.0/16"), agg16.advertised)
+
+	m.mu.Lock()
+	_, has16 := agg8.contributors["10.1.0.0/16"]
+	m.mu.Unlock()
+	assert.False(t, has16, "/16 aggregate must not be a contributor to /8")
+}
+
+func TestDeleteAggregateReturnsWithdraw(t *testing.T) {
+	m := newTestAggMgr()
+	aggPrefix := netip.MustParsePrefix("10.1.0.0/16")
+	assert.NoError(t, m.AddAggregate(bgp.RF_IPv4_UC, aggPrefix, false, false, ""))
+	m.evaluate(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.1.1.0/24"), localPath(t, "10.1.1.0/24", []uint32{65001}))
+
+	withdraw, err := m.DeleteAggregate(bgp.RF_IPv4_UC, aggPrefix)
+	assert.NoError(t, err)
+	assert.NotNil(t, withdraw)
+	assert.True(t, withdraw.IsWithdraw)
+
+	_, err = m.DeleteAggregate(bgp.RF_IPv4_UC, aggPrefix)
+	assert.Error(t, err)
+}

--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -143,12 +143,13 @@ func makeAttributeList(
 }
 
 type TableManager struct {
-	mu             sync.RWMutex // protects tables and vrfs maps
-	tables         map[bgp.Family]*Table
-	vrfs           map[string]*Vrf
-	rfList         []bgp.Family
-	maxPathCounted atomic.Uint64
-	logger         *slog.Logger
+	mu               sync.RWMutex // protects tables and vrfs maps
+	tables           map[bgp.Family]*Table
+	vrfs             map[string]*Vrf
+	rfList           []bgp.Family
+	maxPathCounted   atomic.Uint64
+	logger           *slog.Logger
+	aggregateManager *AggregateManager
 }
 
 func NewTableManager(logger *slog.Logger, rfList []bgp.Family) *TableManager {
@@ -169,6 +170,43 @@ func NewTableManager(logger *slog.Logger, rfList []bgp.Family) *TableManager {
 // no lock is needed as rfList is not mutable, callers must treat the result as read-only.
 func (manager *TableManager) GetRFlist() []bgp.Family {
 	return manager.rfList
+}
+
+func (manager *TableManager) SetAggregateManager(am *AggregateManager) {
+	manager.aggregateManager = am
+}
+
+func (manager *TableManager) GetAggregateManager() *AggregateManager {
+	return manager.aggregateManager
+}
+
+// SeedAggregate scans all destinations in the family table and returns aggregate-triggered paths.
+func (manager *TableManager) SeedAggregate(family bgp.Family) []*Path {
+	if manager.aggregateManager == nil {
+		return nil
+	}
+	manager.mu.RLock()
+	tbl, ok := manager.tables[family]
+	manager.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+
+	var results []*Path
+	for _, shard := range tbl.destinations.shards {
+		shard.mu.RLock()
+		for _, dests := range shard.mp {
+			for _, dest := range dests {
+				best := dest.GetBestPath(GLOBAL_RIB_NAME, 0)
+				if best == nil {
+					continue
+				}
+				results = append(results, manager.aggregateManager.evaluate(family, prefixOf(best), best)...)
+			}
+		}
+		shard.mu.RUnlock()
+	}
+	return results
 }
 
 func (manager *TableManager) AddVrf(name string, id uint32, rd bgp.RouteDistinguisherInterface, importRt, exportRt []bgp.ExtendedCommunityInterface, info *PeerInfo) ([]*Path, error) {
@@ -252,12 +290,26 @@ func (manager *TableManager) Update(newPath *Path) []*Update {
 		return updates
 	}
 
-	updates = append(updates, table.update(newPath))
+	u := table.update(newPath)
+	updates = append(updates, u)
+
 	if family == bgp.RF_EVPN {
 		for _, p := range manager.handleMacMobility(newPath) {
 			updates = append(updates, table.update(p))
 		}
 	}
+
+	if manager.aggregateManager != nil && manager.aggregateManager.Active() {
+		var newBest *Path
+		if len(u.KnownPathList) > 0 && !u.KnownPathList[0].IsNexthopInvalid {
+			newBest = u.KnownPathList[0]
+		}
+		dest := prefixOf(newPath)
+		for _, aggPath := range manager.aggregateManager.evaluate(family, dest, newBest) {
+			updates = append(updates, table.update(aggPath))
+		}
+	}
+
 	return updates
 }
 

--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -145,12 +145,13 @@ func makeAttributeList(
 }
 
 type TableManager struct {
-	mu             sync.RWMutex // protects tables and vrfs maps
-	tables         map[bgp.Family]*Table
-	vrfs           map[string]*Vrf
-	rfList         []bgp.Family
-	maxPathCounted atomic.Uint64
-	logger         *slog.Logger
+	mu               sync.RWMutex // protects tables and vrfs maps
+	tables           map[bgp.Family]*Table
+	vrfs             map[string]*Vrf
+	rfList           []bgp.Family
+	maxPathCounted   atomic.Uint64
+	logger           *slog.Logger
+	aggregateManager *AggregateManager
 }
 
 func NewTableManager(logger *slog.Logger, rfList []bgp.Family) *TableManager {
@@ -171,6 +172,43 @@ func NewTableManager(logger *slog.Logger, rfList []bgp.Family) *TableManager {
 // no lock is needed as rfList is not mutable, callers must treat the result as read-only.
 func (manager *TableManager) GetRFlist() []bgp.Family {
 	return manager.rfList
+}
+
+func (manager *TableManager) SetAggregateManager(am *AggregateManager) {
+	manager.aggregateManager = am
+}
+
+func (manager *TableManager) GetAggregateManager() *AggregateManager {
+	return manager.aggregateManager
+}
+
+// SeedAggregate scans all destinations in the family table and returns aggregate-triggered paths.
+func (manager *TableManager) SeedAggregate(family bgp.Family) []*Path {
+	if manager.aggregateManager == nil {
+		return nil
+	}
+	manager.mu.RLock()
+	tbl, ok := manager.tables[family]
+	manager.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+
+	var results []*Path
+	for _, shard := range tbl.destinations.shards {
+		shard.mu.RLock()
+		for _, dests := range shard.mp {
+			for _, dest := range dests {
+				best := dest.GetBestPath(GLOBAL_RIB_NAME, 0)
+				if best == nil {
+					continue
+				}
+				results = append(results, manager.aggregateManager.evaluate(family, prefixOf(best), best)...)
+			}
+		}
+		shard.mu.RUnlock()
+	}
+	return results
 }
 
 func (manager *TableManager) AddVrf(name string, id uint32, rd bgp.RouteDistinguisherInterface, importRt, exportRt []bgp.ExtendedCommunityInterface, info *PeerInfo) ([]*Path, error) {
@@ -254,12 +292,26 @@ func (manager *TableManager) Update(newPath *Path) []*Update {
 		return updates
 	}
 
-	updates = append(updates, table.update(newPath))
+	u := table.update(newPath)
+	updates = append(updates, u)
+
 	if family == bgp.RF_EVPN {
 		for _, p := range manager.handleMacMobility(newPath) {
 			updates = append(updates, table.update(p))
 		}
 	}
+
+	if manager.aggregateManager != nil && manager.aggregateManager.Active() {
+		var newBest *Path
+		if len(u.KnownPathList) > 0 && !u.KnownPathList[0].IsNexthopInvalid {
+			newBest = u.KnownPathList[0]
+		}
+		dest := prefixOf(newPath)
+		for _, aggPath := range manager.aggregateManager.evaluate(family, dest, newBest) {
+			updates = append(updates, table.update(aggPath))
+		}
+	}
+
 	return updates
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -389,6 +389,19 @@ func InitialConfig(ctx context.Context, bgpServer *server.BgpServer, newConfig *
 		}
 	}
 
+	for _, a := range newConfig.Global.Aggregates {
+		if err := bgpServer.AddAggregate(ctx, &api.AddAggregateRequest{
+			Aggregate: &api.AggregateAddress{
+				Prefix:      a.Config.Prefix.String(),
+				SummaryOnly: a.Config.SummaryOnly,
+				AsSet:       a.Config.AsSet,
+				PolicyName:  a.Config.PolicyName,
+			},
+		}); err != nil {
+			return nil, err
+		}
+	}
+
 	addPeerGroups(ctx, bgpServer, addedPg)
 	addDynamicNeighbors(ctx, bgpServer, newConfig.DynamicNeighbors)
 	addNeighbors(ctx, bgpServer, added)
@@ -425,6 +438,36 @@ func UpdateConfig(ctx context.Context, bgpServer *server.BgpServer, c, newConfig
 	if !newConfig.Global.ApplyPolicy.Config.Equal(&c.Global.ApplyPolicy.Config) {
 		assignGlobalpolicy(ctx, bgpServer, &newConfig.Global.ApplyPolicy.Config)
 		updatePolicy = true
+	}
+
+	oldAggs := map[string]oc.Aggregate{}
+	for _, a := range c.Global.Aggregates {
+		oldAggs[a.Config.Prefix.String()] = a
+	}
+	newAggs := map[string]oc.Aggregate{}
+	for _, a := range newConfig.Global.Aggregates {
+		newAggs[a.Config.Prefix.String()] = a
+	}
+	for k, a := range oldAggs {
+		n, ok := newAggs[k]
+		if !ok || !a.Config.Equal(&n.Config) {
+			if err := bgpServer.DeleteAggregate(ctx, &api.DeleteAggregateRequest{Prefix: a.Config.Prefix.String()}); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for k, a := range newAggs {
+		o, ok := oldAggs[k]
+		if !ok || !o.Config.Equal(&a.Config) {
+			if err := bgpServer.AddAggregate(ctx, &api.AddAggregateRequest{Aggregate: &api.AggregateAddress{
+				Prefix:      a.Config.Prefix.String(),
+				SummaryOnly: a.Config.SummaryOnly,
+				AsSet:       a.Config.AsSet,
+				PolicyName:  a.Config.PolicyName,
+			}}); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	addPeerGroups(ctx, bgpServer, addedPg)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -397,6 +397,19 @@ func InitialConfig(ctx context.Context, bgpServer *server.BgpServer, newConfig *
 		}
 	}
 
+	for _, a := range newConfig.Global.Aggregates {
+		if err := bgpServer.AddAggregate(ctx, &api.AddAggregateRequest{
+			Aggregate: &api.AggregateAddress{
+				Prefix:      a.Config.Prefix.String(),
+				SummaryOnly: a.Config.SummaryOnly,
+				AsSet:       a.Config.AsSet,
+				PolicyName:  a.Config.PolicyName,
+			},
+		}); err != nil {
+			return nil, err
+		}
+	}
+
 	addPeerGroups(ctx, bgpServer, addedPg)
 	addDynamicNeighbors(ctx, bgpServer, newConfig.DynamicNeighbors)
 	addNeighbors(ctx, bgpServer, added)
@@ -442,6 +455,36 @@ func UpdateConfig(ctx context.Context, bgpServer *server.BgpServer, c, newConfig
 	// keychains and new keys must exist before peers can reference them
 	addTcpAoKeychains(ctx, bgpServer, addedKeychains)
 	updateTcpAoKeychains(ctx, bgpServer, upsertKeyUpdates)
+
+	oldAggs := map[string]oc.Aggregate{}
+	for _, a := range c.Global.Aggregates {
+		oldAggs[a.Config.Prefix.String()] = a
+	}
+	newAggs := map[string]oc.Aggregate{}
+	for _, a := range newConfig.Global.Aggregates {
+		newAggs[a.Config.Prefix.String()] = a
+	}
+	for k, a := range oldAggs {
+		n, ok := newAggs[k]
+		if !ok || !a.Config.Equal(&n.Config) {
+			if err := bgpServer.DeleteAggregate(ctx, &api.DeleteAggregateRequest{Prefix: a.Config.Prefix.String()}); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for k, a := range newAggs {
+		o, ok := oldAggs[k]
+		if !ok || !o.Config.Equal(&a.Config) {
+			if err := bgpServer.AddAggregate(ctx, &api.AddAggregateRequest{Aggregate: &api.AggregateAddress{
+				Prefix:      a.Config.Prefix.String(),
+				SummaryOnly: a.Config.SummaryOnly,
+				AsSet:       a.Config.AsSet,
+				PolicyName:  a.Config.PolicyName,
+			}}); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	addPeerGroups(ctx, bgpServer, addedPg)
 	deletePeerGroups(ctx, bgpServer, deletedPg)

--- a/pkg/config/oc/bgp_configs.go
+++ b/pkg/config/oc/bgp_configs.go
@@ -1162,6 +1162,70 @@ func (lhs *DynamicNeighbor) Equal(rhs *DynamicNeighbor) bool {
 }
 
 // struct for container gobgp:state.
+type AggregateState struct {
+	// original -> gobgp:prefix
+	// gobgp:prefix's original type is inet:ip-prefix.
+	Prefix netip.Prefix `mapstructure:"prefix" json:"prefix,omitempty"`
+	// original -> gobgp:summary-only
+	SummaryOnly bool `mapstructure:"summary-only" json:"summary-only,omitempty"`
+	// original -> gobgp:as-set
+	AsSet bool `mapstructure:"as-set" json:"as-set,omitempty"`
+	// original -> gobgp:policy-name
+	PolicyName string `mapstructure:"policy-name" json:"policy-name,omitempty"`
+}
+
+// struct for container gobgp:config.
+type AggregateConfig struct {
+	// original -> gobgp:prefix
+	// gobgp:prefix's original type is inet:ip-prefix.
+	Prefix netip.Prefix `mapstructure:"prefix" json:"prefix,omitempty"`
+	// original -> gobgp:summary-only
+	SummaryOnly bool `mapstructure:"summary-only" json:"summary-only,omitempty"`
+	// original -> gobgp:as-set
+	AsSet bool `mapstructure:"as-set" json:"as-set,omitempty"`
+	// original -> gobgp:policy-name
+	PolicyName string `mapstructure:"policy-name" json:"policy-name,omitempty"`
+}
+
+func (lhs *AggregateConfig) Equal(rhs *AggregateConfig) bool {
+	if lhs == nil || rhs == nil {
+		return false
+	}
+	if lhs.Prefix != rhs.Prefix {
+		return false
+	}
+	if lhs.SummaryOnly != rhs.SummaryOnly {
+		return false
+	}
+	if lhs.AsSet != rhs.AsSet {
+		return false
+	}
+	if lhs.PolicyName != rhs.PolicyName {
+		return false
+	}
+	return true
+}
+
+// struct for container gobgp:aggregate.
+type Aggregate struct {
+	// original -> gobgp:prefix
+	// original -> gobgp:aggregate-config
+	Config AggregateConfig `mapstructure:"config" json:"config,omitempty"`
+	// original -> gobgp:aggregate-state
+	State AggregateState `mapstructure:"state" json:"state,omitempty"`
+}
+
+func (lhs *Aggregate) Equal(rhs *Aggregate) bool {
+	if lhs == nil || rhs == nil {
+		return false
+	}
+	if !lhs.Config.Equal(&(rhs.Config)) {
+		return false
+	}
+	return true
+}
+
+// struct for container gobgp:state.
 type CollectorState struct {
 	// original -> gobgp:url
 	Url string `mapstructure:"url" json:"url,omitempty"`
@@ -5173,6 +5237,8 @@ type Global struct {
 	// routing table, i.e., export (send) and import (receive),
 	// depending on the context.
 	ApplyPolicy ApplyPolicy `mapstructure:"apply-policy" json:"apply-policy,omitempty"`
+	// original -> gobgp:aggregates
+	Aggregates []Aggregate `mapstructure:"aggregates" json:"aggregates,omitempty"`
 }
 
 func (lhs *Global) Equal(rhs *Global) bool {
@@ -5207,6 +5273,14 @@ func (lhs *Global) Equal(rhs *Global) bool {
 	}
 	if !lhs.ApplyPolicy.Equal(&(rhs.ApplyPolicy)) {
 		return false
+	}
+	if len(lhs.Aggregates) != len(rhs.Aggregates) {
+		return false
+	}
+	for i, r := range rhs.Aggregates {
+		if !r.Equal(&lhs.Aggregates[i]) {
+			return false
+		}
 	}
 	return true
 }

--- a/pkg/config/oc/bgp_configs.go
+++ b/pkg/config/oc/bgp_configs.go
@@ -1316,6 +1316,70 @@ func (lhs *DynamicNeighbor) Equal(rhs *DynamicNeighbor) bool {
 }
 
 // struct for container gobgp:state.
+type AggregateState struct {
+	// original -> gobgp:prefix
+	// gobgp:prefix's original type is inet:ip-prefix.
+	Prefix netip.Prefix `mapstructure:"prefix" json:"prefix,omitempty"`
+	// original -> gobgp:summary-only
+	SummaryOnly bool `mapstructure:"summary-only" json:"summary-only,omitempty"`
+	// original -> gobgp:as-set
+	AsSet bool `mapstructure:"as-set" json:"as-set,omitempty"`
+	// original -> gobgp:policy-name
+	PolicyName string `mapstructure:"policy-name" json:"policy-name,omitempty"`
+}
+
+// struct for container gobgp:config.
+type AggregateConfig struct {
+	// original -> gobgp:prefix
+	// gobgp:prefix's original type is inet:ip-prefix.
+	Prefix netip.Prefix `mapstructure:"prefix" json:"prefix,omitempty"`
+	// original -> gobgp:summary-only
+	SummaryOnly bool `mapstructure:"summary-only" json:"summary-only,omitempty"`
+	// original -> gobgp:as-set
+	AsSet bool `mapstructure:"as-set" json:"as-set,omitempty"`
+	// original -> gobgp:policy-name
+	PolicyName string `mapstructure:"policy-name" json:"policy-name,omitempty"`
+}
+
+func (lhs *AggregateConfig) Equal(rhs *AggregateConfig) bool {
+	if lhs == nil || rhs == nil {
+		return false
+	}
+	if lhs.Prefix != rhs.Prefix {
+		return false
+	}
+	if lhs.SummaryOnly != rhs.SummaryOnly {
+		return false
+	}
+	if lhs.AsSet != rhs.AsSet {
+		return false
+	}
+	if lhs.PolicyName != rhs.PolicyName {
+		return false
+	}
+	return true
+}
+
+// struct for container gobgp:aggregate.
+type Aggregate struct {
+	// original -> gobgp:prefix
+	// original -> gobgp:aggregate-config
+	Config AggregateConfig `mapstructure:"config" json:"config,omitempty"`
+	// original -> gobgp:aggregate-state
+	State AggregateState `mapstructure:"state" json:"state,omitempty"`
+}
+
+func (lhs *Aggregate) Equal(rhs *Aggregate) bool {
+	if lhs == nil || rhs == nil {
+		return false
+	}
+	if !lhs.Config.Equal(&(rhs.Config)) {
+		return false
+	}
+	return true
+}
+
+// struct for container gobgp:state.
 type CollectorState struct {
 	// original -> gobgp:url
 	Url string `mapstructure:"url" json:"url,omitempty"`
@@ -5336,6 +5400,8 @@ type Global struct {
 	// routing table, i.e., export (send) and import (receive),
 	// depending on the context.
 	ApplyPolicy ApplyPolicy `mapstructure:"apply-policy" json:"apply-policy,omitempty"`
+	// original -> gobgp:aggregates
+	Aggregates []Aggregate `mapstructure:"aggregates" json:"aggregates,omitempty"`
 }
 
 func (lhs *Global) Equal(rhs *Global) bool {
@@ -5370,6 +5436,14 @@ func (lhs *Global) Equal(rhs *Global) bool {
 	}
 	if !lhs.ApplyPolicy.Equal(&(rhs.ApplyPolicy)) {
 		return false
+	}
+	if len(lhs.Aggregates) != len(rhs.Aggregates) {
+		return false
+	}
+	for i, r := range rhs.Aggregates {
+		if !r.Equal(&lhs.Aggregates[i]) {
+			return false
+		}
 	}
 	return true
 }

--- a/pkg/config/server_config_test.go
+++ b/pkg/config/server_config_test.go
@@ -14,6 +14,77 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newTestServer(t *testing.T) (*server.BgpServer, context.Context) {
+	t.Helper()
+	s := server.NewBgpServer()
+	go s.Serve()
+	t.Cleanup(func() { _ = s.StopBgp(context.Background(), &api.StopBgpRequest{}) })
+	return s, context.Background()
+}
+
+func baseGlobal(port int32) oc.Global {
+	return oc.Global{Config: oc.GlobalConfig{As: 65001, RouterId: netip.MustParseAddr("10.0.0.1"), Port: port}}
+}
+
+func listAggregates(t *testing.T, s *server.BgpServer, ctx context.Context) []*api.AggregateAddressInfo {
+	t.Helper()
+	var out []*api.AggregateAddressInfo
+	require.NoError(t, s.ListAggregate(ctx, &api.ListAggregateRequest{}, func(a *api.AggregateAddressInfo) {
+		out = append(out, a)
+	}))
+	return out
+}
+
+func TestInitialConfigAppliesAggregates(t *testing.T) {
+	s, ctx := newTestServer(t)
+	cfg := &oc.BgpConfigSet{
+		Global: baseGlobal(-1),
+	}
+	cfg.Global.Aggregates = []oc.Aggregate{
+		{Config: oc.AggregateConfig{Prefix: netip.MustParsePrefix("10.0.0.0/8"), SummaryOnly: true}},
+	}
+	_, err := InitialConfig(ctx, s, cfg, false)
+	require.NoError(t, err)
+
+	aggs := listAggregates(t, s, ctx)
+	require.Len(t, aggs, 1)
+	assert.Equal(t, "10.0.0.0/8", aggs[0].Aggregate.Prefix)
+	assert.True(t, aggs[0].Aggregate.SummaryOnly)
+}
+
+func TestUpdateConfigAggregateDiff(t *testing.T) {
+	s, ctx := newTestServer(t)
+	initial := &oc.BgpConfigSet{Global: baseGlobal(-1)}
+	initial.Global.Aggregates = []oc.Aggregate{
+		{Config: oc.AggregateConfig{Prefix: netip.MustParsePrefix("10.0.0.0/8")}},
+		{Config: oc.AggregateConfig{Prefix: netip.MustParsePrefix("192.168.0.0/16")}},
+	}
+	current, err := InitialConfig(ctx, s, initial, false)
+	require.NoError(t, err)
+	require.Len(t, listAggregates(t, s, ctx), 2)
+
+	updated := &oc.BgpConfigSet{Global: baseGlobal(-1)}
+	updated.Global.Aggregates = []oc.Aggregate{
+		{Config: oc.AggregateConfig{Prefix: netip.MustParsePrefix("10.0.0.0/8"), SummaryOnly: true}},
+		{Config: oc.AggregateConfig{Prefix: netip.MustParsePrefix("172.16.0.0/12")}},
+	}
+	_, err = UpdateConfig(ctx, s, current, updated)
+	require.NoError(t, err)
+
+	aggs := listAggregates(t, s, ctx)
+	require.Len(t, aggs, 2)
+	prefixes := map[string]bool{}
+	for _, a := range aggs {
+		prefixes[a.Aggregate.Prefix] = true
+		if a.Aggregate.Prefix == "10.0.0.0/8" {
+			assert.True(t, a.Aggregate.SummaryOnly)
+		}
+	}
+	assert.True(t, prefixes["10.0.0.0/8"])
+	assert.True(t, prefixes["172.16.0.0/12"])
+	assert.False(t, prefixes["192.168.0.0/16"])
+}
+
 type ErrorCaptureHandler struct {
 	configErrors []string
 	baseHandler  slog.Handler

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -841,6 +841,31 @@ func (s *server) DeleteVrf(ctx context.Context, r *api.DeleteVrfRequest) (*api.D
 	return &api.DeleteVrfResponse{}, s.bgpServer.DeleteVrf(ctx, r)
 }
 
+func (s *server) ListAggregate(r *api.ListAggregateRequest, stream api.GoBgpService_ListAggregateServer) error {
+	ctx, cancel := context.WithCancel(stream.Context())
+	defer cancel()
+	var sendErr error
+	fn := func(a *api.AggregateAddressInfo) {
+		if sendErr = stream.Send(&api.ListAggregateResponse{Aggregate: a}); sendErr != nil {
+			cancel()
+			return
+		}
+	}
+	err := s.bgpServer.ListAggregate(ctx, r, fn)
+	if sendErr != nil {
+		return sendErr
+	}
+	return err
+}
+
+func (s *server) AddAggregate(ctx context.Context, r *api.AddAggregateRequest) (*api.AddAggregateResponse, error) {
+	return &api.AddAggregateResponse{}, s.bgpServer.AddAggregate(ctx, r)
+}
+
+func (s *server) DeleteAggregate(ctx context.Context, r *api.DeleteAggregateRequest) (*api.DeleteAggregateResponse, error) {
+	return &api.DeleteAggregateResponse{}, s.bgpServer.DeleteAggregate(ctx, r)
+}
+
 func readMpGracefulRestartFromAPIStruct(c *oc.MpGracefulRestart, a *api.MpGracefulRestart) {
 	if c == nil || a == nil {
 		return

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -828,6 +828,31 @@ func (s *server) DeleteVrf(ctx context.Context, r *api.DeleteVrfRequest) (*api.D
 	return &api.DeleteVrfResponse{}, s.bgpServer.DeleteVrf(ctx, r)
 }
 
+func (s *server) ListAggregate(r *api.ListAggregateRequest, stream api.GoBgpService_ListAggregateServer) error {
+	ctx, cancel := context.WithCancel(stream.Context())
+	defer cancel()
+	var sendErr error
+	fn := func(a *api.AggregateAddressInfo) {
+		if sendErr = stream.Send(&api.ListAggregateResponse{Aggregate: a}); sendErr != nil {
+			cancel()
+			return
+		}
+	}
+	err := s.bgpServer.ListAggregate(ctx, r, fn)
+	if sendErr != nil {
+		return sendErr
+	}
+	return err
+}
+
+func (s *server) AddAggregate(ctx context.Context, r *api.AddAggregateRequest) (*api.AddAggregateResponse, error) {
+	return &api.AddAggregateResponse{}, s.bgpServer.AddAggregate(ctx, r)
+}
+
+func (s *server) DeleteAggregate(ctx context.Context, r *api.DeleteAggregateRequest) (*api.DeleteAggregateResponse, error) {
+	return &api.DeleteAggregateResponse{}, s.bgpServer.DeleteAggregate(ctx, r)
+}
+
 func readMpGracefulRestartFromAPIStruct(c *oc.MpGracefulRestart, a *api.MpGracefulRestart) {
 	if c == nil || a == nil {
 		return

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -572,6 +572,17 @@ func filterpath(peer *peer, path, old *table.Path) *table.Path {
 }
 
 func (s *BgpServer) prePolicyFilterpath(peer *peer, path, old *table.Path) (*table.Path, *table.PolicyOptions, bool) {
+	if path != nil && !path.IsWithdraw && s.globalRib != nil {
+		if aggMgr := s.globalRib.GetAggregateManager(); aggMgr != nil && aggMgr.Active() {
+			if pfx, ok := path.GetNlri().(*bgp.IPAddrPrefix); ok && aggMgr.Suppressed(path.GetFamily(), pfx.Prefix) {
+				peerInfo := peer.peerInfo.Load()
+				if peerInfo == nil {
+					return nil, nil, true
+				}
+				return nil, &table.PolicyOptions{Info: peerInfo}, false
+			}
+		}
+	}
 	// Special handling for RTM NLRI.
 	if path != nil && path.GetFamily() == bgp.RF_RTC_UC && !path.IsWithdraw {
 		// If the given "path" is locally generated and the same with "old", we
@@ -2597,6 +2608,8 @@ func (s *BgpServer) StartBgp(ctx context.Context, r *api.StartBgpRequest) error 
 		if err := s.policy.Initialize(); err != nil {
 			return err
 		}
+		peerInfo := &table.PeerInfo{AS: c.Config.As, LocalAS: c.Config.As, LocalID: c.Config.RouterId}
+		s.globalRib.SetAggregateManager(table.NewAggregateManager(s.logger, s.policy, peerInfo))
 		s.bgpConfig.Global = *c
 		// update route selection options
 		table.SelectionOptions = c.RouteSelectionOptions.Config
@@ -4225,6 +4238,105 @@ func (s *BgpServer) DeletePolicy(ctx context.Context, r *api.DeletePolicyRequest
 
 		return s.policy.DeletePolicy(p, r.All, r.PreserveStatements, l)
 	}, false)
+}
+
+func (s *BgpServer) AddAggregate(ctx context.Context, r *api.AddAggregateRequest) error {
+	if r == nil || r.Aggregate == nil {
+		return fmt.Errorf("nil request")
+	}
+	return s.mgmtOperation(func() error {
+		aggMgr := s.globalRib.GetAggregateManager()
+		if aggMgr == nil {
+			return fmt.Errorf("aggregate manager not initialized")
+		}
+		prefix, err := netip.ParsePrefix(r.Aggregate.Prefix)
+		if err != nil {
+			return fmt.Errorf("invalid prefix: %w", err)
+		}
+		family := bgp.RF_IPv4_UC
+		if prefix.Addr().Is6() {
+			family = bgp.RF_IPv6_UC
+		}
+		if err := aggMgr.AddAggregate(family, prefix, r.Aggregate.SummaryOnly, r.Aggregate.AsSet, r.Aggregate.PolicyName); err != nil {
+			return err
+		}
+		if paths := s.globalRib.SeedAggregate(family); len(paths) > 0 {
+			s.propagateUpdate(nil, paths)
+		}
+		return nil
+	}, true)
+}
+
+func (s *BgpServer) DeleteAggregate(ctx context.Context, r *api.DeleteAggregateRequest) error {
+	if r == nil {
+		return fmt.Errorf("nil request")
+	}
+	return s.mgmtOperation(func() error {
+		aggMgr := s.globalRib.GetAggregateManager()
+		if aggMgr == nil {
+			return fmt.Errorf("aggregate manager not initialized")
+		}
+		prefix, err := netip.ParsePrefix(r.Prefix)
+		if err != nil {
+			return fmt.Errorf("invalid prefix: %w", err)
+		}
+		family := bgp.RF_IPv4_UC
+		if prefix.Addr().Is6() {
+			family = bgp.RF_IPv6_UC
+		}
+		withdraw, err := aggMgr.DeleteAggregate(family, prefix)
+		if err != nil {
+			return err
+		}
+		if withdraw != nil {
+			s.propagateUpdate(nil, []*table.Path{withdraw})
+		}
+		return nil
+	}, true)
+}
+
+func (s *BgpServer) ListAggregate(ctx context.Context, r *api.ListAggregateRequest, fn func(*api.AggregateAddressInfo)) error {
+	if r == nil {
+		return fmt.Errorf("nil request")
+	}
+	var l []*api.AggregateAddressInfo
+	err := s.mgmtOperation(func() error {
+		aggMgr := s.globalRib.GetAggregateManager()
+		if aggMgr == nil {
+			return nil
+		}
+		var familyPtr *bgp.Family
+		if r.Family != nil {
+			f := bgp.NewFamily(uint16(r.Family.Afi), uint8(r.Family.Safi))
+			familyPtr = &f
+		}
+		infos := aggMgr.List(familyPtr)
+		l = make([]*api.AggregateAddressInfo, 0, len(infos))
+		for _, info := range infos {
+			l = append(l, &api.AggregateAddressInfo{
+				Aggregate: &api.AggregateAddress{
+					Prefix:      info.Prefix.String(),
+					SummaryOnly: info.SummaryOnly,
+					AsSet:       info.AsSet,
+					PolicyName:  info.PolicyName,
+				},
+				NumContributors: uint32(info.Contributors),
+			})
+		}
+		return nil
+	}, false)
+	if err != nil {
+		return err
+	}
+	for _, a := range l {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			fn(a)
+		}
+	}
+	return nil
 }
 
 func (s *BgpServer) toPolicyInfo(name string, dir api.PolicyDirection) (string, table.PolicyDirection, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -584,6 +584,17 @@ func filterpath(peer *peer, path, old *table.Path) *table.Path {
 }
 
 func (s *BgpServer) prePolicyFilterpath(peer *peer, path, old *table.Path) (*table.Path, *table.PolicyOptions, bool) {
+	if path != nil && !path.IsWithdraw && s.globalRib != nil {
+		if aggMgr := s.globalRib.GetAggregateManager(); aggMgr != nil && aggMgr.Active() {
+			if pfx, ok := path.GetNlri().(*bgp.IPAddrPrefix); ok && aggMgr.Suppressed(path.GetFamily(), pfx.Prefix) {
+				peerInfo := peer.peerInfo.Load()
+				if peerInfo == nil {
+					return nil, nil, true
+				}
+				return nil, &table.PolicyOptions{Info: peerInfo}, false
+			}
+		}
+	}
 	// Special handling for RTM NLRI.
 	if path != nil && path.GetFamily() == bgp.RF_RTC_UC && !path.IsWithdraw {
 		// If the given "path" is locally generated and the same with "old", we
@@ -2680,6 +2691,8 @@ func (s *BgpServer) StartBgp(ctx context.Context, r *api.StartBgpRequest) error 
 		if err := s.policy.Initialize(); err != nil {
 			return err
 		}
+		peerInfo := &table.PeerInfo{AS: c.Config.As, LocalAS: c.Config.As, LocalID: c.Config.RouterId}
+		s.globalRib.SetAggregateManager(table.NewAggregateManager(s.logger, s.policy, peerInfo))
 		s.bgpConfig.Global = *c
 		// update route selection options
 		table.SelectionOptions = c.RouteSelectionOptions.Config
@@ -4364,6 +4377,105 @@ func (s *BgpServer) DeletePolicy(ctx context.Context, r *api.DeletePolicyRequest
 
 		return s.policy.DeletePolicy(p, r.All, r.PreserveStatements, l)
 	}, false)
+}
+
+func (s *BgpServer) AddAggregate(ctx context.Context, r *api.AddAggregateRequest) error {
+	if r == nil || r.Aggregate == nil {
+		return fmt.Errorf("nil request")
+	}
+	return s.mgmtOperation(func() error {
+		aggMgr := s.globalRib.GetAggregateManager()
+		if aggMgr == nil {
+			return fmt.Errorf("aggregate manager not initialized")
+		}
+		prefix, err := netip.ParsePrefix(r.Aggregate.Prefix)
+		if err != nil {
+			return fmt.Errorf("invalid prefix: %w", err)
+		}
+		family := bgp.RF_IPv4_UC
+		if prefix.Addr().Is6() {
+			family = bgp.RF_IPv6_UC
+		}
+		if err := aggMgr.AddAggregate(family, prefix, r.Aggregate.SummaryOnly, r.Aggregate.AsSet, r.Aggregate.PolicyName); err != nil {
+			return err
+		}
+		if paths := s.globalRib.SeedAggregate(family); len(paths) > 0 {
+			s.propagateUpdate(nil, paths)
+		}
+		return nil
+	}, true)
+}
+
+func (s *BgpServer) DeleteAggregate(ctx context.Context, r *api.DeleteAggregateRequest) error {
+	if r == nil {
+		return fmt.Errorf("nil request")
+	}
+	return s.mgmtOperation(func() error {
+		aggMgr := s.globalRib.GetAggregateManager()
+		if aggMgr == nil {
+			return fmt.Errorf("aggregate manager not initialized")
+		}
+		prefix, err := netip.ParsePrefix(r.Prefix)
+		if err != nil {
+			return fmt.Errorf("invalid prefix: %w", err)
+		}
+		family := bgp.RF_IPv4_UC
+		if prefix.Addr().Is6() {
+			family = bgp.RF_IPv6_UC
+		}
+		withdraw, err := aggMgr.DeleteAggregate(family, prefix)
+		if err != nil {
+			return err
+		}
+		if withdraw != nil {
+			s.propagateUpdate(nil, []*table.Path{withdraw})
+		}
+		return nil
+	}, true)
+}
+
+func (s *BgpServer) ListAggregate(ctx context.Context, r *api.ListAggregateRequest, fn func(*api.AggregateAddressInfo)) error {
+	if r == nil {
+		return fmt.Errorf("nil request")
+	}
+	var l []*api.AggregateAddressInfo
+	err := s.mgmtOperation(func() error {
+		aggMgr := s.globalRib.GetAggregateManager()
+		if aggMgr == nil {
+			return nil
+		}
+		var familyPtr *bgp.Family
+		if r.Family != nil {
+			f := bgp.NewFamily(uint16(r.Family.Afi), uint8(r.Family.Safi))
+			familyPtr = &f
+		}
+		infos := aggMgr.List(familyPtr)
+		l = make([]*api.AggregateAddressInfo, 0, len(infos))
+		for _, info := range infos {
+			l = append(l, &api.AggregateAddressInfo{
+				Aggregate: &api.AggregateAddress{
+					Prefix:      info.Prefix.String(),
+					SummaryOnly: info.SummaryOnly,
+					AsSet:       info.AsSet,
+					PolicyName:  info.PolicyName,
+				},
+				NumContributors: uint32(info.Contributors),
+			})
+		}
+		return nil
+	}, false)
+	if err != nil {
+		return err
+	}
+	for _, a := range l {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			fn(a)
+		}
+	}
+	return nil
 }
 
 func (s *BgpServer) toPolicyInfo(name string, dir api.PolicyDirection) (string, table.PolicyDirection, error) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1604,6 +1604,39 @@ func TestFilterpathWithRejectPolicy(t *testing.T) {
 	}
 }
 
+func TestFilterpathSuppressedNoOldNoPanic(t *testing.T) {
+	rib := table.NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
+	gConf := &oc.Global{Config: oc.GlobalConfig{As: 65000, RouterId: netip.MustParseAddr("1.1.1.1")}}
+	nConf := &oc.Neighbor{}
+	localAddr := netip.MustParseAddr("1.1.1.1")
+	aggPeerInfo := table.NewPeerInfo(gConf, nConf, 0, 65000, localAddr, localAddr, localAddr, localAddr)
+	aggMgr := table.NewAggregateManager(logger, table.NewRoutingPolicy(logger), aggPeerInfo)
+	if err := aggMgr.AddAggregate(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.0.0.0/8"), true, false, ""); err != nil {
+		t.Fatal(err)
+	}
+	rib.SetAggregateManager(aggMgr)
+
+	peer := newPeerandInfo(t, 65000, 65001, "192.168.0.1", rib)
+	pi := peer.peerInfo.Load()
+	pa := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65001})}),
+	}
+	aggNlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.1.1.0/24"))
+	contributor := table.NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: aggNlri}, false, pa, time.Now(), false)
+	rib.Update(contributor)
+
+	s := NewBgpServer()
+	s.globalRib = rib
+
+	moreSpecific, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.1.1.0/24"))
+	newPath := table.NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: moreSpecific}, false, pa, time.Now(), false)
+	oldPath := newPath.Clone(false)
+
+	result := s.filterpath(peer, newPath, oldPath)
+	assert.NotNil(t, result, "suppressed path with prior advertisement must produce a withdraw, not nil")
+	assert.True(t, result.IsWithdraw, "suppressed path must be withdrawn to peer")
+}
+
 func TestPeerGroup(test *testing.T) {
 	assert := assert.New(test)
 	s := NewBgpServer()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1808,6 +1808,39 @@ func TestFilterpathWithRejectPolicy(t *testing.T) {
 	}
 }
 
+func TestFilterpathSuppressedNoOldNoPanic(t *testing.T) {
+	rib := table.NewTableManager(logger, []bgp.Family{bgp.RF_IPv4_UC})
+	gConf := &oc.Global{Config: oc.GlobalConfig{As: 65000, RouterId: netip.MustParseAddr("1.1.1.1")}}
+	nConf := &oc.Neighbor{}
+	localAddr := netip.MustParseAddr("1.1.1.1")
+	aggPeerInfo := table.NewPeerInfo(gConf, nConf, 0, 65000, localAddr, localAddr, localAddr, localAddr)
+	aggMgr := table.NewAggregateManager(logger, table.NewRoutingPolicy(logger), aggPeerInfo)
+	if err := aggMgr.AddAggregate(bgp.RF_IPv4_UC, netip.MustParsePrefix("10.0.0.0/8"), true, false, ""); err != nil {
+		t.Fatal(err)
+	}
+	rib.SetAggregateManager(aggMgr)
+
+	peer := newPeerandInfo(t, 65000, 65001, "192.168.0.1", rib)
+	pi := peer.peerInfo.Load()
+	pa := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{bgp.NewAs4PathParam(bgp.BGP_ASPATH_ATTR_TYPE_SEQ, []uint32{65001})}),
+	}
+	aggNlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.1.1.0/24"))
+	contributor := table.NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: aggNlri}, false, pa, time.Now(), false)
+	rib.Update(contributor)
+
+	s := NewBgpServer()
+	s.globalRib = rib
+
+	moreSpecific, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.1.1.0/24"))
+	newPath := table.NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: moreSpecific}, false, pa, time.Now(), false)
+	oldPath := newPath.Clone(false)
+
+	result := s.filterpath(peer, newPath, oldPath)
+	assert.NotNil(t, result, "suppressed path with prior advertisement must produce a withdraw, not nil")
+	assert.True(t, result.IsWithdraw, "suppressed path must be withdrawn to peer")
+}
+
 func TestPeerGroup(test *testing.T) {
 	assert := assert.New(test)
 	s := NewBgpServer()

--- a/proto/api/gobgp.proto
+++ b/proto/api/gobgp.proto
@@ -69,6 +69,10 @@ service GoBgpService {
   rpc DeleteVrf(DeleteVrfRequest) returns (DeleteVrfResponse);
   rpc ListVrf(ListVrfRequest) returns (stream ListVrfResponse);
 
+  rpc AddAggregate(AddAggregateRequest) returns (AddAggregateResponse);
+  rpc DeleteAggregate(DeleteAggregateRequest) returns (DeleteAggregateResponse);
+  rpc ListAggregate(ListAggregateRequest) returns (stream ListAggregateResponse);
+
   rpc AddPolicy(AddPolicyRequest) returns (AddPolicyResponse);
   rpc DeletePolicy(DeletePolicyRequest) returns (DeletePolicyResponse);
   rpc ListPolicy(ListPolicyRequest) returns (stream ListPolicyResponse);
@@ -1441,4 +1445,36 @@ message BfdState {
   uint64 received_error = 3;
   uint64 invalid_packet = 4;
   uint64 unknown_peer = 5;
+}
+
+message AggregateAddress {
+  string prefix = 1;
+  bool summary_only = 2;
+  string policy_name = 3;
+  bool as_set = 4;
+}
+
+message AggregateAddressInfo {
+  AggregateAddress aggregate = 1;
+  uint32 num_contributors = 2;
+}
+
+message AddAggregateRequest {
+  AggregateAddress aggregate = 1;
+}
+
+message AddAggregateResponse {}
+
+message DeleteAggregateRequest {
+  string prefix = 1;
+}
+
+message DeleteAggregateResponse {}
+
+message ListAggregateRequest {
+  Family family = 1;
+}
+
+message ListAggregateResponse {
+  AggregateAddressInfo aggregate = 1;
 }

--- a/proto/api/gobgp.proto
+++ b/proto/api/gobgp.proto
@@ -69,6 +69,10 @@ service GoBgpService {
   rpc DeleteVrf(DeleteVrfRequest) returns (DeleteVrfResponse);
   rpc ListVrf(ListVrfRequest) returns (stream ListVrfResponse);
 
+  rpc AddAggregate(AddAggregateRequest) returns (AddAggregateResponse);
+  rpc DeleteAggregate(DeleteAggregateRequest) returns (DeleteAggregateResponse);
+  rpc ListAggregate(ListAggregateRequest) returns (stream ListAggregateResponse);
+
   rpc AddPolicy(AddPolicyRequest) returns (AddPolicyResponse);
   rpc DeletePolicy(DeletePolicyRequest) returns (DeletePolicyResponse);
   rpc ListPolicy(ListPolicyRequest) returns (stream ListPolicyResponse);
@@ -1498,4 +1502,36 @@ message ListTcpAoKeychainRequest {
 
 message ListTcpAoKeychainResponse {
   TcpAoKeychain keychain = 1;
+}
+
+message AggregateAddress {
+  string prefix = 1;
+  bool summary_only = 2;
+  string policy_name = 3;
+  bool as_set = 4;
+}
+
+message AggregateAddressInfo {
+  AggregateAddress aggregate = 1;
+  uint32 num_contributors = 2;
+}
+
+message AddAggregateRequest {
+  AggregateAddress aggregate = 1;
+}
+
+message AddAggregateResponse {}
+
+message DeleteAggregateRequest {
+  string prefix = 1;
+}
+
+message DeleteAggregateResponse {}
+
+message ListAggregateRequest {
+  Family family = 1;
+}
+
+message ListAggregateResponse {
+  AggregateAddressInfo aggregate = 1;
 }

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -1664,4 +1664,47 @@ module gobgp {
     description "BFD configuration for neighbor";
     uses gobgp-bfd-config-set;
   }
+
+  grouping gobgp-aggregate-config {
+    description "Configuration of a locally generated aggregate route.";
+    leaf prefix {
+      type inet:ip-prefix;
+    }
+    leaf summary-only {
+      type boolean;
+      description "Suppress the more-specific contributing routes.";
+    }
+    leaf as-set {
+      type boolean;
+      description "Generate an AS_SET from the contributing routes' AS paths.";
+    }
+    leaf policy-name {
+      type string;
+      description "Policy that contributing routes must pass.";
+    }
+  }
+
+  grouping gobgp-aggregates {
+    container aggregates {
+      list aggregate {
+        key "prefix";
+        leaf prefix {
+          type leafref {
+            path "../config/prefix";
+          }
+        }
+        container config {
+          uses gobgp-aggregate-config;
+        }
+        container state {
+          config false;
+          uses gobgp-aggregate-config;
+        }
+      }
+    }
+  }
+
+  augment "/bgp:bgp/bgp:global" {
+    uses gobgp-aggregates;
+  }
 }

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -1863,4 +1863,47 @@ module gobgp {
   }
 
   uses keychain-top;
+
+  grouping gobgp-aggregate-config {
+    description "Configuration of a locally generated aggregate route.";
+    leaf prefix {
+      type inet:ip-prefix;
+    }
+    leaf summary-only {
+      type boolean;
+      description "Suppress the more-specific contributing routes.";
+    }
+    leaf as-set {
+      type boolean;
+      description "Generate an AS_SET from the contributing routes' AS paths.";
+    }
+    leaf policy-name {
+      type string;
+      description "Policy that contributing routes must pass.";
+    }
+  }
+
+  grouping gobgp-aggregates {
+    container aggregates {
+      list aggregate {
+        key "prefix";
+        leaf prefix {
+          type leafref {
+            path "../config/prefix";
+          }
+        }
+        container config {
+          uses gobgp-aggregate-config;
+        }
+        container state {
+          config false;
+          uses gobgp-aggregate-config;
+        }
+      }
+    }
+  }
+
+  augment "/bgp:bgp/bgp:global" {
+    uses gobgp-aggregates;
+  }
 }


### PR DESCRIPTION
Implements `aggregate-address` for IPv4/IPv6 unicast, configurable via the config file (`[[global.aggregates]]`), gRPC, and CLI (`gobgp global aggregate`). Supports `summary-only`, `as-set` (RFC 4271 AS_SET / ATOMIC_AGGREGATE / AGGREGATOR), and filtering contributors through a policy. The engine is event-driven off RIB updates, so it adds no per-update RIB scan. Closes #3259.

`pkg/config/oc/bgp_configs.go` was hand-edited to match the `gobgp.yang` change because I couldn't get pyang set up locally.