### PR TITLE
fix: clear ribout cache on peer down

### DIFF
--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -83,6 +83,27 @@ func (r ribout) update(p *table.Path) bool {
 	return true
 }
 
+func (r ribout) dropPeer(peer netip.Addr) {
+	for key, paths := range r {
+		n := paths[:0]
+		for _, p := range paths {
+			if p == nil {
+				continue
+			}
+			src := p.GetSource()
+			if src != nil && src.Address == peer {
+				continue
+			}
+			n = append(n, p)
+		}
+		if len(n) == 0 {
+			delete(r, key)
+		} else {
+			r[key] = n
+		}
+	}
+}
+
 func bmpAddPathMarshallingOption(path *table.Path) *bgp.MarshallingOption {
 	return &bgp.MarshallingOption{
 		AddPath: map[bgp.Family]bgp.BGPAddPathMode{
@@ -258,6 +279,7 @@ func (b *bmpClient) loop() {
 									return false
 								}
 							} else if msg.Type != apiutil.PEER_EVENT_INIT && msg.OldState == bgp.BGP_FSM_ESTABLISHED {
+								b.ribout.dropPeer(msg.PeerAddress)
 								if err := write(bmpPeerDown(msg, bmp.BMP_PEER_TYPE_GLOBAL, false, 0)); err != nil {
 									return false
 								}

--- a/pkg/server/bmp_test.go
+++ b/pkg/server/bmp_test.go
@@ -140,3 +140,31 @@ func TestBMPLocRIBPeerUpCarriesAddPathCapabilityWhenEnabled(t *testing.T) {
 	require.Equal(t, bgp.RF_IPv6_UC, addPath.Tuples[1].Family)
 	require.Equal(t, bgp.BGP_ADD_PATH_BOTH, addPath.Tuples[1].Mode)
 }
+
+func TestRiboutDropPeerRemovesCachedPaths(t *testing.T) {
+	out := newribout()
+	peer1 := netip.MustParseAddr("198.51.100.1")
+	p1 := makeIPv4Path(t, "10.0.0.0/24", "192.0.2.1", "198.51.100.1", 65001, 1)
+	p2 := makeIPv4Path(t, "10.0.0.0/24", "192.0.2.2", "198.51.100.2", 65002, 2)
+
+	require.True(t, out.update(p1))
+	require.True(t, out.update(p2))
+
+	out.dropPeer(peer1)
+
+	require.True(t, out.update(p1))
+	require.False(t, out.update(p2))
+}
+
+func TestRiboutDropPeerAllowsIdenticalResendAfterFlap(t *testing.T) {
+	out := newribout()
+	peer := netip.MustParseAddr("198.51.100.1")
+	p := makeIPv4Path(t, "10.0.0.0/24", "192.0.2.1", "198.51.100.1", 65001, 1)
+
+	require.True(t, out.update(p))
+	require.False(t, out.update(p))
+
+	out.dropPeer(peer)
+
+	require.True(t, out.update(p))
+}


### PR DESCRIPTION
Drop cached BMP route-monitoring state when a peer leaves ESTABLISHED so
identical routes are reported again after the session comes back.