### PR TITLE
server/bmp: report Adj-RIB-In withdrawals to clear ribout on peer down

### DIFF
--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -140,6 +140,11 @@ func (b *bmpClient) loop() {
 			}
 			if b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY || b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
 				ops = append(ops, WatchUpdate(true, "", ""))
+				// Adj-RIB-In withdrawals generated on peer down / graceful-restart
+				// expiry are not received on the wire, so they arrive on a separate
+				// watch type. They clear the ribout cache so identical routes are
+				// reported again after the session re-establishes.
+				ops = append(ops, WatchAdjInWithdraw())
 			}
 			if b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY || b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
 				ops = append(ops, WatchPostUpdate(true, "", ""))

--- a/pkg/server/bmp_test.go
+++ b/pkg/server/bmp_test.go
@@ -125,6 +125,46 @@ func findAddPathCapability(open *bgp.BGPOpen) *bgp.CapAddPath {
 	return nil
 }
 
+// A withdraw generated on peer down (DropAll clones the Adj-RIB-In path with
+// IsWithdraw=true) must clear the ribout cache so that an identical path sent
+// after the session re-establishes is reported to the BMP server again.
+func TestRiboutWithdrawAllowsIdenticalResendAfterFlap(t *testing.T) {
+	r := newribout()
+	p := makeIPv4Path(t, "10.0.3.0/24", "192.0.2.31", "198.51.100.31", 65301, 0)
+
+	// First advertisement is reported.
+	require.True(t, r.update(p))
+	// Identical re-advertisement while the session is up is suppressed.
+	require.False(t, r.update(p))
+
+	// Peer goes down: DropAll yields a withdraw clone sharing the same source.
+	w := p.Clone(true)
+	require.True(t, w.IsWithdraw)
+	require.Equal(t, p.GetSource(), w.GetSource())
+	require.True(t, r.update(w))
+
+	// After the flap the identical path must be reported again.
+	require.True(t, r.update(p))
+}
+
+// A withdraw for one peer must not evict another peer's cached path for the
+// same prefix.
+func TestRiboutWithdrawKeepsOtherPeersPath(t *testing.T) {
+	r := newribout()
+	p1 := makeIPv4Path(t, "10.0.4.0/24", "192.0.2.41", "198.51.100.41", 65401, 0)
+	p2 := makeIPv4Path(t, "10.0.4.0/24", "192.0.2.42", "198.51.100.42", 65402, 0)
+
+	require.True(t, r.update(p1))
+	require.True(t, r.update(p2))
+
+	// Withdraw p1 only.
+	require.True(t, r.update(p1.Clone(true)))
+
+	// p2 is still cached (suppressed), p1 can be reported again.
+	require.False(t, r.update(p2))
+	require.True(t, r.update(p1))
+}
+
 func TestBMPLocRIBPeerUpOmitsAddPathCapabilityWhenDisabled(t *testing.T) {
 	open := localRIBPeerUpOpen(t, false)
 	require.Nil(t, findAddPathCapability(open))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -920,6 +920,51 @@ func (s *BgpServer) notifyPostPolicyUpdateWatcher(peer *peer, pathList []*table.
 	s.notifyWatcher(watchEventTypePostUpdate, ev)
 }
 
+// notifyAdjInWithdrawWatcher emits Adj-RIB-In withdrawals that gobgp generates
+// internally (peer down, graceful-restart timer expiry, de-configuration)
+// rather than receiving on the wire. Pre-policy route monitoring (BMP) needs
+// these so that a peer's Adj-RIB-In view is cleared; without them a cached path
+// would suppress an identical re-advertisement after the session comes back.
+//
+// The paths carry no BGP message payload (they were never on the wire), so the
+// event is delivered on a dedicated watch type. Consumers regenerate a withdraw
+// UPDATE from PathList. MRT deliberately does not subscribe to this type.
+func (s *BgpServer) notifyAdjInWithdrawWatcher(peer *peer, pathList []*table.Path) {
+	if !s.isWatched(watchEventTypeAdjInWithdraw) || peer == nil {
+		return
+	}
+
+	withdrawals := make([]*table.Path, 0, len(pathList))
+	for _, p := range pathList {
+		if p != nil && p.IsWithdraw {
+			withdrawals = append(withdrawals, p)
+		}
+	}
+	if len(withdrawals) == 0 {
+		return
+	}
+
+	cloned := clonePathList(withdrawals)
+	n := s.toConfig(peer, false)
+	conf := peer.fsm.pConf.ReadOnly()
+	peer.fsm.lock.Lock()
+	_, y := peer.fsm.capMap[bgp.BGP_CAP_FOUR_OCTET_AS_NUMBER]
+	peer.fsm.lock.Unlock()
+	ev := &watchEventUpdate{
+		PeerAS:       conf.State.PeerAs,
+		LocalAS:      conf.Config.LocalAs,
+		PeerAddress:  conf.State.NeighborAddress,
+		LocalAddress: conf.Transport.State.LocalAddress,
+		PeerID:       conf.State.RemoteRouterId,
+		FourBytesAs:  y,
+		Timestamp:    time.Now(),
+		PostPolicy:   false,
+		PathList:     cloned,
+		Neighbor:     n,
+	}
+	s.notifyWatcher(watchEventTypeAdjInWithdraw, ev)
+}
+
 func newWatchEventPeer(peer *peer, m *fsmMsg, newState, oldState bgp.FSMState, t apiutil.PeerEventType) *watchEventPeer {
 	peer.fsm.lock.Lock()
 	conf := peer.fsm.pConf.ReadCopy()
@@ -1194,6 +1239,16 @@ func (s *BgpServer) handleRouteRefresh(peer *peer, e *fsmMsg) {
 			sendfsmOutgoingMsg(peer, paths)
 		}
 	})
