### PR TITLE
packet/bgp: fix SRv6InformationSubTLV sub-sub-TLV decode over-read

### DIFF
--- a/pkg/packet/bgp/prefix_sid.go
+++ b/pkg/packet/bgp/prefix_sid.go
@@ -403,11 +403,19 @@ func (s *SRv6InformationSubTLV) DecodeFromBytes(data []byte) error {
 	p += 2
 	// reserved byte
 	p++
-	if p+3 > len(data) {
+	// Sub-Sub-TLVs are bounded by this sub-TLV's declared Length, not by
+	// the caller's remaining buffer, which may still hold sibling
+	// sub-TLVs of the enclosing Service TLV. subTLVHdrLen + Length is the
+	// end of this sub-TLV's body.
+	end := subTLVHdrLen + int(s.Length)
+	if end > len(data) {
+		return malformedAttrListErr("decoding failed: Prefix SID TLV malformed")
+	}
+	if p+3 > end {
 		// There is no Sub Sub TLVs detected, returning
 		return nil
 	}
-	stlvs := data[p:]
+	stlvs := data[p:end]
 	for len(stlvs) >= prefixSIDtlvHdrLen {
 		t := &SubSubTLV{}
 		_, err := t.DecodeFromBytes(stlvs)

--- a/pkg/packet/bgp/prefix_sid_multi_subtlv_test.go
+++ b/pkg/packet/bgp/prefix_sid_multi_subtlv_test.go
@@ -1,0 +1,41 @@
+package bgp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Two SRv6 Information sub-TLVs (RFC 9252) packed into one SRv6 L3
+// Service TLV. Each carries exactly one SID Structure sub-sub-TLV. The
+// decoder must attribute each sub-sub-TLV to its own parent and must not
+// read past the first sub-TLV's declared Length into the second.
+func TestSRv6InformationSubTLV_DoesNotOverreadSibling(t *testing.T) {
+	assert := assert.New(t)
+
+	info := func(lastSIDByte, subSubFirst byte) []byte {
+		return []byte{
+			0x01, 0x00, 0x1e, // Type=1 (Information), Length=30
+			0x00,                                                                                                  // Reserved
+			0x20, 0x01, 0x00, 0x00, 0x00, 0x05, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, lastSIDByte, // SID (16)
+			0x00,       // Flags
+			0x00, 0x13, // Endpoint Behavior
+			0x00,                                                        // Reserved
+			0x01, 0x00, 0x06, subSubFirst, 0x18, 0x10, 0x00, 0x10, 0x40, // SID Structure sub-sub-TLV
+		}
+	}
+
+	body := append(info(0x01, 0x28), info(0x02, 0x30)...)
+	// SRv6 L3 Service TLV: Type + Length + Reserved + two Information sub-TLVs
+	raw := append([]byte{0x05, 0x00, byte(1 + len(body)), 0x00}, body...)
+
+	s := &SRv6ServiceTLV{}
+	assert.NoError(s.DecodeFromBytes(raw))
+	assert.Equal(2, len(s.SubTLVs))
+
+	first := s.SubTLVs[0].(*SRv6InformationSubTLV)
+	second := s.SubTLVs[1].(*SRv6InformationSubTLV)
+	assert.Equal(1, len(first.SubSubTLVs),
+		"first Information sub-TLV must not absorb the sibling's bytes as its own sub-sub-TLVs")
+	assert.Equal(1, len(second.SubSubTLVs))
+}


### PR DESCRIPTION
go test, two SRv6 Information sub-TLVs packed in one SRv6 L3 Service TLV:

    prefix_sid_multi_subtlv_test.go:38: Not equal:
                expected: 1
                actual  : 2
    first Information sub-TLV must not absorb the sibling's bytes as its own sub-sub-TLVs

`SRv6InformationSubTLV.DecodeFromBytes` walks its Sub-Sub-TLVs over `data[p:]`, bounded by the whole slice the caller hands it. `SRv6ServiceTLV`/`SRv6L3ServiceAttribute` pass the entire enclosing Service TLV body (not this sub-TLV alone), so once a second Information sub-TLV follows, the first reads past its own declared `Length` and consumes the sibling's type/length header as a sub-sub-TLV. The sibling is then parsed a second time by the outer loop, so its SID Structure ends up attached to the wrong parent (or the whole attribute is rejected when the borrowed bytes do not form a valid sub-sub-TLV).

Clamp the loop to `subTLVHdrLen + Length`, the end of this sub-TLV's body, and reject a declared length that runs past the buffer.