### PR TITLE
packet/bmp: validate declared length in TLV16 value decoders

### DIFF
--- a/pkg/packet/bmp/bmp.go
+++ b/pkg/packet/bmp/bmp.go
@@ -810,6 +810,9 @@ func NewBMPTermTLV16(t uint16, v uint16) *BMPTermTLV16 {
 }
 
 func (s *BMPTermTLV16) ParseValue(data []byte) error {
+	if s.Length != 2 {
+		return fmt.Errorf("invalid length: %d bytes (%d bytes expected)", s.Length, 2)
+	}
 	s.Value = binary.BigEndian.Uint16(data[:2])
 	return nil
 }
@@ -972,6 +975,9 @@ func NewBMPRouteMirrTLV16(t uint16, v uint16) *BMPRouteMirrTLV16 {
 }
 
 func (s *BMPRouteMirrTLV16) ParseValue(data []byte) error {
+	if s.Length != 2 {
+		return fmt.Errorf("invalid length: %d bytes (%d bytes expected)", s.Length, 2)
+	}
 	s.Value = binary.BigEndian.Uint16(data[:2])
 	return nil
 }

--- a/pkg/packet/bmp/bmp_test.go
+++ b/pkg/packet/bmp/bmp_test.go
@@ -222,6 +222,27 @@ func Test_RouteMonitoringUnknownType(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func Test_TLV16RejectsShortLength(t *testing.T) {
+	// The Termination "Reason" and Route-Mirroring "Information" TLVs both
+	// carry a fixed 2-octet value, but their value parsers read those two
+	// octets without checking the declared TLV length. The enclosing loop
+	// only guarantees len(data) >= Length, so a TLV announcing a length
+	// below 2 made ParseValue read past its own value into the following
+	// TLV. Reject the mismatched length up front, like the Stats TLV parsers.
+
+	// type=Reason(1), length=1, then a String(0) TLV; the 2-octet read
+	// straddles the TLV boundary.
+	shortReason := []byte{0x00, 0x01, 0x00, 0x01, 0xaa, 0x00, 0x00, 0x00, 0x01, 0x58}
+	require.Error(t, (&BMPTermination{}).ParseBody(nil, shortReason))
+	// A correctly sized Reason still decodes.
+	require.NoError(t, (&BMPTermination{}).ParseBody(nil, []byte{0x00, 0x01, 0x00, 0x02, 0x00, 0x01}))
+
+	// type=Information(1), length=1, followed by another Information TLV.
+	shortInfo := []byte{0x00, 0x01, 0x00, 0x01, 0xaa, 0x00, 0x01, 0x00, 0x02, 0xbb, 0xcc}
+	require.Error(t, (&BMPRouteMirroring{}).ParseBody(nil, shortInfo))
+	require.NoError(t, (&BMPRouteMirroring{}).ParseBody(nil, []byte{0x00, 0x01, 0x00, 0x02, 0x00, 0x01}))
+}
+
 //nolint:errcheck
 func FuzzParseBMPMessage(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {


### PR DESCRIPTION
A BMP Termination "Reason" TLV that declares a 1-octet value:

    tlv[0] Reason16 value=0xaa00

The reason byte on the wire is 0xaa; the trailing 0x00 is read one octet
past the declared value, out of the following TLV's type field.

BMPTermTLV16.ParseValue and BMPRouteMirrTLV16.ParseValue read a fixed
Uint16(data[:2]) without checking the TLV length, unlike BMPStatsTLV32/64
which reject a mismatched Length. ParseBody only guarantees
len(data) >= Length, so a TLV shorter than 2 octets reads into the next
TLV and misframes the rest of the message; a Length of 0 also leaves the
loop advance at zero so it never terminates. Reject Length != 2 in both,
matching the Stats TLV parsers.
