### PR TITLE
table, server: fix update suppression for paths differing only in nexthop or NLRI payload

### DIFF
--- a/internal/pkg/table/destination_test.go
+++ b/internal/pkg/table/destination_test.go
@@ -916,3 +916,43 @@ func TestUpdateGetMultiBestPathDiff(t *testing.T) {
 	assert.Equal(t, oldA.GetNexthop(), withdraw[0].GetNexthop())
 	assert.True(t, withdraw[0].IsWithdraw)
 }
+
+// TestGetChanges_NonKeyNlriOrNexthopOnlyChange reproduces update suppression
+// for a locally re-added path whose route key is unchanged but whose NLRI
+// payload (MUP TEID) or MP_REACH nexthop is: such a change must be
+// re-advertised, even though the attributes hash (which excludes
+// MP_REACH_NLRI) stays the same.
+func TestGetChanges_NonKeyNlriOrNexthopOnlyChange(t *testing.T) {
+	newPath := func(teid, nexthop netip.Addr) *Path {
+		p := mupT1stPath(t, teid, nexthop)
+		p.SetHash(attrsHashLikeEagerSites(p))
+		return p
+	}
+
+	p1 := newPath(netip.MustParseAddr("0.0.0.100"), netip.MustParseAddr("10.0.0.1"))
+	d := &destination{nlri: p1.GetNlri(), localIdMap: NewBitmap(64)}
+	d.localIdMap.Flag(0)
+
+	u1, _ := d.Calculate(logger, p1)
+	best1, _, _ := u1.GetChanges(GLOBAL_RIB_NAME, 0, false)
+	assert.NotNil(t, best1, "initial add should be advertised")
+
+	// same route key and nexthop, TEID changed
+	p2 := newPath(netip.MustParseAddr("0.0.0.200"), netip.MustParseAddr("10.0.0.1"))
+	assert.Equal(t, p1.GetHash(), p2.GetHash())
+	u2, _ := d.Calculate(logger, p2)
+	best2, _, _ := u2.GetChanges(GLOBAL_RIB_NAME, 0, false)
+	assert.NotNil(t, best2, "TEID-only change should be advertised")
+
+	// same route key and TEID, nexthop changed
+	p3 := newPath(netip.MustParseAddr("0.0.0.200"), netip.MustParseAddr("10.0.0.2"))
+	u3, _ := d.Calculate(logger, p3)
+	best3, _, _ := u3.GetChanges(GLOBAL_RIB_NAME, 0, false)
+	assert.NotNil(t, best3, "nexthop-only change should be advertised")
+
+	// unchanged re-add stays suppressed
+	p4 := newPath(netip.MustParseAddr("0.0.0.200"), netip.MustParseAddr("10.0.0.2"))
+	u4, _ := d.Calculate(logger, p4)
+	best4, _, _ := u4.GetChanges(GLOBAL_RIB_NAME, 0, false)
+	assert.Nil(t, best4, "identical re-add should stay suppressed")
+}

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -474,6 +474,14 @@ func (path *Path) GetNexthop() netip.Addr {
 	return netip.Addr{}
 }
 
