### PR TITLE
Support VRF for TCP MD5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,3 +618,25 @@ jobs:
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
           PYTHONPATH=test python3 test/scenario_test/mup_test.py --gobgp-image gobgp -x -s
+
+  tcp-md5:
+    name: tcp-md5
+    runs-on: ubuntu-24.04
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v7
+        with:
+          path: artifact
+      # ubuntu-24.04's system python is v3.12 which breaks the test.
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: test
+        run: |
+          docker load < artifact/gobgp.tar
+          sudo apt-get update
+          sudo apt-get install -y linux-modules-extra-$(uname -r)
+          sudo modprobe vrf
+          python -m pip install -r test/pip-requires.txt
+          PYTHONPATH=test python test/scenario_test/tcp_md5_test.py --gobgp-image gobgp -x -s

--- a/internal/pkg/netutils/sockopt.go
+++ b/internal/pkg/netutils/sockopt.go
@@ -24,8 +24,8 @@ import (
 	"syscall"
 )
 
-func SetTCPMD5SigSockopt(l *net.TCPListener, address string, key string) error {
-	return SetTcpMD5SigSockopt(l, address, key)
+func SetTCPMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
+	return SetTcpMD5SigSockopt(l, bindInterface, address, key)
 }
 
 func SetTCPTTLSockopt(conn net.Conn, ttl int) error {

--- a/internal/pkg/netutils/sockopt_bsd.go
+++ b/internal/pkg/netutils/sockopt_bsd.go
@@ -27,7 +27,7 @@ const (
 	ipv6MinHopCount = 73   // Generalized TTL Security Mechanism (RFC5082)
 )
 
-func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+func SetTcpMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
 	sc, err := l.SyscallConn()
 	if err != nil {
 		return err

--- a/internal/pkg/netutils/sockopt_darwin.go
+++ b/internal/pkg/netutils/sockopt_darwin.go
@@ -24,7 +24,7 @@ import (
 	"syscall"
 )
 
-func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+func SetTcpMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
 	return fmt.Errorf("setting md5 is not supported")
 }
 

--- a/internal/pkg/netutils/sockopt_linux.go
+++ b/internal/pkg/netutils/sockopt_linux.go
@@ -23,10 +23,10 @@ import (
 	"net"
 	"net/netip"
 	"os"
-	"strconv"
 	"strings"
 	"syscall"
 
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
 
@@ -34,7 +34,7 @@ const (
 	ipv6MinHopCount = 73 // Generalized TTL Security Mechanism (RFC5082)
 )
 
-func buildTcpMD5Sig(address, key string) *unix.TCPMD5Sig {
+func buildTcpMD5Sig(bindInterface netlink.Link, address, key string) *unix.TCPMD5Sig {
 	t := unix.TCPMD5Sig{}
 
 	var addr netip.Addr
@@ -46,7 +46,7 @@ func buildTcpMD5Sig(address, key string) *unix.TCPMD5Sig {
 		}
 		addr = prefix.Addr()
 		t.Prefixlen = uint8(prefix.Bits())
-		t.Flags = unix.TCP_MD5SIG_FLAG_PREFIX
+		t.Flags |= unix.TCP_MD5SIG_FLAG_PREFIX
 	} else {
 		addr, err = netip.ParseAddr(address)
 		if err != nil {
@@ -62,14 +62,18 @@ func buildTcpMD5Sig(address, key string) *unix.TCPMD5Sig {
 		t.Addr.Family = unix.AF_INET6
 		bits := addr.As16()
 		copy(t.Addr.Data[6:], bits[:])
-		if addr.IsLinkLocalUnicast() {
-			t.Ifindex, err = zoneToID(addr.Zone())
-			if err != nil {
-				return nil
-			}
-		}
 	} else {
 		return nil
+	}
+
+	// Ifindex option is only valid for VRF device. It's still valid
+	// to set md5sig for the socket bound to non-VRF device, but in
+	// that case, Ifindex shouldn't be set.
+	//
+	// Ref: https://github.com/torvalds/linux/commit/6b102db50cdde3ba2f78631ed21222edf3a5fb51
+	if bindInterface != nil && bindInterface.Type() == "vrf" {
+		t.Ifindex = int32(bindInterface.Attrs().Index)
+		t.Flags |= unix.TCP_MD5SIG_FLAG_IFINDEX
 	}
 
 	t.Keylen = uint16(len(key))
@@ -78,41 +82,27 @@ func buildTcpMD5Sig(address, key string) *unix.TCPMD5Sig {
 	return &t
 }
 
-func zoneToID(zone string) (int32, error) {
-	if zone == "" {
-		return 0, nil
-	}
-
-	if id, err := strconv.ParseInt(zone, 10, 32); err == nil {
-		return int32(id), nil
-	}
-
-	iface, err := net.InterfaceByName(zone)
-	if err != nil {
-		return 0, fmt.Errorf("interface %q not found: %w", zone, err)
-	}
-	return int32(iface.Index), nil
-}
-
-func SetTCPMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+func SetTCPMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
 	sc, err := l.SyscallConn()
 	if err != nil {
 		return err
 	}
 
+	var link netlink.Link
+	if bindInterface != "" {
+		link, err = netlink.LinkByName(bindInterface)
+		if err != nil {
+			return fmt.Errorf("failed to get link for interface %s: %w", bindInterface, err)
+		}
+	}
+
 	var sockerr error
-	t := buildTcpMD5Sig(address, key)
+	t := buildTcpMD5Sig(link, address, key)
 	if t == nil {
 		return fmt.Errorf("unable to generate TcpMD5Sig from %s", address)
 	}
 	if err := sc.Control(func(s uintptr) {
-		opt := unix.TCP_MD5SIG
-
-		if strings.Contains(address, "/") {
-			opt = unix.TCP_MD5SIG_EXT
-		}
-
-		sockerr = unix.SetsockoptTCPMD5Sig(int(s), unix.IPPROTO_TCP, opt, t)
+		sockerr = unix.SetsockoptTCPMD5Sig(int(s), unix.IPPROTO_TCP, unix.TCP_MD5SIG_EXT, t)
 	}); err != nil {
 		return err
 	}
@@ -199,10 +189,20 @@ func DialerControl(logger *slog.Logger, network, address string, c syscall.RawCo
 
 	var sockerr error
 	if password != "" {
+		var (
+			err  error
+			link netlink.Link
+		)
+		if bindInterface != "" {
+			link, err = netlink.LinkByName(bindInterface)
+			if err != nil {
+				return fmt.Errorf("failed to get link for interface %s: %w", bindInterface, err)
+			}
+		}
 		addr, _, _ := net.SplitHostPort(address)
-		t := buildTcpMD5Sig(addr, password)
+		t := buildTcpMD5Sig(link, addr, password)
 		if err := c.Control(func(fd uintptr) {
-			sockerr = os.NewSyscallError("setSockOpt", unix.SetsockoptTCPMD5Sig(int(fd), unix.IPPROTO_TCP, unix.TCP_MD5SIG, t))
+			sockerr = os.NewSyscallError("setSockOpt", unix.SetsockoptTCPMD5Sig(int(fd), unix.IPPROTO_TCP, unix.TCP_MD5SIG_EXT, t))
 		}); err != nil {
 			return err
 		}

--- a/internal/pkg/netutils/sockopt_linux_test.go
+++ b/internal/pkg/netutils/sockopt_linux_test.go
@@ -23,10 +23,12 @@ import (
 	"syscall"
 	"testing"
 	"unsafe"
+
+	"github.com/vishvananda/netlink"
 )
 
 func Test_buildTcpMD5Sig(t *testing.T) {
-	s := buildTcpMD5Sig("1.2.3.4", "hello")
+	s := buildTcpMD5Sig(nil, "1.2.3.4", "hello")
 
 	if unsafe.Sizeof(*s) != 216 {
 		t.Error("TCPM5Sig struct size is wrong", unsafe.Sizeof(s))
@@ -47,7 +49,7 @@ func Test_buildTcpMD5Sig(t *testing.T) {
 }
 
 func Test_buildTcpMD5Sigv6(t *testing.T) {
-	s := buildTcpMD5Sig("fe80::4850:31ff:fe01:fc55", "helloworld")
+	s := buildTcpMD5Sig(nil, "fe80::4850:31ff:fe01:fc55", "helloworld")
 
 	buf1 := new(bytes.Buffer)
 	if err := binary.Write(buf1, binary.LittleEndian, s); err != nil {
@@ -65,14 +67,48 @@ func Test_buildTcpMD5Sigv6(t *testing.T) {
 	}
 }
 
-func Test_buildTcpMD5Sig_v6Zone(t *testing.T) {
-	s := buildTcpMD5Sig("fe80::4850:31ff:fe01:fc55%123", "helloworld")
-	if s == nil {
-		t.Fatal("Gen md5 sig failed")
+func Test_buildTcpMD5Sig_bindInterface(t *testing.T) {
+	tests := []struct {
+		name            string
+		bindInterface   netlink.Link
+		expectedIfindex int32
+	}{
+		{
+			name:            "Unspecified bindInterface",
+			bindInterface:   nil,
+			expectedIfindex: 0,
+		},
+		{
+			name: "VRF bindInterface",
+			bindInterface: &netlink.Vrf{
+				LinkAttrs: netlink.LinkAttrs{
+					Index: 123,
+				},
+			},
+			expectedIfindex: 123,
+		},
+		{
+			name: "Non-VRF bindInterface",
+			bindInterface: &netlink.GenericLink{
+				LinkAttrs: netlink.LinkAttrs{
+					Index: 123,
+				},
+			},
+			expectedIfindex: 0,
+		},
 	}
 
-	if s.Ifindex != 123 {
-		t.Error("Bad ipv6 if index")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Don't confuse IPv6 zone with ifindex
+			s := buildTcpMD5Sig(tt.bindInterface, "fe80::4850:31ff:fe01:fc55%456", "helloworld")
+			if s == nil {
+				t.Fatal("Gen md5 sig failed")
+			}
+			if s.Ifindex != tt.expectedIfindex {
+				t.Errorf("Unexpected Ifindex value for %T: got %d, want %d", tt.bindInterface, s.Ifindex, tt.expectedIfindex)
+			}
+		})
 	}
 }
 
@@ -90,7 +126,7 @@ func Test_buildTcpMD5Sig_CIDR(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sig := buildTcpMD5Sig(tt.addr, "hello")
+			sig := buildTcpMD5Sig(nil, tt.addr, "hello")
 			if sig == nil {
 				t.Fatal("Gen md5 sig failed")
 			}

--- a/internal/pkg/netutils/sockopt_linux_test.go
+++ b/internal/pkg/netutils/sockopt_linux_test.go
@@ -106,7 +106,7 @@ func Test_buildTcpMD5Sig_bindInterface(t *testing.T) {
 				t.Fatal("Gen md5 sig failed")
 			}
 			if s.Ifindex != tt.expectedIfindex {
-				t.Errorf("Unexpected Ifindex value for %T: got %d, want %d", tt.bindInterface, s.Ifindex, tt.expectedIfindex)
+				t.Errorf("Unexpected ifindex value for %T: got %d, want %d", tt.bindInterface, s.Ifindex, tt.expectedIfindex)
 			}
 		})
 	}

--- a/internal/pkg/netutils/sockopt_openbsd.go
+++ b/internal/pkg/netutils/sockopt_openbsd.go
@@ -355,7 +355,7 @@ func SetSockOptTcpMD5Sig(sc syscall.RawConn, address string, key string) error {
 	return saDelete(address)
 }
 
-func SetTCPMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+func SetTCPMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
 	sc, err := l.SyscallConn()
 	if err != nil {
 		return err

--- a/internal/pkg/netutils/sockopt_stub.go
+++ b/internal/pkg/netutils/sockopt_stub.go
@@ -23,7 +23,7 @@ import (
 	"syscall"
 )
 
-func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+func SetTcpMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
 	return fmt.Errorf("setting md5 is not supported")
 }
 

--- a/internal/pkg/netutils/sockopt_windows.go
+++ b/internal/pkg/netutils/sockopt_windows.go
@@ -31,7 +31,7 @@ const (
 	TCP_MAXSEG      = 0x2  // pulled from https://pkg.go.dev/syscall?GOOS=linux#TCP_MAXSEG
 )
 
-func SetTCPMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+func SetTCPMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
 	return fmt.Errorf("setting md5 is not supported")
 }
 

--- a/pkg/config/oc/bgp_configs.go
+++ b/pkg/config/oc/bgp_configs.go
@@ -5090,6 +5090,9 @@ type GlobalState struct {
 	// original -> gobgp:local-address
 	// original type is list of inet:ip-address
 	LocalAddressList []netip.Addr `mapstructure:"local-address-list" json:"local-address-list,omitempty"`
+	// original -> gobgp:bind-to-device
+	// Device name for binding the BGP listener socket.
+	BindToDevice string `mapstructure:"bind-to-device" json:"bind-to-device,omitempty"`
 }
 
 // struct for container bgp:config.
@@ -5110,6 +5113,9 @@ type GlobalConfig struct {
 	// original -> gobgp:local-address
 	// original type is list of inet:ip-address
 	LocalAddressList []netip.Addr `mapstructure:"local-address-list" json:"local-address-list,omitempty"`
+	// original -> gobgp:bind-to-device
+	// Device name for binding the BGP listener socket.
+	BindToDevice string `mapstructure:"bind-to-device" json:"bind-to-device,omitempty"`
 }
 
 func (lhs *GlobalConfig) Equal(rhs *GlobalConfig) bool {
@@ -5132,6 +5138,9 @@ func (lhs *GlobalConfig) Equal(rhs *GlobalConfig) bool {
 		if l != rhs.LocalAddressList[idx] {
 			return false
 		}
+	}
+	if lhs.BindToDevice != rhs.BindToDevice {
+		return false
 	}
 	return true
 }

--- a/pkg/config/oc/util.go
+++ b/pkg/config/oc/util.go
@@ -768,6 +768,7 @@ func NewGlobalFromConfigStruct(c *Global) *api.Global {
 		ListenAddresses:  l,
 		Families:         families,
 		UseMultiplePaths: c.UseMultiplePaths.Config.Enabled,
+		BindToDevice:     c.Config.BindToDevice,
 		RouteSelectionOptions: &api.RouteSelectionOptionsConfig{
 			AlwaysCompareMed:         c.RouteSelectionOptions.Config.AlwaysCompareMed,
 			IgnoreAsPathLength:       c.RouteSelectionOptions.Config.IgnoreAsPathLength,

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -2433,6 +2433,7 @@ func newGlobalFromAPIStruct(a *api.Global) *oc.Global {
 			RouterId:         netip.MustParseAddr(a.RouterId),
 			Port:             a.ListenPort,
 			LocalAddressList: l,
+			BindToDevice:     a.BindToDevice,
 		},
 		AfiSafis: families,
 		UseMultiplePaths: oc.UseMultiplePaths{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3422,7 +3422,7 @@ func (s *BgpServer) addNeighbor(c *oc.Neighbor) error {
 	if s.bgpConfig.Global.Config.Port > 0 {
 		for _, l := range s.listListeners(addr) {
 			if c.Config.AuthPassword != "" {
-				if err := netutils.SetTCPMD5SigSockopt(l, addr, c.Config.AuthPassword); err != nil {
+				if err := netutils.SetTCPMD5SigSockopt(l, c.Transport.Config.BindInterface, addr, c.Config.AuthPassword); err != nil {
 					s.logger.Warn("failed to set md5",
 						slog.String("Topic", "Peer"),
 						slog.String("Key", addr),
@@ -3552,7 +3552,7 @@ func (s *BgpServer) AddDynamicNeighbor(ctx context.Context, r *api.AddDynamicNei
 			prefix := r.DynamicNeighbor.Prefix
 			addr, _, _ := net.ParseCIDR(prefix)
 			for _, l := range s.listListeners(addr.String()) {
-				if err := netutils.SetTCPMD5SigSockopt(l, prefix, pConf.Config.AuthPassword); err != nil {
+				if err := netutils.SetTCPMD5SigSockopt(l, pConf.Transport.Config.BindInterface, prefix, pConf.Config.AuthPassword); err != nil {
 					s.logger.Warn("failed to set md5",
 						slog.String("Topic", "Peer"),
 						slog.String("Key", prefix),
@@ -3608,7 +3608,7 @@ func (s *BgpServer) deleteNeighbor(c *oc.Neighbor, code, subcode uint8, sendNoti
 	}
 	for _, l := range s.listListeners(addr) {
 		if c.Config.AuthPassword != "" {
-			if err := netutils.SetTCPMD5SigSockopt(l, addr, ""); err != nil {
+			if err := netutils.SetTCPMD5SigSockopt(l, c.Transport.Config.BindInterface, addr, ""); err != nil {
 				n.fsm.logger.Warn("failed to unset md5", slog.String("Err", err.Error()))
 			}
 		}
@@ -3679,7 +3679,7 @@ func (s *BgpServer) DeleteDynamicNeighbor(ctx context.Context, r *api.DeleteDyna
 				addr, _, perr := net.ParseCIDR(prefix)
 				if perr == nil {
 					for _, l := range s.listListeners(addr.String()) {
-						if err := netutils.SetTCPMD5SigSockopt(l, prefix, ""); err != nil {
+						if err := netutils.SetTCPMD5SigSockopt(l, pConf.Transport.Config.BindInterface, prefix, ""); err != nil {
 							s.logger.Warn("failed to clear md5",
 								slog.String("Topic", "Peer"),
 								slog.String("Key", prefix),

--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -388,6 +388,7 @@ class BGPContainer(Container):
         treat_as_withdraw=False,
         remote_as=None,
         mup=False,
+        bind_interface="",
     ):
         neigh_addr = ''
         local_addr = ''
@@ -436,7 +437,8 @@ class BGPContainer(Container):
                             'addpath': addpath,
                             'treat_as_withdraw': treat_as_withdraw,
                             'remote_as': remote_as or peer.asn,
-                            'mup': mup}
+                            'mup': mup,
+                            'bind_interface': bind_interface}
         if self.is_running and reload_config:
             self.create_config()
             self.reload_config()

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -454,6 +454,8 @@ class GoBGPContainer(BGPContainer):
 
             if info['passive']:
                 n['transport']['config']['passive-mode'] = True
+            if info['bind_interface']:
+                n['transport']['config']['bind-interface'] = info['bind_interface']
 
             if info['is_rs_client']:
                 n['route-server'] = {'config': {'route-server-client': True}}

--- a/test/lib/utils.py
+++ b/test/lib/utils.py
@@ -1,0 +1,43 @@
+import time
+
+
+def _get_link_local_address(ctn, ifname):
+    out = ctn.local(
+        'ip -6 -o addr show dev {0} scope link'.format(ifname),
+        capture=True,
+    )
+    for line in out.split('\n'):
+        if ' fe80:' not in line:
+            continue
+        return line.split()[3].split('/')[0]
+    raise Exception('link local address not found')
+
+def _ensure_neighbor_reachable(ctn, ifname, target_lladdr):
+    out = ctn.local('ip -6 n show dev {0}'.format(ifname), capture=True)
+    lines = [line for line in out.split('\n') if line.startswith('fe80')]
+    for line in lines:
+        lladdr = line.split()[0]
+        if lladdr == target_lladdr:
+            return 'REACHABLE' in line
+    return False
+
+
+# probe_link_local_address discovers the IPv6 link local address of the
+# interfaces for container a and b connected p2p (or bridge network that only a
+# and b exists).
+def probe_link_local_address(a, b, aif, bif):
+    done = False
+
+    a_lladdr = _get_link_local_address(a, aif)
+    b_lladdr = _get_link_local_address(b, bif)
+
+    for i in range(20):
+        a.local('ping6 -c 1 {0}%{1}'.format(b_lladdr, aif))
+        b.local('ping6 -c 1 {0}%{1}'.format(a_lladdr, bif))
+        if _ensure_neighbor_reachable(a, aif, b_lladdr) and _ensure_neighbor_reachable(b, bif, a_lladdr):
+            done = True
+            break
+        time.sleep(1)
+
+    if not done:
+        raise Exception('timeout')

--- a/test/scenario_test/bgp_unnumbered_test.py
+++ b/test/scenario_test/bgp_unnumbered_test.py
@@ -16,7 +16,8 @@
 
 import unittest
 from lib import base
-from lib.base import BGP_FSM_ESTABLISHED, local
+from lib import utils
+from lib.base import BGP_FSM_ESTABLISHED, local, Bridge
 from lib.gobgp import GoBGPContainer
 import sys
 import os
@@ -49,31 +50,13 @@ class GoBGPTestBase(unittest.TestCase):
 
         time.sleep(initial_wait_time + 2)
 
-        done = False
+        br = Bridge(name='unnumbered', subnet='fd00:1::/64')
+        [br.addif(ctn) for ctn in [g1, g2]]
 
-        def f(ifname, ctn):
-            out = ctn.local('ip -6 n', capture=True)
-            l = [line for line in out.split('\n') if ifname in line]
-            if len(l) == 0:
-                return False
-            elif len(l) > 1:
-                raise Exception('not p2p link')
-            return 'REACHABLE' in l[0]
+        utils.probe_link_local_address(g1, g2, 'eth1', 'eth1')
 
-        for i in range(20):
-            g1.local('ping6 -c 1 ff02::1%eth0')
-            g2.local('ping6 -c 1 ff02::1%eth0')
-            if f('eth0', g1) and f('eth0', g2):
-                done = True
-                break
-            time.sleep(1)
-
-        if not done:
-            raise Exception('timeout')
-
-        for a, b in combinations(ctns, 2):
-            a.add_peer(b, interface='eth0')
-            b.add_peer(a, interface='eth0')
+        g1.add_peer(g2, interface='eth1')
+        g2.add_peer(g1, interface='eth1')
 
         cls.g1 = g1
         cls.g2 = g2
@@ -81,6 +64,7 @@ class GoBGPTestBase(unittest.TestCase):
     # test each neighbor state is turned establish
     def test_01_neighbor_established(self):
         self.g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g2)
+        self.g2.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g1)
 
     def test_02_add_ipv4_route(self):
 

--- a/test/scenario_test/run_all_tests.sh
+++ b/test/scenario_test/run_all_tests.sh
@@ -66,6 +66,10 @@ PIDS=("${PIDS[@]}" $!)
 python3 $TESTDIR/bgp_unnumbered_test.py --gobgp-image $GOBGP_IMAGE --test-prefix un -s -x --with-xunit --xunit-file=${WS}/nosetest_rs_un.xml &
 PIDS=("${PIDS[@]}" $!)
 
+# tcp md5 test
+python3 $TESTDIR/tcp_md5_test.py --gobgp-image $GOBGP_IMAGE --test-prefix md5 -s -x --with-xunit --xunit-file=${WS}/nosetest_rs_md5.xml &
+PIDS=("${PIDS[@]}" $!)
+
 for (( i = 0; i < ${#PIDS[@]}; ++i ))
 do
     wait ${PIDS[$i]}

--- a/test/scenario_test/tcp_md5_test.py
+++ b/test/scenario_test/tcp_md5_test.py
@@ -1,0 +1,321 @@
+# Copyright (C) 2026 Nippon Telegraph and Telephone Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import collections
+import ipaddress
+import json
+import sys
+import time
+import unittest
+
+collections.Callable = collections.abc.Callable
+
+import nose
+
+from lib import base
+from lib import utils
+from lib.base import (
+    BGP_FSM_ESTABLISHED,
+    BGPContainer,
+    assert_several_times,
+    local,
+    Bridge,
+)
+from lib.gobgp import GoBGPContainer
+from lib.noseplugin import OptionParser, parser_option
+
+
+TCP_MD5_PASSWORD = 'password'
+DYNAMIC_NEIGHBOR_PREFIX = '172.17.0.0/16'
+NETSHOOT_IMAGE = 'nicolaka/netshoot:v0.15'
+VRF_BIND_INTERFACE = 'vrf-md5'
+
+
+def _netshoot(ctn, cmd):
+    return local('docker run --rm --privileged=true --net container:{0} '
+                 '{1} {2}'.format(ctn.docker_name(), NETSHOOT_IMAGE, cmd),
+                 capture=True)
+
+
+def _expected_md5keys(ctn, peer):
+    info = ctn.peers[peer]
+    if info['interface'] != '':
+        addr = ctn.get_neighbor(peer)['state']['neighbor_address']
+    else:
+        addr = info['neigh_addr'].split('/')[0]
+    addr = addr.split('%')[0]
+    prefixlen = 128 if ':' in addr else 32
+    return 'md5keys:{0}/{1}={2}'.format(
+        addr,
+        prefixlen,
+        TCP_MD5_PASSWORD,
+    )
+
+
+def _assert_md5keys(test, ctn, peer):
+    expected = _expected_md5keys(ctn, peer)
+    _assert_md5keys_entry(test, ctn, expected)
+
+
+def _assert_md5keys_entry(test, ctn, expected, established=True,
+                          listen=True):
+    def f():
+        if established:
+            test.assertIn(expected, _netshoot(ctn, 'ss -tni'))
+        if listen:
+            test.assertIn(expected, _netshoot(ctn, 'ss -tlni'))
+
+    assert_several_times(f, t=10, s=1)
+
+
+def _wait_dynamic_established(ctn, peer_addr):
+    def f():
+        peer = json.loads(ctn.local('gobgp -j neighbor {0}'.format(peer_addr),
+                                    capture=True))
+        if peer['state']['session_state'] != 6:
+            raise AssertionError
+
+    assert_several_times(f, t=120, s=1)
+
+
+def _setup_vrf_device(ctn, table_id):
+    subnet = ipaddress.ip_network(ctn.ip_addrs[0][1], strict=False)
+
+    # The osrg/quagga-based test image has an old iproute2 that cannot create
+    # VRF devices. Run netshoot in the same network namespace and use its
+    # iproute2 instead.
+    _netshoot(ctn, 'ip link add {0} type vrf table {1}'.format(
+        VRF_BIND_INTERFACE,
+        table_id,
+    ))
+    _netshoot(ctn, 'ip link set dev {0} up'.format(VRF_BIND_INTERFACE))
+    _netshoot(ctn, 'ip link set dev eth0 master {0}'.format(
+        VRF_BIND_INTERFACE,
+    ))
+    _netshoot(ctn, 'ip route replace table {0} {1} dev eth0'.format(
+        table_id,
+        subnet,
+    ))
+
+
+class GoBGPTCPMD5Test(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        gobgp_ctn_image_name = parser_option.gobgp_image
+        base.TEST_PREFIX = parser_option.test_prefix
+
+        g1 = GoBGPContainer(name='md5-g1', asn=65000,
+                            router_id='192.168.0.1',
+                            ctn_image_name=gobgp_ctn_image_name,
+                            log_level=parser_option.gobgp_log_level)
+        g2 = GoBGPContainer(name='md5-g2', asn=65001,
+                            router_id='192.168.0.2',
+                            ctn_image_name=gobgp_ctn_image_name,
+                            log_level=parser_option.gobgp_log_level)
+
+        ctns = [g1, g2]
+
+        initial_wait_time = max(ctn.run() for ctn in ctns)
+        time.sleep(initial_wait_time)
+
+        g1.add_peer(g2, passwd=TCP_MD5_PASSWORD)
+        g2.add_peer(g1, passwd=TCP_MD5_PASSWORD, passive=True)
+
+        cls.g1 = g1
+        cls.g2 = g2
+
+    def test_01_neighbor_established(self):
+        self.g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g2)
+        self.g2.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g1)
+
+
+class GoBGPTCPMD5UnnumberedTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        gobgp_ctn_image_name = parser_option.gobgp_image
+        base.TEST_PREFIX = parser_option.test_prefix
+
+        g1 = GoBGPContainer(name='g1', asn=65000,
+                            router_id='192.168.0.1',
+                            ctn_image_name=gobgp_ctn_image_name,
+                            log_level=parser_option.gobgp_log_level)
+        g2 = GoBGPContainer(name='g2', asn=65001,
+                            router_id='192.168.0.2',
+                            ctn_image_name=gobgp_ctn_image_name,
+                            log_level=parser_option.gobgp_log_level)
+
+        ctns = [g1, g2]
+
+        initial_wait_time = max(ctn.run() for ctn in ctns)
+        time.sleep(initial_wait_time)
+
+        br = Bridge(name='unnumbered', subnet='fd00:179:5::/64')
+        [br.addif(ctn) for ctn in [g1, g2]]
+
+        utils.probe_link_local_address(g1, g2, 'eth1', 'eth1')
+
+        g1.add_peer(g2, interface='eth1', passwd=TCP_MD5_PASSWORD)
+        g2.add_peer(g1, interface='eth1', passwd=TCP_MD5_PASSWORD,
+                    passive=True)
+
+        cls.g1 = g1
+        cls.g2 = g2
+
+    def test_01_neighbor_established(self):
+        self.g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g2)
+        self.g2.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g1)
+
+    def test_02_md5keys_are_set(self):
+        _assert_md5keys(self, self.g1, self.g2)
+        _assert_md5keys(self, self.g2, self.g1)
+
+
+class GoBGPTCPMD5DynamicNeighborTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        gobgp_ctn_image_name = parser_option.gobgp_image
+        base.TEST_PREFIX = parser_option.test_prefix
+
+        g1 = GoBGPContainer(name='g1', asn=65000,
+                            router_id='192.168.0.1',
+                            ctn_image_name=gobgp_ctn_image_name,
+                            log_level=parser_option.gobgp_log_level,
+                            bgp_config={
+                                'peer-groups': [
+                                    {
+                                        'config': {
+                                            'peer-group-name': 'PG1',
+                                            'peer-as': 65001,
+                                            'auth-password': TCP_MD5_PASSWORD,
+                                        },
+                                    },
+                                ],
+                                'dynamic-neighbors': [
+                                    {
+                                        'config': {
+                                            'prefix': DYNAMIC_NEIGHBOR_PREFIX,
+                                            'peer-group': 'PG1',
+                                        },
+                                    },
+                                ],
+                            })
+        g2 = GoBGPContainer(name='g2', asn=65001,
+                            router_id='192.168.0.2',
+                            ctn_image_name=gobgp_ctn_image_name,
+                            log_level=parser_option.gobgp_log_level)
+
+        ctns = [g1, g2]
+
+        initial_wait_time = max(ctn.run() for ctn in ctns)
+        time.sleep(initial_wait_time)
+
+        g2.add_peer(g1, passwd=TCP_MD5_PASSWORD)
+
+        cls.g1 = g1
+        cls.g2 = g2
+        cls.g2_addr = g2.ip_addrs[0][1].split('/')[0]
+
+    def test_01_neighbor_established(self):
+        self.g2.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g1)
+        _wait_dynamic_established(self.g1, self.g2_addr)
+
+    def test_02_md5keys_are_set(self):
+        self.g2.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g1)
+        _wait_dynamic_established(self.g1, self.g2_addr)
+        expected = 'md5keys:{0}={1}'.format(
+            DYNAMIC_NEIGHBOR_PREFIX,
+            TCP_MD5_PASSWORD,
+        )
+        _assert_md5keys_entry(self, self.g1, expected, established=False)
+        expected = 'md5keys:{0}/32={1}'.format(
+            self.g2_addr,
+            TCP_MD5_PASSWORD,
+        )
+        _assert_md5keys_entry(self, self.g1, expected, listen=False)
+        _assert_md5keys(self, self.g2, self.g1)
+
+
+class GoBGPTCPMD5BindInterfaceVRFTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        gobgp_ctn_image_name = parser_option.gobgp_image
+        base.TEST_PREFIX = parser_option.test_prefix
+
+        g1 = GoBGPContainer(name='vrf-g1', asn=65000,
+                            router_id='192.168.0.1',
+                            ctn_image_name=gobgp_ctn_image_name,
+                            log_level=parser_option.gobgp_log_level,
+                            bgp_config={
+                                'global': {
+                                    'config': {
+                                        'bind-to-device': VRF_BIND_INTERFACE,
+                                    },
+                                },
+                            })
+        g2 = GoBGPContainer(name='vrf-g2', asn=65001,
+                            router_id='192.168.0.2',
+                            ctn_image_name=gobgp_ctn_image_name,
+                            log_level=parser_option.gobgp_log_level,
+                            bgp_config={
+                                'global': {
+                                    'config': {
+                                        'bind-to-device': VRF_BIND_INTERFACE,
+                                    },
+                                },
+                            })
+
+        ctns = [g1, g2]
+
+        initial_wait_time = max(BGPContainer.run(ctn) for ctn in ctns)
+        time.sleep(initial_wait_time)
+
+        _setup_vrf_device(g1, 1010)
+        _setup_vrf_device(g2, 2020)
+
+        g1.start_gobgp()
+        g2.start_gobgp()
+
+        g1.add_peer(g2, passwd=TCP_MD5_PASSWORD, passive=True,
+                    bind_interface=VRF_BIND_INTERFACE)
+        g2.add_peer(g1, passwd=TCP_MD5_PASSWORD,
+                    bind_interface=VRF_BIND_INTERFACE)
+
+        cls.g1 = g1
+        cls.g2 = g2
+
+    def test_01_neighbor_established(self):
+        self.g1.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g2)
+        self.g2.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=self.g1)
+
+    def test_02_md5keys_are_set(self):
+        # ss exposes MD5 keys through INET_DIAG_MD5SIG, but that data does not
+        # include key ifindex. So we just check that the keys are set without
+        # error and we don't check the ifindex part of the key.
+        _assert_md5keys(self, self.g1, self.g2)
+        _assert_md5keys(self, self.g2, self.g1)
+
+
+if __name__ == '__main__':
+    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
+    if int(output) != 0:
+        print("docker not found")
+        sys.exit(1)
+
+    nose.main(argv=sys.argv, addplugins=[OptionParser()],
+              defaultTest=sys.argv[0])

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -1315,6 +1315,10 @@ module gobgp {
     leaf-list local-address {
         type inet:ip-address;
     }
+    leaf bind-to-device {
+        description "Device name for binding the BGP listener socket.";
+        type string;
+    }
   }
 
   augment "/bgp:bgp/bgp:global/bgp:config" {


### PR DESCRIPTION
Copying the commit message from the first commit for convenience.

===

Linux has per-VRF TCP MD5 key registry.

https://github.com/torvalds/linux/commit/6b102db50cdde3ba2f78631ed21222edf3a5fb51

Setting unix.TCPMD5Sig.Ifindex to the VRF's ifindex makes the key scoped within the VRF. GoBGP already has a support for binding Listener/Neighbor socket to VRF, so what we need to do is propagating the interface ifindex to SetTCPMD5SigSockopt call.

Actually, we already have a logic to set unix.TCPMD5Sig.Ifindex, but the current usage is wrong. https://github.com/osrg/gobgp/pull/3370 added it as a part of the MD5 support for IPv6 link-local address peering (a.k.a. BGP Unnumbered).

It derives Ifindex from the IPv6 zone information, but this doesn't have any effect as Ifindex only accepts VRF device's ifindex. Also, it uses unix.TCP_MD5SIG instead of unix.TCP_MD5SIG_EXT and it doesn't set unix.TCP_MD5SIG_FLAG_IFINDEX flag, so the kernel even ignores the parameter.

Remove the current logic and support setting bindInterface derived from the (Dynamic)Neighbor.Transport.Config.BindInterface configuration. Note that technically it is still possible to specify non-VRF interface to this parameter, so the new implementation always checks the interface type via netlink and if the interface is not VRF device, skip setting the parameter.

As a minor cleanup, always use unix.TCP_MD5SIG_EXT instead of unix.TCP_MD5SIG as EXT is a superset of the non-EXT one. We believe the risk of having Linux kernel version that doesn't have EXT support is low these days as it is v4.13 which is almost 10 years old.