### PR TITLE
packet/bgp: clamp SR Policy NLRI endpoint to declared length

### DIFF
--- a/pkg/packet/bgp/sr_policy.go
+++ b/pkg/packet/bgp/sr_policy.go
@@ -50,7 +50,15 @@ func (s *SRPolicyNLRI) decodeFromBytes(data []byte, options ...*MarshallingOptio
 	p += 4
 	s.Color = binary.BigEndian.Uint32(data[p : p+4])
 	p += 4
-	s.Endpoint = data[p:]
+	// Endpoint is the remainder of the declared NLRI length (4 bytes for
+	// IPv4, 16 for IPv6), not the rest of the buffer. When several SR Policy
+	// NLRIs are packed in one MP_REACH, data still holds the trailing
+	// siblings here, so slicing to p: would fold them into this endpoint.
+	endpointLen := int(s.Length) - 8
+	if len(data) < p+endpointLen {
+		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Malformed SR Policy NLRI")
+	}
+	s.Endpoint = data[p : p+endpointLen]
 
 	return nil
 }

--- a/pkg/packet/bgp/sr_policy_test.go
+++ b/pkg/packet/bgp/sr_policy_test.go
@@ -312,3 +312,37 @@ func TestSegmentListRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func Test_SRPolicyNLRIEndpointClampedToLength(t *testing.T) {
+	// Two SR Policy IPv4 NLRIs packed in one MP_REACH buffer. Each NLRI is
+	// 13 bytes: length(1) + distinguisher(4) + color(4) + endpoint(4).
+	mkV4 := func(ep [4]byte) []byte {
+		b := []byte{SRPolicyIPv4NLRILen, 0, 0, 0, 1, 0, 0, 0, 2}
+		return append(b, ep[:]...)
+	}
+	buf := append(mkV4([4]byte{10, 0, 0, 1}), mkV4([4]byte{10, 0, 0, 2})...)
+
+	n, err := NLRIFromSlice(RF_SR_POLICY_IPv4, buf)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	s := n.(*SRPolicyNLRI)
+	if len(s.Endpoint) != 4 {
+		t.Fatalf("endpoint absorbed sibling NLRI bytes: got %d bytes (%x), want 4", len(s.Endpoint), s.Endpoint)
+	}
+	if got := net.IP(s.Endpoint).To4().String(); got != "10.0.0.1" {
+		t.Fatalf("endpoint mismatch: got %s, want 10.0.0.1", got)
+	}
+
+	// IPv6 endpoint is 16 bytes.
+	v6 := []byte{SRPolicyIPv6NLRILen, 0, 0, 0, 1, 0, 0, 0, 2}
+	v6 = append(v6, net.ParseIP("2001:db8::1").To16()...)
+	v6 = append(v6, 0xde, 0xad) // trailing bytes from a following NLRI
+	n, err = NLRIFromSlice(RF_SR_POLICY_IPv6, v6)
+	if err != nil {
+		t.Fatalf("decode v6 failed: %v", err)
+	}
+	if got := len(n.(*SRPolicyNLRI).Endpoint); got != 16 {
+		t.Fatalf("v6 endpoint absorbed trailing bytes: got %d bytes, want 16", got)
+	}
+}


### PR DESCRIPTION
go test, two SR Policy IPv4 NLRIs packed in one MP_REACH:

    endpoint absorbed sibling NLRI bytes: got 17 bytes (0a0000016000000001000000020a000002), want 4

SRPolicyNLRI.decodeFromBytes sets s.Endpoint = data[p:], but NLRIFromSlice hands it the whole remaining attribute buffer. With more than one SR Policy NLRI in an UPDATE, every NLRI except the last stores an endpoint that aliases the following siblings, so String()/MarshalJSON print the wrong endpoint (net.IP().To4()/To16() sees the over-length slice and returns <nil>). The declared length (data[0]/8) already fixes the endpoint at 4 bytes for IPv4 or 16 for IPv6, so slice to that instead of the rest of the buffer.
