### PR TITLE
fix: pass zone for LLA BFD peer

### DIFF
--- a/pkg/server/bfd_peer.go
+++ b/pkg/server/bfd_peer.go
@@ -187,15 +187,23 @@ func (p *bfdPeer) stop() {
 	)
 }
 
+// remoteUDPAddr builds the BFD peer's UDP address. The zone is preserved so a link-local peer
+// (fe80::…%iface, as used by unnumbered single-hop BFD per RFC 5881) can be reached — dialing a
+// link-local address without its zone fails.
+func (p *bfdPeer) remoteUDPAddr() *net.UDPAddr {
+	return &net.UDPAddr{
+		IP:   p.peerAddress.AsSlice(),
+		Zone: p.peerAddress.Zone(),
+		Port: p.peerPort,
+	}
+}
+
 func (p *bfdPeer) startClient() {
 	localAddress := &net.UDPAddr{
 		Port: randRange(bfdSourcePortMin, bfdSourcePortMax),
 	}
 
-	remoteAddress := &net.UDPAddr{
-		IP:   p.peerAddress.AsSlice(),
-		Port: p.peerPort,
-	}
+	remoteAddress := p.remoteUDPAddr()
 
 	var err error
 	p.udpClient, err = net.DialUDP("udp", localAddress, remoteAddress)

--- a/pkg/server/bfd_peer_test.go
+++ b/pkg/server/bfd_peer_test.go
@@ -42,6 +42,34 @@ func Test_NewBfdPeerDefaultPort(t *testing.T) {
 	assert.Equal(BfdServerPort, p.peerPort)
 }
 
+func Test_BfdPeerRemoteUDPAddrZone(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+
+	// link-local peer with an interface zone (unnumbered single-hop BFD): the zone must carry through to
+	// the dialed UDP address, otherwise the socket can't reach the link-local peer.
+	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("fe80::1%eth0"), oc.BfdConfig{
+		Port:    13784,
+		Enabled: true,
+	})
+	defer p.Stop()
+
+	addr := p.remoteUDPAddr()
+	assert.Equal("eth0", addr.Zone)
+	assert.Equal("fe80::1", addr.IP.String())
+	assert.Equal(13784, addr.Port)
+
+	// a global peer carries no zone.
+	g := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("10.0.0.1"), oc.BfdConfig{
+		Port:    13784,
+		Enabled: true,
+	})
+	defer g.Stop()
+
+	assert.Empty(g.remoteUDPAddr().Zone)
+}
+
 func Test_BfdPeerStopIdempotent(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
When using LLA and BFD, we need to know the zone.