### PR TITLE
zebra: reject ZAPI header with Length below header size

### DIFF
--- a/pkg/zebra/zapi.go
+++ b/pkg/zebra/zapi.go
@@ -1778,6 +1778,12 @@ func (h *Header) decodeFromBytes(data []byte) error {
 	default:
 		return fmt.Errorf("unsupported ZAPI version: %d", h.Version)
 	}
+	// The on-wire Len covers the header plus the body. A value below the
+	// header size makes ReceiveSingleMsg compute int(h.Len-HeaderSize) in
+	// uint16, which wraps to a large body length instead of a short read.
+	if h.Len < HeaderSize(h.Version) {
+		return fmt.Errorf("invalid ZAPI message length %d: less than header size %d", h.Len, HeaderSize(h.Version))
+	}
 	return nil
 }
 

--- a/pkg/zebra/zapi_test.go
+++ b/pkg/zebra/zapi_test.go
@@ -78,6 +78,20 @@ func Test_Header(t *testing.T) {
 		h3 := &Header{}
 		err = h3.decodeFromBytes(buf)
 		assert.NotEqual(nil, err, "err should be nil")
+
+		// on-wire Len smaller than the header size must be rejected,
+		// otherwise ReceiveSingleMsg computes int(h.Len-HeaderSize) in
+		// uint16 and wraps to a ~64KiB body read instead of a short one.
+		buf = make([]byte, HeaderSize(v))
+		binary.BigEndian.PutUint16(buf[0:], HeaderSize(v)-1) // Len < header size
+		buf[2] = headerMarker
+		if v >= 4 {
+			buf[2] = frrHeaderMarker
+		}
+		buf[3] = v
+		h4 := &Header{}
+		err = h4.decodeFromBytes(buf)
+		assert.Error(err)
 	}
 }
 


### PR DESCRIPTION
ReceiveSingleMsg frames the ZAPI body straight from the on-wire Length:

    bodyBuf, err := readAll(conn, int(hd.Len-HeaderSize(version)))

`hd.Len` and `HeaderSize` are both uint16, so a message that declares Len below the header size (e.g. Len=4 on ZAPI v6 where HeaderSize is 10) wraps the subtraction to 65530 instead of producing a short read, and gobgp pulls ~64KiB of the following messages in as this one's body, desyncing the stream from zebra.

Validate `Len >= HeaderSize` while decoding the header so the body-length subtraction can no longer wrap. Added a regression case to Test_Header that fails before the change.