+func (path *Path) mpReachNexthops() (netip.Addr, netip.Addr) {
+	if attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_MP_REACH_NLRI); attr != nil {
+		mp := attr.(*bgp.PathAttributeMpReachNLRI)
+		return mp.Nexthop, mp.LinkLocalNexthop
+	}
+	return netip.Addr{}, netip.Addr{}
+}
+
 func (path *Path) SetNexthop(nexthop netip.Addr) {
 	if path.GetFamily() == bgp.RF_IPv4_UC && nexthop.Is6() {
 		path.delPathAttr(bgp.BGP_ATTR_TYPE_NEXT_HOP)
@@ -1049,6 +1057,9 @@ func (lhs *Path) Equal(rhs *Path) bool {
 	if rhs == nil {
 		return false
 	}
+	if lhs == rhs {
+		return true
+	}
 
 	lhsPathAttrs := lhs.GetPathAttrs()
 	rhsPathAttrs := rhs.GetPathAttrs()
@@ -1069,27 +1080,48 @@ func (lhs *Path) Equal(rhs *Path) bool {
 	lhsHash := lhs.attrsHash.Load()
 	rhsHash := rhs.attrsHash.Load()
 	if lhsHash > 0 && rhsHash > 0 { // avoid unnecessary hash calculation
-		return lhsHash == rhsHash
-	}
-	// slow path comparison, could happen as attributes flags is not part of the hash
-	for t, a := range lhsPathAttrs {
-		b := rhsPathAttrs[t]
-		if a.GetType() != b.GetType() {
+		if lhsHash != rhsHash {
 			return false
 		}
-		if a.Len() != b.Len() {
+	} else {
+		// slow path comparison, could happen as attributes flags is not part of the hash
+		for t, a := range lhsPathAttrs {
+			b := rhsPathAttrs[t]
+			if a.GetType() != b.GetType() {
+				return false
+			}
+			if a.Len() != b.Len() {
+				return false
+			}
+			if a.GetFlags() != b.GetFlags() {
+				return false
+			}
+		}
+		// really slow path comparison, if hash not been calculated yet
+		if lhs.GetHash() != rhs.GetHash() {
 			return false
 		}
-		if a.GetFlags() != b.GetFlags() {
-			return false
-		}
-	}
-	// really slow path comparison, if hash not been calculated yet
-	if lhs.GetHash() != rhs.GetHash() {
-		return false
 	}
 
-	return true
+	// The attributes hash deliberately excludes MP_REACH_NLRI so it can double
+	// as the UPDATE batching key (see CreateUpdateMsgFromPaths), so its content
+	// — the nexthops and the NLRI — must be compared explicitly here; every
+	// other attribute, including NEXT_HOP, is covered by the hash. The NLRI
+	// comparison uses serialized bytes because it must cover fields outside
+	// the route key (e.g. the TEID of a MUP type-1 session transformed route),
+	// which nlri.String() does not include.
+	lhsNexthop, lhsLinkLocal := lhs.mpReachNexthops()
+	rhsNexthop, rhsLinkLocal := rhs.mpReachNexthops()
+	if lhsNexthop != rhsNexthop || lhsLinkLocal != rhsLinkLocal {
+		return false
+	}
+	lhsNlri, rhsNlri := lhs.GetNlri(), rhs.GetNlri()
+	if lhsNlri == nil || rhsNlri == nil {
+		return lhsNlri == nil && rhsNlri == nil
+	}
+	lhsNlriBytes, _ := lhsNlri.Serialize()
+	rhsNlriBytes, _ := rhsNlri.Serialize()
+	return bytes.Equal(lhsNlriBytes, rhsNlriBytes)
 }
 
 func (path *Path) MarshalJSON() ([]byte, error) {

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -29,9 +29,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dgryski/go-farm"
+
 	"github.com/osrg/gobgp/v4/pkg/config/oc"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
-	"github.com/segmentio/fasthash/fnv1a"
 )
 
 const (
@@ -1361,13 +1362,21 @@ func (p *Path) ToLocal() *Path {
 	return path
 }
 
+// updateHash must stay in sync with the shared per-UPDATE hash in
+// ProcessMessage (table_manager.go) so that lazily and eagerly hashed
+// paths compare equal. MP_REACH_NLRI is excluded so the hash can double
+// as the UPDATE batching key (see CreateUpdateMsgFromPaths); Equal
+// compares the nexthop and the NLRI explicitly instead.
 func (p *Path) updateHash() {
-	hash := fnv1a.Init64
+	total := bytes.NewBuffer(make([]byte, 0))
 	for _, a := range p.GetPathAttrs() {
+		if a.GetType() == bgp.BGP_ATTR_TYPE_MP_REACH_NLRI {
+			continue
+		}
 		d, _ := a.Serialize()
-		hash = fnv1a.AddBytes64(hash, d)
+		total.Write(d)
 	}
-	p.attrsHash.Store(hash)
+	p.attrsHash.Store(farm.Hash64(total.Bytes()))
 }
 
 func (p *Path) SetHash(v uint64) {

--- a/internal/pkg/table/path_test.go
+++ b/internal/pkg/table/path_test.go
@@ -2,10 +2,13 @@
 package table
 
 import (
+	"bytes"
 	"net"
 	"net/netip"
 	"testing"
 	"time"
+
+	"github.com/dgryski/go-farm"
 
 	"github.com/osrg/gobgp/v4/pkg/config/oc"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
@@ -521,4 +524,136 @@ func TestUnknownPathAttributes(t *testing.T) {
 		}
 	}
 	assert.True(t, found255, "Unknown attribute of type 255 should be present in the path attributes list")
+}
+
+// attrsHashLikeEagerSites mirrors the eager hash computation used for
+// paths originating from ProcessMessage: farm.Hash64 over the serialized
+// path attributes excluding MP_REACH_NLRI.
+func attrsHashLikeEagerSites(p *Path) uint64 {
+	total := bytes.NewBuffer(make([]byte, 0))
+	for _, a := range p.GetPathAttrs() {
+		if a.GetType() == bgp.BGP_ATTR_TYPE_MP_REACH_NLRI {
+			continue
+		}
+		b, _ := a.Serialize()
+		total.Write(b)
+	}
+	return farm.Hash64(total.Bytes())
+}
+
+func mupT1stPath(t *testing.T, teid netip.Addr, nexthop netip.Addr) *Path {
+	t.Helper()
+	rd := bgp.NewRouteDistinguisherTwoOctetAS(65000, 100)
+	nlri := bgp.NewMUPType1SessionTransformedRoute(rd, netip.MustParsePrefix("10.10.10.1/32"), teid, 9, netip.MustParseAddr("10.10.10.1"), nil)
+	mpreach, err := bgp.NewPathAttributeMpReachNLRI(bgp.RF_MUP_IPv4, []bgp.PathNLRI{{NLRI: nlri}}, nexthop)
+	assert.NoError(t, err)
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_INCOMPLETE),
+		mpreach,
+	}
+	return NewPath(bgp.RF_MUP_IPv4, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
+}
+
+func ipv4Path(t *testing.T, nexthop netip.Addr) *Path {
+	t.Helper()
+	nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.20.30.0/24"))
+	nh, err := bgp.NewPathAttributeNextHop(nexthop)
+	assert.NoError(t, err)
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_INCOMPLETE),
+		nh,
+	}
+	return NewPath(bgp.RF_IPv4_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
+}
+
+func TestPathEqual(t *testing.T) {
+	teid1 := netip.MustParseAddr("0.0.0.100")
+	teid2 := netip.MustParseAddr("0.0.0.200")
+	nh1 := netip.MustParseAddr("10.0.0.1")
+	nh2 := netip.MustParseAddr("10.0.0.2")
+
+	t.Run("same pointer", func(t *testing.T) {
+		p := ipv4Path(t, nh1)
+		assert.True(t, p.Equal(p))
+	})
+
+	t.Run("clone", func(t *testing.T) {
+		p := ipv4Path(t, nh1)
+		assert.True(t, p.Equal(p.Clone(false)))
+	})
+
+	t.Run("identical, independently built", func(t *testing.T) {
+		assert.True(t, ipv4Path(t, nh1).Equal(ipv4Path(t, nh1)))
+		assert.True(t, mupT1stPath(t, teid1, nh1).Equal(mupT1stPath(t, teid1, nh1)))
+	})
+
+	t.Run("NEXT_HOP attribute differs", func(t *testing.T) {
+		assert.False(t, ipv4Path(t, nh1).Equal(ipv4Path(t, nh2)))
+	})
+
+	t.Run("MP_REACH nexthop differs", func(t *testing.T) {
+		lhs := mupT1stPath(t, teid1, nh1)
+		rhs := mupT1stPath(t, teid1, nh2)
+		// eager hashes collide because MP_REACH_NLRI is excluded from them
+		lhs.SetHash(attrsHashLikeEagerSites(lhs))
+		rhs.SetHash(attrsHashLikeEagerSites(rhs))
+		assert.Equal(t, lhs.GetHash(), rhs.GetHash())
+		assert.False(t, lhs.Equal(rhs))
+	})
+
+	t.Run("MP_REACH nexthop differs with NEXT_HOP present", func(t *testing.T) {
+		// an UPDATE carrying both IPv4 NLRI and MP_REACH_NLRI is valid; the MP
+		// paths built from it then hold a NEXT_HOP attribute alongside MP_REACH
+		newMixedPath := func(mpNexthop string) *Path {
+			nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:db8:10::/64"))
+			panh, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr("10.0.0.1"))
+			mpreach, err := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri}},
+				netip.MustParseAddr(mpNexthop))
+			assert.NoError(t, err)
+			attrs := []bgp.PathAttributeInterface{
+				bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_INCOMPLETE),
+				panh,
+				mpreach,
+			}
+			p := NewPath(bgp.RF_IPv6_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
+			p.SetHash(attrsHashLikeEagerSites(p))
+			return p
+		}
+		lhs := newMixedPath("2001:db8::1")
+		rhs := newMixedPath("2001:db8::2")
+		assert.Equal(t, lhs.GetHash(), rhs.GetHash())
+		assert.False(t, lhs.Equal(rhs))
+	})
+
+	t.Run("MP_REACH link-local nexthop differs", func(t *testing.T) {
+		newV6Path := func(ll string) *Path {
+			nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:db8:10::/64"))
+			mpreach, err := bgp.NewPathAttributeMpReachNLRI(bgp.RF_IPv6_UC, []bgp.PathNLRI{{NLRI: nlri}},
+				netip.MustParseAddr("2001:db8::1"), netip.MustParseAddr(ll))
+			assert.NoError(t, err)
+			attrs := []bgp.PathAttributeInterface{
+				bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_INCOMPLETE),
+				mpreach,
+			}
+			p := NewPath(bgp.RF_IPv6_UC, nil, bgp.PathNLRI{NLRI: nlri}, false, attrs, time.Now(), false)
+			p.SetHash(attrsHashLikeEagerSites(p))
+			return p
+		}
+		lhs := newV6Path("fe80::1")
+		rhs := newV6Path("fe80::2")
+		assert.Equal(t, lhs.GetHash(), rhs.GetHash())
+		assert.Equal(t, lhs.GetNexthop(), rhs.GetNexthop())
+		assert.False(t, lhs.Equal(rhs))
+	})
+
+	t.Run("NLRI payload outside the route key differs", func(t *testing.T) {
+		lhs := mupT1stPath(t, teid1, nh1)
+		rhs := mupT1stPath(t, teid2, nh1)
+		// same route key (TEID is not part of it), same eager hash
+		assert.Equal(t, lhs.GetNlri().String(), rhs.GetNlri().String())
+		lhs.SetHash(attrsHashLikeEagerSites(lhs))
+		rhs.SetHash(attrsHashLikeEagerSites(rhs))
+		assert.Equal(t, lhs.GetHash(), rhs.GetHash())
+		assert.False(t, lhs.Equal(rhs))
+	})
 }