+}
+
+// dropAdjRIBIn removes the peer's Adj-RIB-In for the given families and
+// propagates the resulting withdrawals. The withdrawals are also reported to
+// pre-policy Adj-RIB-In watchers (BMP) before propagation so that the monitored
+// view is cleared; propagateUpdate itself only reaches post-policy watchers.
+func (s *BgpServer) dropAdjRIBIn(peer *peer, families []bgp.Family) {
+	dropped := peer.DropAll(families)
+	s.notifyAdjInWithdrawWatcher(peer, dropped)
+	s.propagateUpdate(peer, dropped)
 }
 
 func (s *BgpServer) propagateUpdate(peer *peer, pathList []*table.Path) {
@@ -1632,7 +1687,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 			// This avoids rebuilding RIB-out bookkeeping by propagation that starts after the reset.
 			peer.fsm.state.Store(nextState)
 			s.resetAdvertisedRoutes(peer)
-			s.propagateUpdate(peer, peer.DropAll(dropFamilies))
+			s.dropAdjRIBIn(peer, dropFamilies)
 
 			if conf.Config.PeerAs == 0 {
 				peer.fsm.lock.Lock()
@@ -1657,7 +1712,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 				peer.longLivedRunning.Store(true)
 				llgr, no_llgr := peer.llgrFamilies()
 
-				s.propagateUpdate(peer, peer.DropAll(no_llgr))
+				s.dropAdjRIBIn(peer, no_llgr)
 
 				// attach LLGR_STALE community to paths in peer's adj-rib-in
 				// paths with NO_LLGR are deleted
@@ -1686,7 +1741,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 							err := s.mgmtOperation(func() error {
 								peer.fsm.logger.Info("LLGR restart timer expired", slog.String("Family", family.String()), slog.Any("Duration", t))
 
-								s.propagateUpdate(peer, peer.DropAll([]bgp.Family{family}))
+								s.dropAdjRIBIn(peer, []bgp.Family{family})
 
 								// when all llgr restart timer expired, stop PeerRestarting
 								if peer.llgrRestartTimerExpired(family) {
@@ -1722,7 +1777,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 				peer.fsm.pConf.Update(&conf)
 				peer.fsm.lock.Unlock()
 
-				s.propagateUpdate(peer, peer.DropAll(peer.configuredRFlist()))
+				s.dropAdjRIBIn(peer, peer.configuredRFlist())
 
 				if peer.isDynamicNeighbor() {
 					needStopNeighbor = true
@@ -3643,7 +3698,7 @@ func (s *BgpServer) deleteNeighbor(c *oc.Neighbor, code, subcode uint8, sendNoti
 	if sendNotification {
 		n.fsm.deconfiguredNotification <- bgp.NewBGPNotificationMessage(code, subcode, nil)
 	}
-	s.propagateUpdate(n, n.DropAll(n.configuredRFlist()))
+	s.dropAdjRIBIn(n, n.configuredRFlist())
 	s.stopNeighbor(n, -1, nil)
 	return nil
 }
@@ -4742,12 +4797,13 @@ func (s *BgpServer) Log() *slog.Logger {
 type watchEventType string
 
 const (
-	watchEventTypeBestPath   watchEventType = "bestpath"
-	watchEventTypePreUpdate  watchEventType = "preupdate"
-	watchEventTypePostUpdate watchEventType = "postupdate"
-	watchEventTypePeerState  watchEventType = "peerstate"
-	watchEventTypeRecvMsg    watchEventType = "receivedmessage"
-	watchEventTypeEor        watchEventType = "eor"
+	watchEventTypeBestPath      watchEventType = "bestpath"
+	watchEventTypePreUpdate     watchEventType = "preupdate"
+	watchEventTypePostUpdate    watchEventType = "postupdate"
+	watchEventTypeAdjInWithdraw watchEventType = "adjinwithdraw"
+	watchEventTypePeerState     watchEventType = "peerstate"
+	watchEventTypeRecvMsg       watchEventType = "receivedmessage"
+	watchEventTypeEor           watchEventType = "eor"
 )
 
 type watchEvent any
@@ -4846,6 +4902,7 @@ type watchOptions struct {
 	preUpdateFilter  func(w watchEvent) bool
 	postUpdate       bool
 	postUpdateFilter func(w watchEvent) bool
+	adjInWithdraw    bool
 
 	peerState      bool
 	initBest       bool
@@ -4888,6 +4945,17 @@ func WatchUpdate(current bool, peerAddress string, peerGroup string) WatchOption
 				return false
 			}
 		}
+	}
+}
+
+// WatchAdjInWithdraw subscribes to locally-generated Adj-RIB-In withdrawals
+// (e.g. peer down, graceful-restart timer expiry). These paths are not received
+// on the wire, so they carry no BGP message payload. This stream is separate
+// from WatchUpdate so that consumers such as MRT, which dump only real wire
+// messages, are not affected.
+func WatchAdjInWithdraw() WatchOption {
+	return func(o *watchOptions) {
+		o.adjInWithdraw = true
 	}
 }
 
@@ -5190,6 +5258,9 @@ func (s *BgpServer) watch(opts ...WatchOption) (w *watcher) {
 		}
 		if w.opts.postUpdate {
 			register(watchEventTypePostUpdate, w)
+		}
+		if w.opts.adjInWithdraw {
+			register(watchEventTypeAdjInWithdraw, w)
 		}
 		if w.opts.eor {
 			register(watchEventTypeEor, w)


### PR DESCRIPTION
When a peer leaves ESTABLISHED, its Adj-RIB-In is dropped via DropAll, but those withdrawals only reached post-policy watchers through propagateUpdate; pre-policy route monitoring never saw them. As a result the BMP ribout dedup cache kept the peer's paths, so after a flap the identical routes re-advertised on reconnect were suppressed and never re-reported. The BMP station's pre-policy Adj-RIB-In view was left stale.

Deliver the DropAll withdrawals on a dedicated watch stream that BMP subscribes to, so update() clears the cached entries and the routes are reported again after the session comes back. Keep this stream separate from WatchUpdate: MRT dumps only messages seen on the wire, and these locally generated withdrawals have no wire payload, so folding them into the pre-policy stream would corrupt MRT output.

This also keeps graceful restart out of the BMP code. Withdrawals follow DropAll's own schedule, so routes retained during GR are only reported as withdrawn once GR actually removes them, without BMP needing to know GR is in progress.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>