### PR TITLE
scenario_test: migrate test runner from nose to pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/bgp_router_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/bgp_router_test.py --gobgp-image gobgp -x -s
 
   evpn:
     name: evpn
@@ -175,7 +175,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/evpn_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/evpn_test.py --gobgp-image gobgp -x -s
 
   flowspec:
     name: flowspec
@@ -191,7 +191,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/flow_spec_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/flow_spec_test.py --gobgp-image gobgp -x -s
 
   global-policy:
     name: global-policy
@@ -207,7 +207,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/global_policy_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/global_policy_test.py --gobgp-image gobgp -x -s
 
   graceful-restart:
     name: graceful-restart
@@ -223,7 +223,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/graceful_restart_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/graceful_restart_test.py --gobgp-image gobgp -x -s
 
   ibgp:
     name: ibgp
@@ -239,7 +239,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/ibgp_router_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/ibgp_router_test.py --gobgp-image gobgp -x -s
 
   rr:
     name: route-refector
@@ -255,7 +255,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/route_reflector_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/route_reflector_test.py --gobgp-image gobgp -x -s
 
   as2:
     name: as2
@@ -271,7 +271,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/route_server_as2_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/route_server_as2_test.py --gobgp-image gobgp -x -s
 
   ipv4-v6:
     name: ipv4-v6
@@ -290,7 +290,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/route_server_ipv4_v6_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/route_server_ipv4_v6_test.py --gobgp-image gobgp -x -s
 
   malformed:
     name: malformed
@@ -306,7 +306,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/route_server_malformed_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/route_server_malformed_test.py --gobgp-image gobgp -x -s
 
   rs-policy-grpc:
     name: rs-policy-grpc
@@ -322,7 +322,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/route_server_policy_grpc_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/route_server_policy_grpc_test.py --gobgp-image gobgp -x -s
 
   rs-policy:
     name: rs-policy
@@ -345,7 +345,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/route_server_policy_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/route_server_policy_test.py --gobgp-image gobgp -x -s
 
   softreset:
     name: softreset
@@ -361,7 +361,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/route_server_softreset_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/route_server_softreset_test.py --gobgp-image gobgp -x -s
 
   rs1:
     name: routeserver1
@@ -377,7 +377,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/route_server_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/route_server_test.py --gobgp-image gobgp -x -s
 
   rs2:
     name: routeserver2
@@ -393,7 +393,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/route_server_test2.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/route_server_test2.py --gobgp-image gobgp -x -s
 
   llgr:
     name: llgr
@@ -409,7 +409,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/long_lived_graceful_restart_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/long_lived_graceful_restart_test.py --gobgp-image gobgp -x -s
 
   vrf-neighbor1:
     name: vrf-neighbor1
@@ -425,7 +425,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/vrf_neighbor_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/vrf_neighbor_test.py --gobgp-image gobgp -x -s
 
   vrf-neighbor2:
     name: vrf-neighbor2
@@ -441,7 +441,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/vrf_neighbor_test2.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/vrf_neighbor_test2.py --gobgp-image gobgp -x -s
 
   rtc:
     name: rtc
@@ -457,7 +457,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/rtc_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/rtc_test.py --gobgp-image gobgp -x -s
 
   unnumbered:
     name: unnumbered
@@ -480,7 +480,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/bgp_unnumbered_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/bgp_unnumbered_test.py --gobgp-image gobgp -x -s
 
   aspath:
     name: aspath
@@ -496,7 +496,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/aspath_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/aspath_test.py --gobgp-image gobgp -x -s
 
   addpath:
     name: addpath
@@ -512,7 +512,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/addpath_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/addpath_test.py --gobgp-image gobgp -x -s
 
   malformed-handling:
     name: malformed-handling
@@ -528,7 +528,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/bgp_malformed_msg_handling_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/bgp_malformed_msg_handling_test.py --gobgp-image gobgp -x -s
 
   confederation:
     name: confederation
@@ -544,7 +544,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/bgp_confederation_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/bgp_confederation_test.py --gobgp-image gobgp -x -s
 
   zebra:
     name: zebra
@@ -560,7 +560,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/bgp_zebra_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/bgp_zebra_test.py --gobgp-image gobgp -x -s
 
   zebra-nht:
     name: zebra-nht
@@ -576,7 +576,7 @@ jobs:
           docker load < artifact/gobgp-oq.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/bgp_zebra_nht_test.py --gobgp-image gobgp-oq -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/bgp_zebra_nht_test.py --gobgp-image gobgp-oq -x -s
 
   zapi-v3:
     name: zapi-v3
@@ -592,7 +592,7 @@ jobs:
           docker load < artifact/gobgp-oq.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/zapi_v3_test.py --gobgp-image gobgp-oq -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/zapi_v3_test.py --gobgp-image gobgp-oq -x -s
 
   zapi-v3-multipath:
     name: zapi-v3-multipath
@@ -608,7 +608,7 @@ jobs:
           docker load < artifact/gobgp-oq.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/zapi_v3_multipath_test.py --gobgp-image gobgp-oq -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/zapi_v3_multipath_test.py --gobgp-image gobgp-oq -x -s
 
   mup:
     name: mup
@@ -624,7 +624,7 @@ jobs:
           docker load < artifact/gobgp.tar
           sudo apt-get install python3-setuptools
           sudo pip3 install -r test/pip-requires.txt
-          PYTHONPATH=test python3 test/scenario_test/mup_test.py --gobgp-image gobgp -x -s
+          PYTHONPATH=test python3 -m pytest test/scenario_test/mup_test.py --gobgp-image gobgp -x -s
 
   tcp-md5:
     name: tcp-md5
@@ -635,15 +635,11 @@ jobs:
       - uses: actions/download-artifact@v7
         with:
           path: artifact
-      # ubuntu-24.04's system python is v3.12 which breaks the test.
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
       - name: test
         run: |
           docker load < artifact/gobgp.tar
           sudo apt-get update
           sudo apt-get install -y linux-modules-extra-$(uname -r)
           sudo modprobe vrf
-          python -m pip install -r test/pip-requires.txt
-          PYTHONPATH=test python test/scenario_test/tcp_md5_test.py --gobgp-image gobgp -x -s
+          sudo pip3 install -r test/pip-requires.txt
+          PYTHONPATH=test python3 -m pytest test/scenario_test/tcp_md5_test.py --gobgp-image gobgp -x -s

--- a/test/lib/base.py
+++ b/test/lib/base.py
@@ -22,10 +22,7 @@ import itertools
 import textwrap
 from colored import fg, attr
 
-try:
-    from docker import Client
-except ImportError:
-    from docker import APIClient as Client
+from docker import APIClient as Client
 import netaddr
 
 

--- a/test/lib/noseplugin.py
+++ b/test/lib/noseplugin.py
@@ -1,29 +1,11 @@
-import os
-from nose.plugins import Plugin
+class _ParserOption:
+    test_prefix = ""
+    gobgp_image = "osrg/gobgp"
+    exabgp_path = ""
+    go_path = ""
+    gobgp_log_level = "info"
+    test_index = 0
+    config_format = "yaml"
 
