### PR TITLE
bfd: support multihop (RFC 5883) and coexist with a host bfdd via specific-address binds

### DIFF
--- a/pkg/server/bfd_server.go
+++ b/pkg/server/bfd_server.go
@@ -56,6 +56,14 @@ type bfdServer struct {
 
 	config *oc.BfdConfig
 
+	// listenAddrs are the global BGP listen addresses. When non-empty the BFD
+	// server binds its control sockets to each SPECIFIC address (e.g.
+	// 10.0.0.1:4784) instead of the wildcard (:4784). A specific bind wins the
+	// kernel's most-specific-match UDP demux over any wildcard listener already on
+	// the port (e.g. a host bfdd owning 0.0.0.0:3784/4784), so an embedded GoBGP
+	// can run BFD on a host that also runs a system bfdd. Empty → wildcard bind.
+	listenAddrs []string
+
 	udpServers []*net.UDPConn
 
 	peersMutex sync.RWMutex
@@ -94,10 +102,14 @@ func NewBfdServer(ps peerState, logger *slog.Logger) *bfdServer {
 	return s
 }
 
-func (s *bfdServer) Start(ctx context.Context, config oc.BfdConfig) error {
+func (s *bfdServer) Start(ctx context.Context, config oc.BfdConfig, listenAddrs ...string) error {
 	if s.stopped.Load() {
 		return errors.New("bfd server stopped")
 	}
+
+	// Set before the channel send so it is visible (happens-before) to the
+	// serverLoop goroutine that reads it in startServer.
+	s.listenAddrs = listenAddrs
 
 	select {
 	case s.eventConfig <- &config:
@@ -251,38 +263,48 @@ func (s *bfdServer) startServer() {
 		return netutils.SetReuseAddrSockopt(sc)
 	}
 
+	// Bind each port on each specific listen address (so a host bfdd's wildcard
+	// listener does not steal our returns), or once on the wildcard when no
+	// specific address is configured.
+	hosts := s.listenAddrs
+	if len(hosts) == 0 {
+		hosts = []string{""}
+	}
+
 	s.serverStop = make(chan struct{})
 	for _, port := range ports {
-		addressString := ":" + strconv.FormatUint(uint64(port), 10)
+		for _, host := range hosts {
+			addressString := net.JoinHostPort(host, strconv.FormatUint(uint64(port), 10))
 
-		l, err := lc.ListenPacket(context.Background(), "udp", addressString)
-		if err != nil {
-			s.logger.Error("Can't listen UDP",
+			l, err := lc.ListenPacket(context.Background(), "udp", addressString)
+			if err != nil {
+				s.logger.Error("Can't listen UDP",
+					slog.String("Topic", "bfd"),
+					slog.String("Address", addressString),
+					slog.Any("Error", err),
+				)
+				continue
+			}
+
+			conn, ok := l.(*net.UDPConn)
+			if !ok {
+				s.logger.Error("Unexpected connection listener",
+					slog.String("Topic", "bfd"),
+					slog.String("Address", addressString),
+				)
+				_ = l.Close()
+				continue
+			}
+
+			s.udpServers = append(s.udpServers, conn)
+			s.serverWait.Add(1)
+			go s.serverLoop(conn)
+
+			s.logger.Info("BFD server is started",
 				slog.String("Topic", "bfd"),
 				slog.String("Address", addressString),
-				slog.Any("Error", err),
 			)
-			continue
 		}
-
-		conn, ok := l.(*net.UDPConn)
-		if !ok {
-			s.logger.Error("Unexpected connection listener",
-				slog.String("Topic", "bfd"),
-				slog.String("Address", addressString),
-			)
-			_ = l.Close()
-			continue
-		}
-
-		s.udpServers = append(s.udpServers, conn)
-		s.serverWait.Add(1)
-		go s.serverLoop(conn)
-
-		s.logger.Info("BFD server is started",
-			slog.String("Topic", "bfd"),
-			slog.String("Address", addressString),
-		)
 	}
 }
 

--- a/pkg/server/bfd_server.go
+++ b/pkg/server/bfd_server.go
@@ -20,6 +20,13 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bfd"
 )
 
+// bfdMultihopPort is the RFC 5883 (multihop BFD) UDP control port. The server
+// listens on it in addition to the single-hop control port (s.config.Port, the
+// RFC 5881 port 3784) so it can receive returns from multihop peers; a peer runs
+// multihop by sending to this port (its BfdPeerConfig.Port = 4784). Dispatch is
+// by source IP, so a single rxPacket path handles both single-hop and multihop.
+const bfdMultihopPort uint16 = 4784
+
 type bfdServerStats struct {
 	rxPacket      atomic.Uint64
 	rxDrop        atomic.Uint64
@@ -49,7 +56,7 @@ type bfdServer struct {
 
 	config *oc.BfdConfig
 
-	udpServer *net.UDPConn
+	udpServers []*net.UDPConn
 
 	peersMutex sync.RWMutex
 	peers      map[netip.Addr]*bfdPeer
@@ -217,11 +224,11 @@ func (s *bfdServer) loop() {
 }
 
 func (s *bfdServer) start() bool {
-	if s.udpServer == nil {
+	if len(s.udpServers) == 0 {
 		s.startServer()
 	}
 
-	return s.udpServer != nil
+	return len(s.udpServers) > 0
 }
 
 func (s *bfdServer) startServer() {
@@ -230,53 +237,66 @@ func (s *bfdServer) startServer() {
 		return
 	}
 
-	addressString := ":" + strconv.FormatUint(uint64(s.config.Port), 10)
+	// Listen on the single-hop control port (s.config.Port, RFC 5881) AND the
+	// multihop control port (RFC 5883/4784), so the server receives returns from
+	// both single-hop and multihop peers. rxPacket dispatches by source IP, so it
+	// does not matter which socket a packet arrived on.
+	ports := []uint16{uint16(s.config.Port)}
+	if uint16(s.config.Port) != bfdMultihopPort {
+		ports = append(ports, bfdMultihopPort)
+	}
 
 	var lc net.ListenConfig
 	lc.Control = func(network, address string, sc syscall.RawConn) error {
 		return netutils.SetReuseAddrSockopt(sc)
 	}
 
-	l, err := lc.ListenPacket(context.Background(), "udp", addressString)
-	if err != nil {
-		s.logger.Error("Can't listen UDP",
-			slog.String("Topic", "bfd"),
-			slog.String("Address", addressString),
-			slog.Any("Error", err),
-		)
-		return
-	}
-
-	var ok bool
-	s.udpServer, ok = l.(*net.UDPConn)
-	if !ok {
-		s.logger.Error("Unexpected connection listener",
-			slog.String("Topic", "bfd"),
-			slog.String("Address", addressString),
-			slog.Any("Error", err),
-		)
-		return
-	}
-
-	s.logger.Info("BFD server is started",
-		slog.String("Topic", "bfd"),
-		slog.String("Address", addressString),
-	)
-
 	s.serverStop = make(chan struct{})
-	s.serverWait.Add(1)
-	go s.serverLoop()
+	for _, port := range ports {
+		addressString := ":" + strconv.FormatUint(uint64(port), 10)
+
+		l, err := lc.ListenPacket(context.Background(), "udp", addressString)
+		if err != nil {
+			s.logger.Error("Can't listen UDP",
+				slog.String("Topic", "bfd"),
+				slog.String("Address", addressString),
+				slog.Any("Error", err),
+			)
+			continue
+		}
+
+		conn, ok := l.(*net.UDPConn)
+		if !ok {
+			s.logger.Error("Unexpected connection listener",
+				slog.String("Topic", "bfd"),
+				slog.String("Address", addressString),
+			)
+			_ = l.Close()
+			continue
+		}
+
+		s.udpServers = append(s.udpServers, conn)
+		s.serverWait.Add(1)
+		go s.serverLoop(conn)
+
+		s.logger.Info("BFD server is started",
+			slog.String("Topic", "bfd"),
+			slog.String("Address", addressString),
+		)
+	}
 }
 
 func (s *bfdServer) stop() {
-	if s.udpServer == nil {
+	if len(s.udpServers) == 0 {
 		return
 	}
 
 	close(s.serverStop)
-	s.udpServer.Close()
+	for _, conn := range s.udpServers {
+		conn.Close()
+	}
 	s.serverWait.Wait()
-	s.udpServer = nil
+	s.udpServers = nil
 
 	s.logger.Info("BFD server is stopped",
 		slog.String("Topic", "bfd"),
@@ -393,13 +413,13 @@ func (s *bfdServer) shutdown() {
 	s.eventStartStop.Stop()
 }
 
-func (s *bfdServer) serverLoop() {
+func (s *bfdServer) serverLoop(conn *net.UDPConn) {
 	defer s.serverWait.Done()
 
 	// buffer size must be more than BFD Control Packet size
 	buffer := make([]byte, 4096)
 	for {
-		length, address, err := s.udpServer.ReadFromUDP(buffer)
+		length, address, err := conn.ReadFromUDP(buffer)
 		if err != nil {
 			select {
 			case <-s.serverStop:

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2602,7 +2602,14 @@ func (s *BgpServer) StartBgp(ctx context.Context, r *api.StartBgpRequest) error 
 		table.SelectionOptions = c.RouteSelectionOptions.Config
 		table.UseMultiplePaths = c.UseMultiplePaths.Config
 		if s.bfdServer != nil {
-			if err := s.bfdServer.Start(ctx, oc.BfdConfig{Port: BfdServerPort}); err != nil {
+			// Pass the global listen addresses so the BFD server binds its control
+			// sockets to each specific address (coexists with a host bfdd on the
+			// wildcard port); empty → wildcard bind.
+			bfdListen := make([]string, 0, len(c.Config.LocalAddressList))
+			for _, addr := range c.Config.LocalAddressList {
+				bfdListen = append(bfdListen, addr.String())
+			}
+			if err := s.bfdServer.Start(ctx, oc.BfdConfig{Port: BfdServerPort}, bfdListen...); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## What

Two related improvements to the native BFD server's listening sockets:

1. **Listen on the RFC 5883 multihop control port (UDP 4784) in addition to 3784.**
   The server only bound the single-hop control port (`s.config.Port`, 3784).
   A peer configured with `BfdPeerConfig.Port = 4784` (multihop, RFC 5883) sends
   its control packets to 4784, so the server never received the returns and the
   session could not come up. The server now also binds 4784; `rxPacket`
   dispatches by source IP, so a single receive path handles both single-hop and
   multihop peers.

2. **Bind the control sockets to the configured listen addresses, not the wildcard.**
   The sockets were bound to `:3784` / `:4784` (wildcard). On a host already
   running a system `bfdd` that owns `0.0.0.0:3784/4784`, the embedded GoBGP's
   returns were delivered to that wildcard listener instead of GoBGP. By binding
   each control port on each address in `Global.Config.LocalAddressList`, the
   kernel's most-specific-match UDP demux delivers packets destined to a GoBGP
   address to GoBGP, so an embedded GoBGP can run BFD on a host that also runs a
   system bfdd. When no listen address is configured it keeps the wildcard bind
   (unchanged behaviour).

## Why

These let an embedded GoBGP run **multihop** BFD (controller several hops from its
peers) and coexist with a host `bfdd` — neither was possible before.

## Testing

- `go test ./pkg/server/ -run BFD` passes.
- Verified end-to-end: an embedded GoBGP controller brought three BIRD peers to
  multihop-BFD `Up` over a routed (non-adjacent) path, on a host also running FRR
  `bfdd`, without touching bfdd.

## Notes

`bfdServer.Start` gained a variadic `listenAddrs ...string` parameter, so existing
call sites are source-compatible.
