### PR TITLE
bmp: defer GR peer down/up and clear ribout cache on session loss

### DIFF
--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -83,6 +83,54 @@ func (r ribout) update(p *table.Path) bool {
 	return true
 }
 
+func (r ribout) dropPeer(peer netip.Addr) {
+	for key, paths := range r {
+		n := paths[:0]
+		for _, p := range paths {
+			if p == nil {
+				continue
+			}
+			src := p.GetSource()
+			if src != nil && src.Address == peer {
+				continue
+			}
+			n = append(n, p)
+		}
+		if len(n) == 0 {
+			delete(r, key)
+		} else {
+			r[key] = n
+		}
+	}
+}
+
+func bmpShouldSendPeerDown(msg *watchEventPeer) bool {
+	if msg.Type == apiutil.PEER_EVENT_INIT {
+		return false
+	}
+	if msg.StateReason != nil && msg.StateReason.Type == fsmGracefulRestart {
+		return false
+	}
+	if msg.OldState == bgp.BGP_FSM_ESTABLISHED {
+		return true
+	}
+	if msg.StateReason != nil && msg.StateReason.Type == fsmRestartTimerExpired {
+		return true
+	}
+	return false
+}
+
+func bmpShouldSendPeerUp(msg *watchEventPeer, grPending map[netip.Addr]struct{}) bool {
+	if msg.State != bgp.BGP_FSM_ESTABLISHED {
+		return false
+	}
+	if msg.Type == apiutil.PEER_EVENT_INIT {
+		return true
+	}
+	_, pending := grPending[msg.PeerAddress]
+	return !pending
+}
+
 func bmpAddPathMarshallingOption(path *table.Path) *bgp.MarshallingOption {
 	return &bgp.MarshallingOption{
 		AddPath: map[bgp.Family]bgp.BGPAddPathMode{
@@ -254,13 +302,20 @@ func (b *bmpClient) loop() {
 					case *watchEventPeer:
 						if msg.Type != apiutil.PEER_EVENT_END_OF_INIT {
 							if msg.State == bgp.BGP_FSM_ESTABLISHED {
-								if err := write(bmpPeerUp(msg, bmp.BMP_PEER_TYPE_GLOBAL, false, 0)); err != nil {
-									return false
+								if bmpShouldSendPeerUp(msg, b.grPending) {
+									if err := write(bmpPeerUp(msg, bmp.BMP_PEER_TYPE_GLOBAL, false, 0)); err != nil {
+										return false
+									}
 								}
-							} else if msg.Type != apiutil.PEER_EVENT_INIT && msg.OldState == bgp.BGP_FSM_ESTABLISHED {
+								delete(b.grPending, msg.PeerAddress)
+							} else if bmpShouldSendPeerDown(msg) {
+								delete(b.grPending, msg.PeerAddress)
+								b.ribout.dropPeer(msg.PeerAddress)
 								if err := write(bmpPeerDown(msg, bmp.BMP_PEER_TYPE_GLOBAL, false, 0)); err != nil {
 									return false
 								}
+							} else if msg.StateReason != nil && msg.StateReason.Type == fsmGracefulRestart {
+								b.grPending[msg.PeerAddress] = struct{}{}
 							}
 						}
 					case *watchEventMessage:
@@ -367,13 +422,14 @@ func bmpLocRIBPeerDown(localAS uint32, routerID netip.Addr, tableName string, pe
 }
 
 type bmpClient struct {
-	s        *BgpServer
-	dead     chan struct{}
-	host     netip.AddrPort
-	c        *oc.BmpServerConfig
-	ribout   ribout
-	uptime   int64
-	downtime int64
+	s         *BgpServer
+	dead      chan struct{}
+	host      netip.AddrPort
+	c         *oc.BmpServerConfig
+	ribout    ribout
+	grPending map[netip.Addr]struct{}
+	uptime    int64
+	downtime  int64
 }
 
 func bmpPeerUp(ev *watchEventPeer, t uint8, policy bool, pd uint64) *bmp.BMPMessage {
@@ -462,11 +518,12 @@ func (b *bmpClientManager) addServer(c *oc.BmpServerConfig) error {
 		return fmt.Errorf("bmp client %s is already configured", host)
 	}
 	b.clientMap[host] = &bmpClient{
-		s:      b.s,
-		dead:   make(chan struct{}),
-		host:   host,
-		c:      c,
-		ribout: newribout(),
+		s:         b.s,
+		dead:      make(chan struct{}),
+		host:      host,
+		c:         c,
+		ribout:    newribout(),
+		grPending: make(map[netip.Addr]struct{}),
 	}
 	go b.clientMap[host].loop()
 	return nil

--- a/pkg/server/bmp_test.go
+++ b/pkg/server/bmp_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/osrg/gobgp/v4/internal/pkg/table"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 	packetbmp "github.com/osrg/gobgp/v4/pkg/packet/bmp"
 	"github.com/stretchr/testify/require"
@@ -139,4 +140,108 @@ func TestBMPLocRIBPeerUpCarriesAddPathCapabilityWhenEnabled(t *testing.T) {
 	require.Equal(t, bgp.BGP_ADD_PATH_BOTH, addPath.Tuples[0].Mode)
 	require.Equal(t, bgp.RF_IPv6_UC, addPath.Tuples[1].Family)
 	require.Equal(t, bgp.BGP_ADD_PATH_BOTH, addPath.Tuples[1].Mode)
+}
+
+func TestBmpShouldSendPeerDown(t *testing.T) {
+	peerDown := func(oldState bgp.FSMState, reasonType fsmStateReasonType) *watchEventPeer {
+		return &watchEventPeer{
+			Type:        apiutil.PEER_EVENT_STATE,
+			OldState:    oldState,
+			State:       bgp.BGP_FSM_ACTIVE,
+			StateReason: &fsmStateReason{Type: reasonType},
+		}
+	}
+
+	require.False(t, bmpShouldSendPeerDown(peerDown(bgp.BGP_FSM_ESTABLISHED, fsmGracefulRestart)))
+	require.True(t, bmpShouldSendPeerDown(peerDown(bgp.BGP_FSM_ESTABLISHED, fsmHoldTimerExpired)))
+	require.True(t, bmpShouldSendPeerDown(peerDown(bgp.BGP_FSM_ACTIVE, fsmRestartTimerExpired)))
+	require.False(t, bmpShouldSendPeerDown(&watchEventPeer{Type: apiutil.PEER_EVENT_INIT}))
+}
+
+func TestBmpShouldSendPeerUp(t *testing.T) {
+	peer := netip.MustParseAddr("198.51.100.1")
+	grPending := map[netip.Addr]struct{}{peer: {}}
+	established := func(eventType apiutil.PeerEventType) *watchEventPeer {
+		return &watchEventPeer{
+			Type:        eventType,
+			State:       bgp.BGP_FSM_ESTABLISHED,
+			PeerAddress: peer,
+		}
+	}
+
+	require.True(t, bmpShouldSendPeerUp(established(apiutil.PEER_EVENT_INIT), grPending))
+	require.False(t, bmpShouldSendPeerUp(established(apiutil.PEER_EVENT_STATE), grPending))
+	require.True(t, bmpShouldSendPeerUp(established(apiutil.PEER_EVENT_STATE), nil))
+}
+
+func TestBmpGRPendingLifecycle(t *testing.T) {
+	peer := netip.MustParseAddr("198.51.100.1")
+	grPending := make(map[netip.Addr]struct{})
+
+	grStart := &watchEventPeer{
+		Type:        apiutil.PEER_EVENT_STATE,
+		State:       bgp.BGP_FSM_IDLE,
+		OldState:    bgp.BGP_FSM_ESTABLISHED,
+		PeerAddress: peer,
+		StateReason: &fsmStateReason{Type: fsmGracefulRestart},
+	}
+	require.False(t, bmpShouldSendPeerDown(grStart))
+	grPending[peer] = struct{}{}
+
+	grRecovery := &watchEventPeer{
+		Type:        apiutil.PEER_EVENT_STATE,
+		State:       bgp.BGP_FSM_ESTABLISHED,
+		OldState:    bgp.BGP_FSM_OPENCONFIRM,
+		PeerAddress: peer,
+		StateReason: &fsmStateReason{Type: fsmOpenMsgNegotiated},
+	}
+	require.False(t, bmpShouldSendPeerUp(grRecovery, grPending))
+	delete(grPending, peer)
+
+	realDown := &watchEventPeer{
+		Type:        apiutil.PEER_EVENT_STATE,
+		State:       bgp.BGP_FSM_IDLE,
+		OldState:    bgp.BGP_FSM_ESTABLISHED,
+		PeerAddress: peer,
+		StateReason: &fsmStateReason{Type: fsmHoldTimerExpired},
+	}
+	require.True(t, bmpShouldSendPeerDown(realDown))
+	delete(grPending, peer)
+
+	reconnect := &watchEventPeer{
+		Type:        apiutil.PEER_EVENT_STATE,
+		State:       bgp.BGP_FSM_ESTABLISHED,
+		OldState:    bgp.BGP_FSM_OPENCONFIRM,
+		PeerAddress: peer,
+		StateReason: &fsmStateReason{Type: fsmOpenMsgNegotiated},
+	}
+	require.True(t, bmpShouldSendPeerUp(reconnect, grPending))
+}
+
+func TestRiboutDropPeerRemovesCachedPaths(t *testing.T) {
+	out := newribout()
+	peer1 := netip.MustParseAddr("198.51.100.1")
+	p1 := makeIPv4Path(t, "10.0.0.0/24", "192.0.2.1", "198.51.100.1", 65001, 1)
+	p2 := makeIPv4Path(t, "10.0.0.0/24", "192.0.2.2", "198.51.100.2", 65002, 2)
+
+	require.True(t, out.update(p1))
+	require.True(t, out.update(p2))
+
+	out.dropPeer(peer1)
+
+	require.True(t, out.update(p1))
+	require.False(t, out.update(p2))
+}
+
+func TestRiboutDropPeerAllowsIdenticalResendAfterFlap(t *testing.T) {
+	out := newribout()
+	peer := netip.MustParseAddr("198.51.100.1")
+	p := makeIPv4Path(t, "10.0.0.0/24", "192.0.2.1", "198.51.100.1", 65001, 1)
+
+	require.True(t, out.update(p))
+	require.False(t, out.update(p))
+
+	out.dropPeer(peer)
+
+	require.True(t, out.update(p))
 }


### PR DESCRIPTION
Skip BMP Peer Down while a peer is in graceful restart and suppress the redundant Peer Up on GR recovery by tracking GR-pending peers. Clear the ribout deduplication cache on real session loss so routes can be resent after flap. Keep INIT replay Peer Up behavior for BMP session bootstrap.
By the way,  To limit blast radius, only the BMP file is changed; GR-pending state is in-memory and lost on BMP session restart, which may cause a redundant Peer Up on GR recovery in that edge case.