-parser_option = None
 
-
-class OptionParser(Plugin):
-
-    def options(self, parser, env=os.environ):
-        super(OptionParser, self).options(parser, env=env)
-        parser.add_option('--test-prefix', action="store", dest="test_prefix", default="")
-        parser.add_option('--gobgp-image', action="store", dest="gobgp_image", default="osrg/gobgp")
-        parser.add_option('--exabgp-path', action="store", dest="exabgp_path", default="")
-        parser.add_option('--go-path', action="store", dest="go_path", default="")
-        parser.add_option('--gobgp-log-level', action="store",
-                          dest="gobgp_log_level", default="info")
-        parser.add_option('--test-index', action="store", type="int", dest="test_index", default=0)
-        parser.add_option('--config-format', action="store", dest="config_format", default="yaml")
-
-    def configure(self, options, conf):
-        super(OptionParser, self).configure(options, conf)
-        global parser_option
-        parser_option = options
-
-        if not self.enabled:
-            return
-
-    def finalize(self, result):
-        pass
+parser_option = _ParserOption()

--- a/test/pip-requires.txt
+++ b/test/pip-requires.txt
@@ -1,10 +1,9 @@
-nose
+pytest
 toml
 pyyaml
 fabric == 2.4.0
 netaddr
 nsenter
-docker-py
+docker
 colored
 invoke == 1.2.0
-requests <= 2.25.1

--- a/test/scenario_test/addpath_test.py
+++ b/test/scenario_test/addpath_test.py
@@ -21,7 +21,6 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
 from lib import base
 from lib.base import (
@@ -31,7 +30,7 @@ from lib.base import (
 )
 from lib.gobgp import GoBGPContainer
 from lib.exabgp import ExaBGPContainer
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 
 class GoBGPTestBase(unittest.TestCase):
@@ -346,11 +345,3 @@ class GoBGPTestBase(unittest.TestCase):
         assert_several_times(f)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/aspath_test.py
+++ b/test/scenario_test/aspath_test.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -173,11 +172,3 @@ class GoBGPTestBase(unittest.TestCase):
         assert_several_times(f)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/bgp_confederation_test.py
+++ b/test/scenario_test/bgp_confederation_test.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import BGP_FSM_ESTABLISHED, local
@@ -147,11 +146,3 @@ class GoBGPTestBase(unittest.TestCase):
         self._check_global_rib_first(self.quaggas['q22'], '10.0.0.0/24', [65001, 10])
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/bgp_malformed_msg_handling_test.py
+++ b/test/scenario_test/bgp_malformed_msg_handling_test.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import BGP_FSM_ESTABLISHED, local
@@ -99,11 +98,3 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertEqual(dests[0]['paths'][0]['nlri']['prefix'], '20.0.0.0/24')
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/bgp_router_test.py
+++ b/test/scenario_test/bgp_router_test.py
@@ -22,9 +22,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -576,11 +575,3 @@ class GoBGPTestBase(unittest.TestCase):
         q9.wait_for(expected_state=BGP_FSM_ESTABLISHED, peer=g6, timeout=30)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/bgp_unnumbered_test.py
+++ b/test/scenario_test/bgp_unnumbered_test.py
@@ -26,8 +26,7 @@ import time
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 from itertools import combinations
 
 
@@ -76,11 +75,3 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertEqual(len(rib), 1)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/bgp_zebra_nht_test.py
+++ b/test/scenario_test/bgp_zebra_nht_test.py
@@ -20,9 +20,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -198,11 +197,3 @@ class ZebraNHTTest(unittest.TestCase):
             f=lambda: self._assert_best(self.r1, '10.3.2.0/24'), t=60)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/bgp_zebra_test.py
+++ b/test/scenario_test/bgp_zebra_test.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -304,11 +303,3 @@ class GoBGPTestBase(unittest.TestCase):
         validate_nexthops([g3])
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/conftest.py
+++ b/test/scenario_test/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+from lib.noseplugin import parser_option
+
+
+def pytest_addoption(parser):
+    parser.addoption('--test-prefix', default='')
+    parser.addoption('--gobgp-image', default='osrg/gobgp')
+    parser.addoption('--exabgp-path', default='')
+    parser.addoption('--go-path', default='')
+    parser.addoption('--gobgp-log-level', default='info')
+    parser.addoption('--test-index', type=int, default=0)
+    parser.addoption('--config-format', default='yaml')
+
+
+def pytest_configure(config):
+    parser_option.test_prefix = config.getoption('--test-prefix')
+    parser_option.gobgp_image = config.getoption('--gobgp-image')
+    parser_option.exabgp_path = config.getoption('--exabgp-path')
+    parser_option.go_path = config.getoption('--go-path')
+    parser_option.gobgp_log_level = config.getoption('--gobgp-log-level')
+    parser_option.test_index = config.getoption('--test-index')
+    parser_option.config_format = config.getoption('--config-format')

--- a/test/scenario_test/evpn_test.py
+++ b/test/scenario_test/evpn_test.py
@@ -22,9 +22,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -176,11 +175,3 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertEqual(get_mac_mobility_sequence(path['attrs']), -1)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/flow_spec_test.py
+++ b/test/scenario_test/flow_spec_test.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import BGP_FSM_ESTABLISHED, local
@@ -409,11 +408,3 @@ class FlowSpecTest(unittest.TestCase):
         self.assertEqual(0, len(rib_y1))
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/global_policy_test.py
+++ b/test/scenario_test/global_policy_test.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -291,11 +290,3 @@ class GoBGPTestBase(unittest.TestCase):
                 self.assertEqual(p['nexthop'], '0.0.0.0')
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/graceful_restart_test.py
+++ b/test/scenario_test/graceful_restart_test.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -252,11 +251,3 @@ class GoBGPTestBase(unittest.TestCase):
             time.sleep(1)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/ibgp_router_test.py
+++ b/test/scenario_test/ibgp_router_test.py
@@ -22,9 +22,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -292,11 +291,3 @@ class GoBGPTestBase(unittest.TestCase):
         wait_for_completion(f3)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/long_lived_graceful_restart_test.py
+++ b/test/scenario_test/long_lived_graceful_restart_test.py
@@ -22,9 +22,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -276,11 +275,3 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertEqual(comms.count(0xffff0006), 1)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/mup_test.py
+++ b/test/scenario_test/mup_test.py
@@ -24,9 +24,8 @@ log = logging.getLogger(__name__)
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -137,11 +136,3 @@ class GoBGPTestBase(unittest.TestCase):
                     done = True
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/route_reflector_test.py
+++ b/test/scenario_test/route_reflector_test.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import BGP_FSM_ESTABLISHED, local
@@ -287,11 +286,3 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertEqual(100, ar0['local-pref'])
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/route_server_as2_test.py
+++ b/test/scenario_test/route_server_as2_test.py
@@ -21,9 +21,8 @@ import time
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -109,11 +108,3 @@ class GoBGPTestBase(unittest.TestCase):
         self.gobgp.wait_for(expected_state=BGP_FSM_IDLE, peer=q2)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/route_server_ipv4_v6_test.py
