### PR TITLE
scenario_test: update route_server_malformed_test to match RFC 7606 b…

### DIFF
--- a/test/scenario_test/route_server_malformed_test.py
+++ b/test/scenario_test/route_server_malformed_test.py
@@ -107,15 +107,10 @@ class MalformedMpReachNlri(object):
         e1 = env.e1
         e2 = env.e2
 
-        def f():
-            for line in e1.log().split('\n'):
-                if 'UPDATE message error / Attribute Flags Error / 0x600E0411223344' in line:
-                    return True
-            return False
-
-        wait_for(f)
-        # check e2 is still established
+        # RFC 7606: gobgp treats malformed attribute flags as withdraw (no session reset)
+        g1.wait_for(BGP_FSM_ESTABLISHED, e1)
         g1.wait_for(BGP_FSM_ESTABLISHED, e2)
+        assert len(g1.get_global_rib()) == 0
 
     @staticmethod
     def executor(env):
@@ -151,15 +146,10 @@ class MalformedMpUnReachNlri(object):
         e1 = env.e1
         e2 = env.e2
 
-        def f():
-            for line in e1.log().split('\n'):
-                if 'UPDATE message error / Attribute Flags Error / 0x600F0411223344' in line:
-                    return True
-            return False
-
-        wait_for(f)
-        # check e2 is still established
+        # RFC 7606: gobgp treats malformed attribute flags as withdraw (no session reset)
+        g1.wait_for(BGP_FSM_ESTABLISHED, e1)
         g1.wait_for(BGP_FSM_ESTABLISHED, e2)
+        assert len(g1.get_global_rib()) == 0
 
     @staticmethod
     def executor(env):
@@ -202,15 +192,10 @@ class MalformedAsPath(object):
         e1 = env.e1
         e2 = env.e2
 
-        def f():
-            for line in e1.log().split('\n'):
-                if 'UPDATE message error / Attribute Flags Error / 0x60020411223344' in line:
-                    return True
-            return False
-
-        wait_for(f)
-        # check e2 is still established
+        # RFC 7606: gobgp treats malformed attribute flags as withdraw (no session reset)
+        g1.wait_for(BGP_FSM_ESTABLISHED, e1)
         g1.wait_for(BGP_FSM_ESTABLISHED, e2)
+        assert len(g1.get_global_rib()) == 0
 
     @staticmethod
     def executor(env):
@@ -246,15 +231,10 @@ class MalformedAs4Path(object):
         e1 = env.e1
         e2 = env.e2
 
-        def f():
-            for line in e1.log().split('\n'):
-                if 'UPDATE message error / Attribute Flags Error / 0x60110411223344' in line:
-                    return True
-            return False
-
-        wait_for(f)
-        # check e2 is still established
+        # RFC 7606: gobgp treats malformed attribute flags as withdraw (no session reset)
+        g1.wait_for(BGP_FSM_ESTABLISHED, e1)
         g1.wait_for(BGP_FSM_ESTABLISHED, e2)
+        assert len(g1.get_global_rib()) == 0
 
     @staticmethod
     def executor(env):
@@ -297,15 +277,10 @@ class MalformedNexthop(object):
         e1 = env.e1
         e2 = env.e2
 
-        def f():
-            for line in e1.log().split('\n'):
-                if 'UPDATE message error / Attribute Flags Error / 0x600E08010110FFFFFF0000' in line:
-                    return True
-            return False
-
-        wait_for(f)
-        # check e2 is still established
+        # RFC 7606: gobgp treats malformed attribute flags as withdraw (no session reset)
+        g1.wait_for(BGP_FSM_ESTABLISHED, e1)
         g1.wait_for(BGP_FSM_ESTABLISHED, e2)
+        assert len(g1.get_global_rib()) == 0
 
     @staticmethod
     def executor(env):
@@ -348,15 +323,10 @@ class MalformedRouteFamily(object):
         e1 = env.e1
         e2 = env.e2
 
-        def f():
-            for line in e1.log().split('\n'):
-                if 'UPDATE message error / Attribute Flags Error / 0x600E150002011020010DB800000000000000000000000100' in line:
-                    return True
-            return False
-
-        wait_for(f)
-        # check e2 is still established
+        # RFC 7606: gobgp treats malformed attribute flags as withdraw (no session reset)
+        g1.wait_for(BGP_FSM_ESTABLISHED, e1)
         g1.wait_for(BGP_FSM_ESTABLISHED, e2)
+        assert len(g1.get_global_rib()) == 0
 
     @staticmethod
     def executor(env):
@@ -399,15 +369,10 @@ class MalformedAsPathSegmentLengthInvalid(object):
         e1 = env.e1
         e2 = env.e2
 
-        def f():
-            for line in e1.log().split('\n'):
-                if 'UPDATE message error / Malformed AS_PATH / 0x4002040202FFDC' in line:
-                    return True
-            return False
-
-        wait_for(f)
-        # check e2 is still established
+        # RFC 7606: gobgp treats malformed AS_PATH as withdraw (no session reset)
+        g1.wait_for(BGP_FSM_ESTABLISHED, e1)
         g1.wait_for(BGP_FSM_ESTABLISHED, e2)
+        assert len(g1.get_global_rib()) == 0
 
     @staticmethod
     def executor(env):
@@ -445,15 +410,10 @@ class MalformedNexthopLoopbackAddr(object):
         e1 = env.e1
         e2 = env.e2
 
-        def f():
-            for line in e1.log().split('\n'):
-                if 'UPDATE message error / Invalid NEXT_HOP Attribute / 0x4003047F000001' in line:
-                    return True
-            return False
-
-        wait_for(f)
-        # check e2 is still established
+        # RFC 7606: gobgp treats invalid NEXT_HOP as withdraw (no session reset)
+        g1.wait_for(BGP_FSM_ESTABLISHED, e1)
         g1.wait_for(BGP_FSM_ESTABLISHED, e2)
+        assert len(g1.get_global_rib()) == 0
 
     @staticmethod
     def executor(env):
@@ -494,15 +454,10 @@ class MalformedOriginType(object):
         e1 = env.e1
         e2 = env.e2
 
-        def f():
-            for line in e1.log().split('\n'):
-                if 'UPDATE message error / Invalid ORIGIN Attribute / 0x40010104' in line:
-                    return True
-            return False
-
-        wait_for(f)
-        # check e2 is still established
+        # RFC 7606: gobgp treats invalid ORIGIN as withdraw (no session reset)
+        g1.wait_for(BGP_FSM_ESTABLISHED, e1)
         g1.wait_for(BGP_FSM_ESTABLISHED, e2)
+        assert len(g1.get_global_rib()) == 0
 
     @staticmethod
     def executor(env):
@@ -540,7 +495,8 @@ class TestGoBGPBase(unittest.TestCase):
 
     def test(self):
         for e in self.executors:
-            yield e
+            e(self)
+            print('[PASS] %s' % e.__qualname__.split('.')[0], file=sys.stderr, flush=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…ehavior

gobgp implements RFC 7606 error handling: malformed BGP attributes are treated as withdraw instead of causing session reset. Update all 9 scenario checks to verify that sessions remain established and the malformed route is not accepted into the RIB.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>