### PR TITLE
bfd: derive detection time from remote timers

### DIFF
--- a/pkg/server/bfd_peer.go
+++ b/pkg/server/bfd_peer.go
@@ -291,7 +291,18 @@ func (p *bfdPeer) rxPacket(h *bfd.BFDHeader) {
 
 	p.stats.rxPacket.Add(1)
 
-	// NOTE: remote DesiredMinTxInterval and RequiredMinRxInterval ignored
+	// RFC 5880 Section 6.8.4: Detection Time is the remote Detect Mult
+	// multiplied by the negotiated receive interval, i.e. the greater of our
+	// RequiredMinRxInterval and the remote DesiredMinTxInterval.
+	negotiatedRx := p.rxInterval
+	if remoteTx := time.Duration(h.DesiredMinTxInterval) * time.Microsecond; remoteTx > negotiatedRx {
+		negotiatedRx = remoteTx
+	}
+	remoteMult := time.Duration(h.DetectTimeMultiplier)
+	if remoteMult == 0 {
+		remoteMult = time.Duration(p.multiplier)
+	}
+	p.expiryInterval = remoteMult * negotiatedRx
 
 	switch h.State {
 	case bfd.StateAdminDown:
@@ -338,6 +349,11 @@ func (p *bfdPeer) tx() {
 }
 
 func (p *bfdPeer) expiry() {
+	if p.sessionState() == api.BfdSessionState_BFD_SESSION_STATE_DOWN {
+		p.eventExpiry.Stop()
+		return
+	}
+
 	p.logger.Warn("Expired",
 		slog.String("Topic", "bfd"),
 		slog.String("Peer", p.peerAddress.String()),

--- a/pkg/server/bfd_peer.go
+++ b/pkg/server/bfd_peer.go
@@ -34,6 +34,7 @@ type bfdPeerStats struct {
 	txDrop               atomic.Uint64
 	txError              atomic.Uint64
 	invalidDiscriminator atomic.Uint64
+	invalidMultiplier    atomic.Uint64
 	expired              atomic.Uint64
 }
 
@@ -289,6 +290,13 @@ func (p *bfdPeer) rxPacket(h *bfd.BFDHeader) {
 		return
 	}
 
+	// RFC 5880 Section 6.8.6: if the Detect Mult field is zero, the packet
+	// MUST be discarded.
+	if h.DetectTimeMultiplier == 0 {
+		p.stats.invalidMultiplier.Add(1)
+		return
+	}
+
 	p.stats.rxPacket.Add(1)
 
 	// RFC 5880 Section 6.8.4: Detection Time is the remote Detect Mult
@@ -298,11 +306,7 @@ func (p *bfdPeer) rxPacket(h *bfd.BFDHeader) {
 	if remoteTx := time.Duration(h.DesiredMinTxInterval) * time.Microsecond; remoteTx > negotiatedRx {
 		negotiatedRx = remoteTx
 	}
-	remoteMult := time.Duration(h.DetectTimeMultiplier)
-	if remoteMult == 0 {
-		remoteMult = time.Duration(p.multiplier)
-	}
-	p.expiryInterval = remoteMult * negotiatedRx
+	p.expiryInterval = time.Duration(h.DetectTimeMultiplier) * negotiatedRx
 
 	switch h.State {
 	case bfd.StateAdminDown:

--- a/pkg/server/bfd_peer_test.go
+++ b/pkg/server/bfd_peer_test.go
@@ -99,7 +99,7 @@ func Test_RxPacket(t *testing.T) {
 
 	assert.Equal(p.stats.rxPacket.Load(), uint64(0))
 
-	p.Rx(&bfd.BFDHeader{})
+	p.Rx(&bfd.BFDHeader{DetectTimeMultiplier: 5})
 
 	time.Sleep(2 * time.Second)
 	p.Stop()
@@ -124,9 +124,10 @@ func Test_RxPacketRemoteDownResetsPeer(t *testing.T) {
 	p.yourDiscriminator = 12345
 
 	p.rxPacket(&bfd.BFDHeader{
-		State:             bfd.StateDown,
-		MyDiscriminator:   67890,
-		YourDiscriminator: p.myDiscriminator,
+		State:                bfd.StateDown,
+		MyDiscriminator:      67890,
+		YourDiscriminator:    p.myDiscriminator,
+		DetectTimeMultiplier: 5,
 	})
 
 	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_DOWN, api.BfdSessionState(p.state.Load()))
@@ -147,26 +148,29 @@ func Test_RxPacketRFCStateTransitions(t *testing.T) {
 	defer p.Stop()
 
 	p.rxPacket(&bfd.BFDHeader{
-		State:             bfd.StateDown,
-		MyDiscriminator:   111,
-		YourDiscriminator: p.myDiscriminator,
+		State:                bfd.StateDown,
+		MyDiscriminator:      111,
+		YourDiscriminator:    p.myDiscriminator,
+		DetectTimeMultiplier: 5,
 	})
 	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_INIT, api.BfdSessionState(p.state.Load()))
 	assert.Equal(uint32(111), p.yourDiscriminator)
 
 	p.setStateDown()
 	p.rxPacket(&bfd.BFDHeader{
-		State:             bfd.StateUp,
-		MyDiscriminator:   222,
-		YourDiscriminator: p.myDiscriminator,
+		State:                bfd.StateUp,
+		MyDiscriminator:      222,
+		YourDiscriminator:    p.myDiscriminator,
+		DetectTimeMultiplier: 5,
 	})
 	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_DOWN, api.BfdSessionState(p.state.Load()))
 
 	p.setStateInit(333)
 	p.rxPacket(&bfd.BFDHeader{
-		State:             bfd.StateUp,
-		MyDiscriminator:   444,
-		YourDiscriminator: p.myDiscriminator,
+		State:                bfd.StateUp,
+		MyDiscriminator:      444,
+		YourDiscriminator:    p.myDiscriminator,
+		DetectTimeMultiplier: 5,
 	})
 	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_UP, api.BfdSessionState(p.state.Load()))
 	assert.Equal(uint32(444), p.yourDiscriminator)
@@ -205,14 +209,43 @@ func Test_RxPacketDetectionTimeFromRemote(t *testing.T) {
 	// Detection must now track the peer: 3 * max(300ms, 1000ms) = 3000ms.
 	assert.Equal(3*1000*time.Millisecond, p.expiryInterval)
 
-	// A zero-timer keepalive must NOT collapse the detector back to a bogus value:
-	// missing remote fields fall back to our local config, not to 0.
+	// RFC 5880 Section 6.8.6: a packet with Detect Mult == 0 MUST be discarded,
+	// so it must NOT collapse the detector to a bogus value — the previously
+	// negotiated detection time stays in effect.
 	p.rxPacket(&bfd.BFDHeader{
 		State:             bfd.StateUp,
 		MyDiscriminator:   111,
 		YourDiscriminator: p.myDiscriminator,
 	})
-	assert.Equal(3*300*time.Millisecond, p.expiryInterval)
+	assert.Equal(3*1000*time.Millisecond, p.expiryInterval)
+	assert.Equal(uint64(1), p.stats.invalidMultiplier.Load())
+}
+
+func Test_RxPacketZeroMultiplierDiscarded(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
+		Port:                     13784,
+		Enabled:                  true,
+		DetectionMultiplier:      3,
+		RequiredMinimumReceive:   300000,
+		DesiredMinimumTxInterval: 300000,
+	}, "")
+	defer p.Stop()
+
+	// RFC 5880 Section 6.8.6: Detect Mult == 0 MUST be discarded before it can
+	// drive any state transition or reset the detection timer.
+	p.rxPacket(&bfd.BFDHeader{
+		State:                bfd.StateDown,
+		MyDiscriminator:      111,
+		YourDiscriminator:    p.myDiscriminator,
+		DesiredMinTxInterval: 1000000,
+		DetectTimeMultiplier: 0,
+	})
+	assert.Equal(uint64(1), p.stats.invalidMultiplier.Load())
+	assert.Equal(uint64(0), p.stats.rxPacket.Load())
+	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_DOWN, p.sessionState())
 }
 
 func Test_ExpiryDoesNotResetAlreadyDownPeer(t *testing.T) {

--- a/pkg/server/bfd_peer_test.go
+++ b/pkg/server/bfd_peer_test.go
@@ -172,6 +172,65 @@ func Test_RxPacketRFCStateTransitions(t *testing.T) {
 	assert.Equal(uint32(444), p.yourDiscriminator)
 }
 
+// Test_RxPacketDetectionTimeFromRemote pins RFC 5880 Section 6.8.4: the detection time
+// must be the remote Detect Mult multiplied by max(local RequiredMinRx,
+// remote DesiredMinTx), not our own multiplier multiplied by our own rxInterval.
+// With local rx=300ms/mult=3 and remote tx=1000ms, the old detector expired at
+// 900ms, before the next remote packet. After the fix it stretches to 3000ms.
+func Test_RxPacketDetectionTimeFromRemote(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
+		Port:                     13784,
+		Enabled:                  true,
+		DetectionMultiplier:      3,
+		RequiredMinimumReceive:   300000, // 300ms
+		DesiredMinimumTxInterval: 300000,
+	}, "")
+	defer p.Stop()
+
+	// Before any packet: our-config-only baseline (the old, buggy value).
+	assert.Equal(3*300*time.Millisecond, p.expiryInterval)
+
+	// Peer advertises a SLOWER cadence (BIRD default on the tap): tx=1000ms, mult=3.
+	p.rxPacket(&bfd.BFDHeader{
+		State:                 bfd.StateDown,
+		MyDiscriminator:       111,
+		YourDiscriminator:     p.myDiscriminator,
+		DesiredMinTxInterval:  1000000, // 1000ms
+		DetectTimeMultiplier:  3,
+		RequiredMinRxInterval: 1000000,
+	})
+	// Detection must now track the peer: 3 * max(300ms, 1000ms) = 3000ms.
+	assert.Equal(3*1000*time.Millisecond, p.expiryInterval)
+
+	// A zero-timer keepalive must NOT collapse the detector back to a bogus value:
+	// missing remote fields fall back to our local config, not to 0.
+	p.rxPacket(&bfd.BFDHeader{
+		State:             bfd.StateUp,
+		MyDiscriminator:   111,
+		YourDiscriminator: p.myDiscriminator,
+	})
+	assert.Equal(3*300*time.Millisecond, p.expiryInterval)
+}
+
+func Test_ExpiryDoesNotResetAlreadyDownPeer(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
+		Port:    13784,
+		Enabled: true,
+	}, "")
+	defer p.Stop()
+
+	p.setStateDown()
+	p.expiry()
+
+	assert.Equal(int64(0), atomic.LoadInt64(&ps.resetPeerCount))
+}
+
 func Test_TxPacket(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
## Summary
- compute BFD Detection Time from the remote Detect Mult and the negotiated receive interval per RFC 5880 Section 6.8.4
- avoid duplicate peer resets when an already-down session receives a queued expiry tick
- add regression tests for slower remote transmit intervals and already-down expiry handling

## Tests
- go test ./pkg/server -run 'Test_RxPacketDetectionTimeFromRemote|Test_ExpiryDoesNotResetAlreadyDownPeer|Test_ResetPeer|Test_StateUpDown' -race -v\n- go test ./pkg/server\n- golangci-lint run ./pkg/server