### PR TITLE
fix: register bfd for dynamic neighbours

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -369,6 +369,16 @@ func (s *BgpServer) passConnToPeer(conn net.Conn) {
 		}
 
 		s.neighborMap[addr] = peer
+		// register BFD for the dynamic neighbor too (explicit neighbors do this in addNeighbor): the
+		// BFD config is inherited from the peer group. Without this, BFD never runs for dynamic peers.
+		if s.bfdServer != nil && conf.Bfd.Config.Enabled {
+			if err := s.bfdServer.AddPeer(context.Background(), addr, conf.Bfd.Config); err != nil {
+				s.logger.Warn("failed to add BFD peer for dynamic neighbor",
+					slog.String("Topic", "Peer"),
+					slog.String("Key", addr.String()),
+					slog.String("Err", err.Error()))
+			}
+		}
 		s.startFsmHandler(peer)
 		peer.PassConn(conn)
 	} else {
@@ -1540,6 +1550,16 @@ func (s *BgpServer) stopNeighbor(peer *peer, oldState bgp.FSMState, e *fsmMsg) {
 	key := netip.MustParseAddr(peer.ID())
 	if s.neighborMap[key] == peer {
 		delete(s.neighborMap, key)
+	}
+	// deregister BFD here for both static peers (deleted) and dynamic peers (stopped on session loss);
+	// DeletePeer is a no-op for a peer without BFD, so this only errors if the BFD server is stopped.
+	if s.bfdServer != nil {
+		if err := s.bfdServer.DeletePeer(context.Background(), key); err != nil {
+			s.logger.Warn("failed to delete BFD peer",
+				slog.String("Topic", "Peer"),
+				slog.String("Key", key.String()),
+				slog.String("Err", err.Error()))
+		}
 	}
 	peer.stopFSM()
 	s.broadcastPeerState(peer, bgp.BGP_FSM_IDLE, oldState, e)
@@ -3625,18 +3645,6 @@ func (s *BgpServer) deleteNeighbor(c *oc.Neighbor, code, subcode uint8, sendNoti
 	}
 	n.fsm.logger.Info("Delete a peer configuration")
 
-	if s.bfdServer != nil {
-		ipAddr, err := netip.ParseAddr(addr)
-		if err != nil {
-			return fmt.Errorf("failed to parse IP address: %v", err)
-		}
-		if err := s.bfdServer.DeletePeer(context.Background(), ipAddr); err != nil {
-			s.logger.Warn("failed to delete BFD peer",
-				slog.String("Topic", "Peer"),
-				slog.String("Key", addr),
-				slog.String("Err", err.Error()))
-		}
-	}
 	if sendNotification {
 		n.fsm.deconfiguredNotification <- bgp.NewBGPNotificationMessage(code, subcode, nil)
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1765,6 +1765,96 @@ func TestDynamicNeighbor(t *testing.T) {
 	establisedWaiter.Wait(t, 10*time.Second)
 }
 
+// TestDynamicNeighborBfd verifies that BFD is registered for a dynamic neighbor when the peer group has
+// BFD enabled (the accept path), and deregistered when the neighbor goes away (the stop path). Without
+// the fix, BFD never runs for dynamic peers.
+func TestDynamicNeighborBfd(t *testing.T) {
+	assert := assert.New(t)
+	s1 := NewBgpServer()
+	go s1.Serve()
+	err := s1.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        1,
+			RouterId:   "1.1.1.1",
+			ListenPort: 10179,
+		},
+	})
+	assert.NoError(err)
+	defer s1.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	// peer group with BFD enabled; dynamic neighbors inherit this config.
+	g := &oc.PeerGroup{
+		Config: oc.PeerGroupConfig{
+			PeerAs:        2,
+			PeerGroupName: "g",
+		},
+		Bfd: oc.Bfd{
+			Config: oc.BfdConfig{
+				Enabled:                  true,
+				DetectionMultiplier:      3,
+				RequiredMinimumReceive:   300000,
+				DesiredMinimumTxInterval: 300000,
+			},
+		},
+	}
+	err = s1.addPeerGroup(g)
+	assert.NoError(err)
+
+	err = s1.AddDynamicNeighbor(context.Background(), &api.AddDynamicNeighborRequest{
+		DynamicNeighbor: &api.DynamicNeighbor{
+			Prefix:    "127.0.0.0/24",
+			PeerGroup: "g",
+		},
+	})
+	assert.NoError(err)
+
+	s2 := NewBgpServer()
+	go s2.Serve()
+	err = s2.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        2,
+			RouterId:   "2.2.2.2",
+			ListenPort: -1,
+		},
+	})
+	assert.NoError(err)
+	defer s2.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	m := &oc.Neighbor{
+		Config: oc.NeighborConfig{
+			NeighborAddress: netip.MustParseAddr("127.0.0.1"),
+			PeerAs:          1,
+		},
+		Transport: oc.Transport{
+			Config: oc.TransportConfig{RemotePort: 10179},
+		},
+		Timers: oc.Timers{
+			Config: oc.TimersConfig{ConnectRetry: 1, IdleHoldTimeAfterReset: 1},
+		},
+	}
+	waiter := newPeerStateWaiter(s2, api.PeerState_SESSION_STATE_ESTABLISHED)
+	err = s2.AddPeer(context.Background(), &api.AddPeerRequest{Peer: oc.NewPeerFromConfigStruct(m)})
+	assert.NoError(err)
+	waiter.Wait(t, 10*time.Second)
+
+	countBfd := func() int {
+		count := 0
+		s1.ListBfdPeer(context.Background(), func(string, *api.BfdPeerState) { count++ })
+
+		return count
+	}
+
+	// the accept path registers a BFD peer for the dynamic neighbor (inherited peer-group BFD).
+	assert.Eventually(func() bool { return countBfd() == 1 }, 5*time.Second, 100*time.Millisecond,
+		"expected a BFD peer registered for the dynamic neighbor")
+
+	// tearing the session down removes the dynamic neighbor and deregisters its BFD peer.
+	err = s2.DeletePeer(context.Background(), &api.DeletePeerRequest{Address: "127.0.0.1"})
+	assert.NoError(err)
+	assert.Eventually(func() bool { return countBfd() == 0 }, 10*time.Second, 100*time.Millisecond,
+		"expected the BFD peer removed when the dynamic neighbor goes away")
+}
+
 func TestGracefulRestartTimerExpired(t *testing.T) {
 	afiSafis := []*api.AfiSafi{
 		{


### PR DESCRIPTION
Use doing dynamic neighbour discovery and BFD we need to dynamically add/remove peers.