### PR TITLE
bfd: listen on RFC 5883 multihop port

### DIFF
--- a/pkg/server/bfd_server.go
+++ b/pkg/server/bfd_server.go
@@ -20,6 +20,13 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/packet/bfd"
 )
 
+// bfdMultihopPort is the RFC 5883 (multihop BFD) UDP control port. The server
+// listens on it in addition to the single-hop control port (s.config.Port, the
+// RFC 5881 port 3784) so it can receive returns from multihop peers; a peer runs
+// multihop by sending to this port (its BfdPeerConfig.Port = 4784). Dispatch is
+// by source IP, so a single rxPacket path handles both single-hop and multihop.
+const bfdMultihopPort uint16 = 4784
+
 type bfdServerStats struct {
 	rxPacket      atomic.Uint64
 	rxDrop        atomic.Uint64
@@ -50,7 +57,15 @@ type bfdServer struct {
 
 	config *oc.BfdConfig
 
-	udpServer       *net.UDPConn
+	// listenAddrs are the global BGP listen addresses. When non-empty the BFD
+	// server binds its control sockets to each SPECIFIC address (e.g.
+	// 10.0.0.1:4784) instead of the wildcard (:4784). A specific bind wins the
+	// kernel's most-specific-match UDP demux over any wildcard listener already on
+	// the port (e.g. a host bfdd owning 0.0.0.0:3784/4784), so an embedded GoBGP
+	// can run BFD on a host that also runs a system bfdd. Empty → wildcard bind.
+	listenAddrs []string
+
+	udpServers      []*net.UDPConn
 	listenInterface string
 
 	peersMutex sync.RWMutex
@@ -219,11 +234,11 @@ func (s *bfdServer) loop() {
 }
 
 func (s *bfdServer) start() bool {
-	if s.udpServer == nil {
+	if len(s.udpServers) == 0 {
 		s.startServer()
 	}
 
-	return s.udpServer != nil
+	return len(s.udpServers) > 0
 }
 
 func (s *bfdServer) startServer() {
@@ -232,7 +247,14 @@ func (s *bfdServer) startServer() {
 		return
 	}
 
-	addressString := ":" + strconv.FormatUint(uint64(s.config.Port), 10)
+	// Listen on the single-hop control port (s.config.Port, RFC 5881) AND the
+	// multihop control port (RFC 5883/4784), so the server receives returns from
+	// both single-hop and multihop peers. rxPacket dispatches by source IP, so it
+	// does not matter which socket a packet arrived on.
+	ports := []uint16{s.config.Port}
+	if s.config.Port != bfdMultihopPort {
+		ports = append(ports, bfdMultihopPort)
+	}
 
 	var lc net.ListenConfig
 	lc.Control = func(network, address string, sc syscall.RawConn) error {
@@ -246,46 +268,62 @@ func (s *bfdServer) startServer() {
 		return netutils.SetReuseAddrSockopt(sc)
 	}
 
-	l, err := lc.ListenPacket(context.Background(), "udp", addressString)
-	if err != nil {
-		s.logger.Error("Can't listen UDP",
-			slog.String("Topic", "bfd"),
-			slog.String("Address", addressString),
-			slog.Any("Error", err),
-		)
-		return
+	// Bind each port on each specific listen address (so a host bfdd's wildcard
+	// listener does not steal our returns), or once on the wildcard when no
+	// specific address is configured.
+	hosts := s.listenAddrs
+	if len(hosts) == 0 {
+		hosts = []string{""}
 	}
-
-	var ok bool
-	s.udpServer, ok = l.(*net.UDPConn)
-	if !ok {
-		s.logger.Error("Unexpected connection listener",
-			slog.String("Topic", "bfd"),
-			slog.String("Address", addressString),
-			slog.Any("Error", err),
-		)
-		return
-	}
-
-	s.logger.Info("BFD server is started",
-		slog.String("Topic", "bfd"),
-		slog.String("Address", addressString),
-	)
 
 	s.serverStop = make(chan struct{})
-	s.serverWait.Add(1)
-	go s.serverLoop()
+	for _, port := range ports {
+		for _, host := range hosts {
+			addressString := net.JoinHostPort(host, strconv.FormatUint(uint64(port), 10))
+
+			l, err := lc.ListenPacket(context.Background(), "udp", addressString)
+			if err != nil {
+				s.logger.Error("Can't listen UDP",
+					slog.String("Topic", "bfd"),
+					slog.String("Address", addressString),
+					slog.Any("Error", err),
+				)
+				continue
+			}
+
+			conn, ok := l.(*net.UDPConn)
+			if !ok {
+				s.logger.Error("Unexpected connection listener",
+					slog.String("Topic", "bfd"),
+					slog.String("Address", addressString),
+				)
+				_ = l.Close()
+				continue
+			}
+
+			s.udpServers = append(s.udpServers, conn)
+			s.serverWait.Add(1)
+			go s.serverLoop(conn)
+
+			s.logger.Info("BFD server is started",
+				slog.String("Topic", "bfd"),
+				slog.String("Address", addressString),
+			)
+		}
+	}
 }
 
 func (s *bfdServer) stop() {
-	if s.udpServer == nil {
+	if len(s.udpServers) == 0 {
 		return
 	}
 
 	close(s.serverStop)
-	s.udpServer.Close()
+	for _, conn := range s.udpServers {
+		conn.Close()
+	}
 	s.serverWait.Wait()
-	s.udpServer = nil
+	s.udpServers = nil
 
 	s.logger.Info("BFD server is stopped",
 		slog.String("Topic", "bfd"),
@@ -402,13 +440,13 @@ func (s *bfdServer) shutdown() {
 	s.eventStartStop.Stop()
 }
 
-func (s *bfdServer) serverLoop() {
+func (s *bfdServer) serverLoop(conn *net.UDPConn) {
 	defer s.serverWait.Done()
 
 	// buffer size must be more than BFD Control Packet size
 	buffer := make([]byte, 4096)
 	for {
-		length, address, err := s.udpServer.ReadFromUDP(buffer)
+		length, address, err := conn.ReadFromUDP(buffer)
 		if err != nil {
 			select {
 			case <-s.serverStop:

--- a/pkg/server/bfd_server_test.go
+++ b/pkg/server/bfd_server_test.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/netip"
 	"runtime"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
 	api "github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/internal/pkg/netutils"
 	"github.com/osrg/gobgp/v4/pkg/config/oc"
+	"github.com/osrg/gobgp/v4/pkg/packet/bfd"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
 )
@@ -144,6 +148,138 @@ func addPeer(s *bfdServer, port uint16) error {
 		RequiredMinimumReceive:   200000,
 		DesiredMinimumTxInterval: 200000,
 	}, "")
+}
+
+func addBfdPeer(s *bfdServer, peerAddress string, port uint16) error {
+	return s.AddPeer(context.Background(), netip.MustParseAddr(peerAddress), oc.BfdConfig{
+		Port:                     port,
+		Enabled:                  true,
+		DetectionMultiplier:      5,
+		RequiredMinimumReceive:   200000,
+		DesiredMinimumTxInterval: 200000,
+	}, "")
+}
+
+func canBindToDevice(device string) bool {
+	var lc net.ListenConfig
+	lc.Control = func(network, address string, sc syscall.RawConn) error {
+		return netutils.SetBindToDevSockopt(sc, device)
+	}
+
+	l, err := lc.ListenPacket(context.Background(), "udp", "127.0.0.1:0")
+	if err != nil {
+		return false
+	}
+	_ = l.Close()
+	return true
+}
+
+func sendBfdControlPacket(src, dst string, dstPort int, state bfd.StateType) error {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP(src), Port: 0})
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	packet := &bfd.BFDHeader{
+		Version:               1,
+		State:                 state,
+		DetectTimeMultiplier:  3,
+		MyDiscriminator:       99,
+		DesiredMinTxInterval:  200000,
+		RequiredMinRxInterval: 200000,
+	}
+	buffer, err := packet.MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	_, err = conn.WriteToUDP(buffer, &net.UDPAddr{IP: net.ParseIP(dst), Port: dstPort})
+	return err
+}
+
+func eventuallySendBfdAndCheckState(timeout time.Duration, s *bfdServer, peerAddress netip.Addr, dstPort int, packetState bfd.StateType, expected api.BfdSessionState) error {
+	return eventually(timeout, func() error {
+		if err := sendBfdControlPacket(peerAddress.String(), "127.0.0.1", dstPort, packetState); err != nil {
+			return err
+		}
+		state, err := s.GetPeerState(peerAddress)
+		if err != nil {
+			return err
+		}
+		if state.state.SessionState != expected {
+			return fmt.Errorf("must be: peerState == %s", expected)
+		}
+		return nil
+	})
+}
+
+func Test_BfdServerAcceptsSingleHopAndMultihopPorts(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	s := NewBfdServer(ps, slog.Default())
+	s.listenAddrs = []string{"127.0.0.1"}
+	err := s.Start(context.Background(), oc.BfdConfig{Port: BfdServerPort})
+	assert.NoError(err)
+	defer s.Stop()
+
+	peerAddr := netip.MustParseAddr("127.0.0.2")
+	err = addBfdPeer(s, peerAddr.String(), bfdMultihopPort)
+	assert.NoError(err)
+
+	err = eventuallySendBfdAndCheckState(3*time.Second, s, peerAddr, BfdServerPort, bfd.StateDown, api.BfdSessionState_BFD_SESSION_STATE_INIT)
+	assert.NoError(err)
+	err = eventuallySendBfdAndCheckState(3*time.Second, s, peerAddr, int(bfdMultihopPort), bfd.StateInit, api.BfdSessionState_BFD_SESSION_STATE_UP)
+	assert.NoError(err)
+}
+
+func Test_BfdServerEstablishesMultihopSessionOnRFC5883Port(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	s := NewBfdServer(ps, slog.Default())
+	s.listenAddrs = []string{"127.0.0.1"}
+	err := s.Start(context.Background(), oc.BfdConfig{Port: BfdServerPort})
+	assert.NoError(err)
+	defer s.Stop()
+
+	peerAddr := netip.MustParseAddr("127.0.0.2")
+	err = addBfdPeer(s, peerAddr.String(), bfdMultihopPort)
+	assert.NoError(err)
+
+	err = eventuallySendBfdAndCheckState(3*time.Second, s, peerAddr, int(bfdMultihopPort), bfd.StateDown, api.BfdSessionState_BFD_SESSION_STATE_INIT)
+	assert.NoError(err)
+	err = eventuallySendBfdAndCheckState(3*time.Second, s, peerAddr, int(bfdMultihopPort), bfd.StateInit, api.BfdSessionState_BFD_SESSION_STATE_UP)
+	assert.NoError(err)
+}
+
+func Test_BfdServerListenAddrsBindToDeviceAndMultihopPort(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("SO_BINDTODEVICE is Linux-specific")
+	}
+	if !canBindToDevice("lo") {
+		t.Skip("SO_BINDTODEVICE is not permitted in this environment")
+	}
+
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	s := NewBfdServer(ps, slog.Default())
+	s.listenAddrs = []string{"127.0.0.1"}
+	s.listenInterface = "lo"
+	err := s.Start(context.Background(), oc.BfdConfig{Port: BfdServerPort})
+	assert.NoError(err)
+	defer s.Stop()
+
+	peerAddr := netip.MustParseAddr("127.0.0.2")
+	err = addBfdPeer(s, peerAddr.String(), bfdMultihopPort)
+	assert.NoError(err)
+
+	err = eventuallySendBfdAndCheckState(3*time.Second, s, peerAddr, int(bfdMultihopPort), bfd.StateDown, api.BfdSessionState_BFD_SESSION_STATE_INIT)
+	assert.NoError(err)
+	err = eventuallySendBfdAndCheckState(3*time.Second, s, peerAddr, int(bfdMultihopPort), bfd.StateInit, api.BfdSessionState_BFD_SESSION_STATE_UP)
+	assert.NoError(err)
 }
 
 func Test_AddDeletePeer(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2632,7 +2632,15 @@ func (s *BgpServer) StartBgp(ctx context.Context, r *api.StartBgpRequest) error 
 		table.SelectionOptions = c.RouteSelectionOptions.Config
 		table.UseMultiplePaths = c.UseMultiplePaths.Config
 		if s.bfdServer != nil {
+			// Pass the global listen addresses so the BFD server binds its control
+			// sockets to each specific address (coexists with a host bfdd on the
+			// wildcard port); empty → wildcard bind.
+			bfdListen := make([]string, 0, len(c.Config.LocalAddressList))
+			for _, addr := range c.Config.LocalAddressList {
+				bfdListen = append(bfdListen, addr.String())
+			}
 			s.bfdServer.listenInterface = g.BindToDevice
+			s.bfdServer.listenAddrs = bfdListen
 			if err := s.bfdServer.Start(ctx, oc.BfdConfig{Port: BfdServerPort}); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary
- listen on the RFC 5883 multihop BFD control port (4784) in addition to the configured single-hop port
- keep compatibility with upstream interface/device binding by applying listenAddrs alongside listenInterface
- add regression coverage for single-hop and multihop port handling, multihop session establishment, and Linux bind-to-device + multihop behavior

## Tests
- go test ./pkg/server -run 'Test_BfdServer(AcceptsSingleHopAndMultihopPorts|EstablishesMultihopSessionOnRFC5883Port|ListenAddrsBindToDeviceAndMultihopPort)$' -race -v\n- go test -race -timeout 240s ./pkg/server\n- go test ./pkg/server\n- golangci-lint run ./pkg/server