--- a/internal/pkg/table/path_test.go
+++ b/internal/pkg/table/path_test.go
@@ -657,3 +657,18 @@ func TestPathEqual(t *testing.T) {
 		assert.False(t, lhs.Equal(rhs))
 	})
 }
+
+// A path hashed eagerly in ProcessMessage and an identical one hashed
+// lazily via updateHash must produce the same value, or Equal reports a
+// spurious difference and packerV4 batching splits buckets.
+func TestPathAttrsHashConsistency(t *testing.T) {
+	teid := netip.MustParseAddr("0.0.0.100")
+	nh := netip.MustParseAddr("10.0.0.1")
+
+	eager := mupT1stPath(t, teid, nh)
+	eager.SetHash(attrsHashLikeEagerSites(eager))
+	lazy := mupT1stPath(t, teid, nh)
+
+	assert.Equal(t, eager.GetHash(), lazy.GetHash())
+	assert.True(t, eager.Equal(lazy))
+}

--- a/internal/pkg/table/table_manager.go
+++ b/internal/pkg/table/table_manager.go
@@ -61,6 +61,8 @@ func ProcessMessage(m *bgp.BGPMessage, peerInfo *PeerInfo, timestamp time.Time, 
 		attrs = []bgp.PathAttributeInterface{}
 	}
 
