### PR TITLE
packet/bgp: clamp flowspec components to declared NLRI length

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -4525,6 +4525,12 @@ func (n *FlowSpecNLRI) decodeFromBytes(data []byte, options ...*MarshallingOptio
 		length -= 8
 	}
 
+	// keep the component parser within the declared NLRI length. a component's
+	// own operator/value bytes are self-terminating, so without this a
+	// component reaching past `length` consumes bytes from the next NLRI in the
+	// same MP_(UN)REACH attribute and mis-frames it.
+	data = data[:length]
+
 	for l := length; l > 0; {
 		if len(data) == 0 {
 			return malformedAttrListErr("not all flowspec component bytes available")

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -542,6 +542,29 @@ func Test_FlowSpecNlri(t *testing.T) {
 	assert.Equal(n1, n2)
 }
 
+func Test_FlowSpecNlriComponentsClampedToDeclaredLength(t *testing.T) {
+	assert := assert.New(t)
+	item := NewFlowSpecComponentItem(DEC_NUM_OP_EQ, 6)
+	comp := NewFlowSpecComponent(FLOW_SPEC_TYPE_IP_PROTO, []*FlowSpecComponentItem{item})
+	n1, err := NewFlowSpecUnicast(RF_FS_IPv4_UC, []FlowSpecComponentInterface{comp})
+	assert.NoError(err)
+	one, err := n1.Serialize()
+	assert.NoError(err)
+	declared := int(one[0])
+
+	// Declare one byte fewer than the component occupies, then append a byte
+	// that belongs to the next NLRI. The component must not reach past the
+	// declared length into that following byte.
+	buf := make([]byte, len(one))
+	copy(buf, one)
+	buf[0] = byte(declared - 1)
+	buf = append(buf, 0xEE)
+
+	nlri, err := NLRIFromSlice(RF_FS_IPv4_UC, buf)
+	assert.NoError(err)
+	assert.LessOrEqual(nlri.Len(), 1+(declared-1))
+}
+
 func Test_NewFlowSpecComponentItemLength(t *testing.T) {
 	item := NewFlowSpecComponentItem(0, 0)
 	assert.Equal(t, 1, item.Len())


### PR DESCRIPTION
go test, a flowspec NLRI whose declared length is shorter than the bytes its components occupy, followed by the first byte of the next NLRI:

    bgp_test.go: "4" is not less than or equal to "3"
    component read one byte past the declared NLRI length, into the following NLRI

`FlowSpecNLRI.decodeFromBytes` uses the declared NLRI length only as a loop counter and hands each component the whole remaining slice. A flowspec component's operator/value bytes are self-terminating, so a component whose bytes run past `length` keeps reading into the next NLRI packed in the same MP_REACH/MP_UNREACH and folds those bytes into the first NLRI, mis-framing the rest of the list. Clamp `data` to the declared length before the component loop.
