### PR TITLE
config: propagate bind-interface from peer-group transport config

### DIFF
--- a/pkg/config/oc/util.go
+++ b/pkg/config/oc/util.go
@@ -733,11 +733,12 @@ func NewPeerGroupFromConfigStruct(pconf *PeerGroup) *api.PeerGroup {
 			LocalRestarting:     pconf.GracefulRestart.State.LocalRestarting,
 		},
 		Transport: &api.Transport{
-			RemotePort:   uint32(pconf.Transport.Config.RemotePort),
-			LocalAddress: pconf.Transport.Config.LocalAddress.String(),
-			PassiveMode:  pconf.Transport.Config.PassiveMode,
-			TcpMss:       uint32(pconf.Transport.Config.TcpMss),
-			IpTos:        uint32(pconf.Transport.Config.IpTos),
+			RemotePort:    uint32(pconf.Transport.Config.RemotePort),
+			LocalAddress:  pconf.Transport.Config.LocalAddress.String(),
+			PassiveMode:   pconf.Transport.Config.PassiveMode,
+			BindInterface: pconf.Transport.Config.BindInterface,
+			TcpMss:        uint32(pconf.Transport.Config.TcpMss),
+			IpTos:         uint32(pconf.Transport.Config.IpTos),
 		},
 		AfiSafis: afiSafis,
 		Bfd: &api.BfdPeerConfig{

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -1263,6 +1263,7 @@ func newPeerGroupFromAPIStruct(a *api.PeerGroup) (*oc.PeerGroup, error) {
 		}
 		pconf.Transport.Config.PassiveMode = a.Transport.PassiveMode
 		pconf.Transport.Config.RemotePort = uint16(a.Transport.RemotePort)
+		pconf.Transport.Config.BindInterface = a.Transport.BindInterface
 		pconf.Transport.Config.TcpMss = uint16(a.Transport.TcpMss)
 		pconf.Transport.Config.IpTos = uint8(a.Transport.IpTos)
 	}


### PR DESCRIPTION
BindInterface was missing from NewPeerGroupFromConfigStruct and newPeerGroupFromAPIStruct, so transport.config.bind-interface set on a peer-group was silently dropped during the oc.PeerGroup → api.PeerGroup → oc.PeerGroup round-trip on startup.