+++ b/test/scenario_test/route_server_ipv4_v6_test.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import BGP_FSM_ESTABLISHED, local
@@ -168,11 +167,3 @@ class GoBGPIPv6Test(unittest.TestCase):
             self.assertEqual(len(q.get_global_rib(rf='ipv6')), len(q.routes))
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/route_server_malformed_test.py
+++ b/test/scenario_test/route_server_malformed_test.py
@@ -22,9 +22,8 @@ import inspect
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import BGP_FSM_ESTABLISHED, local
@@ -499,11 +498,3 @@ class TestGoBGPBase(unittest.TestCase):
             print('[PASS] %s' % e.__qualname__.split('.')[0], file=sys.stderr, flush=True)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/route_server_policy_grpc_test.py
+++ b/test/scenario_test/route_server_policy_grpc_test.py
@@ -22,13 +22,7 @@ import inspect
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
-from nose.tools import (
-    assert_true,
-    assert_false,
-)
-
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -1261,11 +1255,11 @@ class ImportPolicyCommunityAction(object):
         q1 = env.q1
         q2 = env.q2
         path = g1.get_adj_rib_out(q1)[0]
-        assert_true(community_exists(path, '65100:10'))
-        assert_false(community_exists(path, '65100:20'))
+        assert community_exists(path, '65100:10')
+        assert not community_exists(path, '65100:20')
         path = g1.get_adj_rib_out(q2)[0]
-        assert_true(community_exists(path, '65100:10'))
-        assert_true(community_exists(path, '65100:20'))
+        assert community_exists(path, '65100:10')
+        assert community_exists(path, '65100:20')
 
     @staticmethod
     def executor(env):
@@ -1321,11 +1315,11 @@ class ImportPolicyCommunityReplace(object):
         q1 = env.q1
         q2 = env.q2
         path = g1.get_adj_rib_out(q1)[0]
-        assert_true(community_exists(path, '65100:10'))
-        assert_false(community_exists(path, '65100:20'))
+        assert community_exists(path, '65100:10')
+        assert not community_exists(path, '65100:20')
         path = g1.get_adj_rib_out(q2)[0]
-        assert_false(community_exists(path, '65100:10'))
-        assert_true(community_exists(path, '65100:20'))
+        assert not community_exists(path, '65100:10')
+        assert community_exists(path, '65100:20')
 
     @staticmethod
     def executor(env):
@@ -1393,18 +1387,18 @@ class ImportPolicyCommunityRemove(object):
         q2 = env.q2
         adj_out = g1.get_adj_rib_out(q1)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
+            assert community_exists(path, '65100:10')
             if path['nlri']['prefix'] == '192.168.110.0/24':
-                assert_true(community_exists(path, '65100:20'))
+                assert community_exists(path, '65100:20')
             if path['nlri']['prefix'] == '192.168.120.0/24':
-                assert_true(community_exists(path, '65100:30'))
+                assert community_exists(path, '65100:30')
         adj_out = g1.get_adj_rib_out(q2)
         for path in adj_out:
-            assert_false(community_exists(path, '65100:10'))
+            assert not community_exists(path, '65100:10')
             if path['nlri']['prefix'] == '192.168.110.0/24':
-                assert_false(community_exists(path, '65100:20'))
+                assert not community_exists(path, '65100:20')
             if path['nlri']['prefix'] == '192.168.120.0/24':
-                assert_true(community_exists(path, '65100:30'))
+                assert community_exists(path, '65100:30')
 
     @staticmethod
     def executor(env):
@@ -1461,18 +1455,18 @@ class ImportPolicyCommunityNull(object):
         q2 = env.q2
         adj_out = g1.get_adj_rib_out(q1)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
+            assert community_exists(path, '65100:10')
             if path['nlri']['prefix'] == '192.168.110.0/24':
-                assert_true(community_exists(path, '65100:20'))
+                assert community_exists(path, '65100:20')
             if path['nlri']['prefix'] == '192.168.120.0/24':
-                assert_true(community_exists(path, '65100:30'))
+                assert community_exists(path, '65100:30')
         adj_out = g1.get_adj_rib_out(q2)
         for path in adj_out:
-            assert_false(community_exists(path, '65100:10'))
+            assert not community_exists(path, '65100:10')
             if path['nlri']['prefix'] == '192.168.110.0/24':
-                assert_false(community_exists(path, '65100:20'))
+                assert not community_exists(path, '65100:20')
             if path['nlri']['prefix'] == '192.168.120.0/24':
-                assert_false(community_exists(path, '65100:30'))
+                assert not community_exists(path, '65100:30')
 
     @staticmethod
     def executor(env):
@@ -1529,18 +1523,18 @@ class ExportPolicyCommunityAdd(object):
 
         adj_out = g1.get_adj_rib_out(q1)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
-            assert_false(community_exists(path, '65100:20'))
+            assert community_exists(path, '65100:10')
+            assert not community_exists(path, '65100:20')
 
         local_rib = g1.get_local_rib(q2)
         for path in local_rib[0]['paths']:
-            assert_true(community_exists(path, '65100:10'))
-            assert_false(community_exists(path, '65100:20'))
+            assert community_exists(path, '65100:10')
+            assert not community_exists(path, '65100:20')
 
         adj_out = g1.get_adj_rib_out(q2)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
-            assert_true(community_exists(path, '65100:20'))
+            assert community_exists(path, '65100:10')
+            assert community_exists(path, '65100:20')
 
     @staticmethod
     def executor(env):
@@ -1597,18 +1591,18 @@ class ExportPolicyCommunityReplace(object):
 
         adj_out = g1.get_adj_rib_out(q1)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
-            assert_false(community_exists(path, '65100:20'))
+            assert community_exists(path, '65100:10')
+            assert not community_exists(path, '65100:20')
 
         local_rib = g1.get_local_rib(q2)
         for path in local_rib[0]['paths']:
-            assert_true(community_exists(path, '65100:10'))
-            assert_false(community_exists(path, '65100:20'))
+            assert community_exists(path, '65100:10')
+            assert not community_exists(path, '65100:20')
 
         adj_out = g1.get_adj_rib_out(q2)
         for path in adj_out:
-            assert_false(community_exists(path, '65100:10'))
-            assert_true(community_exists(path, '65100:20'))
+            assert not community_exists(path, '65100:10')
+            assert community_exists(path, '65100:20')
 
     @staticmethod
     def executor(env):
@@ -1665,21 +1659,21 @@ class ExportPolicyCommunityRemove(object):
 
         adj_out = g1.get_adj_rib_out(q1)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
