### PR TITLE
packet/bgp, api, cmd/gobgp: update MUP SAFI support to draft-ietf-bess-mup-safi-01

### DIFF
--- a/api/extcom.pb.go
+++ b/api/extcom.pb.go
@@ -993,29 +993,29 @@ func (x *TrafficRemarkExtended) GetDscp() uint32 {
 	return 0
 }
 
-type MUPExtended struct {
+type MUPTwoOctetAsSpecificExtended struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SubType       uint32                 `protobuf:"varint,1,opt,name=sub_type,json=subType,proto3" json:"sub_type,omitempty"`
-	SegmentId2    uint32                 `protobuf:"varint,2,opt,name=segment_id2,json=segmentId2,proto3" json:"segment_id2,omitempty"`
-	SegmentId4    uint32                 `protobuf:"varint,3,opt,name=segment_id4,json=segmentId4,proto3" json:"segment_id4,omitempty"`
+	Asn           uint32                 `protobuf:"varint,2,opt,name=asn,proto3" json:"asn,omitempty"`
+	LocalAdmin    uint32                 `protobuf:"varint,3,opt,name=local_admin,json=localAdmin,proto3" json:"local_admin,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *MUPExtended) Reset() {
-	*x = MUPExtended{}
+func (x *MUPTwoOctetAsSpecificExtended) Reset() {
+	*x = MUPTwoOctetAsSpecificExtended{}
 	mi := &file_api_extcom_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *MUPExtended) String() string {
+func (x *MUPTwoOctetAsSpecificExtended) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*MUPExtended) ProtoMessage() {}
+func (*MUPTwoOctetAsSpecificExtended) ProtoMessage() {}
 
-func (x *MUPExtended) ProtoReflect() protoreflect.Message {
+func (x *MUPTwoOctetAsSpecificExtended) ProtoReflect() protoreflect.Message {
 	mi := &file_api_extcom_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1027,28 +1027,148 @@ func (x *MUPExtended) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use MUPExtended.ProtoReflect.Descriptor instead.
-func (*MUPExtended) Descriptor() ([]byte, []int) {
+// Deprecated: Use MUPTwoOctetAsSpecificExtended.ProtoReflect.Descriptor instead.
+func (*MUPTwoOctetAsSpecificExtended) Descriptor() ([]byte, []int) {
 	return file_api_extcom_proto_rawDescGZIP(), []int{19}
 }
 
-func (x *MUPExtended) GetSubType() uint32 {
+func (x *MUPTwoOctetAsSpecificExtended) GetSubType() uint32 {
 	if x != nil {
 		return x.SubType
 	}
 	return 0
 }
 
-func (x *MUPExtended) GetSegmentId2() uint32 {
+func (x *MUPTwoOctetAsSpecificExtended) GetAsn() uint32 {
 	if x != nil {
-		return x.SegmentId2
+		return x.Asn
 	}
 	return 0
 }
 
-func (x *MUPExtended) GetSegmentId4() uint32 {
+func (x *MUPTwoOctetAsSpecificExtended) GetLocalAdmin() uint32 {
 	if x != nil {
-		return x.SegmentId4
+		return x.LocalAdmin
+	}
+	return 0
+}
+
+type MUPIPv4AddressSpecificExtended struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SubType       uint32                 `protobuf:"varint,1,opt,name=sub_type,json=subType,proto3" json:"sub_type,omitempty"`
+	Address       string                 `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
+	LocalAdmin    uint32                 `protobuf:"varint,3,opt,name=local_admin,json=localAdmin,proto3" json:"local_admin,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MUPIPv4AddressSpecificExtended) Reset() {
+	*x = MUPIPv4AddressSpecificExtended{}
+	mi := &file_api_extcom_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MUPIPv4AddressSpecificExtended) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MUPIPv4AddressSpecificExtended) ProtoMessage() {}
+
+func (x *MUPIPv4AddressSpecificExtended) ProtoReflect() protoreflect.Message {
+	mi := &file_api_extcom_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MUPIPv4AddressSpecificExtended.ProtoReflect.Descriptor instead.
+func (*MUPIPv4AddressSpecificExtended) Descriptor() ([]byte, []int) {
+	return file_api_extcom_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *MUPIPv4AddressSpecificExtended) GetSubType() uint32 {
+	if x != nil {
+		return x.SubType
+	}
+	return 0
+}
+
+func (x *MUPIPv4AddressSpecificExtended) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *MUPIPv4AddressSpecificExtended) GetLocalAdmin() uint32 {
+	if x != nil {
+		return x.LocalAdmin
+	}
+	return 0
+}
+
+type MUPFourOctetAsSpecificExtended struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SubType       uint32                 `protobuf:"varint,1,opt,name=sub_type,json=subType,proto3" json:"sub_type,omitempty"`
+	Asn           uint32                 `protobuf:"varint,2,opt,name=asn,proto3" json:"asn,omitempty"`
+	LocalAdmin    uint32                 `protobuf:"varint,3,opt,name=local_admin,json=localAdmin,proto3" json:"local_admin,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MUPFourOctetAsSpecificExtended) Reset() {
+	*x = MUPFourOctetAsSpecificExtended{}
+	mi := &file_api_extcom_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MUPFourOctetAsSpecificExtended) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MUPFourOctetAsSpecificExtended) ProtoMessage() {}
+
+func (x *MUPFourOctetAsSpecificExtended) ProtoReflect() protoreflect.Message {
+	mi := &file_api_extcom_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MUPFourOctetAsSpecificExtended.ProtoReflect.Descriptor instead.
+func (*MUPFourOctetAsSpecificExtended) Descriptor() ([]byte, []int) {
+	return file_api_extcom_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *MUPFourOctetAsSpecificExtended) GetSubType() uint32 {
+	if x != nil {
+		return x.SubType
+	}
+	return 0
+}
+
+func (x *MUPFourOctetAsSpecificExtended) GetAsn() uint32 {
+	if x != nil {
+		return x.Asn
+	}
+	return 0
+}
+
+func (x *MUPFourOctetAsSpecificExtended) GetLocalAdmin() uint32 {
+	if x != nil {
+		return x.LocalAdmin
 	}
 	return 0
 }
@@ -1063,7 +1183,7 @@ type VPLSExtended struct {
 
 func (x *VPLSExtended) Reset() {
 	*x = VPLSExtended{}
-	mi := &file_api_extcom_proto_msgTypes[20]
+	mi := &file_api_extcom_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1075,7 +1195,7 @@ func (x *VPLSExtended) String() string {
 func (*VPLSExtended) ProtoMessage() {}
 
 func (x *VPLSExtended) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[20]
+	mi := &file_api_extcom_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1088,7 +1208,7 @@ func (x *VPLSExtended) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VPLSExtended.ProtoReflect.Descriptor instead.
 func (*VPLSExtended) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{20}
+	return file_api_extcom_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *VPLSExtended) GetControlFlags() uint32 {
@@ -1115,7 +1235,7 @@ type ETreeExtended struct {
 
 func (x *ETreeExtended) Reset() {
 	*x = ETreeExtended{}
-	mi := &file_api_extcom_proto_msgTypes[21]
+	mi := &file_api_extcom_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1127,7 +1247,7 @@ func (x *ETreeExtended) String() string {
 func (*ETreeExtended) ProtoMessage() {}
 
 func (x *ETreeExtended) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[21]
+	mi := &file_api_extcom_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1140,7 +1260,7 @@ func (x *ETreeExtended) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ETreeExtended.ProtoReflect.Descriptor instead.
 func (*ETreeExtended) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{21}
+	return file_api_extcom_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ETreeExtended) GetIsLeaf() bool {
@@ -1167,7 +1287,7 @@ type MulticastFlagsExtended struct {
 
 func (x *MulticastFlagsExtended) Reset() {
 	*x = MulticastFlagsExtended{}
-	mi := &file_api_extcom_proto_msgTypes[22]
+	mi := &file_api_extcom_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1179,7 +1299,7 @@ func (x *MulticastFlagsExtended) String() string {
 func (*MulticastFlagsExtended) ProtoMessage() {}
 
 func (x *MulticastFlagsExtended) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[22]
+	mi := &file_api_extcom_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1192,7 +1312,7 @@ func (x *MulticastFlagsExtended) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MulticastFlagsExtended.ProtoReflect.Descriptor instead.
 func (*MulticastFlagsExtended) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{22}
+	return file_api_extcom_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *MulticastFlagsExtended) GetIsIgmpProxy() bool {
@@ -1219,7 +1339,7 @@ type UnknownExtended struct {
 
 func (x *UnknownExtended) Reset() {
 	*x = UnknownExtended{}
-	mi := &file_api_extcom_proto_msgTypes[23]
+	mi := &file_api_extcom_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1231,7 +1351,7 @@ func (x *UnknownExtended) String() string {
 func (*UnknownExtended) ProtoMessage() {}
 
 func (x *UnknownExtended) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[23]
+	mi := &file_api_extcom_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1244,7 +1364,7 @@ func (x *UnknownExtended) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnknownExtended.ProtoReflect.Descriptor instead.
 func (*UnknownExtended) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{23}
+	return file_api_extcom_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *UnknownExtended) GetType() uint32 {
@@ -1285,10 +1405,12 @@ type ExtendedCommunity struct {
 	//	*ExtendedCommunity_RedirectIpv4AddressSpecific
 	//	*ExtendedCommunity_RedirectFourOctetAsSpecific
 	//	*ExtendedCommunity_TrafficRemark
-	//	*ExtendedCommunity_Mup
 	//	*ExtendedCommunity_Vpls
 	//	*ExtendedCommunity_Etree
 	//	*ExtendedCommunity_MulticastFlags
+	//	*ExtendedCommunity_MupTwoOctetAsSpecific
+	//	*ExtendedCommunity_MupIpv4AddressSpecific
+	//	*ExtendedCommunity_MupFourOctetAsSpecific
 	Extcom        isExtendedCommunity_Extcom `protobuf_oneof:"extcom"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1296,7 +1418,7 @@ type ExtendedCommunity struct {
 
 func (x *ExtendedCommunity) Reset() {
 	*x = ExtendedCommunity{}
-	mi := &file_api_extcom_proto_msgTypes[24]
+	mi := &file_api_extcom_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1308,7 +1430,7 @@ func (x *ExtendedCommunity) String() string {
 func (*ExtendedCommunity) ProtoMessage() {}
 
 func (x *ExtendedCommunity) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[24]
+	mi := &file_api_extcom_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1321,7 +1443,7 @@ func (x *ExtendedCommunity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtendedCommunity.ProtoReflect.Descriptor instead.
 func (*ExtendedCommunity) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{24}
+	return file_api_extcom_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ExtendedCommunity) GetExtcom() isExtendedCommunity_Extcom {
@@ -1511,15 +1633,6 @@ func (x *ExtendedCommunity) GetTrafficRemark() *TrafficRemarkExtended {
 	return nil
 }
 
-func (x *ExtendedCommunity) GetMup() *MUPExtended {
-	if x != nil {
-		if x, ok := x.Extcom.(*ExtendedCommunity_Mup); ok {
-			return x.Mup
-		}
-	}
-	return nil
-}
-
 func (x *ExtendedCommunity) GetVpls() *VPLSExtended {
 	if x != nil {
 		if x, ok := x.Extcom.(*ExtendedCommunity_Vpls); ok {
@@ -1542,6 +1655,33 @@ func (x *ExtendedCommunity) GetMulticastFlags() *MulticastFlagsExtended {
 	if x != nil {
 		if x, ok := x.Extcom.(*ExtendedCommunity_MulticastFlags); ok {
 			return x.MulticastFlags
+		}
+	}
+	return nil
+}
+
+func (x *ExtendedCommunity) GetMupTwoOctetAsSpecific() *MUPTwoOctetAsSpecificExtended {
+	if x != nil {
+		if x, ok := x.Extcom.(*ExtendedCommunity_MupTwoOctetAsSpecific); ok {
+			return x.MupTwoOctetAsSpecific
+		}
+	}
+	return nil
+}
+
+func (x *ExtendedCommunity) GetMupIpv4AddressSpecific() *MUPIPv4AddressSpecificExtended {
+	if x != nil {
+		if x, ok := x.Extcom.(*ExtendedCommunity_MupIpv4AddressSpecific); ok {
+			return x.MupIpv4AddressSpecific
+		}
+	}
+	return nil
+}
+
+func (x *ExtendedCommunity) GetMupFourOctetAsSpecific() *MUPFourOctetAsSpecificExtended {
+	if x != nil {
+		if x, ok := x.Extcom.(*ExtendedCommunity_MupFourOctetAsSpecific); ok {
+			return x.MupFourOctetAsSpecific
 		}
 	}
 	return nil
@@ -1631,10 +1771,6 @@ type ExtendedCommunity_TrafficRemark struct {
 	TrafficRemark *TrafficRemarkExtended `protobuf:"bytes,20,opt,name=traffic_remark,json=trafficRemark,proto3,oneof"`
 }
 
-type ExtendedCommunity_Mup struct {
-	Mup *MUPExtended `protobuf:"bytes,21,opt,name=mup,proto3,oneof"`
-}
-
 type ExtendedCommunity_Vpls struct {
 	Vpls *VPLSExtended `protobuf:"bytes,22,opt,name=vpls,proto3,oneof"`
 }
@@ -1645,6 +1781,18 @@ type ExtendedCommunity_Etree struct {
 
 type ExtendedCommunity_MulticastFlags struct {
 	MulticastFlags *MulticastFlagsExtended `protobuf:"bytes,24,opt,name=multicast_flags,json=multicastFlags,proto3,oneof"`
+}
+
+type ExtendedCommunity_MupTwoOctetAsSpecific struct {
+	MupTwoOctetAsSpecific *MUPTwoOctetAsSpecificExtended `protobuf:"bytes,25,opt,name=mup_two_octet_as_specific,json=mupTwoOctetAsSpecific,proto3,oneof"`
+}
+
+type ExtendedCommunity_MupIpv4AddressSpecific struct {
+	MupIpv4AddressSpecific *MUPIPv4AddressSpecificExtended `protobuf:"bytes,26,opt,name=mup_ipv4_address_specific,json=mupIpv4AddressSpecific,proto3,oneof"`
+}
+
+type ExtendedCommunity_MupFourOctetAsSpecific struct {
+	MupFourOctetAsSpecific *MUPFourOctetAsSpecificExtended `protobuf:"bytes,27,opt,name=mup_four_octet_as_specific,json=mupFourOctetAsSpecific,proto3,oneof"`
 }
 
 func (*ExtendedCommunity_Unknown) isExtendedCommunity_Extcom() {}
@@ -1687,13 +1835,17 @@ func (*ExtendedCommunity_RedirectFourOctetAsSpecific) isExtendedCommunity_Extcom
 
 func (*ExtendedCommunity_TrafficRemark) isExtendedCommunity_Extcom() {}
 
-func (*ExtendedCommunity_Mup) isExtendedCommunity_Extcom() {}
-
 func (*ExtendedCommunity_Vpls) isExtendedCommunity_Extcom() {}
 
 func (*ExtendedCommunity_Etree) isExtendedCommunity_Extcom() {}
 
 func (*ExtendedCommunity_MulticastFlags) isExtendedCommunity_Extcom() {}
+
+func (*ExtendedCommunity_MupTwoOctetAsSpecific) isExtendedCommunity_Extcom() {}
+
+func (*ExtendedCommunity_MupIpv4AddressSpecific) isExtendedCommunity_Extcom() {}
+
+func (*ExtendedCommunity_MupFourOctetAsSpecific) isExtendedCommunity_Extcom() {}
 
 type RouteTarget struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1709,7 +1861,7 @@ type RouteTarget struct {
 
 func (x *RouteTarget) Reset() {
 	*x = RouteTarget{}
-	mi := &file_api_extcom_proto_msgTypes[25]
+	mi := &file_api_extcom_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1721,7 +1873,7 @@ func (x *RouteTarget) String() string {
 func (*RouteTarget) ProtoMessage() {}
 
 func (x *RouteTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[25]
+	mi := &file_api_extcom_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1734,7 +1886,7 @@ func (x *RouteTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteTarget.ProtoReflect.Descriptor instead.
 func (*RouteTarget) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{25}
+	return file_api_extcom_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *RouteTarget) GetRt() isRouteTarget_Rt {
@@ -1859,13 +2011,22 @@ const file_api_extcom_proto_rawDesc = "" +
 	"\vlocal_admin\x18\x02 \x01(\rR\n" +
 	"localAdmin\"+\n" +
 	"\x15TrafficRemarkExtended\x12\x12\n" +
-	"\x04dscp\x18\x01 \x01(\rR\x04dscp\"j\n" +
-	"\vMUPExtended\x12\x19\n" +
-	"\bsub_type\x18\x01 \x01(\rR\asubType\x12\x1f\n" +
-	"\vsegment_id2\x18\x02 \x01(\rR\n" +
-	"segmentId2\x12\x1f\n" +
-	"\vsegment_id4\x18\x03 \x01(\rR\n" +
-	"segmentId4\"E\n" +
+	"\x04dscp\x18\x01 \x01(\rR\x04dscp\"m\n" +
+	"\x1dMUPTwoOctetAsSpecificExtended\x12\x19\n" +
+	"\bsub_type\x18\x01 \x01(\rR\asubType\x12\x10\n" +
+	"\x03asn\x18\x02 \x01(\rR\x03asn\x12\x1f\n" +
+	"\vlocal_admin\x18\x03 \x01(\rR\n" +
+	"localAdmin\"v\n" +
+	"\x1eMUPIPv4AddressSpecificExtended\x12\x19\n" +
+	"\bsub_type\x18\x01 \x01(\rR\asubType\x12\x18\n" +
+	"\aaddress\x18\x02 \x01(\tR\aaddress\x12\x1f\n" +
+	"\vlocal_admin\x18\x03 \x01(\rR\n" +
+	"localAdmin\"n\n" +
+	"\x1eMUPFourOctetAsSpecificExtended\x12\x19\n" +
+	"\bsub_type\x18\x01 \x01(\rR\asubType\x12\x10\n" +
+	"\x03asn\x18\x02 \x01(\rR\x03asn\x12\x1f\n" +
+	"\vlocal_admin\x18\x03 \x01(\rR\n" +
+	"localAdmin\"E\n" +
 	"\fVPLSExtended\x12#\n" +
 	"\rcontrol_flags\x18\x01 \x01(\rR\fcontrolFlags\x12\x10\n" +
 	"\x03mtu\x18\x02 \x01(\rR\x03mtu\">\n" +
@@ -1878,7 +2039,7 @@ const file_api_extcom_proto_rawDesc = "" +
 	"isMldProxy\";\n" +
 	"\x0fUnknownExtended\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\rR\x04type\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value\"\xea\f\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value\"\xf4\x0e\n" +
 	"\x11ExtendedCommunity\x120\n" +
 	"\aunknown\x18\x01 \x01(\v2\x14.api.UnknownExtendedH\x00R\aunknown\x12T\n" +
 	"\x15two_octet_as_specific\x18\x02 \x01(\v2\x1f.api.TwoOctetAsSpecificExtendedH\x00R\x12twoOctetAsSpecific\x12V\n" +
@@ -1903,12 +2064,14 @@ const file_api_extcom_proto_rawDesc = "" +
 	"\x1eredirect_two_octet_as_specific\x18\x11 \x01(\v2'.api.RedirectTwoOctetAsSpecificExtendedH\x00R\x1aredirectTwoOctetAsSpecific\x12o\n" +
 	"\x1eredirect_ipv4_address_specific\x18\x12 \x01(\v2(.api.RedirectIPv4AddressSpecificExtendedH\x00R\x1bredirectIpv4AddressSpecific\x12p\n" +
 	"\x1fredirect_four_octet_as_specific\x18\x13 \x01(\v2(.api.RedirectFourOctetAsSpecificExtendedH\x00R\x1bredirectFourOctetAsSpecific\x12C\n" +
-	"\x0etraffic_remark\x18\x14 \x01(\v2\x1a.api.TrafficRemarkExtendedH\x00R\rtrafficRemark\x12$\n" +
-	"\x03mup\x18\x15 \x01(\v2\x10.api.MUPExtendedH\x00R\x03mup\x12'\n" +
+	"\x0etraffic_remark\x18\x14 \x01(\v2\x1a.api.TrafficRemarkExtendedH\x00R\rtrafficRemark\x12'\n" +
 	"\x04vpls\x18\x16 \x01(\v2\x11.api.VPLSExtendedH\x00R\x04vpls\x12*\n" +
 	"\x05etree\x18\x17 \x01(\v2\x12.api.ETreeExtendedH\x00R\x05etree\x12F\n" +
-	"\x0fmulticast_flags\x18\x18 \x01(\v2\x1b.api.MulticastFlagsExtendedH\x00R\x0emulticastFlagsB\b\n" +
-	"\x06extcom\"\x9a\x02\n" +
+	"\x0fmulticast_flags\x18\x18 \x01(\v2\x1b.api.MulticastFlagsExtendedH\x00R\x0emulticastFlags\x12^\n" +
+	"\x19mup_two_octet_as_specific\x18\x19 \x01(\v2\".api.MUPTwoOctetAsSpecificExtendedH\x00R\x15mupTwoOctetAsSpecific\x12`\n" +
+	"\x19mup_ipv4_address_specific\x18\x1a \x01(\v2#.api.MUPIPv4AddressSpecificExtendedH\x00R\x16mupIpv4AddressSpecific\x12a\n" +
+	"\x1amup_four_octet_as_specific\x18\x1b \x01(\v2#.api.MUPFourOctetAsSpecificExtendedH\x00R\x16mupFourOctetAsSpecificB\b\n" +
+	"\x06extcomJ\x04\b\x15\x10\x16R\x03mup\"\x9a\x02\n" +
 	"\vRouteTarget\x12T\n" +
 	"\x15two_octet_as_specific\x18\x01 \x01(\v2\x1f.api.TwoOctetAsSpecificExtendedH\x00R\x12twoOctetAsSpecific\x12V\n" +
 	"\x15ipv4_address_specific\x18\x02 \x01(\v2 .api.IPv4AddressSpecificExtendedH\x00R\x13ipv4AddressSpecific\x12W\n" +
@@ -1927,7 +2090,7 @@ func file_api_extcom_proto_rawDescGZIP() []byte {
 	return file_api_extcom_proto_rawDescData
 }
 
-var file_api_extcom_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_api_extcom_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
 var file_api_extcom_proto_goTypes = []any{
 	(*TwoOctetAsSpecificExtended)(nil),          // 0: api.TwoOctetAsSpecificExtended
 	(*IPv4AddressSpecificExtended)(nil),         // 1: api.IPv4AddressSpecificExtended
@@ -1948,16 +2111,18 @@ var file_api_extcom_proto_goTypes = []any{
 	(*RedirectIPv4AddressSpecificExtended)(nil), // 16: api.RedirectIPv4AddressSpecificExtended
 	(*RedirectFourOctetAsSpecificExtended)(nil), // 17: api.RedirectFourOctetAsSpecificExtended
 	(*TrafficRemarkExtended)(nil),               // 18: api.TrafficRemarkExtended
-	(*MUPExtended)(nil),                         // 19: api.MUPExtended
-	(*VPLSExtended)(nil),                        // 20: api.VPLSExtended
-	(*ETreeExtended)(nil),                       // 21: api.ETreeExtended
-	(*MulticastFlagsExtended)(nil),              // 22: api.MulticastFlagsExtended
-	(*UnknownExtended)(nil),                     // 23: api.UnknownExtended
-	(*ExtendedCommunity)(nil),                   // 24: api.ExtendedCommunity
-	(*RouteTarget)(nil),                         // 25: api.RouteTarget
+	(*MUPTwoOctetAsSpecificExtended)(nil),       // 19: api.MUPTwoOctetAsSpecificExtended
+	(*MUPIPv4AddressSpecificExtended)(nil),      // 20: api.MUPIPv4AddressSpecificExtended
+	(*MUPFourOctetAsSpecificExtended)(nil),      // 21: api.MUPFourOctetAsSpecificExtended
+	(*VPLSExtended)(nil),                        // 22: api.VPLSExtended
+	(*ETreeExtended)(nil),                       // 23: api.ETreeExtended
+	(*MulticastFlagsExtended)(nil),              // 24: api.MulticastFlagsExtended
+	(*UnknownExtended)(nil),                     // 25: api.UnknownExtended
+	(*ExtendedCommunity)(nil),                   // 26: api.ExtendedCommunity
+	(*RouteTarget)(nil),                         // 27: api.RouteTarget
 }
 var file_api_extcom_proto_depIdxs = []int32{
-	23, // 0: api.ExtendedCommunity.unknown:type_name -> api.UnknownExtended
+	25, // 0: api.ExtendedCommunity.unknown:type_name -> api.UnknownExtended
 	0,  // 1: api.ExtendedCommunity.two_octet_as_specific:type_name -> api.TwoOctetAsSpecificExtended
 	1,  // 2: api.ExtendedCommunity.ipv4_address_specific:type_name -> api.IPv4AddressSpecificExtended
 	2,  // 3: api.ExtendedCommunity.four_octet_as_specific:type_name -> api.FourOctetAsSpecificExtended
@@ -1977,18 +2142,20 @@ var file_api_extcom_proto_depIdxs = []int32{
 	16, // 17: api.ExtendedCommunity.redirect_ipv4_address_specific:type_name -> api.RedirectIPv4AddressSpecificExtended
 	17, // 18: api.ExtendedCommunity.redirect_four_octet_as_specific:type_name -> api.RedirectFourOctetAsSpecificExtended
 	18, // 19: api.ExtendedCommunity.traffic_remark:type_name -> api.TrafficRemarkExtended
-	19, // 20: api.ExtendedCommunity.mup:type_name -> api.MUPExtended
-	20, // 21: api.ExtendedCommunity.vpls:type_name -> api.VPLSExtended
-	21, // 22: api.ExtendedCommunity.etree:type_name -> api.ETreeExtended
-	22, // 23: api.ExtendedCommunity.multicast_flags:type_name -> api.MulticastFlagsExtended
-	0,  // 24: api.RouteTarget.two_octet_as_specific:type_name -> api.TwoOctetAsSpecificExtended
-	1,  // 25: api.RouteTarget.ipv4_address_specific:type_name -> api.IPv4AddressSpecificExtended
-	2,  // 26: api.RouteTarget.four_octet_as_specific:type_name -> api.FourOctetAsSpecificExtended
-	27, // [27:27] is the sub-list for method output_type
-	27, // [27:27] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	22, // 20: api.ExtendedCommunity.vpls:type_name -> api.VPLSExtended
+	23, // 21: api.ExtendedCommunity.etree:type_name -> api.ETreeExtended
+	24, // 22: api.ExtendedCommunity.multicast_flags:type_name -> api.MulticastFlagsExtended
+	19, // 23: api.ExtendedCommunity.mup_two_octet_as_specific:type_name -> api.MUPTwoOctetAsSpecificExtended
+	20, // 24: api.ExtendedCommunity.mup_ipv4_address_specific:type_name -> api.MUPIPv4AddressSpecificExtended
+	21, // 25: api.ExtendedCommunity.mup_four_octet_as_specific:type_name -> api.MUPFourOctetAsSpecificExtended
+	0,  // 26: api.RouteTarget.two_octet_as_specific:type_name -> api.TwoOctetAsSpecificExtended
+	1,  // 27: api.RouteTarget.ipv4_address_specific:type_name -> api.IPv4AddressSpecificExtended
+	2,  // 28: api.RouteTarget.four_octet_as_specific:type_name -> api.FourOctetAsSpecificExtended
+	29, // [29:29] is the sub-list for method output_type
+	29, // [29:29] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_api_extcom_proto_init() }
@@ -1996,7 +2163,7 @@ func file_api_extcom_proto_init() {
 	if File_api_extcom_proto != nil {
 		return
 	}
-	file_api_extcom_proto_msgTypes[24].OneofWrappers = []any{
+	file_api_extcom_proto_msgTypes[26].OneofWrappers = []any{
 		(*ExtendedCommunity_Unknown)(nil),
 		(*ExtendedCommunity_TwoOctetAsSpecific)(nil),
 		(*ExtendedCommunity_Ipv4AddressSpecific)(nil),
@@ -2017,12 +2184,14 @@ func file_api_extcom_proto_init() {
 		(*ExtendedCommunity_RedirectIpv4AddressSpecific)(nil),
 		(*ExtendedCommunity_RedirectFourOctetAsSpecific)(nil),
 		(*ExtendedCommunity_TrafficRemark)(nil),
-		(*ExtendedCommunity_Mup)(nil),
 		(*ExtendedCommunity_Vpls)(nil),
 		(*ExtendedCommunity_Etree)(nil),
 		(*ExtendedCommunity_MulticastFlags)(nil),
+		(*ExtendedCommunity_MupTwoOctetAsSpecific)(nil),
+		(*ExtendedCommunity_MupIpv4AddressSpecific)(nil),
+		(*ExtendedCommunity_MupFourOctetAsSpecific)(nil),
 	}
-	file_api_extcom_proto_msgTypes[25].OneofWrappers = []any{
+	file_api_extcom_proto_msgTypes[27].OneofWrappers = []any{
 		(*RouteTarget_TwoOctetAsSpecific)(nil),
 		(*RouteTarget_Ipv4AddressSpecific)(nil),
 		(*RouteTarget_FourOctetAsSpecific)(nil),
@@ -2033,7 +2202,7 @@ func file_api_extcom_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_extcom_proto_rawDesc), len(file_api_extcom_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   26,
+			NumMessages:   28,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/nlri.pb.go
+++ b/api/nlri.pb.go
@@ -2774,25 +2774,332 @@ func (x *MUPDirectSegmentDiscoveryRoute) GetAddress() string {
 	return ""
 }
 
+type MUPSessionParametersTLV struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Teid          uint32                 `protobuf:"varint,1,opt,name=teid,proto3" json:"teid,omitempty"`
+	Qfi           uint32                 `protobuf:"varint,2,opt,name=qfi,proto3" json:"qfi,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MUPSessionParametersTLV) Reset() {
+	*x = MUPSessionParametersTLV{}
+	mi := &file_api_nlri_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MUPSessionParametersTLV) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MUPSessionParametersTLV) ProtoMessage() {}
+
+func (x *MUPSessionParametersTLV) ProtoReflect() protoreflect.Message {
+	mi := &file_api_nlri_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MUPSessionParametersTLV.ProtoReflect.Descriptor instead.
+func (*MUPSessionParametersTLV) Descriptor() ([]byte, []int) {
+	return file_api_nlri_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *MUPSessionParametersTLV) GetTeid() uint32 {
+	if x != nil {
+		return x.Teid
+	}
+	return 0
+}
+
+func (x *MUPSessionParametersTLV) GetQfi() uint32 {
+	if x != nil {
+		return x.Qfi
+	}
+	return 0
+}
+
+type MUPInterworkEndpointTLV struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Address       string                 `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MUPInterworkEndpointTLV) Reset() {
+	*x = MUPInterworkEndpointTLV{}
+	mi := &file_api_nlri_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MUPInterworkEndpointTLV) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MUPInterworkEndpointTLV) ProtoMessage() {}
+
+func (x *MUPInterworkEndpointTLV) ProtoReflect() protoreflect.Message {
+	mi := &file_api_nlri_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MUPInterworkEndpointTLV.ProtoReflect.Descriptor instead.
+func (*MUPInterworkEndpointTLV) Descriptor() ([]byte, []int) {
+	return file_api_nlri_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *MUPInterworkEndpointTLV) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+type MUPSourceAddressTLV struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Address       string                 `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MUPSourceAddressTLV) Reset() {
+	*x = MUPSourceAddressTLV{}
+	mi := &file_api_nlri_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MUPSourceAddressTLV) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MUPSourceAddressTLV) ProtoMessage() {}
+
+func (x *MUPSourceAddressTLV) ProtoReflect() protoreflect.Message {
+	mi := &file_api_nlri_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MUPSourceAddressTLV.ProtoReflect.Descriptor instead.
+func (*MUPSourceAddressTLV) Descriptor() ([]byte, []int) {
+	return file_api_nlri_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *MUPSourceAddressTLV) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+type MUPUnknownTLV struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Type          uint32                 `protobuf:"varint,1,opt,name=type,proto3" json:"type,omitempty"`
+	Value         []byte                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MUPUnknownTLV) Reset() {
+	*x = MUPUnknownTLV{}
+	mi := &file_api_nlri_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MUPUnknownTLV) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MUPUnknownTLV) ProtoMessage() {}
+
+func (x *MUPUnknownTLV) ProtoReflect() protoreflect.Message {
+	mi := &file_api_nlri_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MUPUnknownTLV.ProtoReflect.Descriptor instead.
+func (*MUPUnknownTLV) Descriptor() ([]byte, []int) {
+	return file_api_nlri_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *MUPUnknownTLV) GetType() uint32 {
+	if x != nil {
+		return x.Type
+	}
+	return 0
+}
+
+func (x *MUPUnknownTLV) GetValue() []byte {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+type MUPTLV struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Tlv:
+	//
+	//	*MUPTLV_SessionParameters
+	//	*MUPTLV_InterworkEndpoint
+	//	*MUPTLV_SourceAddress
+	//	*MUPTLV_Unknown
+	Tlv           isMUPTLV_Tlv `protobuf_oneof:"tlv"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MUPTLV) Reset() {
+	*x = MUPTLV{}
+	mi := &file_api_nlri_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MUPTLV) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MUPTLV) ProtoMessage() {}
+
+func (x *MUPTLV) ProtoReflect() protoreflect.Message {
+	mi := &file_api_nlri_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MUPTLV.ProtoReflect.Descriptor instead.
+func (*MUPTLV) Descriptor() ([]byte, []int) {
+	return file_api_nlri_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *MUPTLV) GetTlv() isMUPTLV_Tlv {
+	if x != nil {
+		return x.Tlv
+	}
+	return nil
+}
+
+func (x *MUPTLV) GetSessionParameters() *MUPSessionParametersTLV {
+	if x != nil {
+		if x, ok := x.Tlv.(*MUPTLV_SessionParameters); ok {
+			return x.SessionParameters
+		}
+	}
+	return nil
+}
+
+func (x *MUPTLV) GetInterworkEndpoint() *MUPInterworkEndpointTLV {
+	if x != nil {
+		if x, ok := x.Tlv.(*MUPTLV_InterworkEndpoint); ok {
+			return x.InterworkEndpoint
+		}
+	}
+	return nil
+}
+
+func (x *MUPTLV) GetSourceAddress() *MUPSourceAddressTLV {
+	if x != nil {
+		if x, ok := x.Tlv.(*MUPTLV_SourceAddress); ok {
+			return x.SourceAddress
+		}
+	}
+	return nil
+}
+
+func (x *MUPTLV) GetUnknown() *MUPUnknownTLV {
+	if x != nil {
+		if x, ok := x.Tlv.(*MUPTLV_Unknown); ok {
+			return x.Unknown
+		}
+	}
+	return nil
+}
+
+type isMUPTLV_Tlv interface {
+	isMUPTLV_Tlv()
+}
+
+type MUPTLV_SessionParameters struct {
+	SessionParameters *MUPSessionParametersTLV `protobuf:"bytes,1,opt,name=session_parameters,json=sessionParameters,proto3,oneof"`
+}
+
+type MUPTLV_InterworkEndpoint struct {
+	InterworkEndpoint *MUPInterworkEndpointTLV `protobuf:"bytes,2,opt,name=interwork_endpoint,json=interworkEndpoint,proto3,oneof"`
+}
+
+type MUPTLV_SourceAddress struct {
+	SourceAddress *MUPSourceAddressTLV `protobuf:"bytes,3,opt,name=source_address,json=sourceAddress,proto3,oneof"`
+}
+
+type MUPTLV_Unknown struct {
+	Unknown *MUPUnknownTLV `protobuf:"bytes,4,opt,name=unknown,proto3,oneof"`
+}
+
+func (*MUPTLV_SessionParameters) isMUPTLV_Tlv() {}
+
+func (*MUPTLV_InterworkEndpoint) isMUPTLV_Tlv() {}
+
+func (*MUPTLV_SourceAddress) isMUPTLV_Tlv() {}
+
+func (*MUPTLV_Unknown) isMUPTLV_Tlv() {}
+
 type MUPType1SessionTransformedRoute struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Rd    *RouteDistinguisher    `protobuf:"bytes,1,opt,name=rd,proto3" json:"rd,omitempty"`
 	// Deprecated: Marked as deprecated in api/nlri.proto.
-	PrefixLength          uint32 `protobuf:"varint,2,opt,name=prefix_length,json=prefixLength,proto3" json:"prefix_length,omitempty"`
-	Prefix                string `protobuf:"bytes,3,opt,name=prefix,proto3" json:"prefix,omitempty"`
-	Teid                  uint32 `protobuf:"varint,4,opt,name=teid,proto3" json:"teid,omitempty"`
-	Qfi                   uint32 `protobuf:"varint,5,opt,name=qfi,proto3" json:"qfi,omitempty"`
-	EndpointAddressLength uint32 `protobuf:"varint,6,opt,name=endpoint_address_length,json=endpointAddressLength,proto3" json:"endpoint_address_length,omitempty"`
-	EndpointAddress       string `protobuf:"bytes,7,opt,name=endpoint_address,json=endpointAddress,proto3" json:"endpoint_address,omitempty"`
-	SourceAddressLength   uint32 `protobuf:"varint,8,opt,name=source_address_length,json=sourceAddressLength,proto3" json:"source_address_length,omitempty"`
-	SourceAddress         string `protobuf:"bytes,9,opt,name=source_address,json=sourceAddress,proto3" json:"source_address,omitempty"`
+	PrefixLength          uint32    `protobuf:"varint,2,opt,name=prefix_length,json=prefixLength,proto3" json:"prefix_length,omitempty"`
+	Prefix                string    `protobuf:"bytes,3,opt,name=prefix,proto3" json:"prefix,omitempty"`
+	Teid                  uint32    `protobuf:"varint,4,opt,name=teid,proto3" json:"teid,omitempty"`
+	Qfi                   uint32    `protobuf:"varint,5,opt,name=qfi,proto3" json:"qfi,omitempty"`
+	EndpointAddressLength uint32    `protobuf:"varint,6,opt,name=endpoint_address_length,json=endpointAddressLength,proto3" json:"endpoint_address_length,omitempty"`
+	EndpointAddress       string    `protobuf:"bytes,7,opt,name=endpoint_address,json=endpointAddress,proto3" json:"endpoint_address,omitempty"`
+	SourceAddressLength   uint32    `protobuf:"varint,8,opt,name=source_address_length,json=sourceAddressLength,proto3" json:"source_address_length,omitempty"`
+	SourceAddress         string    `protobuf:"bytes,9,opt,name=source_address,json=sourceAddress,proto3" json:"source_address,omitempty"`
+	Tlvs                  []*MUPTLV `protobuf:"bytes,10,rep,name=tlvs,proto3" json:"tlvs,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
 
 func (x *MUPType1SessionTransformedRoute) Reset() {
 	*x = MUPType1SessionTransformedRoute{}
-	mi := &file_api_nlri_proto_msgTypes[36]
+	mi := &file_api_nlri_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2804,7 +3111,7 @@ func (x *MUPType1SessionTransformedRoute) String() string {
 func (*MUPType1SessionTransformedRoute) ProtoMessage() {}
 
 func (x *MUPType1SessionTransformedRoute) ProtoReflect() protoreflect.Message {
-	mi := &file_api_nlri_proto_msgTypes[36]
+	mi := &file_api_nlri_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2817,7 +3124,7 @@ func (x *MUPType1SessionTransformedRoute) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MUPType1SessionTransformedRoute.ProtoReflect.Descriptor instead.
 func (*MUPType1SessionTransformedRoute) Descriptor() ([]byte, []int) {
-	return file_api_nlri_proto_rawDescGZIP(), []int{36}
+	return file_api_nlri_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *MUPType1SessionTransformedRoute) GetRd() *RouteDistinguisher {
@@ -2884,19 +3191,27 @@ func (x *MUPType1SessionTransformedRoute) GetSourceAddress() string {
 	return ""
 }
 
+func (x *MUPType1SessionTransformedRoute) GetTlvs() []*MUPTLV {
+	if x != nil {
+		return x.Tlvs
+	}
+	return nil
+}
+
 type MUPType2SessionTransformedRoute struct {
 	state                 protoimpl.MessageState `protogen:"open.v1"`
 	Rd                    *RouteDistinguisher    `protobuf:"bytes,1,opt,name=rd,proto3" json:"rd,omitempty"`
 	EndpointAddressLength uint32                 `protobuf:"varint,2,opt,name=endpoint_address_length,json=endpointAddressLength,proto3" json:"endpoint_address_length,omitempty"`
 	EndpointAddress       string                 `protobuf:"bytes,3,opt,name=endpoint_address,json=endpointAddress,proto3" json:"endpoint_address,omitempty"`
 	Teid                  uint32                 `protobuf:"varint,4,opt,name=teid,proto3" json:"teid,omitempty"`
+	Tlvs                  []*MUPTLV              `protobuf:"bytes,5,rep,name=tlvs,proto3" json:"tlvs,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
 
 func (x *MUPType2SessionTransformedRoute) Reset() {
 	*x = MUPType2SessionTransformedRoute{}
-	mi := &file_api_nlri_proto_msgTypes[37]
+	mi := &file_api_nlri_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2908,7 +3223,7 @@ func (x *MUPType2SessionTransformedRoute) String() string {
 func (*MUPType2SessionTransformedRoute) ProtoMessage() {}
 
 func (x *MUPType2SessionTransformedRoute) ProtoReflect() protoreflect.Message {
-	mi := &file_api_nlri_proto_msgTypes[37]
+	mi := &file_api_nlri_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2921,7 +3236,7 @@ func (x *MUPType2SessionTransformedRoute) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MUPType2SessionTransformedRoute.ProtoReflect.Descriptor instead.
 func (*MUPType2SessionTransformedRoute) Descriptor() ([]byte, []int) {
-	return file_api_nlri_proto_rawDescGZIP(), []int{37}
+	return file_api_nlri_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *MUPType2SessionTransformedRoute) GetRd() *RouteDistinguisher {
@@ -2952,6 +3267,13 @@ func (x *MUPType2SessionTransformedRoute) GetTeid() uint32 {
 	return 0
 }
 
+func (x *MUPType2SessionTransformedRoute) GetTlvs() []*MUPTLV {
+	if x != nil {
+		return x.Tlvs
+	}
+	return nil
+}
+
 type LsAddrPrefix_LsNLRI struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Nlri:
@@ -2968,7 +3290,7 @@ type LsAddrPrefix_LsNLRI struct {
 
 func (x *LsAddrPrefix_LsNLRI) Reset() {
 	*x = LsAddrPrefix_LsNLRI{}
-	mi := &file_api_nlri_proto_msgTypes[38]
+	mi := &file_api_nlri_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2980,7 +3302,7 @@ func (x *LsAddrPrefix_LsNLRI) String() string {
 func (*LsAddrPrefix_LsNLRI) ProtoMessage() {}
 
 func (x *LsAddrPrefix_LsNLRI) ProtoReflect() protoreflect.Message {
-	mi := &file_api_nlri_proto_msgTypes[38]
+	mi := &file_api_nlri_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3282,7 +3604,23 @@ const file_api_nlri_proto_rawDesc = "" +
 	"\x06prefix\x18\x02 \x01(\tR\x06prefix\"c\n" +
 	"\x1eMUPDirectSegmentDiscoveryRoute\x12'\n" +
 	"\x02rd\x18\x01 \x01(\v2\x17.api.RouteDistinguisherR\x02rd\x12\x18\n" +
-	"\aaddress\x18\x02 \x01(\tR\aaddress\"\xef\x02\n" +
+	"\aaddress\x18\x02 \x01(\tR\aaddress\"?\n" +
+	"\x17MUPSessionParametersTLV\x12\x12\n" +
+	"\x04teid\x18\x01 \x01(\rR\x04teid\x12\x10\n" +
+	"\x03qfi\x18\x02 \x01(\rR\x03qfi\"3\n" +
+	"\x17MUPInterworkEndpointTLV\x12\x18\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\"/\n" +
+	"\x13MUPSourceAddressTLV\x12\x18\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\"9\n" +
+	"\rMUPUnknownTLV\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\rR\x04type\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value\"\xa0\x02\n" +
+	"\x06MUPTLV\x12M\n" +
+	"\x12session_parameters\x18\x01 \x01(\v2\x1c.api.MUPSessionParametersTLVH\x00R\x11sessionParameters\x12M\n" +
+	"\x12interwork_endpoint\x18\x02 \x01(\v2\x1c.api.MUPInterworkEndpointTLVH\x00R\x11interworkEndpoint\x12A\n" +
+	"\x0esource_address\x18\x03 \x01(\v2\x18.api.MUPSourceAddressTLVH\x00R\rsourceAddress\x12.\n" +
+	"\aunknown\x18\x04 \x01(\v2\x12.api.MUPUnknownTLVH\x00R\aunknownB\x05\n" +
+	"\x03tlv\"\x90\x03\n" +
 	"\x1fMUPType1SessionTransformedRoute\x12'\n" +
 	"\x02rd\x18\x01 \x01(\v2\x17.api.RouteDistinguisherR\x02rd\x12'\n" +
 	"\rprefix_length\x18\x02 \x01(\rB\x02\x18\x01R\fprefixLength\x12\x16\n" +
@@ -3292,12 +3630,15 @@ const file_api_nlri_proto_rawDesc = "" +
 	"\x17endpoint_address_length\x18\x06 \x01(\rR\x15endpointAddressLength\x12)\n" +
 	"\x10endpoint_address\x18\a \x01(\tR\x0fendpointAddress\x122\n" +
 	"\x15source_address_length\x18\b \x01(\rR\x13sourceAddressLength\x12%\n" +
-	"\x0esource_address\x18\t \x01(\tR\rsourceAddress\"\xc1\x01\n" +
+	"\x0esource_address\x18\t \x01(\tR\rsourceAddress\x12\x1f\n" +
+	"\x04tlvs\x18\n" +
+	" \x03(\v2\v.api.MUPTLVR\x04tlvs\"\xe2\x01\n" +
 	"\x1fMUPType2SessionTransformedRoute\x12'\n" +
 	"\x02rd\x18\x01 \x01(\v2\x17.api.RouteDistinguisherR\x02rd\x126\n" +
 	"\x17endpoint_address_length\x18\x02 \x01(\rR\x15endpointAddressLength\x12)\n" +
 	"\x10endpoint_address\x18\x03 \x01(\tR\x0fendpointAddress\x12\x12\n" +
-	"\x04teid\x18\x04 \x01(\rR\x04teid*\xab\x01\n" +
+	"\x04teid\x18\x04 \x01(\rR\x04teid\x12\x1f\n" +
+	"\x04tlvs\x18\x05 \x03(\v2\v.api.MUPTLVR\x04tlvs*\xab\x01\n" +
 	"\n" +
 	"LsNLRIType\x12\x1c\n" +
 	"\x18LS_NLRI_TYPE_UNSPECIFIED\x10\x00\x12\x15\n" +
@@ -3336,7 +3677,7 @@ func file_api_nlri_proto_rawDescGZIP() []byte {
 }
 
 var file_api_nlri_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_api_nlri_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
+var file_api_nlri_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
 var file_api_nlri_proto_goTypes = []any{
 	(LsNLRIType)(0),                                // 0: api.LsNLRIType
 	(LsProtocolID)(0),                              // 1: api.LsProtocolID
@@ -3377,11 +3718,16 @@ var file_api_nlri_proto_goTypes = []any{
 	(*LsAddrPrefix)(nil),                           // 36: api.LsAddrPrefix
 	(*MUPInterworkSegmentDiscoveryRoute)(nil),      // 37: api.MUPInterworkSegmentDiscoveryRoute
 	(*MUPDirectSegmentDiscoveryRoute)(nil),         // 38: api.MUPDirectSegmentDiscoveryRoute
-	(*MUPType1SessionTransformedRoute)(nil),        // 39: api.MUPType1SessionTransformedRoute
-	(*MUPType2SessionTransformedRoute)(nil),        // 40: api.MUPType2SessionTransformedRoute
-	(*LsAddrPrefix_LsNLRI)(nil),                    // 41: api.LsAddrPrefix.LsNLRI
-	(*RouteDistinguisher)(nil),                     // 42: api.RouteDistinguisher
-	(*RouteTarget)(nil),                            // 43: api.RouteTarget
+	(*MUPSessionParametersTLV)(nil),                // 39: api.MUPSessionParametersTLV
+	(*MUPInterworkEndpointTLV)(nil),                // 40: api.MUPInterworkEndpointTLV
+	(*MUPSourceAddressTLV)(nil),                    // 41: api.MUPSourceAddressTLV
+	(*MUPUnknownTLV)(nil),                          // 42: api.MUPUnknownTLV
+	(*MUPTLV)(nil),                                 // 43: api.MUPTLV
+	(*MUPType1SessionTransformedRoute)(nil),        // 44: api.MUPType1SessionTransformedRoute
+	(*MUPType2SessionTransformedRoute)(nil),        // 45: api.MUPType2SessionTransformedRoute
+	(*LsAddrPrefix_LsNLRI)(nil),                    // 46: api.LsAddrPrefix.LsNLRI
+	(*RouteDistinguisher)(nil),                     // 47: api.RouteDistinguisher
+	(*RouteTarget)(nil),                            // 48: api.RouteTarget
 }
 var file_api_nlri_proto_depIdxs = []int32{
 	4,  // 0: api.NLRI.prefix:type_name -> api.IPAddressPrefix
@@ -3403,28 +3749,28 @@ var file_api_nlri_proto_depIdxs = []int32{
 	15, // 16: api.NLRI.sr_policy:type_name -> api.SRPolicyNLRI
 	37, // 17: api.NLRI.mup_interwork_segment_discovery:type_name -> api.MUPInterworkSegmentDiscoveryRoute
 	38, // 18: api.NLRI.mup_direct_segment_discovery:type_name -> api.MUPDirectSegmentDiscoveryRoute
-	39, // 19: api.NLRI.mup_type_1_session_transformed:type_name -> api.MUPType1SessionTransformedRoute
-	40, // 20: api.NLRI.mup_type_2_session_transformed:type_name -> api.MUPType2SessionTransformedRoute
-	42, // 21: api.VPLSNLRI.rd:type_name -> api.RouteDistinguisher
-	42, // 22: api.EVPNEthernetAutoDiscoveryRoute.rd:type_name -> api.RouteDistinguisher
+	44, // 19: api.NLRI.mup_type_1_session_transformed:type_name -> api.MUPType1SessionTransformedRoute
+	45, // 20: api.NLRI.mup_type_2_session_transformed:type_name -> api.MUPType2SessionTransformedRoute
+	47, // 21: api.VPLSNLRI.rd:type_name -> api.RouteDistinguisher
+	47, // 22: api.EVPNEthernetAutoDiscoveryRoute.rd:type_name -> api.RouteDistinguisher
 	8,  // 23: api.EVPNEthernetAutoDiscoveryRoute.esi:type_name -> api.EthernetSegmentIdentifier
-	42, // 24: api.EVPNMACIPAdvertisementRoute.rd:type_name -> api.RouteDistinguisher
+	47, // 24: api.EVPNMACIPAdvertisementRoute.rd:type_name -> api.RouteDistinguisher
 	8,  // 25: api.EVPNMACIPAdvertisementRoute.esi:type_name -> api.EthernetSegmentIdentifier
-	42, // 26: api.EVPNInclusiveMulticastEthernetTagRoute.rd:type_name -> api.RouteDistinguisher
-	42, // 27: api.EVPNEthernetSegmentRoute.rd:type_name -> api.RouteDistinguisher
+	47, // 26: api.EVPNInclusiveMulticastEthernetTagRoute.rd:type_name -> api.RouteDistinguisher
+	47, // 27: api.EVPNEthernetSegmentRoute.rd:type_name -> api.RouteDistinguisher
 	8,  // 28: api.EVPNEthernetSegmentRoute.esi:type_name -> api.EthernetSegmentIdentifier
-	42, // 29: api.EVPNIPPrefixRoute.rd:type_name -> api.RouteDistinguisher
+	47, // 29: api.EVPNIPPrefixRoute.rd:type_name -> api.RouteDistinguisher
 	8,  // 30: api.EVPNIPPrefixRoute.esi:type_name -> api.EthernetSegmentIdentifier
-	42, // 31: api.EVPNIPMSIRoute.rd:type_name -> api.RouteDistinguisher
-	43, // 32: api.EVPNIPMSIRoute.rt:type_name -> api.RouteTarget
-	42, // 33: api.LabeledVPNIPAddressPrefix.rd:type_name -> api.RouteDistinguisher
-	43, // 34: api.RouteTargetMembershipNLRI.rt:type_name -> api.RouteTarget
+	47, // 31: api.EVPNIPMSIRoute.rd:type_name -> api.RouteDistinguisher
+	48, // 32: api.EVPNIPMSIRoute.rt:type_name -> api.RouteTarget
+	47, // 33: api.LabeledVPNIPAddressPrefix.rd:type_name -> api.RouteDistinguisher
+	48, // 34: api.RouteTargetMembershipNLRI.rt:type_name -> api.RouteTarget
 	20, // 35: api.FlowSpecComponent.items:type_name -> api.FlowSpecComponentItem
 	18, // 36: api.FlowSpecRule.ip_prefix:type_name -> api.FlowSpecIPPrefix
 	19, // 37: api.FlowSpecRule.mac:type_name -> api.FlowSpecMAC
 	21, // 38: api.FlowSpecRule.component:type_name -> api.FlowSpecComponent
 	22, // 39: api.FlowSpecNLRI.rules:type_name -> api.FlowSpecRule
-	42, // 40: api.VPNFlowSpecNLRI.rd:type_name -> api.RouteDistinguisher
+	47, // 40: api.VPNFlowSpecNLRI.rd:type_name -> api.RouteDistinguisher
 	22, // 41: api.VPNFlowSpecNLRI.rules:type_name -> api.FlowSpecRule
 	2,  // 42: api.LsPrefixDescriptor.ospf_route_type:type_name -> api.LsOspfRouteType
 	26, // 43: api.LsNodeNLRI.local_node:type_name -> api.LsNodeDescriptor
@@ -3439,22 +3785,28 @@ var file_api_nlri_proto_depIdxs = []int32{
 	33, // 52: api.LsSrv6SIDNLRI.srv6_sid_information:type_name -> api.LsSrv6SIDInformation
 	34, // 53: api.LsSrv6SIDNLRI.multi_topo_id:type_name -> api.LsMultiTopologyIdentifier
 	0,  // 54: api.LsAddrPrefix.type:type_name -> api.LsNLRIType
-	41, // 55: api.LsAddrPrefix.nlri:type_name -> api.LsAddrPrefix.LsNLRI
+	46, // 55: api.LsAddrPrefix.nlri:type_name -> api.LsAddrPrefix.LsNLRI
 	1,  // 56: api.LsAddrPrefix.protocol_id:type_name -> api.LsProtocolID
-	42, // 57: api.MUPInterworkSegmentDiscoveryRoute.rd:type_name -> api.RouteDistinguisher
-	42, // 58: api.MUPDirectSegmentDiscoveryRoute.rd:type_name -> api.RouteDistinguisher
-	42, // 59: api.MUPType1SessionTransformedRoute.rd:type_name -> api.RouteDistinguisher
-	42, // 60: api.MUPType2SessionTransformedRoute.rd:type_name -> api.RouteDistinguisher
-	29, // 61: api.LsAddrPrefix.LsNLRI.node:type_name -> api.LsNodeNLRI
-	30, // 62: api.LsAddrPrefix.LsNLRI.link:type_name -> api.LsLinkNLRI
-	31, // 63: api.LsAddrPrefix.LsNLRI.prefix_v4:type_name -> api.LsPrefixV4NLRI
-	32, // 64: api.LsAddrPrefix.LsNLRI.prefix_v6:type_name -> api.LsPrefixV6NLRI
-	35, // 65: api.LsAddrPrefix.LsNLRI.srv6_sid:type_name -> api.LsSrv6SIDNLRI
-	66, // [66:66] is the sub-list for method output_type
-	66, // [66:66] is the sub-list for method input_type
-	66, // [66:66] is the sub-list for extension type_name
-	66, // [66:66] is the sub-list for extension extendee
-	0,  // [0:66] is the sub-list for field type_name
+	47, // 57: api.MUPInterworkSegmentDiscoveryRoute.rd:type_name -> api.RouteDistinguisher
+	47, // 58: api.MUPDirectSegmentDiscoveryRoute.rd:type_name -> api.RouteDistinguisher
+	39, // 59: api.MUPTLV.session_parameters:type_name -> api.MUPSessionParametersTLV
+	40, // 60: api.MUPTLV.interwork_endpoint:type_name -> api.MUPInterworkEndpointTLV
+	41, // 61: api.MUPTLV.source_address:type_name -> api.MUPSourceAddressTLV
+	42, // 62: api.MUPTLV.unknown:type_name -> api.MUPUnknownTLV
+	47, // 63: api.MUPType1SessionTransformedRoute.rd:type_name -> api.RouteDistinguisher
+	43, // 64: api.MUPType1SessionTransformedRoute.tlvs:type_name -> api.MUPTLV
+	47, // 65: api.MUPType2SessionTransformedRoute.rd:type_name -> api.RouteDistinguisher
+	43, // 66: api.MUPType2SessionTransformedRoute.tlvs:type_name -> api.MUPTLV
+	29, // 67: api.LsAddrPrefix.LsNLRI.node:type_name -> api.LsNodeNLRI
+	30, // 68: api.LsAddrPrefix.LsNLRI.link:type_name -> api.LsLinkNLRI
+	31, // 69: api.LsAddrPrefix.LsNLRI.prefix_v4:type_name -> api.LsPrefixV4NLRI
+	32, // 70: api.LsAddrPrefix.LsNLRI.prefix_v6:type_name -> api.LsPrefixV6NLRI
+	35, // 71: api.LsAddrPrefix.LsNLRI.srv6_sid:type_name -> api.LsSrv6SIDNLRI
+	72, // [72:72] is the sub-list for method output_type
+	72, // [72:72] is the sub-list for method input_type
+	72, // [72:72] is the sub-list for extension type_name
+	72, // [72:72] is the sub-list for extension extendee
+	0,  // [0:72] is the sub-list for field type_name
 }
 
 func init() { file_api_nlri_proto_init() }
@@ -3492,7 +3844,13 @@ func file_api_nlri_proto_init() {
 		(*FlowSpecRule_Mac)(nil),
 		(*FlowSpecRule_Component)(nil),
 	}
-	file_api_nlri_proto_msgTypes[38].OneofWrappers = []any{
+	file_api_nlri_proto_msgTypes[40].OneofWrappers = []any{
+		(*MUPTLV_SessionParameters)(nil),
+		(*MUPTLV_InterworkEndpoint)(nil),
+		(*MUPTLV_SourceAddress)(nil),
+		(*MUPTLV_Unknown)(nil),
+	}
+	file_api_nlri_proto_msgTypes[43].OneofWrappers = []any{
 		(*LsAddrPrefix_LsNLRI_Node)(nil),
 		(*LsAddrPrefix_LsNLRI_Link)(nil),
 		(*LsAddrPrefix_LsNLRI_PrefixV4)(nil),
@@ -3505,7 +3863,7 @@ func file_api_nlri_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_nlri_proto_rawDesc), len(file_api_nlri_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   39,
+			NumMessages:   44,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -384,7 +384,7 @@ func mupParser(args []string) ([]bgp.ExtendedCommunityInterface, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid mup segment ID")
 	}
-	return []bgp.ExtendedCommunityInterface{bgp.NewMUPExtended(uint16(sid2), uint32(sid4))}, nil
+	return []bgp.ExtendedCommunityInterface{bgp.NewMUPExtended(bgp.EC_SUBTYPE_MUP_DIRECT_SEG, uint16(sid2), uint32(sid4))}, nil
 }
 
 var extCommParserMap = map[extCommType]func([]string) ([]bgp.ExtendedCommunityInterface, error){

--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -371,20 +371,97 @@ func lbParser(args []string) ([]bgp.ExtendedCommunityInterface, error) {
 	return []bgp.ExtendedCommunityInterface{bgp.NewLinkBandwidthExtended(uint16(as), float32(bw))}, nil
 }
 
+// mupAsDotRegexp matches the "<upper>.<lower>" AS-dot notation for 4-octet
+// AS numbers, mirroring the convention used by bgp.ParseExtendedCommunity
+// for route targets.
+var mupAsDotRegexp = regexp.MustCompile(`^(\d+)\.(\d+)$`)
+
 func mupParser(args []string) ([]bgp.ExtendedCommunityInterface, error) {
-	if len(args) != 2 || args[0] != extCommNameMap[ctMup] {
+	if len(args) < 2 || args[0] != extCommNameMap[ctMup] {
 		return nil, fmt.Errorf("invalid mup")
 	}
-	a := strings.Split(args[1], ":")
-	sid2, err := strconv.ParseUint(a[0], 10, 16)
-	if err != nil {
-		return nil, fmt.Errorf("invalid mup segment ID")
+	interwork := false
+	value := args[1]
+	switch len(args) {
+	case 2:
+	case 3:
+		switch args[1] {
+		case "direct":
+		case "interwork":
+			interwork = true
+		default:
+			return nil, fmt.Errorf("invalid mup segment type: %s", args[1])
+		}
+		value = args[2]
+	default:
+		return nil, fmt.Errorf("invalid mup")
 	}
-	sid4, err := strconv.ParseUint(a[1], 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("invalid mup segment ID")
+
+	i := strings.LastIndex(value, ":")
+	if i < 0 {
+		return nil, fmt.Errorf("invalid mup segment ID: %s", value)
 	}
-	return []bgp.ExtendedCommunityInterface{bgp.NewMUPExtended(bgp.EC_SUBTYPE_MUP_DIRECT_SEG, uint16(sid2), uint32(sid4))}, nil
+	ga, la := value[:i], value[i+1:]
+
+	if addr, err := netip.ParseAddr(ga); err == nil && addr.Is4() {
+		localAdmin, err := strconv.ParseUint(la, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("invalid mup local admin: %s", la)
+		}
+		subType := bgp.EC_SUBTYPE_MUP_DIRECT_SEG_IPV4
+		if interwork {
+			subType = bgp.EC_SUBTYPE_MUP_INTERWORK_SEG_IPV4
+		}
+		ext, err := bgp.NewMUPIPv4AddressSpecificExtended(subType, addr, uint16(localAdmin))
+		if err != nil {
+			return nil, err
+		}
+		return []bgp.ExtendedCommunityInterface{ext}, nil
+	}
+
+	var as uint64
+	fourOctet := false
+	if m := mupAsDotRegexp.FindStringSubmatch(ga); m != nil {
+		upper, err := strconv.ParseUint(m[1], 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("invalid mup global admin: %s", ga)
+		}
+		lower, err := strconv.ParseUint(m[2], 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("invalid mup global admin: %s", ga)
+		}
+		as = upper<<16 | lower
+		fourOctet = true
+	} else {
+		v, err := strconv.ParseUint(ga, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid mup global admin: %s", ga)
+		}
+		as = v
+		fourOctet = v > 0xffff
+	}
+
+	if fourOctet {
+		localAdmin, err := strconv.ParseUint(la, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("invalid mup local admin: %s", la)
+		}
+		subType := bgp.EC_SUBTYPE_MUP_DIRECT_SEG_4_OCTET_AS
+		if interwork {
+			subType = bgp.EC_SUBTYPE_MUP_INTERWORK_SEG_4_OCTET_AS
+		}
+		return []bgp.ExtendedCommunityInterface{bgp.NewMUPFourOctetAsSpecificExtended(subType, uint32(as), uint16(localAdmin))}, nil
+	}
+
+	localAdmin, err := strconv.ParseUint(la, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid mup local admin: %s", la)
+	}
+	subType := bgp.EC_SUBTYPE_MUP_DIRECT_SEG
+	if interwork {
+		subType = bgp.EC_SUBTYPE_MUP_INTERWORK_SEG
+	}
+	return []bgp.ExtendedCommunityInterface{bgp.NewMUPExtended(subType, uint16(as), uint32(localAdmin))}, nil
 }
 
 var extCommParserMap = map[extCommType]func([]string) ([]bgp.ExtendedCommunityInterface, error){
@@ -1068,7 +1145,7 @@ func parseEvpnArgs(args []string) (bgp.NLRI, []string, error) {
 
 func parseMUPInterworkSegmentDiscoveryRouteArgs(args []string, afi uint16, nexthop string) (bgp.NLRI, *bgp.PathAttributePrefixSID, []string, error) {
 	// Format:
-	// <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...]
+	// <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup [direct|interwork] <global administrator>:<local administrator>]
 	req := 13
 	if len(args) < req {
 		return nil, nil, nil, fmt.Errorf("%d args required at least, but got %d", req, len(args))
@@ -1080,6 +1157,7 @@ func parseMUPInterworkSegmentDiscoveryRouteArgs(args []string, afi uint16, nexth
 		"function-length":     paramSingle,
 		"behavior":            paramSingle,
 		"rt":                  paramList,
+		"mup":                 paramList,
 	})
 	if err != nil {
 		return nil, nil, nil, err
@@ -1142,6 +1220,10 @@ func parseMUPInterworkSegmentDiscoveryRouteArgs(args []string, afi uint16, nexth
 		extcomms = append(extcomms, "rt")
 		extcomms = append(extcomms, m["rt"]...)
 	}
+	if len(m["mup"]) > 0 {
+		extcomms = append(extcomms, "mup")
+		extcomms = append(extcomms, m["mup"]...)
+	}
 
 	r := &bgp.MUPInterworkSegmentDiscoveryRoute{
 		RD:     rd,
@@ -1164,7 +1246,7 @@ func parseMUPDirectSegmentDiscoveryRouteArgs(args []string, afi uint16, nexthop 
 		"locator-node-length": paramSingle,
 		"function-length":     paramSingle,
 		"behavior":            paramSingle,
-		"mup":                 paramSingle,
+		"mup":                 paramList,
 	})
 	if err != nil {
 		return nil, nil, nil, err
@@ -1225,7 +1307,8 @@ func parseMUPDirectSegmentDiscoveryRouteArgs(args []string, afi uint16, nexthop 
 		extcomms = append(extcomms, m["rt"]...)
 	}
 	if len(m["mup"]) > 0 {
-		extcomms = append(extcomms, "mup", m["mup"][0])
+		extcomms = append(extcomms, "mup")
+		extcomms = append(extcomms, m["mup"]...)
 	}
 
 	r := &bgp.MUPDirectSegmentDiscoveryRoute{
@@ -1337,7 +1420,7 @@ func parseMUPType1SessionTransformedRouteArgs(args []string, afi uint16) (bgp.NL
 
 func parseMUPType2SessionTransformedRouteArgs(args []string, afi uint16) (bgp.NLRI, *bgp.PathAttributePrefixSID, []string, error) {
 	// Format:
-	// <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup <segment identifier>]
+	// <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup [direct|interwork] <global administrator>:<local administrator>] [session-teid <teid> session-qfi <qfi>] [interwork-endpoint <addr>] [source-address <addr>]
 	req := 6
 	if len(args) < req {
 		return nil, nil, nil, fmt.Errorf("%d args required at least, but got %d", req, len(args))
@@ -1347,7 +1430,11 @@ func parseMUPType2SessionTransformedRouteArgs(args []string, afi uint16) (bgp.NL
 		"rt":                      paramList,
 		"endpoint-address-length": paramSingle,
 		"teid":                    paramSingle,
-		"mup":                     paramSingle,
+		"mup":                     paramList,
+		"session-teid":            paramSingle,
+		"session-qfi":             paramSingle,
+		"interwork-endpoint":      paramSingle,
+		"source-address":          paramSingle,
 	})
 	if err != nil {
 		return nil, nil, nil, err
@@ -1385,16 +1472,41 @@ func parseMUPType2SessionTransformedRouteArgs(args []string, afi uint16) (bgp.NL
 		extcomms = append(extcomms, m["rt"]...)
 	}
 	if len(m["mup"]) > 0 {
-		extcomms = append(extcomms, "mup", m["mup"][0])
+		extcomms = append(extcomms, "mup")
+		extcomms = append(extcomms, m["mup"]...)
 	}
 
-	r := &bgp.MUPType2SessionTransformedRoute{
-		RD:                    rd,
-		EndpointAddressLength: uint8(eaLen),
-		EndpointAddress:       ea,
-		TEID:                  teid,
+	var tlvs []bgp.MUPTLVInterface
+	if len(m["session-teid"]) > 0 || len(m["session-qfi"]) > 0 {
+		if len(m["session-teid"]) == 0 || len(m["session-qfi"]) == 0 {
+			return nil, nil, nil, fmt.Errorf("session-teid and session-qfi must be specified together")
+		}
+		sessionTeid, err := parseTeid(m["session-teid"][0])
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		sessionQfi, err := strconv.ParseUint(m["session-qfi"][0], 10, 8)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		tlvs = append(tlvs, bgp.NewMUPSessionParametersTLV(sessionTeid, uint8(sessionQfi)))
 	}
-	return bgp.NewMUPNLRI(afi, bgp.MUP_ARCH_TYPE_UNDEFINED, bgp.MUP_ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED, r), nil, extcomms, nil
+	if len(m["interwork-endpoint"]) > 0 {
+		addr, err := netip.ParseAddr(m["interwork-endpoint"][0])
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		tlvs = append(tlvs, bgp.NewMUPInterworkEndpointTLV(addr))
+	}
+	if len(m["source-address"]) > 0 {
+		addr, err := netip.ParseAddr(m["source-address"][0])
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		tlvs = append(tlvs, bgp.NewMUPSourceAddressTLV(addr))
+	}
+
+	return bgp.NewMUPType2SessionTransformedRoute(rd, uint8(eaLen), ea, teid, tlvs...), nil, extcomms, nil
 }
 
 func parseMUPArgs(args []string, afi uint16, nexthop string) (bgp.NLRI, *bgp.PathAttributePrefixSID, []string, error) {
@@ -3317,20 +3429,20 @@ usage: %s rib %s { a-d <A-D> | macadv <MACADV> | multicast <MULTICAST> | esi <ES
 		)
 		helpErrMap[bgp.RF_MUP_IPv4] = fmt.Errorf(`error: %s
 usage: %s rib %s { isd <ISD> | dsd <DSD> | t1st <T1ST> | t2st <T2ST> } -a mup-ipv4
-    <ISD>  : <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...]
-    <DSD>  : <ip address> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup <segment identifier>]
+    <ISD>  : <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup [direct|interwork] <global administrator>:<local administrator>]
+    <DSD>  : <ip address> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup [direct|interwork] <global administrator>:<local administrator>]
     <T1ST> : <ip prefix> rd <rd> [rt <rt>...] teid <teid> qfi <qfi> endpoint <endpoint> [source <source>]
-    <T2ST> : <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup <segment identifier>]`,
+    <T2ST> : <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup [direct|interwork] <global administrator>:<local administrator>] [session-teid <teid> session-qfi <qfi>] [interwork-endpoint <addr>] [source-address <addr>]`,
 			err,
 			cmdstr,
 			modtype,
 		)
 		helpErrMap[bgp.RF_MUP_IPv6] = fmt.Errorf(`error: %s
 usage: %s rib %s { isd <ISD> | dsd <DSD> | t1st <T1ST> | t2st <T2ST> } -a mup-ipv6
-    <ISD>  : <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...]
-    <DSD>  : <ip address> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup <segment identifier>]
+    <ISD>  : <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup [direct|interwork] <global administrator>:<local administrator>]
+    <DSD>  : <ip address> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup [direct|interwork] <global administrator>:<local administrator>]
     <T1ST> : <ip prefix> rd <rd> [rt <rt>...] teid <teid> qfi <qfi> endpoint <endpoint> [source <source>]
-    <T2ST> : <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup <segment identifier>]`,
+    <T2ST> : <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup [direct|interwork] <global administrator>:<local administrator>] [session-teid <teid> session-qfi <qfi>] [interwork-endpoint <addr>] [source-address <addr>]`,
 			err,
 			cmdstr,
 			modtype,

--- a/cmd/gobgp/global_test.go
+++ b/cmd/gobgp/global_test.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -147,4 +148,129 @@ func Test_ParseLsLinkPathDelayMetricTLVsMinGreaterThanMax(t *testing.T) {
 	assert.Error(err)
 	assert.Nil(path)
 	assert.Contains(err.Error(), "min must be <= max")
+}
+
+func Test_mupParser(t *testing.T) {
+	ipv4Addr := netip.MustParseAddr("10.0.0.1")
+	ipv4DirectExt, _ := bgp.NewMUPIPv4AddressSpecificExtended(bgp.EC_SUBTYPE_MUP_DIRECT_SEG_IPV4, ipv4Addr, 100)
+	ipv4InterworkExt, _ := bgp.NewMUPIPv4AddressSpecificExtended(bgp.EC_SUBTYPE_MUP_INTERWORK_SEG_IPV4, ipv4Addr, 100)
+
+	tests := []struct {
+		name    string
+		args    []string
+		want    bgp.ExtendedCommunityInterface
+		wantErr bool
+	}{
+		{"direct 2-octet AS (default keyword)", []string{"mup", "10:10"}, bgp.NewMUPExtended(bgp.EC_SUBTYPE_MUP_DIRECT_SEG, 10, 10), false},
+		{"direct 2-octet AS (explicit keyword)", []string{"mup", "direct", "10:20"}, bgp.NewMUPExtended(bgp.EC_SUBTYPE_MUP_DIRECT_SEG, 10, 20), false},
+		{"direct IPv4", []string{"mup", "10.0.0.1:100"}, ipv4DirectExt, false},
+		{"direct 4-octet AS (plain integer)", []string{"mup", "70000:100"}, bgp.NewMUPFourOctetAsSpecificExtended(bgp.EC_SUBTYPE_MUP_DIRECT_SEG_4_OCTET_AS, 70000, 100), false},
+		{"direct 4-octet AS (AS-dot notation)", []string{"mup", "1.100:100"}, bgp.NewMUPFourOctetAsSpecificExtended(bgp.EC_SUBTYPE_MUP_DIRECT_SEG_4_OCTET_AS, 1<<16|100, 100), false},
+		{"interwork 2-octet AS", []string{"mup", "interwork", "10:20"}, bgp.NewMUPExtended(bgp.EC_SUBTYPE_MUP_INTERWORK_SEG, 10, 20), false},
+		{"interwork IPv4", []string{"mup", "interwork", "10.0.0.1:100"}, ipv4InterworkExt, false},
+		{"interwork 4-octet AS", []string{"mup", "interwork", "70000:100"}, bgp.NewMUPFourOctetAsSpecificExtended(bgp.EC_SUBTYPE_MUP_INTERWORK_SEG_4_OCTET_AS, 70000, 100), false},
+		{"invalid global admin", []string{"mup", "abc:100"}, nil, true},
+		{"local admin overflow (2-octet AS form)", []string{"mup", "10:99999999999"}, nil, true},
+		{"local admin overflow (IPv4 form)", []string{"mup", "10.0.0.1:99999"}, nil, true},
+		{"invalid segment type keyword", []string{"mup", "badkeyword", "10:10"}, nil, true},
+		{"missing colon", []string{"mup", "1000"}, nil, true},
+		{"too few args", []string{"mup"}, nil, true},
+		{"too many args", []string{"mup", "direct", "10:10", "extra"}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			exts, err := mupParser(tt.args)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			if assert.Len(exts, 1) {
+				assert.Equal(tt.want, exts[0])
+			}
+		})
+	}
+}
+
+func Test_ParseMUPType2SessionTransformedRouteArgsTLVs(t *testing.T) {
+	base := []string{"10.0.0.1", "rd", "1.1.1.1:65000", "rt", "65000:1", "endpoint-address-length", "32", "teid", "100", "mup", "10:10"}
+	sessionTeid, _ := parseTeid("300")
+	interworkAddr := netip.MustParseAddr("10.0.0.2")
+	sourceAddr := netip.MustParseAddr("10.0.0.3")
+
+	tests := []struct {
+		name      string
+		extraArgs []string
+		wantErr   bool
+		wantTLVs  []bgp.MUPTLVInterface
+	}{
+		{
+			name:      "session-teid and session-qfi",
+			extraArgs: []string{"session-teid", "300", "session-qfi", "5"},
+			wantTLVs:  []bgp.MUPTLVInterface{bgp.NewMUPSessionParametersTLV(sessionTeid, 5)},
+		},
+		{
+			name:      "interwork-endpoint",
+			extraArgs: []string{"interwork-endpoint", "10.0.0.2"},
+			wantTLVs:  []bgp.MUPTLVInterface{bgp.NewMUPInterworkEndpointTLV(interworkAddr)},
+		},
+		{
+			name:      "source-address",
+			extraArgs: []string{"source-address", "10.0.0.3"},
+			wantTLVs:  []bgp.MUPTLVInterface{bgp.NewMUPSourceAddressTLV(sourceAddr)},
+		},
+		{
+			name:      "all three TLVs",
+			extraArgs: []string{"session-teid", "300", "session-qfi", "5", "interwork-endpoint", "10.0.0.2", "source-address", "10.0.0.3"},
+			wantTLVs: []bgp.MUPTLVInterface{
+				bgp.NewMUPSessionParametersTLV(sessionTeid, 5),
+				bgp.NewMUPInterworkEndpointTLV(interworkAddr),
+				bgp.NewMUPSourceAddressTLV(sourceAddr),
+			},
+		},
+		{
+			name:      "session-teid without session-qfi",
+			extraArgs: []string{"session-teid", "300"},
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			args := append(append([]string{}, base...), tt.extraArgs...)
+			nlri, _, _, err := parseMUPType2SessionTransformedRouteArgs(args, bgp.AFI_IP)
+			if tt.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			mupNlri, ok := nlri.(*bgp.MUPNLRI)
+			if !assert.True(ok) {
+				return
+			}
+			route, ok := mupNlri.RouteTypeData.(*bgp.MUPType2SessionTransformedRoute)
+			if !assert.True(ok) {
+				return
+			}
+			assert.Equal(tt.wantTLVs, route.TLVs)
+		})
+	}
+}
+
+func Test_ParseMUPType2SessionTransformedRouteArgsMUPExtcomm(t *testing.T) {
+	assert := assert.New(t)
+	args := []string{
+		"10.0.0.1", "rd", "1.1.1.1:65000", "rt", "65000:1",
+		"endpoint-address-length", "32", "teid", "100",
+		"mup", "interwork", "10.0.0.2:100",
+	}
+	_, _, extcomms, err := parseMUPType2SessionTransformedRouteArgs(args, bgp.AFI_IP)
+	assert.NoError(err)
+	assert.Equal([]string{"rt", "65000:1", "mup", "interwork", "10.0.0.2:100"}, extcomms)
+
+	exts, err := parseExtendedCommunities(extcomms)
+	assert.NoError(err)
+	want, _ := bgp.NewMUPIPv4AddressSpecificExtended(bgp.EC_SUBTYPE_MUP_INTERWORK_SEG_IPV4, netip.MustParseAddr("10.0.0.2"), 100)
+	assert.Contains(exts, bgp.ExtendedCommunityInterface(want))
 }

--- a/docs/sources/srv6_mup.md
+++ b/docs/sources/srv6_mup.md
@@ -1,6 +1,6 @@
 # BGP Extensions for the Mobile User Plane (MUP) SAFI
 
-This feature is implementation of [the Internet-Draft, BGP Extensions for the Mobile User Plane (MUP) SAFI](https://datatracker.ietf.org/doc/html/draft-mpmz-bess-mup-safi-03).
+This feature is implementation of [the Internet-Draft, BGP Extensions for the Mobile User Plane (MUP) SAFI](https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01).
 
 ## Contents
 
@@ -17,16 +17,16 @@ This feature is implementation of [the Internet-Draft, BGP Extensions for the Mo
 
 ```shell
 # Add a route
-gobgp global rib add -a ipv4-mup isd <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...]
-gobgp global rib add -a ipv6-mup isd <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...]
+gobgp global rib add -a ipv4-mup isd <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup [direct|interwork] <global administrator>:<local administrator>]
+gobgp global rib add -a ipv6-mup isd <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup [direct|interwork] <global administrator>:<local administrator>]
 
 # Show routes
 gobgp global rib -a ipv4-mup
 gobgp global rib -a ipv6-mup
 
 # Delete a route
-gobgp global rib del -a ipv4-mup isd <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...]
-gobgp global rib del -a ipv6-mup isd <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...]
+gobgp global rib del -a ipv4-mup isd <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup [direct|interwork] <global administrator>:<local administrator>]
+gobgp global rib del -a ipv6-mup isd <ip prefix> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup [direct|interwork] <global administrator>:<local administrator>]
 ```
 
 #### Example - Interwork Segment Discovery route
@@ -49,17 +49,19 @@ $ gobgp global rib -a ipv6-mup
 
 ```shell
 # Add a route
-gobgp global rib add -a ipv4-mup dsd <ip address> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup <segment identifier>]
-gobgp global rib add -a ipv6-mup dsd <ip address> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup <segment identifier>]
+gobgp global rib add -a ipv4-mup dsd <ip address> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup [direct|interwork] <global administrator>:<local administrator>]
+gobgp global rib add -a ipv6-mup dsd <ip address> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup [direct|interwork] <global administrator>:<local administrator>]
 
 # Show routes
 gobgp global rib -a ipv4-mup
 gobgp global rib -a ipv6-mup
 
 # Delete a route
-gobgp global rib del -a ipv4-mup dsd <ip address> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup <segment identifier>]
-gobgp global rib del -a ipv6-mup dsd <ip address> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup <segment identifier>]
+gobgp global rib del -a ipv4-mup dsd <ip address> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup [direct|interwork] <global administrator>:<local administrator>]
+gobgp global rib del -a ipv6-mup dsd <ip address> rd <rd> prefix <prefix> locator-node-length <locator-node-length> function-length <function-length> behavior <behavior> [rt <rt>...] [mup [direct|interwork] <global administrator>:<local administrator>]
 ```
+
+The format of the BGP MUP Extended Community: `[direct|interwork] <global administrator>:<local administrator>`. The `direct`/`interwork` keyword is optional and defaults to `direct`. The encoding is inferred from the Global Administrator: an IPv4 address selects the IPv4 Address Specific format, an integer greater than 65535 selects the 4-Octet AS Specific format, and otherwise the 2-Octet AS Specific format is used.
 
 #### Example - Direct Segment Discovery route
 
@@ -119,19 +121,23 @@ $ gobgp global rib -a ipv6-mup
 
 ```shell
 # Add a route
-gobgp global rib add -a ipv4-mup t2st <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup <segment identifier>]
-gobgp global rib add -a ipv6-mup t2st <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup <segment identifier>]
+gobgp global rib add -a ipv4-mup t2st <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup [direct|interwork] <global administrator>:<local administrator>] [session-teid <teid> session-qfi <qfi>] [interwork-endpoint <addr>] [source-address <addr>]
+gobgp global rib add -a ipv6-mup t2st <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup [direct|interwork] <global administrator>:<local administrator>] [session-teid <teid> session-qfi <qfi>] [interwork-endpoint <addr>] [source-address <addr>]
 
 # Show routes
 gobgp global rib -a ipv4-mup
 gobgp global rib -a ipv6-mup
 
 # Delete a route
-gobgp global rib del -a ipv4-mup t2st <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup <segment identifier>]
-gobgp global rib del -a ipv6-mup t2st <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup <segment identifier>]
+gobgp global rib del -a ipv4-mup t2st <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup [direct|interwork] <global administrator>:<local administrator>] [session-teid <teid> session-qfi <qfi>] [interwork-endpoint <addr>] [source-address <addr>]
+gobgp global rib del -a ipv6-mup t2st <endpoint address> rd <rd> [rt <rt>...] endpoint-address-length <endpoint-address-length> teid <teid> [mup [direct|interwork] <global administrator>:<local administrator>] [session-teid <teid> session-qfi <qfi>] [interwork-endpoint <addr>] [source-address <addr>]
 ```
 
-The format of the TEID: hexadecimal (beginning with '0x'), decimal (uint32), or IPv4.
+The format of the TEID: hexadecimal (beginning with '0x'), decimal (uint32), or IPv4. This also applies to the `session-teid` TLV.
+
+The format of the BGP MUP Extended Community: `[direct|interwork] <global administrator>:<local administrator>`. The `direct`/`interwork` keyword is optional and defaults to `direct`. The encoding is inferred from the Global Administrator: an IPv4 address selects the IPv4 Address Specific format, an integer greater than 65535 selects the 4-Octet AS Specific format, and otherwise the 2-Octet AS Specific format is used.
+
+`session-teid` and `session-qfi` add a 3gpp-5g Session Parameters TLV and must be specified together. `interwork-endpoint` and `source-address` add an Interwork Endpoint TLV and a Source Address TLV respectively. All three TLVs are optional and defined in [Section 3.1.5 of the draft](https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.1.5); they apply only to the Type 2 Session Transformed Route.
 
 #### Example - Type 2 Session Transformed Route
 
@@ -150,6 +156,19 @@ $ gobgp global rib -a ipv6-mup
    Network                                                                                TEID       QFI        Endpoint             Next Hop             AS_PATH              Age        Attrs
 *> [type:t2st][rd:100:100][endpoint-address-length:160][endpoint:2001::1][teid:0.0.48.57]                                            10.0.0.2                                  00:00:47   [{Origin: ?} {Extcomms: [10:10], [10:10]}]
 ```
+
+#### Example - Type 2 Session Transformed Route with optional TLVs and the Interwork Segment Extended Community
+
+```console
+# IPv4
+$ gobgp global rib add -a ipv4-mup t2st 10.0.0.1 rd 100:100 rt 10:10 endpoint-address-length 64 teid 12345 mup interwork 10.0.0.2:100 session-teid 100 session-qfi 5 interwork-endpoint 10.0.1.1 source-address 10.0.2.1 nexthop 10.0.0.2
+
+$ gobgp global rib -a ipv4-mup
+   Network                                                                                Next Hop             AS_PATH              Age        Attrs
+*> [type:t2st][rd:100:100][endpoint-address-length:64][endpoint:10.0.0.1][teid:0.0.48.57] 10.0.0.2                                  00:00:01   [{Origin: ?} {Extcomms: [10:10], [10.0.0.2:100]}]
+```
+
+The `mup interwork 10.0.0.2:100` argument attaches an Interwork Segment Extended Community in the IPv4 Address Specific format (inferred from the IPv4 Global Administrator). The `session-teid`, `session-qfi`, `interwork-endpoint` and `source-address` values are carried in the route's optional TLVs; they are not part of the route key and do not appear in the table output, but the JSON output (`gobgp global rib -a ipv4-mup -j`) shows them in the `tlvs` field of the NLRI.
 
 ## Example setup with netns
 

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -1258,10 +1258,10 @@ func (p *Path) ToGlobal(vrf *Vrf) *Path {
 			nlri = bgp.NewMUPDirectSegmentDiscoveryRoute(vrf.Rd, old.Address)
 		case bgp.MUP_ROUTE_TYPE_TYPE_1_SESSION_TRANSFORMED:
 			old := n.RouteTypeData.(*bgp.MUPType1SessionTransformedRoute)
-			nlri = bgp.NewMUPType1SessionTransformedRoute(vrf.Rd, old.Prefix, old.TEID, old.QFI, old.EndpointAddress, old.SourceAddress)
+			nlri = bgp.NewMUPType1SessionTransformedRoute(vrf.Rd, old.Prefix, old.TEID, old.QFI, old.EndpointAddress, old.SourceAddress, old.TLVs...)
 		case bgp.MUP_ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED:
 			old := n.RouteTypeData.(*bgp.MUPType2SessionTransformedRoute)
-			nlri = bgp.NewMUPType2SessionTransformedRoute(vrf.Rd, old.EndpointAddressLength, old.EndpointAddress, old.TEID)
+			nlri = bgp.NewMUPType2SessionTransformedRoute(vrf.Rd, old.EndpointAddressLength, old.EndpointAddress, old.TEID, old.TLVs...)
 		}
 		newFamily = rf
 	default:

--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -2430,7 +2430,7 @@ func unmarshalExComm(a *api.ExtendedCommunitiesAttribute) (*bgp.PathAttributeExt
 			community = bgp.NewTrafficRemarkExtended(uint8(v.Dscp))
 		case *api.ExtendedCommunity_Mup:
 			v := comm.Mup
-			community = bgp.NewMUPExtended(uint16(v.SegmentId2), v.SegmentId4)
+			community = bgp.NewMUPExtended(bgp.ExtendedCommunityAttrSubType(v.SubType), uint16(v.SegmentId2), v.SegmentId4)
 		case *api.ExtendedCommunity_Vpls:
 			v := comm.Vpls
 			community = bgp.NewVPLSExtended(uint8(v.ControlFlags), uint16(v.Mtu))

--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -1333,6 +1333,90 @@ func UnmarshalLsAttribute(a *api.LsAttribute) (*bgp.LsAttribute, error) {
 	return lsAttr, nil
 }
 
+func MarshalMUPTLVs(tlvs []bgp.MUPTLVInterface) ([]*api.MUPTLV, error) {
+	if len(tlvs) == 0 {
+		return nil, nil
+	}
+	apiTLVs := make([]*api.MUPTLV, 0, len(tlvs))
+	for _, tlv := range tlvs {
+		switch t := tlv.(type) {
+		case *bgp.MUPSessionParametersTLV:
+			apiTLVs = append(apiTLVs, &api.MUPTLV{
+				Tlv: &api.MUPTLV_SessionParameters{
+					SessionParameters: &api.MUPSessionParametersTLV{
+						Teid: binary.BigEndian.Uint32(t.TEID.AsSlice()),
+						Qfi:  uint32(t.QFI),
+					},
+				},
+			})
+		case *bgp.MUPInterworkEndpointTLV:
+			apiTLVs = append(apiTLVs, &api.MUPTLV{
+				Tlv: &api.MUPTLV_InterworkEndpoint{
+					InterworkEndpoint: &api.MUPInterworkEndpointTLV{
+						Address: t.Address.String(),
+					},
+				},
+			})
+		case *bgp.MUPSourceAddressTLV:
+			apiTLVs = append(apiTLVs, &api.MUPTLV{
+				Tlv: &api.MUPTLV_SourceAddress{
+					SourceAddress: &api.MUPSourceAddressTLV{
+						Address: t.Address.String(),
+					},
+				},
+			})
+		case *bgp.MUPUnknownTLV:
+			apiTLVs = append(apiTLVs, &api.MUPTLV{
+				Tlv: &api.MUPTLV_Unknown{
+					Unknown: &api.MUPUnknownTLV{
+						Type:  uint32(t.TLVType),
+						Value: t.Value,
+					},
+				},
+			})
+		default:
+			return nil, fmt.Errorf("invalid mup tlv type to marshal: %T", tlv)
+		}
+	}
+	return apiTLVs, nil
+}
+
+func UnmarshalMUPTLVs(tlvs []*api.MUPTLV) ([]bgp.MUPTLVInterface, error) {
+	if len(tlvs) == 0 {
+		return nil, nil
+	}
+	bgpTLVs := make([]bgp.MUPTLVInterface, 0, len(tlvs))
+	for _, tlv := range tlvs {
+		switch t := tlv.GetTlv().(type) {
+		case *api.MUPTLV_SessionParameters:
+			b := make([]byte, 4)
+			binary.BigEndian.PutUint32(b, t.SessionParameters.Teid)
+			teid, ok := netip.AddrFromSlice(b)
+			if !ok {
+				return nil, fmt.Errorf("invalid teid: %x", t.SessionParameters.Teid)
+			}
+			bgpTLVs = append(bgpTLVs, bgp.NewMUPSessionParametersTLV(teid, uint8(t.SessionParameters.Qfi)))
+		case *api.MUPTLV_InterworkEndpoint:
+			address, err := netip.ParseAddr(t.InterworkEndpoint.Address)
+			if err != nil {
+				return nil, err
+			}
+			bgpTLVs = append(bgpTLVs, bgp.NewMUPInterworkEndpointTLV(address))
+		case *api.MUPTLV_SourceAddress:
+			address, err := netip.ParseAddr(t.SourceAddress.Address)
+			if err != nil {
+				return nil, err
+			}
+			bgpTLVs = append(bgpTLVs, bgp.NewMUPSourceAddressTLV(address))
+		case *api.MUPTLV_Unknown:
+			bgpTLVs = append(bgpTLVs, bgp.NewMUPUnknownTLV(uint8(t.Unknown.Type), t.Unknown.Value))
+		default:
+			return nil, fmt.Errorf("invalid mup tlv type to unmarshal: %T", t)
+		}
+	}
+	return bgpTLVs, nil
+}
+
 func MarshalNLRI(value bgp.NLRI) (*api.NLRI, error) {
 	var nlri api.NLRI
 
@@ -1602,6 +1686,10 @@ func MarshalNLRI(value bgp.NLRI) (*api.NLRI, error) {
 				sal = uint32(r.SourceAddressLength)
 				sa = r.SourceAddress.String()
 			}
+			tlvs, err := MarshalMUPTLVs(r.TLVs)
+			if err != nil {
+				return nil, err
+			}
 			nlri.Nlri = &api.NLRI_MupType_1SessionTransformed{
 				MupType_1SessionTransformed: &api.MUPType1SessionTransformedRoute{
 					Rd:                    rd,
@@ -1612,10 +1700,15 @@ func MarshalNLRI(value bgp.NLRI) (*api.NLRI, error) {
 					EndpointAddress:       r.EndpointAddress.String(),
 					SourceAddressLength:   sal,
 					SourceAddress:         sa,
+					Tlvs:                  tlvs,
 				},
 			}
 		case *bgp.MUPType2SessionTransformedRoute:
 			rd, err := MarshalRD(r.RD)
+			if err != nil {
+				return nil, err
+			}
+			tlvs, err := MarshalMUPTLVs(r.TLVs)
 			if err != nil {
 				return nil, err
 			}
@@ -1625,6 +1718,7 @@ func MarshalNLRI(value bgp.NLRI) (*api.NLRI, error) {
 					EndpointAddressLength: uint32(r.EndpointAddressLength),
 					EndpointAddress:       r.EndpointAddress.String(),
 					Teid:                  binary.BigEndian.Uint32(r.TEID.AsSlice()),
+					Tlvs:                  tlvs,
 				},
 			}
 		}
@@ -1870,7 +1964,11 @@ func UnmarshalNLRI(rf bgp.Family, an *api.NLRI) (bgp.NLRI, error) {
 			}
 			sa = &a
 		}
-		nlri = bgp.NewMUPType1SessionTransformedRoute(rd, prefix, teid, uint8(v.Qfi), ea, sa)
+		tlvs, err := UnmarshalMUPTLVs(v.Tlvs)
+		if err != nil {
+			return nil, err
+		}
+		nlri = bgp.NewMUPType1SessionTransformedRoute(rd, prefix, teid, uint8(v.Qfi), ea, sa, tlvs...)
 	case *api.NLRI_MupType_2SessionTransformed:
 		v := n.MupType_2SessionTransformed
 		rd, err := UnmarshalRD(v.Rd)
@@ -1887,7 +1985,11 @@ func UnmarshalNLRI(rf bgp.Family, an *api.NLRI) (bgp.NLRI, error) {
 		if !ok {
 			return nil, fmt.Errorf("invalid teid: %x", v.Teid)
 		}
-		nlri = bgp.NewMUPType2SessionTransformedRoute(rd, uint8(v.EndpointAddressLength), ea, teid)
+		tlvs, err := UnmarshalMUPTLVs(v.Tlvs)
+		if err != nil {
+			return nil, err
+		}
+		nlri = bgp.NewMUPType2SessionTransformedRoute(rd, uint8(v.EndpointAddressLength), ea, teid, tlvs...)
 	case *api.NLRI_LsAddrPrefix:
 		v := n.LsAddrPrefix
 		switch t := v.Nlri.GetNlri().(type) {
@@ -2314,11 +2416,27 @@ func NewExtendedCommunitiesAttributeFromNative(a *bgp.PathAttributeExtendedCommu
 				},
 			}
 		case *bgp.MUPExtended:
-			community.Extcom = &api.ExtendedCommunity_Mup{
-				Mup: &api.MUPExtended{
+			community.Extcom = &api.ExtendedCommunity_MupTwoOctetAsSpecific{
+				MupTwoOctetAsSpecific: &api.MUPTwoOctetAsSpecificExtended{
 					SubType:    uint32(v.SubType),
-					SegmentId2: uint32(v.SegmentID2),
-					SegmentId4: v.SegmentID4,
+					Asn:        uint32(v.SegmentID2),
+					LocalAdmin: v.SegmentID4,
+				},
+			}
+		case *bgp.MUPIPv4AddressSpecificExtended:
+			community.Extcom = &api.ExtendedCommunity_MupIpv4AddressSpecific{
+				MupIpv4AddressSpecific: &api.MUPIPv4AddressSpecificExtended{
+					SubType:    uint32(v.SubType),
+					Address:    v.IPv4.String(),
+					LocalAdmin: uint32(v.LocalAdmin),
+				},
+			}
+		case *bgp.MUPFourOctetAsSpecificExtended:
+			community.Extcom = &api.ExtendedCommunity_MupFourOctetAsSpecific{
+				MupFourOctetAsSpecific: &api.MUPFourOctetAsSpecificExtended{
+					SubType:    uint32(v.SubType),
+					Asn:        v.AS,
+					LocalAdmin: uint32(v.LocalAdmin),
 				},
 			}
 		case *bgp.VPLSExtended:
@@ -2428,9 +2546,34 @@ func unmarshalExComm(a *api.ExtendedCommunitiesAttribute) (*bgp.PathAttributeExt
 		case *api.ExtendedCommunity_TrafficRemark:
 			v := comm.TrafficRemark
 			community = bgp.NewTrafficRemarkExtended(uint8(v.Dscp))
-		case *api.ExtendedCommunity_Mup:
-			v := comm.Mup
-			community = bgp.NewMUPExtended(bgp.ExtendedCommunityAttrSubType(v.SubType), uint16(v.SegmentId2), v.SegmentId4)
+		case *api.ExtendedCommunity_MupTwoOctetAsSpecific:
+			v := comm.MupTwoOctetAsSpecific
+			subType := bgp.ExtendedCommunityAttrSubType(v.SubType)
+			if subType != bgp.EC_SUBTYPE_MUP_DIRECT_SEG && subType != bgp.EC_SUBTYPE_MUP_INTERWORK_SEG {
+				return nil, fmt.Errorf("invalid mup 2-octet as specific sub type: %d", v.SubType)
+			}
+			community = bgp.NewMUPExtended(subType, uint16(v.Asn), v.LocalAdmin)
+		case *api.ExtendedCommunity_MupIpv4AddressSpecific:
+			v := comm.MupIpv4AddressSpecific
+			subType := bgp.ExtendedCommunityAttrSubType(v.SubType)
+			if subType != bgp.EC_SUBTYPE_MUP_DIRECT_SEG_IPV4 && subType != bgp.EC_SUBTYPE_MUP_INTERWORK_SEG_IPV4 {
+				return nil, fmt.Errorf("invalid mup ipv4 address specific sub type: %d", v.SubType)
+			}
+			address, err := netip.ParseAddr(v.Address)
+			if err != nil {
+				return nil, err
+			}
+			community, err = bgp.NewMUPIPv4AddressSpecificExtended(subType, address, uint16(v.LocalAdmin))
+			if err != nil {
+				return nil, err
+			}
+		case *api.ExtendedCommunity_MupFourOctetAsSpecific:
+			v := comm.MupFourOctetAsSpecific
+			subType := bgp.ExtendedCommunityAttrSubType(v.SubType)
+			if subType != bgp.EC_SUBTYPE_MUP_DIRECT_SEG_4_OCTET_AS && subType != bgp.EC_SUBTYPE_MUP_INTERWORK_SEG_4_OCTET_AS {
+				return nil, fmt.Errorf("invalid mup 4-octet as specific sub type: %d", v.SubType)
+			}
+			community = bgp.NewMUPFourOctetAsSpecificExtended(subType, v.Asn, uint16(v.LocalAdmin))
 		case *api.ExtendedCommunity_Vpls:
 			v := comm.Vpls
 			community = bgp.NewVPLSExtended(uint8(v.ControlFlags), uint16(v.Mtu))

--- a/pkg/apiutil/attribute_test.go
+++ b/pkg/apiutil/attribute_test.go
@@ -1131,6 +1131,23 @@ func Test_MpReachNLRIAttribute_MUPType1SessionTransformedRoute(t *testing.T) {
 				SourceAddress:         "10.0.0.2",
 			},
 		},
+		{
+			name: "IPv4_with_TLVs",
+			in: &api.MUPType1SessionTransformedRoute{
+				Rd:                    rd,
+				Prefix:                "192.168.100.1/32",
+				Teid:                  12345,
+				Qfi:                   9,
+				EndpointAddressLength: 32,
+				EndpointAddress:       "10.0.0.1",
+				Tlvs: []*api.MUPTLV{
+					{Tlv: &api.MUPTLV_Unknown{Unknown: &api.MUPUnknownTLV{
+						Type:  200,
+						Value: []byte{0xde, 0xad, 0xbe, 0xef},
+					}}},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		nlris := []*api.NLRI{{Nlri: &api.NLRI_MupType_1SessionTransformed{MupType_1SessionTransformed: tt.in}}}
@@ -1160,28 +1177,64 @@ func Test_MpReachNLRIAttribute_MUPType2SessionTransformedRoute(t *testing.T) {
 		Admin:    65000,
 		Assigned: 100,
 	}}}
-	nlris := []*api.NLRI{{Nlri: &api.NLRI_MupType_2SessionTransformed{MupType_2SessionTransformed: &api.MUPType2SessionTransformedRoute{
-		Rd:                    rd,
-		Teid:                  12345,
-		EndpointAddressLength: 64,
-		EndpointAddress:       "10.0.0.1",
-	}}}}
-
-	input := &api.MpReachNLRIAttribute{
-		Family: &api.Family{
-			Afi:  api.Family_AFI_IP,
-			Safi: api.Family_SAFI_MUP,
+	tests := []struct {
+		name string
+		in   *api.MUPType2SessionTransformedRoute
+	}{
+		{
+			name: "IPv4",
+			in: &api.MUPType2SessionTransformedRoute{
+				Rd:                    rd,
+				Teid:                  12345,
+				EndpointAddressLength: 64,
+				EndpointAddress:       "10.0.0.1",
+			},
 		},
-		NextHops: []string{"0.0.0.0"},
-		Nlris:    nlris,
+		{
+			name: "IPv4_with_TLVs",
+			in: &api.MUPType2SessionTransformedRoute{
+				Rd:                    rd,
+				Teid:                  12345,
+				EndpointAddressLength: 64,
+				EndpointAddress:       "10.0.0.1",
+				Tlvs: []*api.MUPTLV{
+					{Tlv: &api.MUPTLV_SessionParameters{SessionParameters: &api.MUPSessionParametersTLV{
+						Teid: 54321,
+						Qfi:  9,
+					}}},
+					{Tlv: &api.MUPTLV_InterworkEndpoint{InterworkEndpoint: &api.MUPInterworkEndpointTLV{
+						Address: "10.20.30.40",
+					}}},
+					{Tlv: &api.MUPTLV_SourceAddress{SourceAddress: &api.MUPSourceAddressTLV{
+						Address: "2001::100",
+					}}},
+					{Tlv: &api.MUPTLV_Unknown{Unknown: &api.MUPUnknownTLV{
+						Type:  200,
+						Value: []byte{0xde, 0xad, 0xbe, 0xef},
+					}}},
+				},
+			},
+		},
 	}
+	for _, tt := range tests {
+		nlris := []*api.NLRI{{Nlri: &api.NLRI_MupType_2SessionTransformed{MupType_2SessionTransformed: tt.in}}}
 
-	a := &api.Attribute{Attr: &api.Attribute_MpReach{MpReach: input}}
-	n, err := UnmarshalAttribute(a)
-	assert.NoError(err)
+		input := &api.MpReachNLRIAttribute{
+			Family: &api.Family{
+				Afi:  api.Family_AFI_IP,
+				Safi: api.Family_SAFI_MUP,
+			},
+			NextHops: []string{"0.0.0.0"},
+			Nlris:    nlris,
+		}
 
-	output, _ := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
-	assert.True(proto.Equal(input, output))
+		a := &api.Attribute{Attr: &api.Attribute_MpReach{MpReach: input}}
+		n, err := UnmarshalAttribute(a)
+		assert.NoError(err)
+
+		output, _ := NewMpReachNLRIAttributeFromNative(n.(*bgp.PathAttributeMpReachNLRI))
+		assert.True(proto.Equal(input, output), tt.name)
+	}
 }
 
 func Test_MpUnreachNLRIAttribute_IPv4_UC(t *testing.T) {
@@ -1289,9 +1342,20 @@ func Test_ExtendedCommunitiesAttribute(t *testing.T) {
 		{Extcom: &api.ExtendedCommunity_TrafficRemark{TrafficRemark: &api.TrafficRemarkExtended{
 			Dscp: 0x0a, // AF11
 		}}},
-		{Extcom: &api.ExtendedCommunity_Mup{Mup: &api.MUPExtended{
-			SegmentId2: 10,
-			SegmentId4: 100,
+		{Extcom: &api.ExtendedCommunity_MupTwoOctetAsSpecific{MupTwoOctetAsSpecific: &api.MUPTwoOctetAsSpecificExtended{
+			SubType:    0x00, // Direct Segment
+			Asn:        10,
+			LocalAdmin: 100,
+		}}},
+		{Extcom: &api.ExtendedCommunity_MupIpv4AddressSpecific{MupIpv4AddressSpecific: &api.MUPIPv4AddressSpecificExtended{
+			SubType:    0x04, // Interwork Segment
+			Address:    "7.7.7.7",
+			LocalAdmin: 100,
+		}}},
+		{Extcom: &api.ExtendedCommunity_MupFourOctetAsSpecific{MupFourOctetAsSpecific: &api.MUPFourOctetAsSpecificExtended{
+			SubType:    0x05, // Interwork Segment
+			Asn:        65550,
+			LocalAdmin: 100,
 		}}},
 		{Extcom: &api.ExtendedCommunity_Unknown{Unknown: &api.UnknownExtended{
 			Type:  0xff, // Max of uint8
@@ -1956,6 +2020,48 @@ func TestFullCycleSRv6InformationSubTLV(t *testing.T) {
 			if !bytes.Equal(tt.input, recovered) {
 				t.Fatalf("round trip conversion test failed as expected prefix sid attribute %+v does not match actual: %+v", tt.input, recovered)
 			}
+		})
+	}
+}
+
+func Test_ExtendedCommunitiesAttribute_MUPInvalidSubType(t *testing.T) {
+	assert := assert.New(t)
+	tests := []struct {
+		name string
+		in   *api.ExtendedCommunity
+	}{
+		{
+			name: "two-octet AS with IPv4 sub type",
+			in: &api.ExtendedCommunity{Extcom: &api.ExtendedCommunity_MupTwoOctetAsSpecific{MupTwoOctetAsSpecific: &api.MUPTwoOctetAsSpecificExtended{
+				SubType:    0x01,
+				Asn:        10,
+				LocalAdmin: 100,
+			}}},
+		},
+		{
+			name: "IPv4 with two-octet AS sub type",
+			in: &api.ExtendedCommunity{Extcom: &api.ExtendedCommunity_MupIpv4AddressSpecific{MupIpv4AddressSpecific: &api.MUPIPv4AddressSpecificExtended{
+				SubType:    0x00,
+				Address:    "10.0.0.1",
+				LocalAdmin: 100,
+			}}},
+		},
+		{
+			name: "4-octet AS with IPv4 sub type",
+			in: &api.ExtendedCommunity{Extcom: &api.ExtendedCommunity_MupFourOctetAsSpecific{MupFourOctetAsSpecific: &api.MUPFourOctetAsSpecificExtended{
+				SubType:    0x04,
+				Asn:        65550,
+				LocalAdmin: 100,
+			}}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &api.Attribute{Attr: &api.Attribute_ExtendedCommunities{ExtendedCommunities: &api.ExtendedCommunitiesAttribute{
+				Communities: []*api.ExtendedCommunity{tt.in},
+			}}}
+			_, err := UnmarshalAttribute(a)
+			assert.ErrorContains(err, "sub type")
 		})
 	}
 }

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -209,7 +209,12 @@ const (
 
 	EC_SUBTYPE_ORIGIN_VALIDATION ExtendedCommunityAttrSubType = 0x00 // EC_TYPE: 0x43
 
-	EC_SUBTYPE_MUP_DIRECT_SEG ExtendedCommunityAttrSubType = 0x00 // EC_TYPE: 0x0c
+	EC_SUBTYPE_MUP_DIRECT_SEG               ExtendedCommunityAttrSubType = 0x00 // EC_TYPE: 0x0c
+	EC_SUBTYPE_MUP_DIRECT_SEG_IPV4          ExtendedCommunityAttrSubType = 0x01 // EC_TYPE: 0x0c
+	EC_SUBTYPE_MUP_DIRECT_SEG_4_OCTET_AS    ExtendedCommunityAttrSubType = 0x02 // EC_TYPE: 0x0c
+	EC_SUBTYPE_MUP_INTERWORK_SEG            ExtendedCommunityAttrSubType = 0x03 // EC_TYPE: 0x0c
+	EC_SUBTYPE_MUP_INTERWORK_SEG_IPV4       ExtendedCommunityAttrSubType = 0x04 // EC_TYPE: 0x0c
+	EC_SUBTYPE_MUP_INTERWORK_SEG_4_OCTET_AS ExtendedCommunityAttrSubType = 0x05 // EC_TYPE: 0x0c
 
 	EC_SUBTYPE_FLOWSPEC_TRAFFIC_RATE   ExtendedCommunityAttrSubType = 0x06 // EC_TYPE: 0x80
 	EC_SUBTYPE_FLOWSPEC_TRAFFIC_ACTION ExtendedCommunityAttrSubType = 0x07 // EC_TYPE: 0x80

--- a/pkg/packet/bgp/mup.go
+++ b/pkg/packet/bgp/mup.go
@@ -7,8 +7,10 @@ import (
 	"net/netip"
 )
 
-// MUPExtended represents BGP MUP Extended Community as described in
-// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.2
+// MUPExtended represents 2-Octet AS Specific BGP MUP Extended Community as described in
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.2.1
+// The name predates the draft-ietf sub-type restructuring; the encoding is
+// identical to the former Direct-Type Segment Identifier extended community.
 type MUPExtended struct {
 	SubType    ExtendedCommunityAttrSubType
 	SegmentID2 uint16
@@ -18,7 +20,7 @@ type MUPExtended struct {
 func (e *MUPExtended) Serialize() ([]byte, error) {
 	buf := make([]byte, 8)
 	buf[0] = byte(EC_TYPE_MUP)
-	buf[1] = byte(EC_SUBTYPE_MUP_DIRECT_SEG)
+	buf[1] = byte(e.SubType)
 	binary.BigEndian.PutUint16(buf[2:4], e.SegmentID2)
 	binary.BigEndian.PutUint32(buf[4:8], e.SegmentID4)
 	return buf, nil
@@ -42,18 +44,123 @@ func (e *MUPExtended) MarshalJSON() ([]byte, error) {
 }
 
 func (e *MUPExtended) GetTypes() (ExtendedCommunityAttrType, ExtendedCommunityAttrSubType) {
-	return EC_TYPE_MUP, EC_SUBTYPE_MUP_DIRECT_SEG
+	return EC_TYPE_MUP, e.SubType
 }
 
 func (e *MUPExtended) Flat() map[string]string {
 	return map[string]string{}
 }
 
-func NewMUPExtended(sid2 uint16, sid4 uint32) *MUPExtended {
+func NewMUPExtended(subType ExtendedCommunityAttrSubType, sid2 uint16, sid4 uint32) *MUPExtended {
 	return &MUPExtended{
-		SubType:    EC_SUBTYPE_MUP_DIRECT_SEG,
+		SubType:    subType,
 		SegmentID2: sid2,
 		SegmentID4: sid4,
+	}
+}
+
+// MUPIPv4AddressSpecificExtended represents IPv4 Address Specific BGP MUP Extended Community as described in
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.2.2
+type MUPIPv4AddressSpecificExtended struct {
+	SubType    ExtendedCommunityAttrSubType
+	IPv4       netip.Addr
+	LocalAdmin uint16
+}
+
+func (e *MUPIPv4AddressSpecificExtended) Serialize() ([]byte, error) {
+	buf := make([]byte, 8)
+	buf[0] = byte(EC_TYPE_MUP)
+	buf[1] = byte(e.SubType)
+	copy(buf[2:6], e.IPv4.AsSlice())
+	binary.BigEndian.PutUint16(buf[6:8], e.LocalAdmin)
+	return buf, nil
+}
+
+func (e *MUPIPv4AddressSpecificExtended) String() string {
+	return fmt.Sprintf("%s:%d", e.IPv4, e.LocalAdmin)
+}
+
+func (e *MUPIPv4AddressSpecificExtended) MarshalJSON() ([]byte, error) {
+	t, s := e.GetTypes()
+	return json.Marshal(struct {
+		Type      ExtendedCommunityAttrType    `json:"type"`
+		Subtype   ExtendedCommunityAttrSubType `json:"subtype"`
+		SegmentID string                       `json:"segment_id"`
+	}{
+		Type:      t,
+		Subtype:   s,
+		SegmentID: e.String(),
+	})
+}
+
+func (e *MUPIPv4AddressSpecificExtended) GetTypes() (ExtendedCommunityAttrType, ExtendedCommunityAttrSubType) {
+	return EC_TYPE_MUP, e.SubType
+}
+
+func (e *MUPIPv4AddressSpecificExtended) Flat() map[string]string {
+	return map[string]string{}
+}
+
+func NewMUPIPv4AddressSpecificExtended(subType ExtendedCommunityAttrSubType, ip netip.Addr, localAdmin uint16) (*MUPIPv4AddressSpecificExtended, error) {
+	if !ip.Is4() {
+		return nil, fmt.Errorf("invalid IPv4 address: %s", ip)
+	}
+	return &MUPIPv4AddressSpecificExtended{
+		SubType:    subType,
+		IPv4:       ip,
+		LocalAdmin: localAdmin,
+	}, nil
+}
+
+// MUPFourOctetAsSpecificExtended represents 4-Octet AS Specific BGP MUP Extended Community as described in
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.2.3
+type MUPFourOctetAsSpecificExtended struct {
+	SubType    ExtendedCommunityAttrSubType
+	AS         uint32
+	LocalAdmin uint16
+}
+
+func (e *MUPFourOctetAsSpecificExtended) Serialize() ([]byte, error) {
+	buf := make([]byte, 8)
+	buf[0] = byte(EC_TYPE_MUP)
+	buf[1] = byte(e.SubType)
+	binary.BigEndian.PutUint32(buf[2:6], e.AS)
+	binary.BigEndian.PutUint16(buf[6:8], e.LocalAdmin)
+	return buf, nil
+}
+
+func (e *MUPFourOctetAsSpecificExtended) String() string {
+	asUpper := e.AS >> 16
+	asLower := e.AS & 0xffff
+	return fmt.Sprintf("%d.%d:%d", asUpper, asLower, e.LocalAdmin)
+}
+
+func (e *MUPFourOctetAsSpecificExtended) MarshalJSON() ([]byte, error) {
+	t, s := e.GetTypes()
+	return json.Marshal(struct {
+		Type      ExtendedCommunityAttrType    `json:"type"`
+		Subtype   ExtendedCommunityAttrSubType `json:"subtype"`
+		SegmentID string                       `json:"segment_id"`
+	}{
+		Type:      t,
+		Subtype:   s,
+		SegmentID: e.String(),
+	})
+}
+
+func (e *MUPFourOctetAsSpecificExtended) GetTypes() (ExtendedCommunityAttrType, ExtendedCommunityAttrSubType) {
+	return EC_TYPE_MUP, e.SubType
+}
+
+func (e *MUPFourOctetAsSpecificExtended) Flat() map[string]string {
+	return map[string]string{}
+}
+
+func NewMUPFourOctetAsSpecificExtended(subType ExtendedCommunityAttrSubType, as uint32, localAdmin uint16) *MUPFourOctetAsSpecificExtended {
+	return &MUPFourOctetAsSpecificExtended{
+		SubType:    subType,
+		AS:         as,
+		LocalAdmin: localAdmin,
 	}
 }
 
@@ -63,10 +170,22 @@ func parseMUPExtended(data []byte) (ExtendedCommunityInterface, error) {
 		return nil, NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, fmt.Sprintf("ext comm type is not EC_TYPE_MUP: %d", data[0]))
 	}
 	subType := ExtendedCommunityAttrSubType(data[1])
-	if subType == EC_SUBTYPE_MUP_DIRECT_SEG {
+	switch subType {
+	case EC_SUBTYPE_MUP_DIRECT_SEG, EC_SUBTYPE_MUP_INTERWORK_SEG:
 		sid2 := binary.BigEndian.Uint16(data[2:4])
 		sid4 := binary.BigEndian.Uint32(data[4:8])
-		return NewMUPExtended(sid2, sid4), nil
+		return NewMUPExtended(subType, sid2, sid4), nil
+	case EC_SUBTYPE_MUP_DIRECT_SEG_IPV4, EC_SUBTYPE_MUP_INTERWORK_SEG_IPV4:
+		ipv4, ok := netip.AddrFromSlice(data[2:6])
+		if !ok {
+			return nil, NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, fmt.Sprintf("invalid IPv4 address: %x", data[2:6]))
+		}
+		localAdmin := binary.BigEndian.Uint16(data[6:8])
+		return NewMUPIPv4AddressSpecificExtended(subType, ipv4, localAdmin)
+	case EC_SUBTYPE_MUP_DIRECT_SEG_4_OCTET_AS, EC_SUBTYPE_MUP_INTERWORK_SEG_4_OCTET_AS:
+		as := binary.BigEndian.Uint32(data[2:6])
+		localAdmin := binary.BigEndian.Uint16(data[6:8])
+		return NewMUPFourOctetAsSpecificExtended(subType, as, localAdmin), nil
 	}
 	return nil, NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, fmt.Sprintf("unknown mup subtype: %d", subType))
 }

--- a/pkg/packet/bgp/mup.go
+++ b/pkg/packet/bgp/mup.go
@@ -8,7 +8,7 @@ import (
 )
 
 // MUPExtended represents BGP MUP Extended Community as described in
-// https://datatracker.ietf.org/doc/html/draft-mpmz-bess-mup-safi-00#section-3.2
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.2
 type MUPExtended struct {
 	SubType    ExtendedCommunityAttrSubType
 	SegmentID2 uint16
@@ -72,14 +72,14 @@ func parseMUPExtended(data []byte) (ExtendedCommunityInterface, error) {
 }
 
 // BGP MUP SAFI Architecture Type as described in
-// https://datatracker.ietf.org/doc/html/draft-mpmz-bess-mup-safi-00#section-3.1
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.1
 const (
 	MUP_ARCH_TYPE_UNDEFINED = iota
 	MUP_ARCH_TYPE_3GPP_5G
 )
 
 // BGP MUP SAFI Route Type as described in
-// https://datatracker.ietf.org/doc/html/draft-mpmz-bess-mup-safi-00#section-3.1
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.1
 const (
 	_ = iota
 	MUP_ROUTE_TYPE_INTERWORK_SEGMENT_DISCOVERY
@@ -155,6 +155,12 @@ func (n *MUPNLRI) Serialize(options ...*MarshallingOption) ([]byte, error) {
 	tbuf, err := n.RouteTypeData.Serialize()
 	if err != nil {
 		return nil, err
+	}
+	// The Length field is a single octet; NewMUPNLRI truncates larger
+	// route type data (e.g. carrying too many TLVs) and the mismatch
+	// would corrupt the NLRI framing of the whole UPDATE.
+	if len(tbuf) != int(n.Length) {
+		return nil, fmt.Errorf("MUP NLRI length mismatch: %d bytes of route type data with Length %d", len(tbuf), n.Length)
 	}
 	return append(buf, tbuf...), nil
 }
@@ -247,7 +253,7 @@ func EndpointString(nlri NLRI) string {
 }
 
 // MUPInterworkSegmentDiscoveryRoute represents BGP Interwork Segment Discovery route as described in
-// https://datatracker.ietf.org/doc/html/draft-mpmz-bess-mup-safi-00#section-3.1.1
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.1.1
 type MUPInterworkSegmentDiscoveryRoute struct {
 	RD     RouteDistinguisherInterface
 	Prefix netip.Prefix
@@ -332,7 +338,7 @@ func (r *MUPInterworkSegmentDiscoveryRoute) Len() int {
 }
 
 func (r *MUPInterworkSegmentDiscoveryRoute) String() string {
-	// I-D.draft-mpmz-bess-mup-safi-01
+	// I-D.draft-ietf-bess-mup-safi-01
 	// 3.1.1.  BGP Interwork Segment Discovery route
 	// For the purpose of BGP route key processing, only the RD, Prefix Length and Prefix are considered to be part of the prefix in the NLRI.
 	return fmt.Sprintf("[type:isd][rd:%s][prefix:%s]", r.RD, r.Prefix)
@@ -353,7 +359,7 @@ func (r *MUPInterworkSegmentDiscoveryRoute) rd() RouteDistinguisherInterface {
 }
 
 // MUPDirectSegmentDiscoveryRoute represents BGP Direct Segment Discovery route as described in
-// https://datatracker.ietf.org/doc/html/draft-mpmz-bess-mup-safi-00#section-3.1.2
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.1.2
 type MUPDirectSegmentDiscoveryRoute struct {
 	RD      RouteDistinguisherInterface
 	Address netip.Addr
@@ -423,7 +429,7 @@ func (r *MUPDirectSegmentDiscoveryRoute) Len() int {
 }
 
 func (r *MUPDirectSegmentDiscoveryRoute) String() string {
-	// I-D.draft-mpmz-bess-mup-safi-01
+	// I-D.draft-ietf-bess-mup-safi-01
 	// 3.1.2.  BGP Direct Segment Discovery route
 	// For the purpose of BGP route key processing, only the RD and Address are considered to be part of the prefix in the NLRI.
 	return fmt.Sprintf("[type:dsd][rd:%s][prefix:%s]", r.RD, r.Address)
@@ -444,7 +450,7 @@ func (r *MUPDirectSegmentDiscoveryRoute) rd() RouteDistinguisherInterface {
 }
 
 // MUPType1SessionTransformedRoute3GPP5G represents 3GPP 5G specific Type 1 Session Transformed (ST) Route as described in
-// https://datatracker.ietf.org/doc/html/draft-mpmz-bess-mup-safi-03#section-3.1.3
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.1.3
 type MUPType1SessionTransformedRoute struct {
 	RD                    RouteDistinguisherInterface
 	Prefix                netip.Prefix
@@ -454,9 +460,11 @@ type MUPType1SessionTransformedRoute struct {
 	EndpointAddress       netip.Addr
 	SourceAddressLength   uint8
 	SourceAddress         *netip.Addr
+	// TLVs are not part of the route key and are excluded from String().
+	TLVs []MUPTLVInterface
 }
 
-func NewMUPType1SessionTransformedRoute(rd RouteDistinguisherInterface, prefix netip.Prefix, teid netip.Addr, qfi uint8, ea netip.Addr, sa *netip.Addr) *MUPNLRI {
+func NewMUPType1SessionTransformedRoute(rd RouteDistinguisherInterface, prefix netip.Prefix, teid netip.Addr, qfi uint8, ea netip.Addr, sa *netip.Addr, tlvs ...MUPTLVInterface) *MUPNLRI {
 	afi := uint16(AFI_IP)
 	if prefix.Addr().Is6() {
 		afi = uint16(AFI_IP6)
@@ -468,6 +476,7 @@ func NewMUPType1SessionTransformedRoute(rd RouteDistinguisherInterface, prefix n
 		QFI:                   qfi,
 		EndpointAddressLength: uint8(ea.BitLen()),
 		EndpointAddress:       ea,
+		TLVs:                  tlvs,
 	}
 	if sa != nil {
 		r.SourceAddressLength = uint8(sa.BitLen())
@@ -553,7 +562,20 @@ func (r *MUPType1SessionTransformedRoute) DecodeFromBytes(data []byte, afi uint1
 			return malformedAttrListErr(fmt.Sprintf("Invalid Source Address: %x", data[p:p+int(r.SourceAddressLength/8)]))
 		}
 		r.SourceAddress = &sa
+		p += int(r.SourceAddressLength / 8)
+	} else if r.SourceAddressLength != 0 {
+		// Any other length would leave the TLV parser below reading
+		// from a wrong offset.
+		return malformedAttrListErr(fmt.Sprintf("Invalid Source Address length: %d", r.SourceAddressLength))
 	}
+	// draft-ietf-bess-mup-safi-01 Section 3.1.5 defines no TLV applicable to
+	// Type 1 ST routes, but TLVs are still decoded and kept so they are
+	// propagated unchanged when re-advertising the route.
+	tlvs, err := parseMUPTLVs(data[p:])
+	if err != nil {
+		return err
+	}
+	r.TLVs = tlvs
 	return nil
 }
 
@@ -579,7 +601,7 @@ func (r *MUPType1SessionTransformedRoute) Serialize() ([]byte, error) {
 	if r.SourceAddressLength > 0 {
 		buf = append(buf, r.SourceAddress.AsSlice()...)
 	}
-	return buf, nil
+	return serializeMUPTLVs(buf, r.TLVs)
 }
 
 func (r *MUPType1SessionTransformedRoute) AFI() uint16 {
@@ -592,15 +614,16 @@ func (r *MUPType1SessionTransformedRoute) AFI() uint16 {
 func (r *MUPType1SessionTransformedRoute) Len() int {
 	// RD(8) + PrefixLength(1) + Prefix(variable)
 	// + TEID(4) + QFI(1) + EndpointAddressLength(1) + EndpointAddress(4 or 16) + SourceAddressLength(1) + SourceAddress(4 or 16)
+	// + TLVs(variable)
 	l := 16 + (r.Prefix.Bits()+7)/8 + int(r.EndpointAddressLength/8)
 	if r.SourceAddressLength > 0 {
 		l += int(r.SourceAddressLength / 8)
 	}
-	return l
+	return l + mupTLVsLen(r.TLVs)
 }
 
 func (r *MUPType1SessionTransformedRoute) String() string {
-	// I-D.draft-mpmz-bess-mup-safi-01
+	// I-D.draft-ietf-bess-mup-safi-01
 	// 3.1.3.  BGP Type 1 Session Transformed (ST) Route
 	// For the purpose of BGP route key processing, only the RD, Prefix Length and Prefix are considered to be part of the prefix in the NLRI.
 	return fmt.Sprintf("[type:t1st][rd:%s][prefix:%s]", r.RD, r.Prefix)
@@ -614,12 +637,14 @@ func (r *MUPType1SessionTransformedRoute) MarshalJSON() ([]byte, error) {
 		QFI             uint8                       `json:"qfi"`
 		EndpointAddress string                      `json:"endpoint_address"`
 		SourceAddress   string                      `json:"source_address"`
+		TLVs            []MUPTLVInterface           `json:"tlvs,omitempty"`
 	}{
 		RD:              r.RD,
 		Prefix:          r.Prefix.String(),
 		TEID:            r.TEID.String(),
 		QFI:             r.QFI,
 		EndpointAddress: r.EndpointAddress.String(),
+		TLVs:            r.TLVs,
 	}
 	if r.SourceAddress != nil {
 		d.SourceAddress = r.SourceAddress.String()
@@ -632,15 +657,17 @@ func (r *MUPType1SessionTransformedRoute) rd() RouteDistinguisherInterface {
 }
 
 // MUPType2SessionTransformedRoute represents 3GPP 5G specific Type 2 Session Transformed (ST) Route as described in
-// https://datatracker.ietf.org/doc/html/draft-mpmz-bess-mup-safi-00#section-3.1.4
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.1.4
 type MUPType2SessionTransformedRoute struct {
 	RD                    RouteDistinguisherInterface
 	EndpointAddressLength uint8
 	EndpointAddress       netip.Addr
 	TEID                  netip.Addr
+	// TLVs are not part of the route key and are excluded from String().
+	TLVs []MUPTLVInterface
 }
 
-func NewMUPType2SessionTransformedRoute(rd RouteDistinguisherInterface, eaLen uint8, ea netip.Addr, teid netip.Addr) *MUPNLRI {
+func NewMUPType2SessionTransformedRoute(rd RouteDistinguisherInterface, eaLen uint8, ea netip.Addr, teid netip.Addr, tlvs ...MUPTLVInterface) *MUPNLRI {
 	afi := uint16(AFI_IP)
 	if ea.Is6() {
 		afi = AFI_IP6
@@ -650,6 +677,7 @@ func NewMUPType2SessionTransformedRoute(rd RouteDistinguisherInterface, eaLen ui
 		EndpointAddressLength: eaLen,
 		EndpointAddress:       ea,
 		TEID:                  teid,
+		TLVs:                  tlvs,
 	})
 }
 
@@ -707,9 +735,15 @@ func (r *MUPType2SessionTransformedRoute) DecodeFromBytes(data []byte, afi uint1
 			return malformedAttrListErr(fmt.Sprintf("Invalid TEID: %x", data[p:p+l]))
 		}
 		r.TEID = a
+		p += l
 	} else {
 		r.TEID = netip.AddrFrom4([4]byte{0, 0, 0, 0})
 	}
+	tlvs, err := parseMUPTLVs(data[p:])
+	if err != nil {
+		return err
+	}
+	r.TLVs = tlvs
 	return nil
 }
 
@@ -731,7 +765,7 @@ func (r *MUPType2SessionTransformedRoute) Serialize() ([]byte, error) {
 		byteLen := (teidLen + 7) / 8
 		buf = append(buf, r.TEID.AsSlice()[:byteLen]...)
 	}
-	return buf, nil
+	return serializeMUPTLVs(buf, r.TLVs)
 }
 
 func (r *MUPType2SessionTransformedRoute) AFI() uint16 {
@@ -743,13 +777,14 @@ func (r *MUPType2SessionTransformedRoute) AFI() uint16 {
 
 func (r *MUPType2SessionTransformedRoute) Len() int {
 	// RD(8) + EndpointAddressLength(1) + EndpointAddress(4 or 16)
-	// + TEID(4)
+	// + TEID(0-4)
 	// Endpoint Address Length includes TEID Length
-	return 9 + (int(r.EndpointAddressLength)+7)/8
+	// + TLVs(variable)
+	return 9 + (int(r.EndpointAddressLength)+7)/8 + mupTLVsLen(r.TLVs)
 }
 
 func (r *MUPType2SessionTransformedRoute) String() string {
-	// I-D.draft-mpmz-bess-mup-safi-01
+	// I-D.draft-ietf-bess-mup-safi-01
 	// 3.1.4.  BGP Type 2 Session Transformed (ST) Route
 	// For the purpose of BGP route key processing, only the RD, Endpoint Address and Architecture specific Endpoint Identifier are considered to be part of the prefix in the NLRI.
 	return fmt.Sprintf("[type:t2st][rd:%s][endpoint-address-length:%d][endpoint:%s][teid:%s]", r.RD, r.EndpointAddressLength, r.EndpointAddress, r.TEID)
@@ -761,14 +796,321 @@ func (r *MUPType2SessionTransformedRoute) MarshalJSON() ([]byte, error) {
 		EndpointAddressLength uint8                       `json:"endpoint_address_length"`
 		EndpointAddress       string                      `json:"endpoint_address"`
 		TEID                  string                      `json:"teid"`
+		TLVs                  []MUPTLVInterface           `json:"tlvs,omitempty"`
 	}{
 		RD:                    r.RD,
 		EndpointAddressLength: r.EndpointAddressLength,
 		EndpointAddress:       r.EndpointAddress.String(),
 		TEID:                  r.TEID.String(),
+		TLVs:                  r.TLVs,
 	})
 }
 
 func (r *MUPType2SessionTransformedRoute) rd() RouteDistinguisherInterface {
 	return r.RD
+}
+
+// BGP MUP SAFI TLV Types for ST Routes as described in
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.1.5
+const (
+	MUP_TLV_TYPE_3GPP_5G_SESSION_PARAMETERS uint8 = 1
+	MUP_TLV_TYPE_INTERWORK_ENDPOINT         uint8 = 2
+	MUP_TLV_TYPE_SOURCE_ADDRESS             uint8 = 3
+)
+
+type MUPTLVInterface interface {
+	Type() uint8
+	Len() int
+	DecodeFromBytes([]byte) error
+	Serialize() ([]byte, error)
+	String() string
+	MarshalJSON() ([]byte, error)
+}
+
+// MUPSessionParametersTLV represents 3gpp-5g Session Parameters TLV as described in
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.1.5.1
+type MUPSessionParametersTLV struct {
+	TEID netip.Addr
+	QFI  uint8
+}
+
+func NewMUPSessionParametersTLV(teid netip.Addr, qfi uint8) *MUPSessionParametersTLV {
+	return &MUPSessionParametersTLV{
+		TEID: teid,
+		QFI:  qfi,
+	}
+}
+
+func (t *MUPSessionParametersTLV) Type() uint8 {
+	return MUP_TLV_TYPE_3GPP_5G_SESSION_PARAMETERS
+}
+
+func (t *MUPSessionParametersTLV) Len() int {
+	// Type(1) + Length(1) + TEID(4) + QFI(1)
+	return 7
+}
+
+func (t *MUPSessionParametersTLV) DecodeFromBytes(value []byte) error {
+	if len(value) != 5 {
+		return malformedAttrListErr(fmt.Sprintf("invalid 3gpp-5g Session Parameters TLV length: %d", len(value)))
+	}
+	teid, ok := netip.AddrFromSlice(value[:4])
+	if !ok {
+		return malformedAttrListErr(fmt.Sprintf("invalid TEID: %x", value[:4]))
+	}
+	t.TEID = teid
+	t.QFI = value[4]
+	return nil
+}
+
+func (t *MUPSessionParametersTLV) Serialize() ([]byte, error) {
+	if !t.TEID.Is4() {
+		return nil, fmt.Errorf("invalid TEID: %s", t.TEID)
+	}
+	buf := make([]byte, 2, 7)
+	buf[0] = t.Type()
+	buf[1] = 5
+	buf = append(buf, t.TEID.AsSlice()...)
+	buf = append(buf, t.QFI)
+	return buf, nil
+}
+
+func (t *MUPSessionParametersTLV) String() string {
+	return fmt.Sprintf("[teid:%s][qfi:%d]", t.TEID, t.QFI)
+}
+
+func (t *MUPSessionParametersTLV) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type uint8  `json:"type"`
+		TEID string `json:"teid"`
+		QFI  uint8  `json:"qfi"`
+	}{
+		Type: t.Type(),
+		TEID: t.TEID.String(),
+		QFI:  t.QFI,
+	})
+}
+
+// MUPInterworkEndpointTLV represents Interwork Endpoint TLV as described in
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.1.5.2
+type MUPInterworkEndpointTLV struct {
+	Address netip.Addr
+}
+
+func NewMUPInterworkEndpointTLV(address netip.Addr) *MUPInterworkEndpointTLV {
+	return &MUPInterworkEndpointTLV{
+		Address: address,
+	}
+}
+
+func (t *MUPInterworkEndpointTLV) Type() uint8 {
+	return MUP_TLV_TYPE_INTERWORK_ENDPOINT
+}
+
+func (t *MUPInterworkEndpointTLV) Len() int {
+	// Type(1) + Length(1) + Address(4 or 16)
+	return 2 + t.Address.BitLen()/8
+}
+
+func (t *MUPInterworkEndpointTLV) DecodeFromBytes(value []byte) error {
+	if len(value) != 4 && len(value) != 16 {
+		return malformedAttrListErr(fmt.Sprintf("invalid Interwork Endpoint TLV length: %d", len(value)))
+	}
+	address, ok := netip.AddrFromSlice(value)
+	if !ok {
+		return malformedAttrListErr(fmt.Sprintf("invalid Interwork Endpoint TLV address: %x", value))
+	}
+	t.Address = address
+	return nil
+}
+
+func (t *MUPInterworkEndpointTLV) Serialize() ([]byte, error) {
+	if !t.Address.IsValid() {
+		return nil, fmt.Errorf("invalid Interwork Endpoint TLV address: %s", t.Address)
+	}
+	buf := make([]byte, 2, t.Len())
+	buf[0] = t.Type()
+	buf[1] = uint8(t.Address.BitLen() / 8)
+	buf = append(buf, t.Address.AsSlice()...)
+	return buf, nil
+}
+
+func (t *MUPInterworkEndpointTLV) String() string {
+	return fmt.Sprintf("[interwork-endpoint:%s]", t.Address)
+}
+
+func (t *MUPInterworkEndpointTLV) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type    uint8  `json:"type"`
+		Address string `json:"address"`
+	}{
+		Type:    t.Type(),
+		Address: t.Address.String(),
+	})
+}
+
+// MUPSourceAddressTLV represents Source Address TLV as described in
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.1.5.3
+type MUPSourceAddressTLV struct {
+	Address netip.Addr
+}
+
+func NewMUPSourceAddressTLV(address netip.Addr) *MUPSourceAddressTLV {
+	return &MUPSourceAddressTLV{
+		Address: address,
+	}
+}
+
+func (t *MUPSourceAddressTLV) Type() uint8 {
+	return MUP_TLV_TYPE_SOURCE_ADDRESS
+}
+
+func (t *MUPSourceAddressTLV) Len() int {
+	// Type(1) + Length(1) + Address(4 or 16)
+	return 2 + t.Address.BitLen()/8
+}
+
+func (t *MUPSourceAddressTLV) DecodeFromBytes(value []byte) error {
+	if len(value) != 4 && len(value) != 16 {
+		return malformedAttrListErr(fmt.Sprintf("invalid Source Address TLV length: %d", len(value)))
+	}
+	address, ok := netip.AddrFromSlice(value)
+	if !ok {
+		return malformedAttrListErr(fmt.Sprintf("invalid Source Address TLV address: %x", value))
+	}
+	t.Address = address
+	return nil
+}
+
+func (t *MUPSourceAddressTLV) Serialize() ([]byte, error) {
+	if !t.Address.IsValid() {
+		return nil, fmt.Errorf("invalid Source Address TLV address: %s", t.Address)
+	}
+	buf := make([]byte, 2, t.Len())
+	buf[0] = t.Type()
+	buf[1] = uint8(t.Address.BitLen() / 8)
+	buf = append(buf, t.Address.AsSlice()...)
+	return buf, nil
+}
+
+func (t *MUPSourceAddressTLV) String() string {
+	return fmt.Sprintf("[source-address:%s]", t.Address)
+}
+
+func (t *MUPSourceAddressTLV) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type    uint8  `json:"type"`
+		Address string `json:"address"`
+	}{
+		Type:    t.Type(),
+		Address: t.Address.String(),
+	})
+}
+
+// MUPUnknownTLV keeps a TLV of an unknown type as-is so that it is
+// propagated unchanged when re-advertising the route, as required by
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.1.3
+type MUPUnknownTLV struct {
+	TLVType uint8
+	Value   []byte
+}
+
+func NewMUPUnknownTLV(typ uint8, value []byte) *MUPUnknownTLV {
+	return &MUPUnknownTLV{
+		TLVType: typ,
+		Value:   value,
+	}
+}
+
+func (t *MUPUnknownTLV) Type() uint8 {
+	return t.TLVType
+}
+
+func (t *MUPUnknownTLV) Len() int {
+	return 2 + len(t.Value)
+}
+
+func (t *MUPUnknownTLV) DecodeFromBytes(value []byte) error {
+	t.Value = append([]byte(nil), value...)
+	return nil
+}
+
+func (t *MUPUnknownTLV) Serialize() ([]byte, error) {
+	if len(t.Value) > 255 {
+		return nil, fmt.Errorf("invalid MUP TLV value length: %d", len(t.Value))
+	}
+	buf := make([]byte, 2, t.Len())
+	buf[0] = t.TLVType
+	buf[1] = uint8(len(t.Value))
+	buf = append(buf, t.Value...)
+	return buf, nil
+}
+
+func (t *MUPUnknownTLV) String() string {
+	return fmt.Sprintf("[unknown-tlv-type:%d][value:%x]", t.TLVType, t.Value)
+}
+
+func (t *MUPUnknownTLV) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  uint8  `json:"type"`
+		Value []byte `json:"value"`
+	}{
+		Type:  t.TLVType,
+		Value: t.Value,
+	})
+}
+
+// parseMUPTLVs parses the optional TLVs following the mandatory fields of
+// Type 1 and Type 2 Session Transformed routes.
+// https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01#section-3.1.3
+// requires zero remaining octets to mean no TLVs, and a single remaining
+// octet cannot hold a TLV header, making the NLRI malformed.
+func parseMUPTLVs(data []byte) ([]MUPTLVInterface, error) {
+	var tlvs []MUPTLVInterface
+	for len(data) > 0 {
+		if len(data) < 2 {
+			return nil, malformedAttrListErr("invalid MUP TLV: no room for Type and Length")
+		}
+		typ := data[0]
+		l := int(data[1])
+		if len(data) < 2+l {
+			return nil, malformedAttrListErr(fmt.Sprintf("invalid MUP TLV: declared length %d exceeds remaining %d octets", l, len(data)-2))
+		}
+		var tlv MUPTLVInterface
+		switch typ {
+		case MUP_TLV_TYPE_3GPP_5G_SESSION_PARAMETERS:
+			tlv = &MUPSessionParametersTLV{}
+		case MUP_TLV_TYPE_INTERWORK_ENDPOINT:
+			tlv = &MUPInterworkEndpointTLV{}
+		case MUP_TLV_TYPE_SOURCE_ADDRESS:
+			tlv = &MUPSourceAddressTLV{}
+		default:
+			tlv = &MUPUnknownTLV{TLVType: typ}
+		}
+		if err := tlv.DecodeFromBytes(data[2 : 2+l]); err != nil {
+			return nil, err
+		}
+		tlvs = append(tlvs, tlv)
+		data = data[2+l:]
+	}
+	return tlvs, nil
+}
+
+func serializeMUPTLVs(buf []byte, tlvs []MUPTLVInterface) ([]byte, error) {
+	for _, t := range tlvs {
+		b, err := t.Serialize()
+		if err != nil {
+			return nil, err
+		}
+		buf = append(buf, b...)
+	}
+	return buf, nil
+}
+
+func mupTLVsLen(tlvs []MUPTLVInterface) int {
+	l := 0
+	for _, t := range tlvs {
+		l += t.Len()
+	}
+	return l
 }

--- a/pkg/packet/bgp/mup_test.go
+++ b/pkg/packet/bgp/mup_test.go
@@ -289,3 +289,254 @@ func Test_MUPType2SessionTransformedRouteIPv6(t *testing.T) {
 		})
 	}
 }
+
+func Test_MUPType1SessionTransformedRouteTLVs(t *testing.T) {
+	assert := assert.New(t)
+	rd, _ := ParseRouteDistinguisher("100:100")
+	tests := []struct {
+		name string
+		in   *MUPType1SessionTransformedRoute
+	}{
+		{
+			// No TLV is applicable to Type 1 ST routes, but received TLVs
+			// must be kept and propagated unchanged.
+			name: "session parameters",
+			in: &MUPType1SessionTransformedRoute{
+				RD:                    rd,
+				Prefix:                netip.MustParsePrefix("192.100.0.0/24"),
+				TEID:                  netip.MustParseAddr("0.0.0.100"),
+				QFI:                   9,
+				EndpointAddressLength: 32,
+				EndpointAddress:       netip.MustParseAddr("10.10.10.1"),
+				TLVs: []MUPTLVInterface{
+					NewMUPSessionParametersTLV(netip.MustParseAddr("0.0.0.200"), 11),
+				},
+			},
+		},
+		{
+			name: "unknown TLV",
+			in: &MUPType1SessionTransformedRoute{
+				RD:                    rd,
+				Prefix:                netip.MustParsePrefix("192.100.0.0/24"),
+				TEID:                  netip.MustParseAddr("0.0.0.100"),
+				QFI:                   9,
+				EndpointAddressLength: 32,
+				EndpointAddress:       netip.MustParseAddr("10.10.10.1"),
+				TLVs: []MUPTLVInterface{
+					NewMUPUnknownTLV(200, []byte{0xde, 0xad, 0xbe, 0xef}),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n1 := NewMUPNLRI(AFI_IP, MUP_ARCH_TYPE_3GPP_5G, MUP_ROUTE_TYPE_TYPE_1_SESSION_TRANSFORMED, tt.in)
+			buf1, err := n1.Serialize()
+			assert.NoError(err)
+			n2, err := NLRIFromSlice(RF_MUP_IPv4, buf1)
+			assert.NoError(err)
+
+			t.Logf("%s", n1)
+			t.Logf("%s", n2)
+
+			assert.Equal(n1, n2)
+		})
+	}
+}
+
+func Test_MUPType2SessionTransformedRouteTLVs(t *testing.T) {
+	assert := assert.New(t)
+	rd, _ := ParseRouteDistinguisher("100:100")
+	tests := []struct {
+		name string
+		in   *MUPType2SessionTransformedRoute
+		afi  uint16
+		rf   Family
+	}{
+		{
+			name: "session parameters",
+			in: &MUPType2SessionTransformedRoute{
+				RD:                    rd,
+				EndpointAddressLength: 64,
+				EndpointAddress:       netip.MustParseAddr("10.10.10.1"),
+				TEID:                  netip.MustParseAddr("0.0.0.100"),
+				TLVs: []MUPTLVInterface{
+					NewMUPSessionParametersTLV(netip.MustParseAddr("0.0.0.200"), 9),
+				},
+			},
+			afi: AFI_IP,
+			rf:  RF_MUP_IPv4,
+		},
+		{
+			name: "interwork endpoint IPv4",
+			in: &MUPType2SessionTransformedRoute{
+				RD:                    rd,
+				EndpointAddressLength: 64,
+				EndpointAddress:       netip.MustParseAddr("10.10.10.1"),
+				TEID:                  netip.MustParseAddr("0.0.0.100"),
+				TLVs: []MUPTLVInterface{
+					NewMUPInterworkEndpointTLV(netip.MustParseAddr("10.20.30.40")),
+				},
+			},
+			afi: AFI_IP,
+			rf:  RF_MUP_IPv4,
+		},
+		{
+			name: "interwork endpoint IPv6",
+			in: &MUPType2SessionTransformedRoute{
+				RD:                    rd,
+				EndpointAddressLength: 160,
+				EndpointAddress:       netip.MustParseAddr("2001::1"),
+				TEID:                  netip.MustParseAddr("0.0.0.100"),
+				TLVs: []MUPTLVInterface{
+					NewMUPInterworkEndpointTLV(netip.MustParseAddr("2001::100")),
+				},
+			},
+			afi: AFI_IP6,
+			rf:  RF_MUP_IPv6,
+		},
+		{
+			name: "source address",
+			in: &MUPType2SessionTransformedRoute{
+				RD:                    rd,
+				EndpointAddressLength: 64,
+				EndpointAddress:       netip.MustParseAddr("10.10.10.1"),
+				TEID:                  netip.MustParseAddr("0.0.0.100"),
+				TLVs: []MUPTLVInterface{
+					NewMUPSourceAddressTLV(netip.MustParseAddr("10.0.0.1")),
+				},
+			},
+			afi: AFI_IP,
+			rf:  RF_MUP_IPv4,
+		},
+		{
+			name: "multiple TLVs",
+			in: &MUPType2SessionTransformedRoute{
+				RD:                    rd,
+				EndpointAddressLength: 64,
+				EndpointAddress:       netip.MustParseAddr("10.10.10.1"),
+				TEID:                  netip.MustParseAddr("0.0.0.100"),
+				TLVs: []MUPTLVInterface{
+					NewMUPSessionParametersTLV(netip.MustParseAddr("0.0.0.200"), 9),
+					NewMUPInterworkEndpointTLV(netip.MustParseAddr("10.20.30.40")),
+					NewMUPSourceAddressTLV(netip.MustParseAddr("2001::100")),
+					NewMUPUnknownTLV(200, []byte{0xde, 0xad, 0xbe, 0xef}),
+				},
+			},
+			afi: AFI_IP,
+			rf:  RF_MUP_IPv4,
+		},
+		{
+			name: "TLV after zero length TEID",
+			in: &MUPType2SessionTransformedRoute{
+				RD:                    rd,
+				EndpointAddressLength: 32,
+				EndpointAddress:       netip.MustParseAddr("10.10.10.1"),
+				TEID:                  netip.MustParseAddr("0.0.0.0"),
+				TLVs: []MUPTLVInterface{
+					NewMUPSessionParametersTLV(netip.MustParseAddr("0.0.0.200"), 9),
+				},
+			},
+			afi: AFI_IP,
+			rf:  RF_MUP_IPv4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n1 := NewMUPNLRI(tt.afi, MUP_ARCH_TYPE_3GPP_5G, MUP_ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED, tt.in)
+			buf1, err := n1.Serialize()
+			assert.NoError(err)
+			n2, err := NLRIFromSlice(tt.rf, buf1)
+			assert.NoError(err)
+
+			t.Logf("%s", n1)
+			t.Logf("%s", n2)
+
+			assert.Equal(n1, n2)
+		})
+	}
+}
+
+func Test_MUPTLVsNotPartOfRouteKey(t *testing.T) {
+	assert := assert.New(t)
+	rd, _ := ParseRouteDistinguisher("100:100")
+	ea := netip.MustParseAddr("10.10.10.1")
+	teid := netip.MustParseAddr("0.0.0.100")
+	without := NewMUPType2SessionTransformedRoute(rd, 64, ea, teid)
+	with := NewMUPType2SessionTransformedRoute(rd, 64, ea, teid,
+		NewMUPSessionParametersTLV(netip.MustParseAddr("0.0.0.200"), 9),
+		NewMUPInterworkEndpointTLV(netip.MustParseAddr("10.20.30.40")),
+	)
+	assert.Equal(without.String(), with.String())
+
+	prefix := netip.MustParsePrefix("192.100.0.0/24")
+	t1without := NewMUPType1SessionTransformedRoute(rd, prefix, teid, 9, ea, nil)
+	t1with := NewMUPType1SessionTransformedRoute(rd, prefix, teid, 9, ea, nil,
+		NewMUPUnknownTLV(200, []byte{0xde, 0xad}))
+	assert.Equal(t1without.String(), t1with.String())
+}
+
+func Test_MUPTLVsMalformed(t *testing.T) {
+	assert := assert.New(t)
+	rd, _ := ParseRouteDistinguisher("100:100")
+	base := NewMUPType2SessionTransformedRoute(rd, 64, netip.MustParseAddr("10.10.10.1"), netip.MustParseAddr("0.0.0.100"))
+	tests := []struct {
+		name string
+		tail []byte // appended after the mandatory fields, added to the NLRI Length
+	}{
+		{
+			// a single remaining octet cannot hold a TLV header
+			name: "remaining 1 octet",
+			tail: []byte{0x01},
+		},
+		{
+			name: "declared length exceeds remaining octets",
+			tail: []byte{0x01, 0x05, 0x00},
+		},
+		{
+			name: "session parameters TLV with invalid length",
+			tail: []byte{0x01, 0x04, 0x00, 0x00, 0x00, 0x64},
+		},
+		{
+			name: "interwork endpoint TLV with invalid length",
+			tail: []byte{0x02, 0x05, 0x0a, 0x14, 0x1e, 0x28, 0x00},
+		},
+		{
+			name: "source address TLV with invalid length",
+			tail: []byte{0x03, 0x05, 0x0a, 0x14, 0x1e, 0x28, 0x00},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf, err := base.Serialize()
+			assert.NoError(err)
+			buf = append(buf, tt.tail...)
+			buf[3] += uint8(len(tt.tail))
+			_, err = NLRIFromSlice(RF_MUP_IPv4, buf)
+			assert.Error(err)
+		})
+	}
+
+	t.Run("NLRI length shorter than mandatory fields", func(t *testing.T) {
+		buf, err := base.Serialize()
+		assert.NoError(err)
+		buf[3] -= 1
+		_, err = NLRIFromSlice(RF_MUP_IPv4, buf)
+		assert.Error(err)
+	})
+}
+
+func Test_MUPNLRILengthOverflow(t *testing.T) {
+	assert := assert.New(t)
+	rd, _ := ParseRouteDistinguisher("100:100")
+	tlvs := make([]MUPTLVInterface, 3)
+	for i := range tlvs {
+		tlvs[i] = NewMUPUnknownTLV(200, make([]byte, 100))
+	}
+	n := NewMUPType2SessionTransformedRoute(rd, 64, netip.MustParseAddr("10.10.10.1"), netip.MustParseAddr("0.0.0.100"), tlvs...)
+	_, err := n.Serialize()
+	assert.ErrorContains(err, "length mismatch")
+}

--- a/pkg/packet/bgp/mup_test.go
+++ b/pkg/packet/bgp/mup_test.go
@@ -9,21 +9,64 @@ import (
 )
 
 func Test_MUPExtended(t *testing.T) {
-	assert := assert.New(t)
-	exts := make([]ExtendedCommunityInterface, 0)
-	exts = append(exts, NewMUPExtended(100, 10000))
-	m1 := NewPathAttributeExtendedCommunities(exts)
-	buf1, err := m1.Serialize()
-	require.NoError(t, err)
+	mustMUPIPv4AddressSpecificExtended := func(subType ExtendedCommunityAttrSubType, ip netip.Addr, localAdmin uint16) *MUPIPv4AddressSpecificExtended {
+		e, err := NewMUPIPv4AddressSpecificExtended(subType, ip, localAdmin)
+		require.NoError(t, err)
+		return e
+	}
+	tests := []struct {
+		name string
+		in   ExtendedCommunityInterface
+	}{
+		{
+			name: "direct segment 2-octet AS",
+			in:   NewMUPExtended(EC_SUBTYPE_MUP_DIRECT_SEG, 100, 10000),
+		},
+		{
+			name: "direct segment IPv4",
+			in:   mustMUPIPv4AddressSpecificExtended(EC_SUBTYPE_MUP_DIRECT_SEG_IPV4, netip.MustParseAddr("10.0.0.1"), 100),
+		},
+		{
+			name: "direct segment 4-octet AS",
+			in:   NewMUPFourOctetAsSpecificExtended(EC_SUBTYPE_MUP_DIRECT_SEG_4_OCTET_AS, 65550, 100),
+		},
+		{
+			name: "interwork segment 2-octet AS",
+			in:   NewMUPExtended(EC_SUBTYPE_MUP_INTERWORK_SEG, 100, 10000),
+		},
+		{
+			name: "interwork segment IPv4",
+			in:   mustMUPIPv4AddressSpecificExtended(EC_SUBTYPE_MUP_INTERWORK_SEG_IPV4, netip.MustParseAddr("10.0.0.1"), 100),
+		},
+		{
+			name: "interwork segment 4-octet AS",
+			in:   NewMUPFourOctetAsSpecificExtended(EC_SUBTYPE_MUP_INTERWORK_SEG_4_OCTET_AS, 65550, 100),
+		},
+	}
 
-	m2 := NewPathAttributeExtendedCommunities(nil)
-	err = m2.DecodeFromBytes(buf1)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			m1 := NewPathAttributeExtendedCommunities([]ExtendedCommunityInterface{tt.in})
+			buf1, err := m1.Serialize()
+			require.NoError(t, err)
 
-	_, err = m2.Serialize()
-	require.NoError(t, err)
+			m2 := NewPathAttributeExtendedCommunities(nil)
+			err = m2.DecodeFromBytes(buf1)
+			require.NoError(t, err)
 
-	assert.Equal(m1, m2)
+			_, err = m2.Serialize()
+			require.NoError(t, err)
+
+			assert.Equal(m1, m2)
+		})
+	}
+}
+
+func Test_MUPExtendedUnknownSubType(t *testing.T) {
+	buf := []byte{byte(EC_TYPE_MUP), 0x06, 0, 100, 0, 0, 0x27, 0x10}
+	_, err := parseMUPExtended(buf)
+	assert.Error(t, err)
 }
 
 func Test_MUPInterworkSegmentDiscoveryRouteIPv4(t *testing.T) {

--- a/proto/api/extcom.proto
+++ b/proto/api/extcom.proto
@@ -98,10 +98,29 @@ message TrafficRemarkExtended {
   uint32 dscp = 1;
 }
 
-message MUPExtended {
+// BGP MUP Extended Communities as described in
+// draft-ietf-bess-mup-safi-01 Section 3.2. The sub_type distinguishes
+// both the value format and the semantics: 0x00, 0x01 and 0x02
+// identify a Direct Segment and 0x03, 0x04 and 0x05 an Interwork
+// Segment, in the 2-octet AS, IPv4 address and 4-octet AS formats
+// respectively.
+
+message MUPTwoOctetAsSpecificExtended {
   uint32 sub_type = 1;
-  uint32 segment_id2 = 2;
-  uint32 segment_id4 = 3;
+  uint32 asn = 2;
+  uint32 local_admin = 3;
+}
+
+message MUPIPv4AddressSpecificExtended {
+  uint32 sub_type = 1;
+  string address = 2;
+  uint32 local_admin = 3;
+}
+
+message MUPFourOctetAsSpecificExtended {
+  uint32 sub_type = 1;
+  uint32 asn = 2;
+  uint32 local_admin = 3;
 }
 
 message VPLSExtended {
@@ -125,6 +144,11 @@ message UnknownExtended {
 }
 
 message ExtendedCommunity {
+  // Field 21 was the MUPExtended message, superseded by
+  // MUPTwoOctetAsSpecificExtended.
+  reserved 21;
+  reserved "mup";
+
   oneof extcom {
     UnknownExtended unknown = 1;
     TwoOctetAsSpecificExtended two_octet_as_specific = 2;
@@ -146,10 +170,12 @@ message ExtendedCommunity {
     RedirectIPv4AddressSpecificExtended redirect_ipv4_address_specific = 18;
     RedirectFourOctetAsSpecificExtended redirect_four_octet_as_specific = 19;
     TrafficRemarkExtended traffic_remark = 20;
-    MUPExtended mup = 21;
     VPLSExtended vpls = 22;
     ETreeExtended etree = 23;
     MulticastFlagsExtended multicast_flags = 24;
+    MUPTwoOctetAsSpecificExtended mup_two_octet_as_specific = 25;
+    MUPIPv4AddressSpecificExtended mup_ipv4_address_specific = 26;
+    MUPFourOctetAsSpecificExtended mup_four_octet_as_specific = 27;
   }
 }
 

--- a/proto/api/nlri.proto
+++ b/proto/api/nlri.proto
@@ -341,6 +341,36 @@ message MUPDirectSegmentDiscoveryRoute {
   string address = 2;
 }
 
+// Optional TLVs for MUP Session Transformed routes as described in
+// draft-ietf-bess-mup-safi-01 Section 3.1.5.
+
+message MUPSessionParametersTLV {
+  uint32 teid = 1;
+  uint32 qfi = 2;
+}
+
+message MUPInterworkEndpointTLV {
+  string address = 1;
+}
+
+message MUPSourceAddressTLV {
+  string address = 1;
+}
+
+message MUPUnknownTLV {
+  uint32 type = 1;
+  bytes value = 2;
+}
+
+message MUPTLV {
+  oneof tlv {
+    MUPSessionParametersTLV session_parameters = 1;
+    MUPInterworkEndpointTLV interwork_endpoint = 2;
+    MUPSourceAddressTLV source_address = 3;
+    MUPUnknownTLV unknown = 4;
+  }
+}
+
 message MUPType1SessionTransformedRoute {
   RouteDistinguisher rd = 1;
   uint32 prefix_length = 2 [deprecated = true];
@@ -351,6 +381,7 @@ message MUPType1SessionTransformedRoute {
   string endpoint_address = 7;
   uint32 source_address_length = 8;
   string source_address = 9;
+  repeated MUPTLV tlvs = 10;
 }
 
 message MUPType2SessionTransformedRoute {
@@ -358,4 +389,5 @@ message MUPType2SessionTransformedRoute {
   uint32 endpoint_address_length = 2;
   string endpoint_address = 3;
   uint32 teid = 4;
+  repeated MUPTLV tlvs = 5;
 }

--- a/test/scenario_test/mup_test.py
+++ b/test/scenario_test/mup_test.py
@@ -79,6 +79,8 @@ class GoBGPTestBase(unittest.TestCase):
                 ('mup_t2st_route_ipv4', 'ipv4-mup', 't2st 10.0.0.1 rd 100:100 rt 10:10 endpoint-address-length 64 teid 12345 mup 10:10 nexthop 10.0.0.2', '10.0.0.2'),
                 ('mup_t2st_route_ipv4_hex_teid', 'ipv4-mup', 't2st 10.0.0.1 rd 100:100 rt 10:10 endpoint-address-length 48 teid 0xbeef mup 10:10 nexthop 10.0.0.2', '10.0.0.2'),
                 ('mup_t2st_route_ipv4_ip_teid', 'ipv4-mup', 't2st 10.0.0.1 rd 100:100 rt 10:10 endpoint-address-length 64 teid 0.0.0.100 mup 10:10 nexthop 10.0.0.2', '10.0.0.2'),
+                ('mup_t2st_route_ipv4_with_tlvs', 'ipv4-mup', 't2st 10.0.0.1 rd 100:100 rt 10:10 endpoint-address-length 64 teid 12345 mup 10:10 session-teid 100 session-qfi 5 interwork-endpoint 10.0.1.1 source-address 10.0.2.1 nexthop 10.0.0.2', '10.0.0.2'),
+                ('mup_t2st_route_ipv4_with_interwork_extcomm', 'ipv4-mup', 't2st 10.0.0.1 rd 100:100 rt 10:10 endpoint-address-length 64 teid 12345 mup interwork 10.0.0.1:100 nexthop 10.0.0.2', '10.0.0.2'),
                 ('mup_isd_route_ipv6', 'ipv6-mup', 'isd 2001::/64 rd 100:100 prefix 2001:db8:1:1::/64 locator-node-length 24 function-length 16 behavior ENDM_GTP6E rt 10:10 nexthop 2001::2', '2001::2'),
                 ('mup_dsd_route_ipv6', 'ipv6-mup', 'dsd 2001::1 rd 100:100 prefix 2001:db8:2:2::/64 locator-node-length 24 function-length 16 behavior END_DT6 rt 10:10 mup 10:10 nexthop 2001::2', '2001::2'),
                 ('mup_t1st_route_ipv6', 'ipv6-mup', 't1st 2001:db8:1:1::1/128 rd 100:100 rt 10:10 teid 12345 qfi 9 endpoint 2001::1 nexthop 10.0.0.2', '10.0.0.2'),
@@ -88,6 +90,8 @@ class GoBGPTestBase(unittest.TestCase):
                 ('mup_t2st_route_ipv6', 'ipv6-mup', 't2st 2001::1 rd 100:100 rt 10:10 endpoint-address-length 160 teid 12345 mup 10:10 nexthop 10.0.0.2', '10.0.0.2'),
                 ('mup_t2st_route_ipv6_hex_teid', 'ipv6-mup', 't2st 2001::1 rd 100:100 rt 10:10 endpoint-address-length 144 teid 0xbeef mup 10:10 nexthop 10.0.0.2', '10.0.0.2'),
                 ('mup_t2st_route_ipv6_ip_teid', 'ipv6-mup', 't2st 2001::1 rd 100:100 rt 10:10 endpoint-address-length 160 teid 0.0.0.100 mup 10:10 nexthop 10.0.0.2', '10.0.0.2'),
+                ('mup_t2st_route_ipv6_with_tlvs', 'ipv6-mup', 't2st 2001::1 rd 100:100 rt 10:10 endpoint-address-length 160 teid 12345 mup 10:10 session-teid 100 session-qfi 5 interwork-endpoint 2001::2 source-address 2001::3 nexthop 10.0.0.2', '10.0.0.2'),
+                ('mup_t2st_route_ipv6_with_interwork_extcomm', 'ipv6-mup', 't2st 2001::1 rd 100:100 rt 10:10 endpoint-address-length 160 teid 12345 mup interwork 10.0.0.1:100 nexthop 10.0.0.2', '10.0.0.2'),
                 ]
         for msg, rf, route, nh in tests:
             with self.subTest(msg):

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -173,14 +173,14 @@ module gobgp {
     base bgp-types:afi-safi-type;
     description
       "MUP IPv4 (AFI,SAFI = 1,85)";
-    reference "https://www.ietf.org/archive/id/draft-mpmz-bess-mup-safi-01.html";
+    reference "https://www.ietf.org/archive/id/draft-ietf-bess-mup-safi-01.html";
   }
 
   identity IPV6-MUP {
     base bgp-types:afi-safi-type;
     description
       "MUP IPv6 (AFI,SAFI = 2,85)";
-    reference "https://www.ietf.org/archive/id/draft-mpmz-bess-mup-safi-01.html";
+    reference "https://www.ietf.org/archive/id/draft-ietf-bess-mup-safi-01.html";
   }
 
   grouping gobgp-message-counter {

--- a/tools/spell-check/dictionary.txt
+++ b/tools/spell-check/dictionary.txt
@@ -21,6 +21,7 @@ gobgpd
 grpc
 gzip
 ibgp
+interwork
 ipproto
 isis
 keepalive


### PR DESCRIPTION
This PR updates the BGP MUP SAFI implementation from draft-mpmz-bess-mup-safi to [draft-ietf-bess-mup-safi-01](https://datatracker.ietf.org/doc/html/draft-ietf-bess-mup-safi-01).

- packet/bgp: add the optional TLVs of the Type 1/2 Session Transformed routes — 3gpp-5g Session Parameters (TEID + QFI), Interwork Endpoint and Source Address — with pass-through of unknown TLV types (Section 3.1.5). Type 1 ST routes with an invalid Source Address Length are now rejected.
- packet/bgp: restructure the BGP MUP Extended Community per Section 3.2 — Sub-Types 0x00-0x02 for Direct Segment and 0x03-0x05 for Interwork Segment, in the 2-octet AS, IPv4 address and 4-octet AS formats.
- api: expose the new TLVs and the per-format extended community messages over gRPC. The deprecated `MUPExtended` message is no longer accepted on unmarshal.
- cmd/gobgp: extend the extended community argument to `mup [direct|interwork] <global administrator>:<local administrator>` (defaults to `direct`; the existing syntax keeps working) and add the `t2st` arguments `session-teid`, `session-qfi`, `interwork-endpoint` and `source-address`.
- docs: update `docs/sources/srv6_mup.md`.
