### PR TITLE
packet/bgp: reject out-of-range prefix length in EVPNIPPrefixRoute

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -3002,6 +3002,9 @@ func (er *EVPNIPPrefixRoute) DecodeFromBytes(data []byte) error {
 	er.ETag = binary.BigEndian.Uint32(data[18:22])
 
 	er.IPPrefixLength = data[22]
+	if int(er.IPPrefixLength) > addrLen*8 {
+		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, fmt.Sprintf("Invalid IP Prefix length: %d", er.IPPrefixLength))
+	}
 
 	offset := 23 // RD(8) + ESI(10) + ETag(4) + IPPrefixLength(1)
 	er.IPPrefix, _ = netip.AddrFromSlice(data[offset : offset+addrLen])

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -838,6 +838,48 @@ func Test_EVPNIPPrefixRoute(t *testing.T) {
 	assert.Equal(n1, n2)
 }
 
+func Test_EVPNIPPrefixRouteRejectsOversizedPrefixLength(t *testing.T) {
+	assert := assert.New(t)
+	rd, _ := ParseRouteDistinguisher("100:100")
+	esi := EthernetSegmentIdentifier{Type: ESI_ARBITRARY, Value: make([]byte, 9)}
+
+	v4 := NewEVPNNLRI(EVPN_IP_PREFIX, &EVPNIPPrefixRoute{
+		RD:             rd,
+		ESI:            esi,
+		ETag:           10,
+		IPPrefixLength: 24,
+		IPPrefix:       netip.AddrFrom4([4]byte{10, 10, 10, 0}),
+		GWIPAddress:    netip.AddrFrom4([4]byte{10, 10, 10, 10}),
+		Label:          1000,
+	})
+	buf, err := v4.Serialize()
+	assert.NoError(err)
+	// Wire layout: RouteType(1) + Length(1) + RD(8) + ESI(10) + ETag(4)
+	// + IPPrefixLength(1) ..., so the length octet is at index 24.
+	const plOffset = 2 + 22
+	buf[plOffset] = 33 // /33 cannot exist for an IPv4 EVPN prefix
+	_, err = NLRIFromSlice(RF_EVPN, buf)
+	assert.Error(err)
+	buf[plOffset] = 24 // a legal length still decodes
+	_, err = NLRIFromSlice(RF_EVPN, buf)
+	assert.NoError(err)
+
+	v6 := NewEVPNNLRI(EVPN_IP_PREFIX, &EVPNIPPrefixRoute{
+		RD:             rd,
+		ESI:            esi,
+		ETag:           10,
+		IPPrefixLength: 64,
+		IPPrefix:       netip.MustParseAddr("2001:db8::"),
+		GWIPAddress:    netip.MustParseAddr("2001:db8::1"),
+		Label:          1000,
+	})
+	buf6, err := v6.Serialize()
+	assert.NoError(err)
+	buf6[plOffset] = 129 // /129 cannot exist for an IPv6 EVPN prefix
+	_, err = NLRIFromSlice(RF_EVPN, buf6)
+	assert.Error(err)
+}
+
 func Test_EVPNMacIPAdvertisementRoute(t *testing.T) {
 	rd, err := ParseRouteDistinguisher("100:100")
 	require.NoError(t, err)


### PR DESCRIPTION
A crafted EVPN Type-5 (IP Prefix) NLRI decodes with any prefix length:

    [type:Prefix][rd:0:0][etag:0][prefix:1.2.3.4/255]

EVPNIPPrefixRoute.DecodeFromBytes reads the IP Prefix Length octet straight from the wire but never bounds it to the address family, unlike IPAddrPrefixDefault.decodePrefix and the sibling MAC/IP, Multicast and Ethernet-Segment routes (which reject IP lengths outside {0,32,128}). A peer can inject an illegal /33..255 (IPv4) or /129..255 (IPv6) length; the bogus value becomes part of the route key and is re-advertised to other peers. The prefix bytes are sliced with a fixed address length so there is no over-read, only a wrong stored length.

Add the same addrLen*8 check the other prefix decoders already use, and a regression test covering the v4 and v6 cases.
