### PR TITLE
server: fix GR LocalRestarting not cleared when transitioning peer ap…

### DIFF
--- a/pkg/server/peer.go
+++ b/pkg/server/peer.go
@@ -349,29 +349,35 @@ func (peer *peer) setRtcEORWait(waiting bool) {
 	peer.fsm.logger.Debug("Set rtcEORWait", slog.Bool("Data", waiting))
 }
 
+// allNegotiatedEORReceived reports whether EOR has been received for all
+// negotiated GR address families. This applies the post-ESTABLISHED check
+// based on State (negotiated capabilities), not Config.
+func (peer *peer) allNegotiatedEORReceived() bool {
+	for _, a := range peer.fsm.pConf.ReadOnly().AfiSafis {
+		if s := a.MpGracefulRestart.State; s.Enabled && s.Received && !s.EndOfRibReceived {
+			return false
+		}
+	}
+	return true
+}
+
 // receivedAllEOR reports whether the restarting speaker has received EOR from
 // this peer for all negotiated GR address families. Per RFC 4724 Section 4.1,
 // a peer that does not advertise GR capability is excluded from the EOR wait.
 // A peer that has GR configured but has not yet reached ESTABLISHED is treated
 // as pending: its EOR has not been received and cannot be skipped.
 func (peer *peer) receivedAllEOR() bool {
-	conf := peer.fsm.pConf.ReadOnly()
 	if peer.fsm.state.Load() != bgp.BGP_FSM_ESTABLISHED {
 		// Session not yet established: if GR is configured for any family,
 		// we must wait — the peer may still advertise GR capability in its OPEN.
-		for _, a := range conf.AfiSafis {
+		for _, a := range peer.fsm.pConf.ReadOnly().AfiSafis {
 			if a.MpGracefulRestart.Config.Enabled {
 				return false
 			}
 		}
 		return true
 	}
-	for _, a := range conf.AfiSafis {
-		if s := a.MpGracefulRestart.State; s.Enabled && s.Received && !s.EndOfRibReceived {
-			return false
-		}
-	}
-	return true
+	return peer.allNegotiatedEORReceived()
 }
 
 func (peer *peer) configuredRFlist() []bgp.Family {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1783,6 +1783,16 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 				// the Selection_Deferral_Timer referred to below has expired.
 				allEnd := func() bool {
 					for _, p := range s.neighborMap {
+						if p == peer {
+							// This peer is transitioning to ESTABLISHED inside
+							// this callback, so fsm.state.Store() has not been
+							// called yet. Apply the post-ESTABLISHED EOR check
+							// directly instead of going through receivedAllEOR().
+							if !p.allNegotiatedEORReceived() {
+								return false
+							}
+							continue
+						}
 						if !p.receivedAllEOR() {
 							return false
 						}


### PR DESCRIPTION
…pears as OPENCONFIRM

In the ESTABLISHED state-change callback, fsm.state.Store() is called after the callback returns. When allEnd checks receivedAllEOR() for the transitioning peer, fsm.state.Load() still returns OPENCONFIRM, causing receivedAllEOR() to treat it as pending and allEnd to remain false. LocalRestarting is never cleared, suppressing updates until the deferral timer expires.

Fix by applying allNegotiatedEORReceived() directly to the transitioning peer (p == peer) in the allEnd check, bypassing the state check that is only unreliable in this specific callback context. Extract the post-ESTABLISHED EOR check into allNegotiatedEORReceived() to avoid duplicating the logic.