-            assert_true(community_exists(path, '65100:20'))
-            assert_true(community_exists(path, '65100:30'))
+            assert community_exists(path, '65100:10')
+            assert community_exists(path, '65100:20')
+            assert community_exists(path, '65100:30')
 
         local_rib = g1.get_local_rib(q2)
         for path in local_rib[0]['paths']:
-            assert_true(community_exists(path, '65100:10'))
-            assert_true(community_exists(path, '65100:20'))
-            assert_true(community_exists(path, '65100:30'))
+            assert community_exists(path, '65100:10')
+            assert community_exists(path, '65100:20')
+            assert community_exists(path, '65100:30')
 
         adj_out = g1.get_adj_rib_out(q2)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
-            assert_false(community_exists(path, '65100:20'))
-            assert_false(community_exists(path, '65100:30'))
+            assert community_exists(path, '65100:10')
+            assert not community_exists(path, '65100:20')
+            assert not community_exists(path, '65100:30')
 
     @staticmethod
     def executor(env):
@@ -1736,21 +1730,21 @@ class ExportPolicyCommunityNull(object):
 
         adj_out = g1.get_adj_rib_out(q1)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
-            assert_true(community_exists(path, '65100:20'))
-            assert_true(community_exists(path, '65100:30'))
+            assert community_exists(path, '65100:10')
+            assert community_exists(path, '65100:20')
+            assert community_exists(path, '65100:30')
 
         local_rib = g1.get_local_rib(q2)
         for path in local_rib[0]['paths']:
-            assert_true(community_exists(path, '65100:10'))
-            assert_true(community_exists(path, '65100:20'))
-            assert_true(community_exists(path, '65100:30'))
+            assert community_exists(path, '65100:10')
+            assert community_exists(path, '65100:20')
+            assert community_exists(path, '65100:30')
 
         adj_out = g1.get_adj_rib_out(q2)
         for path in adj_out:
-            assert_false(community_exists(path, '65100:10'))
-            assert_false(community_exists(path, '65100:20'))
-            assert_false(community_exists(path, '65100:30'))
+            assert not community_exists(path, '65100:10')
+            assert not community_exists(path, '65100:20')
+            assert not community_exists(path, '65100:30')
 
     @staticmethod
     def executor(env):
@@ -1811,13 +1805,13 @@ class ImportPolicyMedReplace(object):
         q2 = env.q2
 
         adj_out = g1.get_adj_rib_out(q1)
-        assert_true(metric(adj_out[0]) == 300)
+        assert metric(adj_out[0]) == 300
 
         local_rib = g1.get_local_rib(q2)
-        assert_true(metric(local_rib[0]['paths'][0]) == 300)
+        assert metric(local_rib[0]['paths'][0]) == 300
 
         adj_out = g1.get_adj_rib_out(q2)
-        assert_true(metric(adj_out[0]) == 100)
+        assert metric(adj_out[0]) == 100
 
     @staticmethod
     def executor(env):
@@ -1871,13 +1865,13 @@ class ImportPolicyMedAdd(object):
         q2 = env.q2
 
         adj_out = g1.get_adj_rib_out(q1)
-        assert_true(metric(adj_out[0]) == 300)
+        assert metric(adj_out[0]) == 300
 
         local_rib = g1.get_local_rib(q2)
-        assert_true(metric(local_rib[0]['paths'][0]) == 300)
+        assert metric(local_rib[0]['paths'][0]) == 300
 
         adj_out = g1.get_adj_rib_out(q2)
-        assert_true(metric(adj_out[0]) == 400)
+        assert metric(adj_out[0]) == 400
 
     @staticmethod
     def executor(env):
@@ -1931,13 +1925,13 @@ class ImportPolicyMedSub(object):
         q2 = env.q2
 
         adj_out = g1.get_adj_rib_out(q1)
-        assert_true(metric(adj_out[0]) == 300)
+        assert metric(adj_out[0]) == 300
 
         local_rib = g1.get_local_rib(q2)
-        assert_true(metric(local_rib[0]['paths'][0]) == 300)
+        assert metric(local_rib[0]['paths'][0]) == 300
 
         adj_out = g1.get_adj_rib_out(q2)
-        assert_true(metric(adj_out[0]) == 200)
+        assert metric(adj_out[0]) == 200
 
     @staticmethod
     def executor(env):
@@ -1991,13 +1985,13 @@ class ExportPolicyMedReplace(object):
         q2 = env.q2
 
         adj_out = g1.get_adj_rib_out(q1)
-        assert_true(metric(adj_out[0]) == 300)
+        assert metric(adj_out[0]) == 300
 
         local_rib = g1.get_local_rib(q2)
-        assert_true(metric(local_rib[0]['paths'][0]) == 300)
+        assert metric(local_rib[0]['paths'][0]) == 300
 
         adj_out = g1.get_adj_rib_out(q2)
-        assert_true(metric(adj_out[0]) == 100)
+        assert metric(adj_out[0]) == 100
 
     @staticmethod
     def executor(env):
@@ -2051,13 +2045,13 @@ class ExportPolicyMedAdd(object):
         q2 = env.q2
 
         adj_out = g1.get_adj_rib_out(q1)
-        assert_true(metric(adj_out[0]) == 300)
+        assert metric(adj_out[0]) == 300
 
         local_rib = g1.get_local_rib(q2)
-        assert_true(metric(local_rib[0]['paths'][0]) == 300)
+        assert metric(local_rib[0]['paths'][0]) == 300
 
         adj_out = g1.get_adj_rib_out(q2)
-        assert_true(metric(adj_out[0]) == 400)
+        assert metric(adj_out[0]) == 400
 
     @staticmethod
     def executor(env):
@@ -2111,13 +2105,13 @@ class ExportPolicyMedSub(object):
         q2 = env.q2
 
         adj_out = g1.get_adj_rib_out(q1)
-        assert_true(metric(adj_out[0]) == 300)
+        assert metric(adj_out[0]) == 300
 
         local_rib = g1.get_local_rib(q2)
-        assert_true(metric(local_rib[0]['paths'][0]) == 300)
+        assert metric(local_rib[0]['paths'][0]) == 300
 
         adj_out = g1.get_adj_rib_out(q2)
-        assert_true(metric(adj_out[0]) == 200)
+        assert metric(adj_out[0]) == 200
 
     @staticmethod
     def executor(env):
