### PR TITLE
pkg/server: fix Loc-RIB BMP Peer Up to match RFC 9069

### DIFF
--- a/pkg/server/bmp.go
+++ b/pkg/server/bmp.go
@@ -199,7 +199,6 @@ func (b *bmpClient) loop() {
 					"global",
 					0,
 					time.Now().Unix(),
-					table.UseMultiplePaths.Enabled,
 				)); err != nil {
 					return false
 				}
@@ -309,36 +308,49 @@ func (b *bmpClient) loop() {
 	}
 }
 
-func bmpLocRIBPeerUp(localAS uint32, routerID netip.Addr, tableName string, peerDist uint64, timestamp int64, addPathEnabled bool) *bmp.BMPMessage {
+func bmpLocRIBPeerUp(localAS uint32, routerID netip.Addr, tableName string, peerDist uint64, timestamp int64) *bmp.BMPMessage {
 	const asTrans uint16 = 23456
 
 	myAS := asTrans
 	opts := []bgp.OptionParameterInterface{}
 	if localAS <= 0xffff {
 		myAS = uint16(localAS)
-	} else {
-		opts = append(opts, bgp.NewOptionParameterCapability([]bgp.ParameterCapabilityInterface{
-			bgp.NewCapFourOctetASNumber(localAS),
-		}))
 	}
-	if addPathEnabled {
-		opts = append(opts, bgp.NewOptionParameterCapability([]bgp.ParameterCapabilityInterface{
-			bgp.NewCapAddPath([]*bgp.CapAddPathTuple{
-				bgp.NewCapAddPathTuple(bgp.RF_IPv4_UC, bgp.BGP_ADD_PATH_BOTH),
-				bgp.NewCapAddPathTuple(bgp.RF_IPv6_UC, bgp.BGP_ADD_PATH_BOTH),
-			}),
-		}))
-	}
+	// RFC 9069 5.2: "Capabilities MUST include the 4-octet ASN and all necessary
+	// capabilities to represent the Loc-RIB Route Monitoring messages." The
+	// 4-octet ASN capability is therefore advertised unconditionally, not only
+	// when the ASN does not fit in the 2-octet My Autonomous System field.
+	opts = append(opts, bgp.NewOptionParameterCapability([]bgp.ParameterCapabilityInterface{
+		bgp.NewCapFourOctetASNumber(localAS),
+	}))
+	// Loc-RIB Route Monitoring messages are always marshalled with
+	// BGP_ADD_PATH_BOTH (see bmpAddPathMarshallingOption), so the receiver always
+	// needs the ADD-PATH capability to decode their NLRIs. Advertising it only
+	// when global multipath happened to be enabled left the fabricated OPEN
+	// describing an encoding that was not the one on the wire, and every NLRI was
+	// then parsed 4 octets out of step.
+	opts = append(opts, bgp.NewOptionParameterCapability([]bgp.ParameterCapabilityInterface{
+		bgp.NewCapAddPath([]*bgp.CapAddPathTuple{
+			bgp.NewCapAddPathTuple(bgp.RF_IPv4_UC, bgp.BGP_ADD_PATH_BOTH),
+			bgp.NewCapAddPathTuple(bgp.RF_IPv6_UC, bgp.BGP_ADD_PATH_BOTH),
+		}),
+	}))
 
 	open, _ := bgp.NewBGPOpenMessage(myAS, 90, routerID, opts)
 
+	// RFC 9069 5.1: for a Loc-RIB Instance Peer only the Peer Address is
+	// zero-filled. The Peer AS is "the primary router BGP autonomous system
+	// number" and the Peer BGP ID is "the global instance router-id". They must
+	// match the header the Route Monitoring messages carry (see bmpPeerRoute),
+	// otherwise a receiver cannot correlate this Peer Up with them and loses the
+	// capabilities negotiated above.
 	ph := bmp.NewBMPPeerHeader(
 		bmp.BMP_PEER_TYPE_LOCAL_RIB,
 		0,
 		peerDist,
 		netip.Addr{},
-		0,
-		netip.IPv4Unspecified(),
+		localAS,
+		routerID,
 		float64(timestamp),
 	)
 	return bmp.NewBMPPeerUpNotification(
@@ -353,13 +365,17 @@ func bmpLocRIBPeerUp(localAS uint32, routerID netip.Addr, tableName string, peer
 }
 
 func bmpLocRIBPeerDown(localAS uint32, routerID netip.Addr, tableName string, peerDist uint64, timestamp int64) *bmp.BMPMessage {
+	// RFC 9069 5.1: as in bmpLocRIBPeerUp, only the Peer Address is zero-filled.
+	// The Peer AS and Peer BGP ID identify the router, so that a receiver can tie
+	// this Peer Down to the Peer Up and the Route Monitoring messages for the
+	// same Loc-RIB instance.
 	ph := bmp.NewBMPPeerHeader(
 		bmp.BMP_PEER_TYPE_LOCAL_RIB,
 		0,
 		peerDist,
 		netip.Addr{},
-		0,
-		netip.IPv4Unspecified(),
+		localAS,
+		routerID,
 		float64(timestamp),
 	)
 	return bmp.NewBMPPeerDownNotification(

--- a/pkg/server/bmp_test.go
+++ b/pkg/server/bmp_test.go
@@ -96,18 +96,41 @@ func TestBMPAddPathMarshallingOptionCarriesPathIDOnWithdraw(t *testing.T) {
 	_ = update.WithdrawnRoutes[0].ID
 }
 
-func localRIBPeerUpOpen(t *testing.T, addPathEnabled bool) *bgp.BGPOpen {
+const (
+	locRIBTestAS       = uint32(65002)
+	locRIBTestRouterID = "100.1.1.102"
+)
+
+func localRIBPeerUp(t *testing.T) *packetbmp.BMPMessage {
 	t.Helper()
-	msg := bmpLocRIBPeerUp(
-		65002,
-		netip.MustParseAddr("100.1.1.102"),
+	return bmpLocRIBPeerUp(
+		locRIBTestAS,
+		netip.MustParseAddr(locRIBTestRouterID),
 		"global",
 		0,
 		time.Now().Unix(),
-		addPathEnabled,
 	)
-	up := msg.Body.(*packetbmp.BMPPeerUpNotification)
+}
+
+func localRIBPeerUpOpen(t *testing.T) *bgp.BGPOpen {
+	t.Helper()
+	up := localRIBPeerUp(t).Body.(*packetbmp.BMPPeerUpNotification)
 	return up.SentOpenMsg.Body.(*bgp.BGPOpen)
+}
+
+func findFourOctetASCapability(open *bgp.BGPOpen) *bgp.CapFourOctetASNumber {
+	for _, p := range open.OptParams {
+		param, ok := p.(*bgp.OptionParameterCapability)
+		if !ok {
+			continue
+		}
+		for _, c := range param.Capability {
+			if fourOctet, ok := c.(*bgp.CapFourOctetASNumber); ok {
+				return fourOctet
+			}
+		}
+	}
+	return nil
 }
 
 func findAddPathCapability(open *bgp.BGPOpen) *bgp.CapAddPath {
@@ -165,13 +188,12 @@ func TestRiboutWithdrawKeepsOtherPeersPath(t *testing.T) {
 	require.True(t, r.update(p1))
 }
 
-func TestBMPLocRIBPeerUpOmitsAddPathCapabilityWhenDisabled(t *testing.T) {
-	open := localRIBPeerUpOpen(t, false)
-	require.Nil(t, findAddPathCapability(open))
-}
-
-func TestBMPLocRIBPeerUpCarriesAddPathCapabilityWhenEnabled(t *testing.T) {
-	open := localRIBPeerUpOpen(t, true)
+// Loc-RIB Route Monitoring messages are always marshalled with add-path (see
+// TestBMPAddPathMarshallingOptionCarriesPathIDOnWithdraw), so the fabricated
+// OPEN must always advertise the capability. Omitting it left receivers parsing
+// the NLRIs 4 octets out of step. RFC 9069 5.2.
+func TestBMPLocRIBPeerUpAlwaysCarriesAddPathCapability(t *testing.T) {
+	open := localRIBPeerUpOpen(t)
 	addPath := findAddPathCapability(open)
 	require.NotNil(t, addPath)
 	require.Len(t, addPath.Tuples, 2)
@@ -179,4 +201,69 @@ func TestBMPLocRIBPeerUpCarriesAddPathCapabilityWhenEnabled(t *testing.T) {
 	require.Equal(t, bgp.BGP_ADD_PATH_BOTH, addPath.Tuples[0].Mode)
 	require.Equal(t, bgp.RF_IPv6_UC, addPath.Tuples[1].Family)
 	require.Equal(t, bgp.BGP_ADD_PATH_BOTH, addPath.Tuples[1].Mode)
+}
+
+// RFC 9069 5.2: "Capabilities MUST include the 4-octet ASN and all necessary
+// capabilities to represent the Loc-RIB Route Monitoring messages."
+//
+// RFC 6793 3: the capability is advertised whatever the ASN is, and carries the
+// real AS number. Only the 2-octet My Autonomous System field changes: it holds
+// the AS when it fits, and AS_TRANS (23456) when it does not.
+func TestBMPLocRIBPeerUpAlwaysCarriesFourOctetASCapability(t *testing.T) {
+	const asTrans = uint16(23456)
+
+	tests := []struct {
+		name     string
+		localAS  uint32
+		wantMyAS uint16
+	}{
+		{"two-octet AS is carried in My AS", 65002, 65002},
+		{"four-octet AS falls back to AS_TRANS in My AS", 4200000000, asTrans},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := bmpLocRIBPeerUp(tt.localAS, netip.MustParseAddr(locRIBTestRouterID), "global", 0, time.Now().Unix())
+			open := msg.Body.(*packetbmp.BMPPeerUpNotification).SentOpenMsg.Body.(*bgp.BGPOpen)
+
+			require.Equal(t, tt.wantMyAS, open.MyAS)
+
+			fourOctet := findFourOctetASCapability(open)
+			require.NotNil(t, fourOctet, "the capability is advertised whatever the ASN is")
+			require.Equal(t, tt.localAS, fourOctet.CapValue, "the capability carries the real AS number")
+
+			// and the per-peer header always carries the real AS, never AS_TRANS
+			require.Equal(t, tt.localAS, msg.PeerHeader.PeerAS)
+		})
+	}
+}
+
+// RFC 9069 5.1: only the Peer Address is zero-filled for a Loc-RIB Instance
+// Peer. The Peer AS is the router's ASN and the Peer BGP ID is its router-id,
+// and both must match the header carried by the Loc-RIB Route Monitoring
+// messages, or a receiver cannot correlate the two and loses the capabilities
+// negotiated in this Peer Up.
+func TestBMPLocRIBPeerUpHeaderIdentifiesTheRouter(t *testing.T) {
+	ph := localRIBPeerUp(t).PeerHeader
+	require.Equal(t, packetbmp.BMP_PEER_TYPE_LOCAL_RIB, ph.PeerType)
+	require.Equal(t, locRIBTestAS, ph.PeerAS)
+	require.Equal(t, netip.MustParseAddr(locRIBTestRouterID), ph.PeerBGPID)
+	require.False(t, ph.PeerAddress.IsValid(), "peer address must be zero-filled")
+}
+
+// bmpLocRIBPeerDown carries the same per-peer header as the Peer Up and the
+// Route Monitoring messages, so a receiver can tie the teardown to the instance
+// it was told about. RFC 9069 5.1.
+func TestBMPLocRIBPeerDownHeaderIdentifiesTheRouter(t *testing.T) {
+	msg := bmpLocRIBPeerDown(
+		locRIBTestAS,
+		netip.MustParseAddr(locRIBTestRouterID),
+		"global",
+		0,
+		time.Now().Unix(),
+	)
+	ph := msg.PeerHeader
+	require.Equal(t, packetbmp.BMP_PEER_TYPE_LOCAL_RIB, ph.PeerType)
+	require.Equal(t, locRIBTestAS, ph.PeerAS)
+	require.Equal(t, netip.MustParseAddr(locRIBTestRouterID), ph.PeerBGPID)
+	require.False(t, ph.PeerAddress.IsValid(), "peer address must be zero-filled")
 }


### PR DESCRIPTION

Fixes #3499

Loc-RIB Route Monitoring messages are always marshalled with `BGP_ADD_PATH_BOTH` (`bmpAddPathMarshallingOption`), but the Peer Up that is supposed to describe that encoding disagreed with it in two ways, which left the feed unparseable by any conforming receiver: an injected `10.101.0.0/24` is decoded as `101.0.0.0/10`.

### 1. The fabricated OPEN did not advertise the capabilities the encoder uses

The ADD-PATH capability was only advertised when `table.UseMultiplePaths.Enabled` was set, an unrelated global multipath setting. With the default config the OPEN carried no optional parameters at all, so a receiver was told "no ADD-PATH" and parsed every NLRI 4 octets out of step.

RFC 9069 §5.2 requires the fabricated OPEN's capabilities to "represent the Loc-RIB Route Monitoring messages", and requires the 4-octet ASN capability unconditionally (it was only sent when the ASN did not fit in the 2-octet My Autonomous System field).

Both capabilities are now always advertised, and the `addPathEnabled` parameter is removed, since the Loc-RIB encoder is unconditionally add-path.

### 2. The per-peer header did not identify the router

The Peer Up zero-filled the Peer BGP ID and the Peer AS, while the Route Monitoring messages carry the router-id and the local AS (`bmpPeerRoute`). Receivers key per-session state such as negotiated capabilities on that identity, so the capabilities were filed under `0.0.0.0` and looked up under the router-id, and were lost even once advertised.

RFC 9069 §5.1 zero-fills only the Peer Address: the Peer BGP ID is "the global instance router-id" and the Peer AS is "the primary router BGP autonomous system number". The Peer Up even contradicted itself, since the fabricated OPEN it carries already held the correct AS and router-id.

`bmpLocRIBPeerDown` zero-filled the same two fields and is fixed with it, so a receiver can tie the teardown to the instance it was told about.

### Tests

`TestBMPLocRIBPeerUpOmitsAddPathCapabilityWhenDisabled` asserted the first bug, and is replaced by `TestBMPLocRIBPeerUpAlwaysCarriesAddPathCapability`. That is consistent with `TestBMPAddPathMarshallingOptionCarriesPathIDOnWithdraw`, which already asserts the Loc-RIB encoding is always add-path: the two tests previously contradicted each other. Added `TestBMPLocRIBPeerUpAlwaysCarriesFourOctetASCapability`, `TestBMPLocRIBPeerUpHeaderIdentifiesTheRouter` and `TestBMPLocRIBPeerDownHeaderIdentifiesTheRouter`.

`go test ./pkg/server/` passes in full.

### Verification

Against goBMP as the receiver, with the **default** config (multipath off, the case that was broken):

before

```text
    prefix    | path_id
--------------+---------
 101.0.0.0/10 |
 24.0.0.0/1   |
```

after

```text
    prefix     | path_id
---------------+---------
 10.101.0.0/24 | 1
 10.102.0.0/24 | 1
 10.99.0.0/24  | 1
```

matching `gobgp global rib`. With multipath additionally enabled, multiple paths for the same prefix appear with distinct path-ids, as expected.

Each fix was also tested in isolation: fixing only the header still leaves the capability unadvertised with the default config, and fixing only the capability still leaves it filed under an identity the Route Monitoring messages never use. Both are required.
