### PR TITLE
packet/mrt: fix attribute-length truncation in parseRibEntry

### DIFF
--- a/pkg/packet/mrt/mrt.go
+++ b/pkg/packet/mrt/mrt.go
@@ -444,12 +444,12 @@ func parseRibEntry(data []byte, family bgp.Family, isAddPath bool, prefix ...bgp
 			mp.Value = []bgp.PathNLRI{{NLRI: prefix[0], ID: e.PathIdentifier}}
 		}
 
-		pLen := uint16(p.Len())
-		if pLen > attrLen {
+		pLen := p.Len()
+		if pLen > int(attrLen) {
 			return nil, nil, fmt.Errorf("path attribute length %d exceeds remaining attribute length %d", pLen, attrLen)
 		}
-		attrLen -= pLen
-		data = data[p.Len():]
+		attrLen -= uint16(pLen)
+		data = data[pLen:]
 		e.PathAttributes = append(e.PathAttributes, p)
 	}
 	return e, data, nil

--- a/pkg/packet/mrt/mrt_test.go
+++ b/pkg/packet/mrt/mrt_test.go
@@ -135,6 +135,28 @@ func TestParsePeerIndexTable_LargeViewNameDoesNotPanic(t *testing.T) {
 	}
 }
 
+func TestParseRibEntry_OversizedAttrLengthRejected(t *testing.T) {
+	// Regression: p.Len() is an int, and an extended-length path attribute can
+	// be up to 65539 bytes. Casting it to uint16 before the "exceeds remaining
+	// attribute length" check wraps the value (65539 -> 3), letting an attribute
+	// that overruns the declared attribute region slip past the bound. The parser
+	// then consumes bytes past the region (belonging to following records) and
+	// mis-frames every subsequent RIB entry.
+	valueLen := 0xffff // p.Len() == 4 + 0xffff == 65539
+
+	var data []byte
+	data = append(data, 0x00, 0x01)             // PeerIndex
+	data = append(data, 0x00, 0x00, 0x00, 0x00) // OriginatedTime
+	data = append(data, 0x00, 0x03)             // Attribute Length: region declared as 3 bytes
+	// optional extended-length unknown attribute overrunning the 3-byte region
+	data = append(data, 0x90, 0xff, 0xff, 0xff) // flags(OPTIONAL|EXTENDED_LENGTH), type, length=0xffff
+	data = append(data, bytes.Repeat([]byte{0}, valueLen)...)
+
+	if _, _, err := parseRibEntry(data, bgp.RF_IPv4_UC, false); err == nil {
+		t.Fatal("parseRibEntry accepted an attribute overrunning the declared attribute length")
+	}
+}
+
 func TestMrtRibEntry(t *testing.T) {
 	aspath1 := []bgp.AsPathParamInterface{
 		bgp.NewAs4PathParam(2, []uint32{1000}),


### PR DESCRIPTION
go test, a RIB entry declaring a 3-byte attribute region but carrying one oversized extended-length attribute:

    mrt_test.go:156: parseRibEntry accepted an attribute overrunning the declared attribute length

parseRibEntry casts p.Len() to uint16 before the "exceeds remaining attribute length" check. An extended-length path attribute runs up to 65539 bytes, so the cast wraps (65539 -> 3), the guard passes, and the loop consumes the whole attribute past the declared region, then advances data into the following records. On-wire BGP messages cap at 65535 so the equivalent BGPUpdate path-attribute loop cannot reach this; MRT records are not capped, so a crafted TABLE_DUMP_V2 dump does. Compare and subtract in int so the bound holds for attributes larger than 65535.