+	// one hash shared by every path of this update; must stay in sync
+	// with Path.updateHash (farm.Hash64 over attrs without MP_REACH_NLRI)
 	var hash uint64
 	if len(attrs) != 0 {
 		total := bytes.NewBuffer(make([]byte, 0))

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -16,7 +16,6 @@
 package server
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -31,7 +30,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgryski/go-farm"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -588,17 +586,6 @@ func api2Path(resource api.TableType, path *api.Path, isWithdraw bool) (*table.P
 
 	doWithdraw := isWithdraw || path.IsWithdraw
 	newPath := table.NewPath(rf, pi, bgp.PathNLRI{NLRI: nlri, ID: path.Identifier}, doWithdraw, pattrs, time.Now(), path.NoImplicitWithdraw)
-	if !doWithdraw {
-		total := bytes.NewBuffer(make([]byte, 0))
-		for _, a := range newPath.GetPathAttrs() {
-			if a.GetType() == bgp.BGP_ATTR_TYPE_MP_REACH_NLRI {
-				continue
-			}
-			b, _ := a.Serialize()
-			total.Write(b)
-		}
-		newPath.SetHash(farm.Hash64(total.Bytes()))
-	}
 	newPath.SetIsFromExternal(path.IsFromExternal)
 	return newPath, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2449,17 +2449,6 @@ func apiutil2Path(path *apiutil.Path, isVRFTable bool, isWithdraw ...bool) (*tab
 	if p == nil {
 		return nil, fmt.Errorf("invalid path: %v", path)
 	}
-	if !doWithdraw {
-		total := bytes.NewBuffer(make([]byte, 0))
-		for _, a := range pattrs {
-			if a.GetType() == bgp.BGP_ATTR_TYPE_MP_REACH_NLRI {
-				continue
-			}
-			b, _ := a.Serialize()
-			total.Write(b)
-		}
-		p.SetHash(farm.Hash64(total.Bytes()))
-	}
 	p.SetIsFromExternal(path.IsFromExternal)
 	return p, nil
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -74,6 +74,62 @@ func TestWatchPostUpdateWithLocalRoute(t *testing.T) {
 	s.watch(WatchPostUpdate(true, "10.2.2.2", ""))
 }
 
+// TestWatchBestPathNexthopOnlyChange verifies that re-adding a local path
+// with only its nexthop changed produces a new best path event. For MP
+// families the nexthop lives in MP_REACH_NLRI, which is excluded from the
+// path attributes hash, so this used to be suppressed as a no-op change.
+func TestWatchBestPathNexthopOnlyChange(t *testing.T) {
+	s := NewBgpServer()
+	go s.Serve()
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        1,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	w := s.watch(WatchBestPath(false))
+	defer w.Stop()
+
+	waitEvent := func() *watchEventBestPath {
+		t.Helper()
+		select {
+		case ev := <-w.Event():
+			return ev.(*watchEventBestPath)
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for best path event")
+			return nil
+		}
+	}
+
+	addPath := func(nexthop string) {
+		t.Helper()
+		panh, _ := bgp.NewPathAttributeNextHop(netip.MustParseAddr(nexthop))
+		attrs := []bgp.PathAttributeInterface{
+			bgp.NewPathAttributeOrigin(0),
+			panh,
+		}
+		nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("2001:db8:10::/64"))
+		path, _ := apiutil.NewPath(bgp.RF_IPv6_UC, nlri, false, attrs, time.Now())
+		_, err := s.AddPath(apiutil.AddPathRequest{Paths: []*apiutil.Path{mustApi2apiutilPath(path)}})
+		require.NoError(t, err)
+	}
+
+	addPath("2001:db8::1")
+	ev := waitEvent()
+	require.Len(t, ev.PathList, 1)
+	assert.Equal(t, "2001:db8::1", ev.PathList[0].GetNexthop().String())
+
+	// re-add the same prefix with only the nexthop changed
+	addPath("2001:db8::2")
+	ev = waitEvent()
+	require.Len(t, ev.PathList, 1)
+	assert.Equal(t, "2001:db8::2", ev.PathList[0].GetNexthop().String())
+}
+
 func TestStop(t *testing.T) {
 	assert := assert.New(t)
 	s := NewBgpServer()


### PR DESCRIPTION
Re-adding a locally originated path with the same route key but a different nexthop or different NLRI payload fields outside the route key (e.g. the TEID of a MUP type-1 session transformed route) is not re-advertised to peers.

`Path.Equal` compares the path attributes hash, which deliberately excludes MP_REACH_NLRI because the hash doubles as the UPDATE batching key. Two paths differing only in nexthop or non-key NLRI content therefore compared as equal, and `Update.GetChanges` suppressed the re-advertisement. This affects all MP families; the same suppression also applies to paths received from peers, since `ProcessMessage` computes the hash with the same exclusion.

- `table: fix Path.Equal ignoring nexthop and NLRI payload` — compare the nexthop and the serialized NLRI explicitly after the hash check.
- `table: make lazy path attributes hash consistent with eager sites` — `updateHash` used fnv1a over all attributes while the eager sites use farm.Hash64 without MP_REACH_NLRI, so paths whose attributes were modified after creation (VRF import, policy) could never compare hash-equal to unmodified ones.
- `server: rely on lazy path attributes hash` — drop the two copies of the eager hash loop that duplicated `updateHash`.

Reproduced by the added tests: `TestPathEqual`, `TestGetChanges_NonKeyNlriOrNexthopOnlyChange`, and `TestWatchBestPathNexthopOnlyChange` fail on master without the fix.