@@ -2184,19 +2178,19 @@ class ExportPolicyAsPathPrepend(object):
         q2 = env.q2
 
         path = g1.get_adj_rib_out(q1, prefix='192.168.20.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_adj_rib_out(q1, prefix='192.168.200.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_local_rib(q2, prefix='192.168.20.0/24')[0]['paths'][0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_adj_rib_out(q2, prefix='192.168.20.0/24')[0]
-        assert_true(path['aspath'] == ([65005] * 5) + [e1.asn])
+        assert path['aspath'] == ([65005] * 5 + [e1.asn])
 
         path = g1.get_adj_rib_out(q2, prefix='192.168.200.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
     @staticmethod
     def executor(env):
@@ -2253,19 +2247,19 @@ class ImportPolicyAsPathPrependLastAS(object):
         q2 = env.q2
 
         path = g1.get_adj_rib_out(q1, prefix='192.168.20.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_adj_rib_out(q1, prefix='192.168.200.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_local_rib(q2, prefix='192.168.20.0/24')[0]['paths'][0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_adj_rib_out(q2, prefix='192.168.20.0/24')[0]
-        assert_true(path['aspath'] == ([e1.asn] * 5) + [e1.asn])
+        assert path['aspath'] == ([e1.asn] * 5 + [e1.asn])
 
         path = g1.get_adj_rib_out(q2, prefix='192.168.200.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
     @staticmethod
     def executor(env):
@@ -2322,19 +2316,19 @@ class ExportPolicyAsPathPrependLastAS(object):
         q2 = env.q2
 
         path = g1.get_adj_rib_out(q1, prefix='192.168.20.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_adj_rib_out(q1, prefix='192.168.200.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_local_rib(q2, prefix='192.168.20.0/24')[0]['paths'][0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_adj_rib_out(q2, prefix='192.168.20.0/24')[0]
-        assert_true(path['aspath'] == ([e1.asn] * 5) + [e1.asn])
+        assert path['aspath'] == ([e1.asn] * 5 + [e1.asn])
 
         path = g1.get_adj_rib_out(q2, prefix='192.168.200.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
     @staticmethod
     def executor(env):
@@ -2488,9 +2482,9 @@ class ImportPolicyExCommunityAdd(object):
         q1 = env.q1
         q2 = env.q2
         path = g1.get_adj_rib_out(q1)[0]
-        assert_false(ext_community_exists(path, 'RT:65000:1'))
+        assert not ext_community_exists(path, 'RT:65000:1')
         path = g1.get_adj_rib_out(q2)[0]
-        assert_true(ext_community_exists(path, 'RT:65000:1'))
+        assert ext_community_exists(path, 'RT:65000:1')
 
     @staticmethod
     def executor(env):
@@ -2545,14 +2539,14 @@ class ImportPolicyExCommunityAdd2(object):
         q1 = env.q1
         q2 = env.q2
         path = g1.get_adj_rib_out(q1)[0]
-        assert_true(ext_community_exists(path, 'RT:65000:1'))
-        assert_false(ext_community_exists(path, 'RT:65100:100'))
+        assert ext_community_exists(path, 'RT:65000:1')
+        assert not ext_community_exists(path, 'RT:65100:100')
         path = g1.get_local_rib(q2)[0]['paths'][0]
-        assert_true(ext_community_exists(path, 'RT:65000:1'))
-        assert_false(ext_community_exists(path, 'RT:65100:100'))
+        assert ext_community_exists(path, 'RT:65000:1')
+        assert not ext_community_exists(path, 'RT:65100:100')
         path = g1.get_adj_rib_out(q2)[0]
-        assert_true(ext_community_exists(path, 'RT:65000:1'))
-        assert_true(ext_community_exists(path, 'RT:65100:100'))
+        assert ext_community_exists(path, 'RT:65000:1')
+        assert ext_community_exists(path, 'RT:65100:100')
 
     @staticmethod
     def executor(env):
@@ -2607,14 +2601,14 @@ class ImportPolicyExCommunityMultipleAdd(object):
         q1 = env.q1
         q2 = env.q2
         path = g1.get_adj_rib_out(q1)[0]
-        assert_false(ext_community_exists(path, 'RT:65100:100'))
-        assert_false(ext_community_exists(path, 'RT:100:100'))
+        assert not ext_community_exists(path, 'RT:65100:100')
+        assert not ext_community_exists(path, 'RT:100:100')
         path = g1.get_local_rib(q2)[0]['paths'][0]
-        assert_false(ext_community_exists(path, 'RT:65100:100'))
-        assert_false(ext_community_exists(path, 'RT:100:100'))
+        assert not ext_community_exists(path, 'RT:65100:100')
+        assert not ext_community_exists(path, 'RT:100:100')
         path = g1.get_adj_rib_out(q2)[0]
-        assert_true(ext_community_exists(path, 'RT:65100:100'))
-        assert_true(ext_community_exists(path, 'RT:100:100'))
+        assert ext_community_exists(path, 'RT:65100:100')
+        assert ext_community_exists(path, 'RT:100:100')
 
     @staticmethod
     def executor(env):
@@ -2669,11 +2663,11 @@ class ExportPolicyExCommunityAdd(object):
         q1 = env.q1
         q2 = env.q2
         path = g1.get_adj_rib_out(q1)[0]
-        assert_false(ext_community_exists(path, 'RT:65000:1'))
+        assert not ext_community_exists(path, 'RT:65000:1')
         path = g1.get_local_rib(q2)[0]['paths'][0]
-        assert_false(ext_community_exists(path, 'RT:65000:1'))
+        assert not ext_community_exists(path, 'RT:65000:1')
         path = g1.get_adj_rib_out(q2)[0]
-        assert_true(ext_community_exists(path, 'RT:65000:1'))
+        assert ext_community_exists(path, 'RT:65000:1')
 
     @staticmethod
     def executor(env):
@@ -2716,11 +2710,3 @@ class TestGoBGPBase(unittest.TestCase):
             print('[PASS] %s' % e.__qualname__.split('.')[0], file=sys.stderr, flush=True)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/route_server_policy_test.py
+++ b/test/scenario_test/route_server_policy_test.py
@@ -22,13 +22,7 @@ import inspect
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
-from nose.tools import (
-    assert_true,
-    assert_false,
-)
-
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -1402,11 +1396,11 @@ class ImportPolicyCommunityAction(object):
         q1 = env.q1
         q2 = env.q2
         path = g1.get_adj_rib_out(q1)[0]
-        assert_true(community_exists(path, '65100:10'))
-        assert_false(community_exists(path, '65100:20'))
+        assert community_exists(path, '65100:10')
+        assert not community_exists(path, '65100:20')
         path = g1.get_adj_rib_out(q2)[0]
-        assert_true(community_exists(path, '65100:10'))
-        assert_true(community_exists(path, '65100:20'))
+        assert community_exists(path, '65100:10')
+        assert community_exists(path, '65100:20')
 
     @staticmethod
     def executor(env):
@@ -1469,11 +1463,11 @@ class ImportPolicyCommunityReplace(object):
         q1 = env.q1
         q2 = env.q2
         path = g1.get_adj_rib_out(q1)[0]
-        assert_true(community_exists(path, '65100:10'))
-        assert_false(community_exists(path, '65100:20'))
+        assert community_exists(path, '65100:10')
+        assert not community_exists(path, '65100:20')
         path = g1.get_adj_rib_out(q2)[0]
-        assert_false(community_exists(path, '65100:10'))
-        assert_true(community_exists(path, '65100:20'))
+        assert not community_exists(path, '65100:10')
+        assert community_exists(path, '65100:20')
 
     @staticmethod
     def executor(env):
@@ -1548,18 +1542,18 @@ class ImportPolicyCommunityRemove(object):
         q2 = env.q2
         adj_out = g1.get_adj_rib_out(q1)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
+            assert community_exists(path, '65100:10')
             if path['nlri']['prefix'] == '192.168.110.0/24':
-                assert_true(community_exists(path, '65100:20'))
+                assert community_exists(path, '65100:20')
             if path['nlri']['prefix'] == '192.168.120.0/24':
-                assert_true(community_exists(path, '65100:30'))
+                assert community_exists(path, '65100:30')
         adj_out = g1.get_adj_rib_out(q2)
         for path in adj_out:
-            assert_false(community_exists(path, '65100:10'))
+            assert not community_exists(path, '65100:10')
             if path['nlri']['prefix'] == '192.168.110.0/24':
-                assert_false(community_exists(path, '65100:20'))
+                assert not community_exists(path, '65100:20')
             if path['nlri']['prefix'] == '192.168.120.0/24':
-                assert_true(community_exists(path, '65100:30'))
+                assert community_exists(path, '65100:30')
 
     @staticmethod
     def executor(env):
@@ -1624,18 +1618,18 @@ class ImportPolicyCommunityNull(object):
         q2 = env.q2
         adj_out = g1.get_adj_rib_out(q1)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
+            assert community_exists(path, '65100:10')
             if path['nlri']['prefix'] == '192.168.110.0/24':
-                assert_true(community_exists(path, '65100:20'))
+                assert community_exists(path, '65100:20')
             if path['nlri']['prefix'] == '192.168.120.0/24':
-                assert_true(community_exists(path, '65100:30'))
+                assert community_exists(path, '65100:30')
         adj_out = g1.get_adj_rib_out(q2)
         for path in adj_out:
-            assert_false(community_exists(path, '65100:10'))
+            assert not community_exists(path, '65100:10')
             if path['nlri']['prefix'] == '192.168.110.0/24':
-                assert_false(community_exists(path, '65100:20'))
+                assert not community_exists(path, '65100:20')
             if path['nlri']['prefix'] == '192.168.120.0/24':
-                assert_false(community_exists(path, '65100:30'))
+                assert not community_exists(path, '65100:30')
 
     @staticmethod
     def executor(env):
@@ -1699,18 +1693,18 @@ class ExportPolicyCommunityAdd(object):
 
         adj_out = g1.get_adj_rib_out(q1)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
-            assert_false(community_exists(path, '65100:20'))
+            assert community_exists(path, '65100:10')
+            assert not community_exists(path, '65100:20')
 
         local_rib = g1.get_local_rib(q2)
         for path in local_rib[0]['paths']:
-            assert_true(community_exists(path, '65100:10'))
-            assert_false(community_exists(path, '65100:20'))
+            assert community_exists(path, '65100:10')
+            assert not community_exists(path, '65100:20')
 
         adj_out = g1.get_adj_rib_out(q2)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
-            assert_true(community_exists(path, '65100:20'))
+            assert community_exists(path, '65100:10')
+            assert community_exists(path, '65100:20')
 
     @staticmethod
     def executor(env):
@@ -1774,18 +1768,18 @@ class ExportPolicyCommunityReplace(object):
 
         adj_out = g1.get_adj_rib_out(q1)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
-            assert_false(community_exists(path, '65100:20'))
+            assert community_exists(path, '65100:10')
+            assert not community_exists(path, '65100:20')
 
         local_rib = g1.get_local_rib(q2)
         for path in local_rib[0]['paths']:
-            assert_true(community_exists(path, '65100:10'))
-            assert_false(community_exists(path, '65100:20'))
+            assert community_exists(path, '65100:10')
+            assert not community_exists(path, '65100:20')
 
         adj_out = g1.get_adj_rib_out(q2)
         for path in adj_out:
-            assert_false(community_exists(path, '65100:10'))
-            assert_true(community_exists(path, '65100:20'))
+            assert not community_exists(path, '65100:10')
+            assert community_exists(path, '65100:20')
 
     @staticmethod
     def executor(env):
@@ -1849,21 +1843,21 @@ class ExportPolicyCommunityRemove(object):
 
         adj_out = g1.get_adj_rib_out(q1)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
-            assert_true(community_exists(path, '65100:20'))
-            assert_true(community_exists(path, '65100:30'))
+            assert community_exists(path, '65100:10')
+            assert community_exists(path, '65100:20')
+            assert community_exists(path, '65100:30')
 
         local_rib = g1.get_local_rib(q2)
         for path in local_rib[0]['paths']:
-            assert_true(community_exists(path, '65100:10'))
-            assert_true(community_exists(path, '65100:20'))
-            assert_true(community_exists(path, '65100:30'))
+            assert community_exists(path, '65100:10')
+            assert community_exists(path, '65100:20')
+            assert community_exists(path, '65100:30')
 
         adj_out = g1.get_adj_rib_out(q2)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
-            assert_false(community_exists(path, '65100:20'))
-            assert_false(community_exists(path, '65100:30'))
+            assert community_exists(path, '65100:10')
+            assert not community_exists(path, '65100:20')
+            assert not community_exists(path, '65100:30')
 
     @staticmethod
     def executor(env):
@@ -1927,21 +1921,21 @@ class ExportPolicyCommunityNull(object):
 
         adj_out = g1.get_adj_rib_out(q1)
         for path in adj_out:
-            assert_true(community_exists(path, '65100:10'))
-            assert_true(community_exists(path, '65100:20'))
-            assert_true(community_exists(path, '65100:30'))
+            assert community_exists(path, '65100:10')
+            assert community_exists(path, '65100:20')
+            assert community_exists(path, '65100:30')
 
         local_rib = g1.get_local_rib(q2)
         for path in local_rib[0]['paths']:
-            assert_true(community_exists(path, '65100:10'))
-            assert_true(community_exists(path, '65100:20'))
-            assert_true(community_exists(path, '65100:30'))
+            assert community_exists(path, '65100:10')
+            assert community_exists(path, '65100:20')
+            assert community_exists(path, '65100:30')
 
         adj_out = g1.get_adj_rib_out(q2)
         for path in adj_out:
-            assert_false(community_exists(path, '65100:10'))
-            assert_false(community_exists(path, '65100:20'))
-            assert_false(community_exists(path, '65100:30'))
+            assert not community_exists(path, '65100:10')
+            assert not community_exists(path, '65100:20')
+            assert not community_exists(path, '65100:30')
 
     @staticmethod
     def executor(env):
@@ -2003,13 +1997,13 @@ class ImportPolicyMedReplace(object):
         q2 = env.q2
 
         adj_out = g1.get_adj_rib_out(q1)
-        assert_true(metric(adj_out[0]) == 300)
+        assert metric(adj_out[0]) == 300
 
         local_rib = g1.get_local_rib(q2)
-        assert_true(metric(local_rib[0]['paths'][0]) == 300)
+        assert metric(local_rib[0]['paths'][0]) == 300
 
         adj_out = g1.get_adj_rib_out(q2)
-        assert_true(metric(adj_out[0]) == 100)
+        assert metric(adj_out[0]) == 100
 
     @staticmethod
     def executor(env):
@@ -2064,13 +2058,13 @@ class ImportPolicyMedAdd(object):
         q2 = env.q2
 
         adj_out = g1.get_adj_rib_out(q1)
-        assert_true(metric(adj_out[0]) == 300)
+        assert metric(adj_out[0]) == 300
 
         local_rib = g1.get_local_rib(q2)
-        assert_true(metric(local_rib[0]['paths'][0]) == 300)
+        assert metric(local_rib[0]['paths'][0]) == 300
 
         adj_out = g1.get_adj_rib_out(q2)
-        assert_true(metric(adj_out[0]) == 400)
+        assert metric(adj_out[0]) == 400
 
     @staticmethod
     def executor(env):
@@ -2125,13 +2119,13 @@ class ImportPolicyMedSub(object):
         q2 = env.q2
 
         adj_out = g1.get_adj_rib_out(q1)
-        assert_true(metric(adj_out[0]) == 300)
+        assert metric(adj_out[0]) == 300
 
         local_rib = g1.get_local_rib(q2)
-        assert_true(metric(local_rib[0]['paths'][0]) == 300)
+        assert metric(local_rib[0]['paths'][0]) == 300
 
         adj_out = g1.get_adj_rib_out(q2)
-        assert_true(metric(adj_out[0]) == 200)
+        assert metric(adj_out[0]) == 200
 
     @staticmethod
     def executor(env):
@@ -2186,13 +2180,13 @@ class ExportPolicyMedReplace(object):
         q2 = env.q2
 
         adj_out = g1.get_adj_rib_out(q1)
-        assert_true(metric(adj_out[0]) == 300)
+        assert metric(adj_out[0]) == 300
 
         local_rib = g1.get_local_rib(q2)
-        assert_true(metric(local_rib[0]['paths'][0]) == 300)
+        assert metric(local_rib[0]['paths'][0]) == 300
 
         adj_out = g1.get_adj_rib_out(q2)
-        assert_true(metric(adj_out[0]) == 100)
+        assert metric(adj_out[0]) == 100
 
     @staticmethod
     def executor(env):
@@ -2247,13 +2241,13 @@ class ExportPolicyMedAdd(object):
         q2 = env.q2
 
         adj_out = g1.get_adj_rib_out(q1)
-        assert_true(metric(adj_out[0]) == 300)
+        assert metric(adj_out[0]) == 300
 
         local_rib = g1.get_local_rib(q2)
-        assert_true(metric(local_rib[0]['paths'][0]) == 300)
+        assert metric(local_rib[0]['paths'][0]) == 300
 
         adj_out = g1.get_adj_rib_out(q2)
-        assert_true(metric(adj_out[0]) == 400)
+        assert metric(adj_out[0]) == 400
 
     @staticmethod
     def executor(env):
@@ -2308,13 +2302,13 @@ class ExportPolicyMedSub(object):
         q2 = env.q2
 
         adj_out = g1.get_adj_rib_out(q1)
-        assert_true(metric(adj_out[0]) == 300)
+        assert metric(adj_out[0]) == 300
 
         local_rib = g1.get_local_rib(q2)
-        assert_true(metric(local_rib[0]['paths'][0]) == 300)
+        assert metric(local_rib[0]['paths'][0]) == 300
 
         adj_out = g1.get_adj_rib_out(q2)
-        assert_true(metric(adj_out[0]) == 200)
+        assert metric(adj_out[0]) == 200
 
     @staticmethod
     def executor(env):
@@ -2389,19 +2383,19 @@ class ExportPolicyAsPathPrepend(object):
         q2 = env.q2
 
         path = g1.get_adj_rib_out(q1, prefix='192.168.20.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_adj_rib_out(q1, prefix='192.168.200.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_local_rib(q2, prefix='192.168.20.0/24')[0]['paths'][0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_adj_rib_out(q2, prefix='192.168.20.0/24')[0]
-        assert_true(path['aspath'] == ([65005] * 5) + [e1.asn])
+        assert path['aspath'] == ([65005] * 5 + [e1.asn])
 
         path = g1.get_adj_rib_out(q2, prefix='192.168.200.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
     @staticmethod
     def executor(env):
@@ -2466,19 +2460,19 @@ class ImportPolicyAsPathPrependLastAS(object):
         q2 = env.q2
 
         path = g1.get_adj_rib_out(q1, prefix='192.168.20.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_adj_rib_out(q1, prefix='192.168.200.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_local_rib(q2, prefix='192.168.20.0/24')[0]['paths'][0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_adj_rib_out(q2, prefix='192.168.20.0/24')[0]
-        assert_true(path['aspath'] == ([e1.asn] * 5) + [e1.asn])
+        assert path['aspath'] == ([e1.asn] * 5 + [e1.asn])
 
         path = g1.get_adj_rib_out(q2, prefix='192.168.200.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
     @staticmethod
     def executor(env):
@@ -2543,19 +2537,19 @@ class ExportPolicyAsPathPrependLastAS(object):
         q2 = env.q2
 
         path = g1.get_adj_rib_out(q1, prefix='192.168.20.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_adj_rib_out(q1, prefix='192.168.200.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_local_rib(q2, prefix='192.168.20.0/24')[0]['paths'][0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
         path = g1.get_adj_rib_out(q2, prefix='192.168.20.0/24')[0]
-        assert_true(path['aspath'] == ([e1.asn] * 5) + [e1.asn])
+        assert path['aspath'] == ([e1.asn] * 5 + [e1.asn])
 
         path = g1.get_adj_rib_out(q2, prefix='192.168.200.0/24')[0]
-        assert_true(path['aspath'] == [e1.asn])
+        assert path['aspath'] == [e1.asn]
 
     @staticmethod
     def executor(env):
@@ -2746,9 +2740,9 @@ class ImportPolicyExCommunityAdd(object):
         q1 = env.q1
         q2 = env.q2
         path = g1.get_adj_rib_out(q1)[0]
-        assert_false(ext_community_exists(path, 'RT:65000:1'))
+        assert not ext_community_exists(path, 'RT:65000:1')
         path = g1.get_adj_rib_out(q2)[0]
-        assert_true(ext_community_exists(path, 'RT:65000:1'))
+        assert ext_community_exists(path, 'RT:65000:1')
 
     @staticmethod
     def executor(env):
@@ -2826,14 +2820,14 @@ class ImportPolicyExCommunityAdd2(object):
         q1 = env.q1
         q2 = env.q2
         path = g1.get_adj_rib_out(q1)[0]
-        assert_true(ext_community_exists(path, 'RT:65000:1'))
-        assert_false(ext_community_exists(path, 'RT:65100:100'))
+        assert ext_community_exists(path, 'RT:65000:1')
+        assert not ext_community_exists(path, 'RT:65100:100')
         path = g1.get_local_rib(q2)[0]['paths'][0]
-        assert_true(ext_community_exists(path, 'RT:65000:1'))
-        assert_false(ext_community_exists(path, 'RT:65100:100'))
+        assert ext_community_exists(path, 'RT:65000:1')
+        assert not ext_community_exists(path, 'RT:65100:100')
         path = g1.get_adj_rib_out(q2)[0]
-        assert_true(ext_community_exists(path, 'RT:65000:1'))
-        assert_true(ext_community_exists(path, 'RT:65100:100'))
+        assert ext_community_exists(path, 'RT:65000:1')
+        assert ext_community_exists(path, 'RT:65100:100')
 
     @staticmethod
     def executor(env):
@@ -2911,14 +2905,14 @@ class ImportPolicyExCommunityMultipleAdd(object):
         q1 = env.q1
         q2 = env.q2
         path = g1.get_adj_rib_out(q1)[0]
-        assert_false(ext_community_exists(path, 'RT:65100:100'))
-        assert_false(ext_community_exists(path, 'RT:100:100'))
+        assert not ext_community_exists(path, 'RT:65100:100')
+        assert not ext_community_exists(path, 'RT:100:100')
         path = g1.get_local_rib(q2)[0]['paths'][0]
-        assert_false(ext_community_exists(path, 'RT:65100:100'))
-        assert_false(ext_community_exists(path, 'RT:100:100'))
+        assert not ext_community_exists(path, 'RT:65100:100')
+        assert not ext_community_exists(path, 'RT:100:100')
         path = g1.get_adj_rib_out(q2)[0]
-        assert_true(ext_community_exists(path, 'RT:65100:100'))
-        assert_true(ext_community_exists(path, 'RT:100:100'))
+        assert ext_community_exists(path, 'RT:65100:100')
+        assert ext_community_exists(path, 'RT:100:100')
 
     @staticmethod
     def executor(env):
@@ -2996,11 +2990,11 @@ class ExportPolicyExCommunityAdd(object):
         q1 = env.q1
         q2 = env.q2
         path = g1.get_adj_rib_out(q1)[0]
-        assert_false(ext_community_exists(path, 'RT:65000:1'))
+        assert not ext_community_exists(path, 'RT:65000:1')
         path = g1.get_local_rib(q2)[0]['paths'][0]
-        assert_false(ext_community_exists(path, 'RT:65000:1'))
+        assert not ext_community_exists(path, 'RT:65000:1')
         path = g1.get_adj_rib_out(q2)[0]
-        assert_true(ext_community_exists(path, 'RT:65000:1'))
+        assert ext_community_exists(path, 'RT:65000:1')
 
     @staticmethod
     def executor(env):
@@ -3191,11 +3185,3 @@ class TestGoBGPBase(unittest.TestCase):
             print('[PASS] %s' % e.__qualname__.split('.')[0], file=sys.stderr, flush=True)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/route_server_softreset_test.py
+++ b/test/scenario_test/route_server_softreset_test.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import BGP_FSM_ESTABLISHED, local
@@ -135,11 +134,3 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertEqual(num, num1)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/route_server_test.py
+++ b/test/scenario_test/route_server_test.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -250,11 +249,3 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertTrue(done)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/route_server_test2.py
+++ b/test/scenario_test/route_server_test2.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import BGP_FSM_ESTABLISHED, local
@@ -101,11 +100,3 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertEqual(advertised, 1)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/rtc_test.py
+++ b/test/scenario_test/rtc_test.py
@@ -22,9 +22,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import BGP_FSM_ESTABLISHED, local
@@ -998,11 +997,3 @@ class GoBGPTestBase(unittest.TestCase):
         self.g5.local("gobgp vrf del vrf1")
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/tcp_md5_test.py
+++ b/test/scenario_test/tcp_md5_test.py
@@ -22,7 +22,6 @@ import unittest
 
 collections.Callable = collections.abc.Callable
 
-import nose
 
 from lib import base
 from lib import utils
@@ -34,7 +33,7 @@ from lib.base import (
     Bridge,
 )
 from lib.gobgp import GoBGPContainer
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 
 TCP_MD5_PASSWORD = 'password'
@@ -311,11 +310,3 @@ class GoBGPTCPMD5BindInterfaceVRFTest(unittest.TestCase):
         _assert_md5keys(self, self.g2, self.g1)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/vrf_neighbor_test.py
+++ b/test/scenario_test/vrf_neighbor_test.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import BGP_FSM_ESTABLISHED, local
@@ -169,11 +168,3 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertEqual([self.g5.asn, self.g4.asn, self.g3.asn], path['aspath'])
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/vrf_neighbor_test2.py
+++ b/test/scenario_test/vrf_neighbor_test2.py
@@ -21,9 +21,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -137,11 +136,3 @@ class GoBGPTestBase(unittest.TestCase):
         wait_for_completion(lambda: len(self.g2.get_global_rib()) == 0)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/zapi_v3_multipath_test.py
+++ b/test/scenario_test/zapi_v3_multipath_test.py
@@ -20,9 +20,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import BGP_FSM_ESTABLISHED, local
@@ -256,11 +255,3 @@ class GoBGPTestBase(unittest.TestCase):
         self.assertEqual(len(kernel_routes), 0)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])

--- a/test/scenario_test/zapi_v3_test.py
+++ b/test/scenario_test/zapi_v3_test.py
@@ -20,9 +20,8 @@ import unittest
 import collections
 collections.Callable = collections.abc.Callable
 
-import nose
 
-from lib.noseplugin import OptionParser, parser_option
+from lib.noseplugin import parser_option
 
 from lib import base
 from lib.base import (
@@ -152,11 +151,3 @@ class GoBGPTestBase(unittest.TestCase):
             t=30)
 
 
-if __name__ == '__main__':
-    output = local("which docker 2>&1 > /dev/null ; echo $?", capture=True)
-    if int(output) != 0:
-        print("docker not found")
-        sys.exit(1)
-
-    nose.main(argv=sys.argv, addplugins=[OptionParser()],
-              defaultTest=sys.argv[0])


### PR DESCRIPTION
nose is no longer maintained and its incompatibility with Python 3.12 forced the tcp-md5 job to pin Python 3.11 as a workaround. Switching to pytest removes that constraint and allows the tcp-md5 job to use the system Python like every other test job.

Replace the nose Plugin-based option parser with a plain class holding defaults and a conftest.py that registers the same CLI options via pytest's addoption hook. Drop nose.tools assert helpers in favour of standard assert statements. Update pip-requires.txt to pull pytest and the current docker SDK package name.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>