### PR TITLE
config: remove trailing whitespace from gobgp.yang

### DIFF
--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -1516,7 +1516,7 @@ module gobgp {
       default 3784;
       description
         "Destination UDP port for BFD control packets.
-        Using a non-default port deviates from RFC 5881, 
+        Using a non-default port deviates from RFC 5881,
         which explicitly mandates destination UDP port 3784.";
       reference "RFC 5881 §4";
     }


### PR DESCRIPTION
The generator already strips trailing whitespace when producing Go bindings, so generate.rs is unchanged.