### PR TITLE
api,server: add TCP-AO keychain API and  keychain store implementation

### DIFF
--- a/api/gobgp.pb.go
+++ b/api/gobgp.pb.go
@@ -647,6 +647,55 @@ func (BfdDiagnosticCode) EnumDescriptor() ([]byte, []int) {
 	return file_api_gobgp_proto_rawDescGZIP(), []int{10}
 }
 
+type TcpAoAlgorithm int32
+
+const (
+	TcpAoAlgorithm_TCP_AO_ALGORITHM_UNSPECIFIED     TcpAoAlgorithm = 0
+	TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96    TcpAoAlgorithm = 1
+	TcpAoAlgorithm_TCP_AO_ALGORITHM_AES_128_CMAC_96 TcpAoAlgorithm = 2
+)
+
+// Enum value maps for TcpAoAlgorithm.
+var (
+	TcpAoAlgorithm_name = map[int32]string{
+		0: "TCP_AO_ALGORITHM_UNSPECIFIED",
+		1: "TCP_AO_ALGORITHM_HMAC_SHA1_96",
+		2: "TCP_AO_ALGORITHM_AES_128_CMAC_96",
+	}
+	TcpAoAlgorithm_value = map[string]int32{
+		"TCP_AO_ALGORITHM_UNSPECIFIED":     0,
+		"TCP_AO_ALGORITHM_HMAC_SHA1_96":    1,
+		"TCP_AO_ALGORITHM_AES_128_CMAC_96": 2,
+	}
+)
+
+func (x TcpAoAlgorithm) Enum() *TcpAoAlgorithm {
+	p := new(TcpAoAlgorithm)
+	*p = x
+	return p
+}
+
+func (x TcpAoAlgorithm) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TcpAoAlgorithm) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_gobgp_proto_enumTypes[11].Descriptor()
+}
+
+func (TcpAoAlgorithm) Type() protoreflect.EnumType {
+	return &file_api_gobgp_proto_enumTypes[11]
+}
+
+func (x TcpAoAlgorithm) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TcpAoAlgorithm.Descriptor instead.
+func (TcpAoAlgorithm) EnumDescriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{11}
+}
+
 type WatchEventRequest_Table_Filter_Type int32
 
 const (
@@ -686,11 +735,11 @@ func (x WatchEventRequest_Table_Filter_Type) String() string {
 }
 
 func (WatchEventRequest_Table_Filter_Type) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[11].Descriptor()
+	return file_api_gobgp_proto_enumTypes[12].Descriptor()
 }
 
 func (WatchEventRequest_Table_Filter_Type) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[11]
+	return &file_api_gobgp_proto_enumTypes[12]
 }
 
 func (x WatchEventRequest_Table_Filter_Type) Number() protoreflect.EnumNumber {
@@ -738,11 +787,11 @@ func (x WatchEventResponse_PeerEvent_Type) String() string {
 }
 
 func (WatchEventResponse_PeerEvent_Type) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[12].Descriptor()
+	return file_api_gobgp_proto_enumTypes[13].Descriptor()
 }
 
 func (WatchEventResponse_PeerEvent_Type) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[12]
+	return &file_api_gobgp_proto_enumTypes[13]
 }
 
 func (x WatchEventResponse_PeerEvent_Type) Number() protoreflect.EnumNumber {
@@ -790,11 +839,11 @@ func (x ResetPeerRequest_Direction) String() string {
 }
 
 func (ResetPeerRequest_Direction) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[13].Descriptor()
+	return file_api_gobgp_proto_enumTypes[14].Descriptor()
 }
 
 func (ResetPeerRequest_Direction) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[13]
+	return &file_api_gobgp_proto_enumTypes[14]
 }
 
 func (x ResetPeerRequest_Direction) Number() protoreflect.EnumNumber {
@@ -843,11 +892,11 @@ func (x TableLookupPrefix_Type) String() string {
 }
 
 func (TableLookupPrefix_Type) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[14].Descriptor()
+	return file_api_gobgp_proto_enumTypes[15].Descriptor()
 }
 
 func (TableLookupPrefix_Type) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[14]
+	return &file_api_gobgp_proto_enumTypes[15]
 }
 
 func (x TableLookupPrefix_Type) Number() protoreflect.EnumNumber {
@@ -889,11 +938,11 @@ func (x ListPathRequest_SortType) String() string {
 }
 
 func (ListPathRequest_SortType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[15].Descriptor()
+	return file_api_gobgp_proto_enumTypes[16].Descriptor()
 }
 
 func (ListPathRequest_SortType) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[15]
+	return &file_api_gobgp_proto_enumTypes[16]
 }
 
 func (x ListPathRequest_SortType) Number() protoreflect.EnumNumber {
@@ -938,11 +987,11 @@ func (x EnableMrtRequest_DumpType) String() string {
 }
 
 func (EnableMrtRequest_DumpType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[16].Descriptor()
+	return file_api_gobgp_proto_enumTypes[17].Descriptor()
 }
 
 func (EnableMrtRequest_DumpType) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[16]
+	return &file_api_gobgp_proto_enumTypes[17]
 }
 
 func (x EnableMrtRequest_DumpType) Number() protoreflect.EnumNumber {
@@ -996,11 +1045,11 @@ func (x AddBmpRequest_MonitoringPolicy) String() string {
 }
 
 func (AddBmpRequest_MonitoringPolicy) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[17].Descriptor()
+	return file_api_gobgp_proto_enumTypes[18].Descriptor()
 }
 
 func (AddBmpRequest_MonitoringPolicy) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[17]
+	return &file_api_gobgp_proto_enumTypes[18]
 }
 
 func (x AddBmpRequest_MonitoringPolicy) Number() protoreflect.EnumNumber {
@@ -1048,11 +1097,11 @@ func (x Validation_Reason) String() string {
 }
 
 func (Validation_Reason) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[18].Descriptor()
+	return file_api_gobgp_proto_enumTypes[19].Descriptor()
 }
 
 func (Validation_Reason) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[18]
+	return &file_api_gobgp_proto_enumTypes[19]
 }
 
 func (x Validation_Reason) Number() protoreflect.EnumNumber {
@@ -1109,11 +1158,11 @@ func (x PeerState_SessionState) String() string {
 }
 
 func (PeerState_SessionState) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[19].Descriptor()
+	return file_api_gobgp_proto_enumTypes[20].Descriptor()
 }
 
 func (PeerState_SessionState) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[19]
+	return &file_api_gobgp_proto_enumTypes[20]
 }
 
 func (x PeerState_SessionState) Number() protoreflect.EnumNumber {
@@ -1161,11 +1210,11 @@ func (x PeerState_AdminState) String() string {
 }
 
 func (PeerState_AdminState) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[20].Descriptor()
+	return file_api_gobgp_proto_enumTypes[21].Descriptor()
 }
 
 func (PeerState_AdminState) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[20]
+	return &file_api_gobgp_proto_enumTypes[21]
 }
 
 func (x PeerState_AdminState) Number() protoreflect.EnumNumber {
@@ -1244,11 +1293,11 @@ func (x PeerState_DisconnectReason) String() string {
 }
 
 func (PeerState_DisconnectReason) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[21].Descriptor()
+	return file_api_gobgp_proto_enumTypes[22].Descriptor()
 }
 
 func (PeerState_DisconnectReason) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[21]
+	return &file_api_gobgp_proto_enumTypes[22]
 }
 
 func (x PeerState_DisconnectReason) Number() protoreflect.EnumNumber {
@@ -1296,11 +1345,11 @@ func (x MatchSet_Type) String() string {
 }
 
 func (MatchSet_Type) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[22].Descriptor()
+	return file_api_gobgp_proto_enumTypes[23].Descriptor()
 }
 
 func (MatchSet_Type) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[22]
+	return &file_api_gobgp_proto_enumTypes[23]
 }
 
 func (x MatchSet_Type) Number() protoreflect.EnumNumber {
@@ -1348,11 +1397,11 @@ func (x Conditions_RouteType) String() string {
 }
 
 func (Conditions_RouteType) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[23].Descriptor()
+	return file_api_gobgp_proto_enumTypes[24].Descriptor()
 }
 
 func (Conditions_RouteType) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[23]
+	return &file_api_gobgp_proto_enumTypes[24]
 }
 
 func (x Conditions_RouteType) Number() protoreflect.EnumNumber {
@@ -1400,11 +1449,11 @@ func (x CommunityAction_Type) String() string {
 }
 
 func (CommunityAction_Type) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[24].Descriptor()
+	return file_api_gobgp_proto_enumTypes[25].Descriptor()
 }
 
 func (CommunityAction_Type) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[24]
+	return &file_api_gobgp_proto_enumTypes[25]
 }
 
 func (x CommunityAction_Type) Number() protoreflect.EnumNumber {
@@ -1449,11 +1498,11 @@ func (x MedAction_Type) String() string {
 }
 
 func (MedAction_Type) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[25].Descriptor()
+	return file_api_gobgp_proto_enumTypes[26].Descriptor()
 }
 
 func (MedAction_Type) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[25]
+	return &file_api_gobgp_proto_enumTypes[26]
 }
 
 func (x MedAction_Type) Number() protoreflect.EnumNumber {
@@ -1513,11 +1562,11 @@ func (x SetLogLevelRequest_Level) String() string {
 }
 
 func (SetLogLevelRequest_Level) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_gobgp_proto_enumTypes[26].Descriptor()
+	return file_api_gobgp_proto_enumTypes[27].Descriptor()
 }
 
 func (SetLogLevelRequest_Level) Type() protoreflect.EnumType {
-	return &file_api_gobgp_proto_enumTypes[26]
+	return &file_api_gobgp_proto_enumTypes[27]
 }
 
 func (x SetLogLevelRequest_Level) Number() protoreflect.EnumNumber {
@@ -12774,6 +12823,494 @@ func (x *BfdState) GetUnknownPeer() uint64 {
 	return 0
 }
 
+type TcpAoKey struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	SendId            uint32                 `protobuf:"varint,1,opt,name=send_id,json=sendId,proto3" json:"send_id,omitempty"`
+	ReceiveId         uint32                 `protobuf:"varint,2,opt,name=receive_id,json=receiveId,proto3" json:"receive_id,omitempty"`
+	Algorithm         TcpAoAlgorithm         `protobuf:"varint,3,opt,name=algorithm,proto3,enum=api.TcpAoAlgorithm" json:"algorithm,omitempty"`
+	MasterKey         []byte                 `protobuf:"bytes,4,opt,name=master_key,json=masterKey,proto3" json:"master_key,omitempty"` // write-only
+	ExcludeTcpOptions bool                   `protobuf:"varint,5,opt,name=exclude_tcp_options,json=excludeTcpOptions,proto3" json:"exclude_tcp_options,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *TcpAoKey) Reset() {
+	*x = TcpAoKey{}
+	mi := &file_api_gobgp_proto_msgTypes[193]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TcpAoKey) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TcpAoKey) ProtoMessage() {}
+
+func (x *TcpAoKey) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[193]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TcpAoKey.ProtoReflect.Descriptor instead.
+func (*TcpAoKey) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{193}
+}
+
+func (x *TcpAoKey) GetSendId() uint32 {
+	if x != nil {
+		return x.SendId
+	}
+	return 0
+}
+
+func (x *TcpAoKey) GetReceiveId() uint32 {
+	if x != nil {
+		return x.ReceiveId
+	}
+	return 0
+}
+
+func (x *TcpAoKey) GetAlgorithm() TcpAoAlgorithm {
+	if x != nil {
+		return x.Algorithm
+	}
+	return TcpAoAlgorithm_TCP_AO_ALGORITHM_UNSPECIFIED
+}
+
+func (x *TcpAoKey) GetMasterKey() []byte {
+	if x != nil {
+		return x.MasterKey
+	}
+	return nil
+}
+
+func (x *TcpAoKey) GetExcludeTcpOptions() bool {
+	if x != nil {
+		return x.ExcludeTcpOptions
+	}
+	return false
+}
+
+type TcpAoKeychain struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Keys          []*TcpAoKey            `protobuf:"bytes,2,rep,name=keys,proto3" json:"keys,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TcpAoKeychain) Reset() {
+	*x = TcpAoKeychain{}
+	mi := &file_api_gobgp_proto_msgTypes[194]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TcpAoKeychain) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TcpAoKeychain) ProtoMessage() {}
+
+func (x *TcpAoKeychain) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[194]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TcpAoKeychain.ProtoReflect.Descriptor instead.
+func (*TcpAoKeychain) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{194}
+}
+
+func (x *TcpAoKeychain) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *TcpAoKeychain) GetKeys() []*TcpAoKey {
+	if x != nil {
+		return x.Keys
+	}
+	return nil
+}
+
+type AddTcpAoKeychainRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Keychain      *TcpAoKeychain         `protobuf:"bytes,1,opt,name=keychain,proto3" json:"keychain,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddTcpAoKeychainRequest) Reset() {
+	*x = AddTcpAoKeychainRequest{}
+	mi := &file_api_gobgp_proto_msgTypes[195]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddTcpAoKeychainRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddTcpAoKeychainRequest) ProtoMessage() {}
+
+func (x *AddTcpAoKeychainRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[195]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddTcpAoKeychainRequest.ProtoReflect.Descriptor instead.
+func (*AddTcpAoKeychainRequest) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{195}
+}
+
+func (x *AddTcpAoKeychainRequest) GetKeychain() *TcpAoKeychain {
+	if x != nil {
+		return x.Keychain
+	}
+	return nil
+}
+
+type AddTcpAoKeychainResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Keychain      *TcpAoKeychain         `protobuf:"bytes,1,opt,name=keychain,proto3" json:"keychain,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddTcpAoKeychainResponse) Reset() {
+	*x = AddTcpAoKeychainResponse{}
+	mi := &file_api_gobgp_proto_msgTypes[196]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddTcpAoKeychainResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddTcpAoKeychainResponse) ProtoMessage() {}
+
+func (x *AddTcpAoKeychainResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[196]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddTcpAoKeychainResponse.ProtoReflect.Descriptor instead.
+func (*AddTcpAoKeychainResponse) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{196}
+}
+
+func (x *AddTcpAoKeychainResponse) GetKeychain() *TcpAoKeychain {
+	if x != nil {
+		return x.Keychain
+	}
+	return nil
+}
+
+type UpdateTcpAoKeychainRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	AddKeys       []*TcpAoKey            `protobuf:"bytes,2,rep,name=add_keys,json=addKeys,proto3" json:"add_keys,omitempty"`
+	DeleteKeys    []*TcpAoKey            `protobuf:"bytes,3,rep,name=delete_keys,json=deleteKeys,proto3" json:"delete_keys,omitempty"` // only send_id and receive_id are used
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateTcpAoKeychainRequest) Reset() {
+	*x = UpdateTcpAoKeychainRequest{}
+	mi := &file_api_gobgp_proto_msgTypes[197]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateTcpAoKeychainRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateTcpAoKeychainRequest) ProtoMessage() {}
+
+func (x *UpdateTcpAoKeychainRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[197]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateTcpAoKeychainRequest.ProtoReflect.Descriptor instead.
+func (*UpdateTcpAoKeychainRequest) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{197}
+}
+
+func (x *UpdateTcpAoKeychainRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *UpdateTcpAoKeychainRequest) GetAddKeys() []*TcpAoKey {
+	if x != nil {
+		return x.AddKeys
+	}
+	return nil
+}
+
+func (x *UpdateTcpAoKeychainRequest) GetDeleteKeys() []*TcpAoKey {
+	if x != nil {
+		return x.DeleteKeys
+	}
+	return nil
+}
+
+type UpdateTcpAoKeychainResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Keychain      *TcpAoKeychain         `protobuf:"bytes,1,opt,name=keychain,proto3" json:"keychain,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateTcpAoKeychainResponse) Reset() {
+	*x = UpdateTcpAoKeychainResponse{}
+	mi := &file_api_gobgp_proto_msgTypes[198]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateTcpAoKeychainResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateTcpAoKeychainResponse) ProtoMessage() {}
+
+func (x *UpdateTcpAoKeychainResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[198]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateTcpAoKeychainResponse.ProtoReflect.Descriptor instead.
+func (*UpdateTcpAoKeychainResponse) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{198}
+}
+
+func (x *UpdateTcpAoKeychainResponse) GetKeychain() *TcpAoKeychain {
+	if x != nil {
+		return x.Keychain
+	}
+	return nil
+}
+
+type DeleteTcpAoKeychainRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteTcpAoKeychainRequest) Reset() {
+	*x = DeleteTcpAoKeychainRequest{}
+	mi := &file_api_gobgp_proto_msgTypes[199]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteTcpAoKeychainRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteTcpAoKeychainRequest) ProtoMessage() {}
+
+func (x *DeleteTcpAoKeychainRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[199]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteTcpAoKeychainRequest.ProtoReflect.Descriptor instead.
+func (*DeleteTcpAoKeychainRequest) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{199}
+}
+
+func (x *DeleteTcpAoKeychainRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type DeleteTcpAoKeychainResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteTcpAoKeychainResponse) Reset() {
+	*x = DeleteTcpAoKeychainResponse{}
+	mi := &file_api_gobgp_proto_msgTypes[200]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteTcpAoKeychainResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteTcpAoKeychainResponse) ProtoMessage() {}
+
+func (x *DeleteTcpAoKeychainResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[200]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteTcpAoKeychainResponse.ProtoReflect.Descriptor instead.
+func (*DeleteTcpAoKeychainResponse) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{200}
+}
+
+type ListTcpAoKeychainRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTcpAoKeychainRequest) Reset() {
+	*x = ListTcpAoKeychainRequest{}
+	mi := &file_api_gobgp_proto_msgTypes[201]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTcpAoKeychainRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTcpAoKeychainRequest) ProtoMessage() {}
+
+func (x *ListTcpAoKeychainRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[201]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTcpAoKeychainRequest.ProtoReflect.Descriptor instead.
+func (*ListTcpAoKeychainRequest) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{201}
+}
+
+func (x *ListTcpAoKeychainRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type ListTcpAoKeychainResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Keychain      *TcpAoKeychain         `protobuf:"bytes,1,opt,name=keychain,proto3" json:"keychain,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTcpAoKeychainResponse) Reset() {
+	*x = ListTcpAoKeychainResponse{}
+	mi := &file_api_gobgp_proto_msgTypes[202]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTcpAoKeychainResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTcpAoKeychainResponse) ProtoMessage() {}
+
+func (x *ListTcpAoKeychainResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_gobgp_proto_msgTypes[202]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTcpAoKeychainResponse.ProtoReflect.Descriptor instead.
+func (*ListTcpAoKeychainResponse) Descriptor() ([]byte, []int) {
+	return file_api_gobgp_proto_rawDescGZIP(), []int{202}
+}
+
+func (x *ListTcpAoKeychainResponse) GetKeychain() *TcpAoKeychain {
+	if x != nil {
+		return x.Keychain
+	}
+	return nil
+}
+
 type WatchEventRequest_Peer struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -12782,7 +13319,7 @@ type WatchEventRequest_Peer struct {
 
 func (x *WatchEventRequest_Peer) Reset() {
 	*x = WatchEventRequest_Peer{}
-	mi := &file_api_gobgp_proto_msgTypes[193]
+	mi := &file_api_gobgp_proto_msgTypes[203]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12794,7 +13331,7 @@ func (x *WatchEventRequest_Peer) String() string {
 func (*WatchEventRequest_Peer) ProtoMessage() {}
 
 func (x *WatchEventRequest_Peer) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[193]
+	mi := &file_api_gobgp_proto_msgTypes[203]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12819,7 +13356,7 @@ type WatchEventRequest_Table struct {
 
 func (x *WatchEventRequest_Table) Reset() {
 	*x = WatchEventRequest_Table{}
-	mi := &file_api_gobgp_proto_msgTypes[194]
+	mi := &file_api_gobgp_proto_msgTypes[204]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12831,7 +13368,7 @@ func (x *WatchEventRequest_Table) String() string {
 func (*WatchEventRequest_Table) ProtoMessage() {}
 
 func (x *WatchEventRequest_Table) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[194]
+	mi := &file_api_gobgp_proto_msgTypes[204]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12866,7 +13403,7 @@ type WatchEventRequest_Table_Filter struct {
 
 func (x *WatchEventRequest_Table_Filter) Reset() {
 	*x = WatchEventRequest_Table_Filter{}
-	mi := &file_api_gobgp_proto_msgTypes[195]
+	mi := &file_api_gobgp_proto_msgTypes[205]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12878,7 +13415,7 @@ func (x *WatchEventRequest_Table_Filter) String() string {
 func (*WatchEventRequest_Table_Filter) ProtoMessage() {}
 
 func (x *WatchEventRequest_Table_Filter) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[195]
+	mi := &file_api_gobgp_proto_msgTypes[205]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12932,7 +13469,7 @@ type WatchEventResponse_PeerEvent struct {
 
 func (x *WatchEventResponse_PeerEvent) Reset() {
 	*x = WatchEventResponse_PeerEvent{}
-	mi := &file_api_gobgp_proto_msgTypes[196]
+	mi := &file_api_gobgp_proto_msgTypes[206]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12944,7 +13481,7 @@ func (x *WatchEventResponse_PeerEvent) String() string {
 func (*WatchEventResponse_PeerEvent) ProtoMessage() {}
 
 func (x *WatchEventResponse_PeerEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[196]
+	mi := &file_api_gobgp_proto_msgTypes[206]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12983,7 +13520,7 @@ type WatchEventResponse_TableEvent struct {
 
 func (x *WatchEventResponse_TableEvent) Reset() {
 	*x = WatchEventResponse_TableEvent{}
-	mi := &file_api_gobgp_proto_msgTypes[197]
+	mi := &file_api_gobgp_proto_msgTypes[207]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12995,7 +13532,7 @@ func (x *WatchEventResponse_TableEvent) String() string {
 func (*WatchEventResponse_TableEvent) ProtoMessage() {}
 
 func (x *WatchEventResponse_TableEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[197]
+	mi := &file_api_gobgp_proto_msgTypes[207]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13028,7 +13565,7 @@ type ListBmpResponse_BmpStation struct {
 
 func (x *ListBmpResponse_BmpStation) Reset() {
 	*x = ListBmpResponse_BmpStation{}
-	mi := &file_api_gobgp_proto_msgTypes[198]
+	mi := &file_api_gobgp_proto_msgTypes[208]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13040,7 +13577,7 @@ func (x *ListBmpResponse_BmpStation) String() string {
 func (*ListBmpResponse_BmpStation) ProtoMessage() {}
 
 func (x *ListBmpResponse_BmpStation) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[198]
+	mi := &file_api_gobgp_proto_msgTypes[208]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13080,7 +13617,7 @@ type ListBmpResponse_BmpStation_Conf struct {
 
 func (x *ListBmpResponse_BmpStation_Conf) Reset() {
 	*x = ListBmpResponse_BmpStation_Conf{}
-	mi := &file_api_gobgp_proto_msgTypes[199]
+	mi := &file_api_gobgp_proto_msgTypes[209]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13092,7 +13629,7 @@ func (x *ListBmpResponse_BmpStation_Conf) String() string {
 func (*ListBmpResponse_BmpStation_Conf) ProtoMessage() {}
 
 func (x *ListBmpResponse_BmpStation_Conf) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[199]
+	mi := &file_api_gobgp_proto_msgTypes[209]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13132,7 +13669,7 @@ type ListBmpResponse_BmpStation_State struct {
 
 func (x *ListBmpResponse_BmpStation_State) Reset() {
 	*x = ListBmpResponse_BmpStation_State{}
-	mi := &file_api_gobgp_proto_msgTypes[200]
+	mi := &file_api_gobgp_proto_msgTypes[210]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13144,7 +13681,7 @@ func (x *ListBmpResponse_BmpStation_State) String() string {
 func (*ListBmpResponse_BmpStation_State) ProtoMessage() {}
 
 func (x *ListBmpResponse_BmpStation_State) ProtoReflect() protoreflect.Message {
-	mi := &file_api_gobgp_proto_msgTypes[200]
+	mi := &file_api_gobgp_proto_msgTypes[210]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14120,7 +14657,36 @@ const file_api_gobgp_proto_rawDesc = "" +
 	"\rreceived_drop\x18\x02 \x01(\x04R\freceivedDrop\x12%\n" +
 	"\x0ereceived_error\x18\x03 \x01(\x04R\rreceivedError\x12%\n" +
 	"\x0einvalid_packet\x18\x04 \x01(\x04R\rinvalidPacket\x12!\n" +
-	"\funknown_peer\x18\x05 \x01(\x04R\vunknownPeer*\x97\x01\n" +
+	"\funknown_peer\x18\x05 \x01(\x04R\vunknownPeer\"\xc9\x01\n" +
+	"\bTcpAoKey\x12\x17\n" +
+	"\asend_id\x18\x01 \x01(\rR\x06sendId\x12\x1d\n" +
+	"\n" +
+	"receive_id\x18\x02 \x01(\rR\treceiveId\x121\n" +
+	"\talgorithm\x18\x03 \x01(\x0e2\x13.api.TcpAoAlgorithmR\talgorithm\x12\"\n" +
+	"\n" +
+	"master_key\x18\x04 \x01(\fB\x03\x80\x01\x01R\tmasterKey\x12.\n" +
+	"\x13exclude_tcp_options\x18\x05 \x01(\bR\x11excludeTcpOptions\"F\n" +
+	"\rTcpAoKeychain\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
+	"\x04keys\x18\x02 \x03(\v2\r.api.TcpAoKeyR\x04keys\"I\n" +
+	"\x17AddTcpAoKeychainRequest\x12.\n" +
+	"\bkeychain\x18\x01 \x01(\v2\x12.api.TcpAoKeychainR\bkeychain\"J\n" +
+	"\x18AddTcpAoKeychainResponse\x12.\n" +
+	"\bkeychain\x18\x01 \x01(\v2\x12.api.TcpAoKeychainR\bkeychain\"\x8a\x01\n" +
+	"\x1aUpdateTcpAoKeychainRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12(\n" +
+	"\badd_keys\x18\x02 \x03(\v2\r.api.TcpAoKeyR\aaddKeys\x12.\n" +
+	"\vdelete_keys\x18\x03 \x03(\v2\r.api.TcpAoKeyR\n" +
+	"deleteKeys\"M\n" +
+	"\x1bUpdateTcpAoKeychainResponse\x12.\n" +
+	"\bkeychain\x18\x01 \x01(\v2\x12.api.TcpAoKeychainR\bkeychain\"0\n" +
+	"\x1aDeleteTcpAoKeychainRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"\x1d\n" +
+	"\x1bDeleteTcpAoKeychainResponse\".\n" +
+	"\x18ListTcpAoKeychainRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"K\n" +
+	"\x19ListTcpAoKeychainResponse\x12.\n" +
+	"\bkeychain\x18\x01 \x01(\v2\x12.api.TcpAoKeychainR\bkeychain*\x97\x01\n" +
 	"\tTableType\x12\x1a\n" +
 	"\x16TABLE_TYPE_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11TABLE_TYPE_GLOBAL\x10\x01\x12\x14\n" +
@@ -14187,7 +14753,11 @@ const file_api_gobgp_proto_rawDesc = "" +
 	"\x1dBFD_DIAGNOSTIC_CODE_PATH_DOWN\x10\x05\x12.\n" +
 	"*BFD_DIAGNOSTIC_CODE_CONCATENATED_PATH_DOWN\x10\x06\x12-\n" +
 	")BFD_DIAGNOSTIC_CODE_ADMINISTRATIVELY_DOWN\x10\a\x126\n" +
-	"2BFD_DIAGNOSTIC_CODE_REVERSE_CONCATENATED_PATH_DOWN\x10\b2\x94\x1d\n" +
+	"2BFD_DIAGNOSTIC_CODE_REVERSE_CONCATENATED_PATH_DOWN\x10\b*{\n" +
+	"\x0eTcpAoAlgorithm\x12 \n" +
+	"\x1cTCP_AO_ALGORITHM_UNSPECIFIED\x10\x00\x12!\n" +
+	"\x1dTCP_AO_ALGORITHM_HMAC_SHA1_96\x10\x01\x12$\n" +
+	" TCP_AO_ALGORITHM_AES_128_CMAC_96\x10\x022\xef\x1f\n" +
 	"\fGoBgpService\x127\n" +
 	"\bStartBgp\x12\x14.api.StartBgpRequest\x1a\x15.api.StartBgpResponse\x124\n" +
 	"\aStopBgp\x12\x13.api.StopBgpRequest\x1a\x14.api.StopBgpResponse\x121\n" +
@@ -14252,7 +14822,11 @@ const file_api_gobgp_proto_rawDesc = "" +
 	"\x06AddBmp\x12\x12.api.AddBmpRequest\x1a\x13.api.AddBmpResponse\x12:\n" +
 	"\tDeleteBmp\x12\x15.api.DeleteBmpRequest\x1a\x16.api.DeleteBmpResponse\x126\n" +
 	"\aListBmp\x12\x13.api.ListBmpRequest\x1a\x14.api.ListBmpResponse0\x01\x12@\n" +
-	"\vSetLogLevel\x12\x17.api.SetLogLevelRequest\x1a\x18.api.SetLogLevelResponseB\"Z github.com/osrg/gobgp/v4/api;apib\x06proto3"
+	"\vSetLogLevel\x12\x17.api.SetLogLevelRequest\x1a\x18.api.SetLogLevelResponse\x12O\n" +
+	"\x10AddTcpAoKeychain\x12\x1c.api.AddTcpAoKeychainRequest\x1a\x1d.api.AddTcpAoKeychainResponse\x12X\n" +
+	"\x13UpdateTcpAoKeychain\x12\x1f.api.UpdateTcpAoKeychainRequest\x1a .api.UpdateTcpAoKeychainResponse\x12X\n" +
+	"\x13DeleteTcpAoKeychain\x12\x1f.api.DeleteTcpAoKeychainRequest\x1a .api.DeleteTcpAoKeychainResponse\x12T\n" +
+	"\x11ListTcpAoKeychain\x12\x1d.api.ListTcpAoKeychainRequest\x1a\x1e.api.ListTcpAoKeychainResponse0\x01B\"Z github.com/osrg/gobgp/v4/api;apib\x06proto3"
 
 var (
 	file_api_gobgp_proto_rawDescOnce sync.Once
@@ -14266,8 +14840,8 @@ func file_api_gobgp_proto_rawDescGZIP() []byte {
 	return file_api_gobgp_proto_rawDescData
 }
 
-var file_api_gobgp_proto_enumTypes = make([]protoimpl.EnumInfo, 27)
-var file_api_gobgp_proto_msgTypes = make([]protoimpl.MessageInfo, 201)
+var file_api_gobgp_proto_enumTypes = make([]protoimpl.EnumInfo, 28)
+var file_api_gobgp_proto_msgTypes = make([]protoimpl.MessageInfo, 211)
 var file_api_gobgp_proto_goTypes = []any{
 	(TableType)(0),                           // 0: api.TableType
 	(ValidationState)(0),                     // 1: api.ValidationState
@@ -14280,560 +14854,587 @@ var file_api_gobgp_proto_goTypes = []any{
 	(PolicyDirection)(0),                     // 8: api.PolicyDirection
 	(BfdSessionState)(0),                     // 9: api.BfdSessionState
 	(BfdDiagnosticCode)(0),                   // 10: api.BfdDiagnosticCode
-	(WatchEventRequest_Table_Filter_Type)(0), // 11: api.WatchEventRequest.Table.Filter.Type
-	(WatchEventResponse_PeerEvent_Type)(0),   // 12: api.WatchEventResponse.PeerEvent.Type
-	(ResetPeerRequest_Direction)(0),          // 13: api.ResetPeerRequest.Direction
-	(TableLookupPrefix_Type)(0),              // 14: api.TableLookupPrefix.Type
-	(ListPathRequest_SortType)(0),            // 15: api.ListPathRequest.SortType
-	(EnableMrtRequest_DumpType)(0),           // 16: api.EnableMrtRequest.DumpType
-	(AddBmpRequest_MonitoringPolicy)(0),      // 17: api.AddBmpRequest.MonitoringPolicy
-	(Validation_Reason)(0),                   // 18: api.Validation.Reason
-	(PeerState_SessionState)(0),              // 19: api.PeerState.SessionState
-	(PeerState_AdminState)(0),                // 20: api.PeerState.AdminState
-	(PeerState_DisconnectReason)(0),          // 21: api.PeerState.DisconnectReason
-	(MatchSet_Type)(0),                       // 22: api.MatchSet.Type
-	(Conditions_RouteType)(0),                // 23: api.Conditions.RouteType
-	(CommunityAction_Type)(0),                // 24: api.CommunityAction.Type
-	(MedAction_Type)(0),                      // 25: api.MedAction.Type
-	(SetLogLevelRequest_Level)(0),            // 26: api.SetLogLevelRequest.Level
-	(*StartBgpRequest)(nil),                  // 27: api.StartBgpRequest
-	(*StartBgpResponse)(nil),                 // 28: api.StartBgpResponse
-	(*StopBgpRequest)(nil),                   // 29: api.StopBgpRequest
-	(*StopBgpResponse)(nil),                  // 30: api.StopBgpResponse
-	(*GetBgpRequest)(nil),                    // 31: api.GetBgpRequest
-	(*GetBgpResponse)(nil),                   // 32: api.GetBgpResponse
-	(*WatchEventRequest)(nil),                // 33: api.WatchEventRequest
-	(*WatchEventResponse)(nil),               // 34: api.WatchEventResponse
-	(*AddPeerRequest)(nil),                   // 35: api.AddPeerRequest
-	(*AddPeerResponse)(nil),                  // 36: api.AddPeerResponse
-	(*DeletePeerRequest)(nil),                // 37: api.DeletePeerRequest
-	(*DeletePeerResponse)(nil),               // 38: api.DeletePeerResponse
-	(*ListPeerRequest)(nil),                  // 39: api.ListPeerRequest
-	(*ListPeerResponse)(nil),                 // 40: api.ListPeerResponse
-	(*UpdatePeerRequest)(nil),                // 41: api.UpdatePeerRequest
-	(*UpdatePeerResponse)(nil),               // 42: api.UpdatePeerResponse
-	(*ResetPeerRequest)(nil),                 // 43: api.ResetPeerRequest
-	(*ResetPeerResponse)(nil),                // 44: api.ResetPeerResponse
-	(*ShutdownPeerRequest)(nil),              // 45: api.ShutdownPeerRequest
-	(*ShutdownPeerResponse)(nil),             // 46: api.ShutdownPeerResponse
-	(*EnablePeerRequest)(nil),                // 47: api.EnablePeerRequest
-	(*EnablePeerResponse)(nil),               // 48: api.EnablePeerResponse
-	(*DisablePeerRequest)(nil),               // 49: api.DisablePeerRequest
-	(*DisablePeerResponse)(nil),              // 50: api.DisablePeerResponse
-	(*AddPeerGroupRequest)(nil),              // 51: api.AddPeerGroupRequest
-	(*AddPeerGroupResponse)(nil),             // 52: api.AddPeerGroupResponse
-	(*DeletePeerGroupRequest)(nil),           // 53: api.DeletePeerGroupRequest
-	(*DeletePeerGroupResponse)(nil),          // 54: api.DeletePeerGroupResponse
-	(*UpdatePeerGroupRequest)(nil),           // 55: api.UpdatePeerGroupRequest
-	(*UpdatePeerGroupResponse)(nil),          // 56: api.UpdatePeerGroupResponse
-	(*ListPeerGroupRequest)(nil),             // 57: api.ListPeerGroupRequest
-	(*ListPeerGroupResponse)(nil),            // 58: api.ListPeerGroupResponse
-	(*AddDynamicNeighborRequest)(nil),        // 59: api.AddDynamicNeighborRequest
-	(*AddDynamicNeighborResponse)(nil),       // 60: api.AddDynamicNeighborResponse
-	(*DeleteDynamicNeighborRequest)(nil),     // 61: api.DeleteDynamicNeighborRequest
-	(*DeleteDynamicNeighborResponse)(nil),    // 62: api.DeleteDynamicNeighborResponse
-	(*ListDynamicNeighborRequest)(nil),       // 63: api.ListDynamicNeighborRequest
-	(*ListDynamicNeighborResponse)(nil),      // 64: api.ListDynamicNeighborResponse
-	(*AddPathRequest)(nil),                   // 65: api.AddPathRequest
-	(*AddPathResponse)(nil),                  // 66: api.AddPathResponse
-	(*DeletePathRequest)(nil),                // 67: api.DeletePathRequest
-	(*DeletePathResponse)(nil),               // 68: api.DeletePathResponse
-	(*TableLookupPrefix)(nil),                // 69: api.TableLookupPrefix
-	(*ListPathRequest)(nil),                  // 70: api.ListPathRequest
-	(*ListPathResponse)(nil),                 // 71: api.ListPathResponse
-	(*AddPathStreamRequest)(nil),             // 72: api.AddPathStreamRequest
-	(*AddPathStreamResponse)(nil),            // 73: api.AddPathStreamResponse
-	(*GetTableRequest)(nil),                  // 74: api.GetTableRequest
-	(*GetTableResponse)(nil),                 // 75: api.GetTableResponse
-	(*AddVrfRequest)(nil),                    // 76: api.AddVrfRequest
-	(*AddVrfResponse)(nil),                   // 77: api.AddVrfResponse
-	(*DeleteVrfRequest)(nil),                 // 78: api.DeleteVrfRequest
-	(*DeleteVrfResponse)(nil),                // 79: api.DeleteVrfResponse
-	(*ListVrfRequest)(nil),                   // 80: api.ListVrfRequest
-	(*ListVrfResponse)(nil),                  // 81: api.ListVrfResponse
-	(*AddPolicyRequest)(nil),                 // 82: api.AddPolicyRequest
-	(*AddPolicyResponse)(nil),                // 83: api.AddPolicyResponse
-	(*DeletePolicyRequest)(nil),              // 84: api.DeletePolicyRequest
-	(*DeletePolicyResponse)(nil),             // 85: api.DeletePolicyResponse
-	(*ListPolicyRequest)(nil),                // 86: api.ListPolicyRequest
-	(*ListPolicyResponse)(nil),               // 87: api.ListPolicyResponse
-	(*SetPoliciesRequest)(nil),               // 88: api.SetPoliciesRequest
-	(*SetPoliciesResponse)(nil),              // 89: api.SetPoliciesResponse
-	(*AddDefinedSetRequest)(nil),             // 90: api.AddDefinedSetRequest
-	(*AddDefinedSetResponse)(nil),            // 91: api.AddDefinedSetResponse
-	(*DeleteDefinedSetRequest)(nil),          // 92: api.DeleteDefinedSetRequest
-	(*DeleteDefinedSetResponse)(nil),         // 93: api.DeleteDefinedSetResponse
-	(*ListDefinedSetRequest)(nil),            // 94: api.ListDefinedSetRequest
-	(*ListDefinedSetResponse)(nil),           // 95: api.ListDefinedSetResponse
-	(*AddStatementRequest)(nil),              // 96: api.AddStatementRequest
-	(*AddStatementResponse)(nil),             // 97: api.AddStatementResponse
-	(*DeleteStatementRequest)(nil),           // 98: api.DeleteStatementRequest
-	(*DeleteStatementResponse)(nil),          // 99: api.DeleteStatementResponse
-	(*ListStatementRequest)(nil),             // 100: api.ListStatementRequest
-	(*ListStatementResponse)(nil),            // 101: api.ListStatementResponse
-	(*AddPolicyAssignmentRequest)(nil),       // 102: api.AddPolicyAssignmentRequest
-	(*AddPolicyAssignmentResponse)(nil),      // 103: api.AddPolicyAssignmentResponse
-	(*DeletePolicyAssignmentRequest)(nil),    // 104: api.DeletePolicyAssignmentRequest
-	(*DeletePolicyAssignmentResponse)(nil),   // 105: api.DeletePolicyAssignmentResponse
-	(*ListPolicyAssignmentRequest)(nil),      // 106: api.ListPolicyAssignmentRequest
-	(*ListPolicyAssignmentResponse)(nil),     // 107: api.ListPolicyAssignmentResponse
-	(*SetPolicyAssignmentRequest)(nil),       // 108: api.SetPolicyAssignmentRequest
-	(*SetPolicyAssignmentResponse)(nil),      // 109: api.SetPolicyAssignmentResponse
-	(*AddRpkiRequest)(nil),                   // 110: api.AddRpkiRequest
-	(*AddRpkiResponse)(nil),                  // 111: api.AddRpkiResponse
-	(*DeleteRpkiRequest)(nil),                // 112: api.DeleteRpkiRequest
-	(*DeleteRpkiResponse)(nil),               // 113: api.DeleteRpkiResponse
-	(*ListRpkiRequest)(nil),                  // 114: api.ListRpkiRequest
-	(*ListRpkiResponse)(nil),                 // 115: api.ListRpkiResponse
-	(*EnableRpkiRequest)(nil),                // 116: api.EnableRpkiRequest
-	(*EnableRpkiResponse)(nil),               // 117: api.EnableRpkiResponse
-	(*DisableRpkiRequest)(nil),               // 118: api.DisableRpkiRequest
-	(*DisableRpkiResponse)(nil),              // 119: api.DisableRpkiResponse
-	(*ResetRpkiRequest)(nil),                 // 120: api.ResetRpkiRequest
-	(*ResetRpkiResponse)(nil),                // 121: api.ResetRpkiResponse
-	(*ListRpkiTableRequest)(nil),             // 122: api.ListRpkiTableRequest
-	(*ListRpkiTableResponse)(nil),            // 123: api.ListRpkiTableResponse
-	(*EnableZebraRequest)(nil),               // 124: api.EnableZebraRequest
-	(*EnableZebraResponse)(nil),              // 125: api.EnableZebraResponse
-	(*EnableMrtRequest)(nil),                 // 126: api.EnableMrtRequest
-	(*EnableMrtResponse)(nil),                // 127: api.EnableMrtResponse
-	(*DisableMrtRequest)(nil),                // 128: api.DisableMrtRequest
-	(*DisableMrtResponse)(nil),               // 129: api.DisableMrtResponse
-	(*AddBmpRequest)(nil),                    // 130: api.AddBmpRequest
-	(*AddBmpResponse)(nil),                   // 131: api.AddBmpResponse
-	(*DeleteBmpRequest)(nil),                 // 132: api.DeleteBmpRequest
-	(*DeleteBmpResponse)(nil),                // 133: api.DeleteBmpResponse
-	(*ListBmpRequest)(nil),                   // 134: api.ListBmpRequest
-	(*ListBmpResponse)(nil),                  // 135: api.ListBmpResponse
-	(*Validation)(nil),                       // 136: api.Validation
-	(*Path)(nil),                             // 137: api.Path
-	(*Destination)(nil),                      // 138: api.Destination
-	(*Peer)(nil),                             // 139: api.Peer
-	(*PeerGroup)(nil),                        // 140: api.PeerGroup
-	(*DynamicNeighbor)(nil),                  // 141: api.DynamicNeighbor
-	(*ApplyPolicy)(nil),                      // 142: api.ApplyPolicy
-	(*PrefixLimit)(nil),                      // 143: api.PrefixLimit
-	(*PeerConf)(nil),                         // 144: api.PeerConf
-	(*PeerGroupConf)(nil),                    // 145: api.PeerGroupConf
-	(*PeerGroupState)(nil),                   // 146: api.PeerGroupState
-	(*TtlSecurity)(nil),                      // 147: api.TtlSecurity
-	(*EbgpMultihop)(nil),                     // 148: api.EbgpMultihop
-	(*RouteReflector)(nil),                   // 149: api.RouteReflector
-	(*PeerState)(nil),                        // 150: api.PeerState
-	(*Messages)(nil),                         // 151: api.Messages
-	(*Message)(nil),                          // 152: api.Message
-	(*Queues)(nil),                           // 153: api.Queues
-	(*Timers)(nil),                           // 154: api.Timers
-	(*TimersConfig)(nil),                     // 155: api.TimersConfig
-	(*TimersState)(nil),                      // 156: api.TimersState
-	(*Transport)(nil),                        // 157: api.Transport
-	(*RouteServer)(nil),                      // 158: api.RouteServer
-	(*GracefulRestart)(nil),                  // 159: api.GracefulRestart
-	(*MpGracefulRestartConfig)(nil),          // 160: api.MpGracefulRestartConfig
-	(*MpGracefulRestartState)(nil),           // 161: api.MpGracefulRestartState
-	(*MpGracefulRestart)(nil),                // 162: api.MpGracefulRestart
-	(*AfiSafiConfig)(nil),                    // 163: api.AfiSafiConfig
-	(*AfiSafiState)(nil),                     // 164: api.AfiSafiState
-	(*RouteSelectionOptionsConfig)(nil),      // 165: api.RouteSelectionOptionsConfig
-	(*RouteSelectionOptionsState)(nil),       // 166: api.RouteSelectionOptionsState
-	(*RouteSelectionOptions)(nil),            // 167: api.RouteSelectionOptions
-	(*UseMultiplePathsConfig)(nil),           // 168: api.UseMultiplePathsConfig
-	(*UseMultiplePathsState)(nil),            // 169: api.UseMultiplePathsState
-	(*EbgpConfig)(nil),                       // 170: api.EbgpConfig
-	(*EbgpState)(nil),                        // 171: api.EbgpState
-	(*Ebgp)(nil),                             // 172: api.Ebgp
-	(*IbgpConfig)(nil),                       // 173: api.IbgpConfig
-	(*IbgpState)(nil),                        // 174: api.IbgpState
-	(*Ibgp)(nil),                             // 175: api.Ibgp
-	(*UseMultiplePaths)(nil),                 // 176: api.UseMultiplePaths
-	(*RouteTargetMembershipConfig)(nil),      // 177: api.RouteTargetMembershipConfig
-	(*RouteTargetMembershipState)(nil),       // 178: api.RouteTargetMembershipState
-	(*RouteTargetMembership)(nil),            // 179: api.RouteTargetMembership
-	(*LongLivedGracefulRestartConfig)(nil),   // 180: api.LongLivedGracefulRestartConfig
-	(*LongLivedGracefulRestartState)(nil),    // 181: api.LongLivedGracefulRestartState
-	(*LongLivedGracefulRestart)(nil),         // 182: api.LongLivedGracefulRestart
-	(*AfiSafi)(nil),                          // 183: api.AfiSafi
-	(*AddPathsConfig)(nil),                   // 184: api.AddPathsConfig
-	(*AddPathsState)(nil),                    // 185: api.AddPathsState
-	(*AddPaths)(nil),                         // 186: api.AddPaths
-	(*Prefix)(nil),                           // 187: api.Prefix
-	(*DefinedSet)(nil),                       // 188: api.DefinedSet
-	(*MatchSet)(nil),                         // 189: api.MatchSet
-	(*AsPathLength)(nil),                     // 190: api.AsPathLength
-	(*CommunityCount)(nil),                   // 191: api.CommunityCount
-	(*LocalPrefEq)(nil),                      // 192: api.LocalPrefEq
-	(*MedEq)(nil),                            // 193: api.MedEq
-	(*Conditions)(nil),                       // 194: api.Conditions
-	(*CommunityAction)(nil),                  // 195: api.CommunityAction
-	(*MedAction)(nil),                        // 196: api.MedAction
-	(*AsPrependAction)(nil),                  // 197: api.AsPrependAction
-	(*NexthopAction)(nil),                    // 198: api.NexthopAction
-	(*LocalPrefAction)(nil),                  // 199: api.LocalPrefAction
-	(*OriginAction)(nil),                     // 200: api.OriginAction
-	(*Actions)(nil),                          // 201: api.Actions
-	(*Statement)(nil),                        // 202: api.Statement
-	(*Policy)(nil),                           // 203: api.Policy
-	(*PolicyAssignment)(nil),                 // 204: api.PolicyAssignment
-	(*RoutingPolicy)(nil),                    // 205: api.RoutingPolicy
-	(*Roa)(nil),                              // 206: api.Roa
-	(*Vrf)(nil),                              // 207: api.Vrf
-	(*DefaultRouteDistance)(nil),             // 208: api.DefaultRouteDistance
-	(*Global)(nil),                           // 209: api.Global
-	(*Confederation)(nil),                    // 210: api.Confederation
-	(*RPKIConf)(nil),                         // 211: api.RPKIConf
-	(*RPKIState)(nil),                        // 212: api.RPKIState
-	(*Rpki)(nil),                             // 213: api.Rpki
-	(*SetLogLevelRequest)(nil),               // 214: api.SetLogLevelRequest
-	(*SetLogLevelResponse)(nil),              // 215: api.SetLogLevelResponse
-	(*BfdAsyncCounters)(nil),                 // 216: api.BfdAsyncCounters
-	(*BfdPeerState)(nil),                     // 217: api.BfdPeerState
-	(*BfdPeerConfig)(nil),                    // 218: api.BfdPeerConfig
-	(*BfdState)(nil),                         // 219: api.BfdState
-	(*WatchEventRequest_Peer)(nil),           // 220: api.WatchEventRequest.Peer
-	(*WatchEventRequest_Table)(nil),          // 221: api.WatchEventRequest.Table
-	(*WatchEventRequest_Table_Filter)(nil),   // 222: api.WatchEventRequest.Table.Filter
-	(*WatchEventResponse_PeerEvent)(nil),     // 223: api.WatchEventResponse.PeerEvent
-	(*WatchEventResponse_TableEvent)(nil),    // 224: api.WatchEventResponse.TableEvent
-	(*ListBmpResponse_BmpStation)(nil),       // 225: api.ListBmpResponse.BmpStation
-	(*ListBmpResponse_BmpStation_Conf)(nil),  // 226: api.ListBmpResponse.BmpStation.Conf
-	(*ListBmpResponse_BmpStation_State)(nil), // 227: api.ListBmpResponse.BmpStation.State
-	(*Family)(nil),                           // 228: api.Family
-	(*NLRI)(nil),                             // 229: api.NLRI
-	(*Attribute)(nil),                        // 230: api.Attribute
-	(*timestamppb.Timestamp)(nil),            // 231: google.protobuf.Timestamp
-	(*Capability)(nil),                       // 232: api.Capability
-	(*RouteDistinguisher)(nil),               // 233: api.RouteDistinguisher
-	(*RouteTarget)(nil),                      // 234: api.RouteTarget
+	(TcpAoAlgorithm)(0),                      // 11: api.TcpAoAlgorithm
+	(WatchEventRequest_Table_Filter_Type)(0), // 12: api.WatchEventRequest.Table.Filter.Type
+	(WatchEventResponse_PeerEvent_Type)(0),   // 13: api.WatchEventResponse.PeerEvent.Type
+	(ResetPeerRequest_Direction)(0),          // 14: api.ResetPeerRequest.Direction
+	(TableLookupPrefix_Type)(0),              // 15: api.TableLookupPrefix.Type
+	(ListPathRequest_SortType)(0),            // 16: api.ListPathRequest.SortType
+	(EnableMrtRequest_DumpType)(0),           // 17: api.EnableMrtRequest.DumpType
+	(AddBmpRequest_MonitoringPolicy)(0),      // 18: api.AddBmpRequest.MonitoringPolicy
+	(Validation_Reason)(0),                   // 19: api.Validation.Reason
+	(PeerState_SessionState)(0),              // 20: api.PeerState.SessionState
+	(PeerState_AdminState)(0),                // 21: api.PeerState.AdminState
+	(PeerState_DisconnectReason)(0),          // 22: api.PeerState.DisconnectReason
+	(MatchSet_Type)(0),                       // 23: api.MatchSet.Type
+	(Conditions_RouteType)(0),                // 24: api.Conditions.RouteType
+	(CommunityAction_Type)(0),                // 25: api.CommunityAction.Type
+	(MedAction_Type)(0),                      // 26: api.MedAction.Type
+	(SetLogLevelRequest_Level)(0),            // 27: api.SetLogLevelRequest.Level
+	(*StartBgpRequest)(nil),                  // 28: api.StartBgpRequest
+	(*StartBgpResponse)(nil),                 // 29: api.StartBgpResponse
+	(*StopBgpRequest)(nil),                   // 30: api.StopBgpRequest
+	(*StopBgpResponse)(nil),                  // 31: api.StopBgpResponse
+	(*GetBgpRequest)(nil),                    // 32: api.GetBgpRequest
+	(*GetBgpResponse)(nil),                   // 33: api.GetBgpResponse
+	(*WatchEventRequest)(nil),                // 34: api.WatchEventRequest
+	(*WatchEventResponse)(nil),               // 35: api.WatchEventResponse
+	(*AddPeerRequest)(nil),                   // 36: api.AddPeerRequest
+	(*AddPeerResponse)(nil),                  // 37: api.AddPeerResponse
+	(*DeletePeerRequest)(nil),                // 38: api.DeletePeerRequest
+	(*DeletePeerResponse)(nil),               // 39: api.DeletePeerResponse
+	(*ListPeerRequest)(nil),                  // 40: api.ListPeerRequest
+	(*ListPeerResponse)(nil),                 // 41: api.ListPeerResponse
+	(*UpdatePeerRequest)(nil),                // 42: api.UpdatePeerRequest
+	(*UpdatePeerResponse)(nil),               // 43: api.UpdatePeerResponse
+	(*ResetPeerRequest)(nil),                 // 44: api.ResetPeerRequest
+	(*ResetPeerResponse)(nil),                // 45: api.ResetPeerResponse
+	(*ShutdownPeerRequest)(nil),              // 46: api.ShutdownPeerRequest
+	(*ShutdownPeerResponse)(nil),             // 47: api.ShutdownPeerResponse
+	(*EnablePeerRequest)(nil),                // 48: api.EnablePeerRequest
+	(*EnablePeerResponse)(nil),               // 49: api.EnablePeerResponse
+	(*DisablePeerRequest)(nil),               // 50: api.DisablePeerRequest
+	(*DisablePeerResponse)(nil),              // 51: api.DisablePeerResponse
+	(*AddPeerGroupRequest)(nil),              // 52: api.AddPeerGroupRequest
+	(*AddPeerGroupResponse)(nil),             // 53: api.AddPeerGroupResponse
+	(*DeletePeerGroupRequest)(nil),           // 54: api.DeletePeerGroupRequest
+	(*DeletePeerGroupResponse)(nil),          // 55: api.DeletePeerGroupResponse
+	(*UpdatePeerGroupRequest)(nil),           // 56: api.UpdatePeerGroupRequest
+	(*UpdatePeerGroupResponse)(nil),          // 57: api.UpdatePeerGroupResponse
+	(*ListPeerGroupRequest)(nil),             // 58: api.ListPeerGroupRequest
+	(*ListPeerGroupResponse)(nil),            // 59: api.ListPeerGroupResponse
+	(*AddDynamicNeighborRequest)(nil),        // 60: api.AddDynamicNeighborRequest
+	(*AddDynamicNeighborResponse)(nil),       // 61: api.AddDynamicNeighborResponse
+	(*DeleteDynamicNeighborRequest)(nil),     // 62: api.DeleteDynamicNeighborRequest
+	(*DeleteDynamicNeighborResponse)(nil),    // 63: api.DeleteDynamicNeighborResponse
+	(*ListDynamicNeighborRequest)(nil),       // 64: api.ListDynamicNeighborRequest
+	(*ListDynamicNeighborResponse)(nil),      // 65: api.ListDynamicNeighborResponse
+	(*AddPathRequest)(nil),                   // 66: api.AddPathRequest
+	(*AddPathResponse)(nil),                  // 67: api.AddPathResponse
+	(*DeletePathRequest)(nil),                // 68: api.DeletePathRequest
+	(*DeletePathResponse)(nil),               // 69: api.DeletePathResponse
+	(*TableLookupPrefix)(nil),                // 70: api.TableLookupPrefix
+	(*ListPathRequest)(nil),                  // 71: api.ListPathRequest
+	(*ListPathResponse)(nil),                 // 72: api.ListPathResponse
+	(*AddPathStreamRequest)(nil),             // 73: api.AddPathStreamRequest
+	(*AddPathStreamResponse)(nil),            // 74: api.AddPathStreamResponse
+	(*GetTableRequest)(nil),                  // 75: api.GetTableRequest
+	(*GetTableResponse)(nil),                 // 76: api.GetTableResponse
+	(*AddVrfRequest)(nil),                    // 77: api.AddVrfRequest
+	(*AddVrfResponse)(nil),                   // 78: api.AddVrfResponse
+	(*DeleteVrfRequest)(nil),                 // 79: api.DeleteVrfRequest
+	(*DeleteVrfResponse)(nil),                // 80: api.DeleteVrfResponse
+	(*ListVrfRequest)(nil),                   // 81: api.ListVrfRequest
+	(*ListVrfResponse)(nil),                  // 82: api.ListVrfResponse
+	(*AddPolicyRequest)(nil),                 // 83: api.AddPolicyRequest
+	(*AddPolicyResponse)(nil),                // 84: api.AddPolicyResponse
+	(*DeletePolicyRequest)(nil),              // 85: api.DeletePolicyRequest
+	(*DeletePolicyResponse)(nil),             // 86: api.DeletePolicyResponse
+	(*ListPolicyRequest)(nil),                // 87: api.ListPolicyRequest
+	(*ListPolicyResponse)(nil),               // 88: api.ListPolicyResponse
+	(*SetPoliciesRequest)(nil),               // 89: api.SetPoliciesRequest
+	(*SetPoliciesResponse)(nil),              // 90: api.SetPoliciesResponse
+	(*AddDefinedSetRequest)(nil),             // 91: api.AddDefinedSetRequest
+	(*AddDefinedSetResponse)(nil),            // 92: api.AddDefinedSetResponse
+	(*DeleteDefinedSetRequest)(nil),          // 93: api.DeleteDefinedSetRequest
+	(*DeleteDefinedSetResponse)(nil),         // 94: api.DeleteDefinedSetResponse
+	(*ListDefinedSetRequest)(nil),            // 95: api.ListDefinedSetRequest
+	(*ListDefinedSetResponse)(nil),           // 96: api.ListDefinedSetResponse
+	(*AddStatementRequest)(nil),              // 97: api.AddStatementRequest
+	(*AddStatementResponse)(nil),             // 98: api.AddStatementResponse
+	(*DeleteStatementRequest)(nil),           // 99: api.DeleteStatementRequest
+	(*DeleteStatementResponse)(nil),          // 100: api.DeleteStatementResponse
+	(*ListStatementRequest)(nil),             // 101: api.ListStatementRequest
+	(*ListStatementResponse)(nil),            // 102: api.ListStatementResponse
+	(*AddPolicyAssignmentRequest)(nil),       // 103: api.AddPolicyAssignmentRequest
+	(*AddPolicyAssignmentResponse)(nil),      // 104: api.AddPolicyAssignmentResponse
+	(*DeletePolicyAssignmentRequest)(nil),    // 105: api.DeletePolicyAssignmentRequest
+	(*DeletePolicyAssignmentResponse)(nil),   // 106: api.DeletePolicyAssignmentResponse
+	(*ListPolicyAssignmentRequest)(nil),      // 107: api.ListPolicyAssignmentRequest
+	(*ListPolicyAssignmentResponse)(nil),     // 108: api.ListPolicyAssignmentResponse
+	(*SetPolicyAssignmentRequest)(nil),       // 109: api.SetPolicyAssignmentRequest
+	(*SetPolicyAssignmentResponse)(nil),      // 110: api.SetPolicyAssignmentResponse
+	(*AddRpkiRequest)(nil),                   // 111: api.AddRpkiRequest
+	(*AddRpkiResponse)(nil),                  // 112: api.AddRpkiResponse
+	(*DeleteRpkiRequest)(nil),                // 113: api.DeleteRpkiRequest
+	(*DeleteRpkiResponse)(nil),               // 114: api.DeleteRpkiResponse
+	(*ListRpkiRequest)(nil),                  // 115: api.ListRpkiRequest
+	(*ListRpkiResponse)(nil),                 // 116: api.ListRpkiResponse
+	(*EnableRpkiRequest)(nil),                // 117: api.EnableRpkiRequest
+	(*EnableRpkiResponse)(nil),               // 118: api.EnableRpkiResponse
+	(*DisableRpkiRequest)(nil),               // 119: api.DisableRpkiRequest
+	(*DisableRpkiResponse)(nil),              // 120: api.DisableRpkiResponse
+	(*ResetRpkiRequest)(nil),                 // 121: api.ResetRpkiRequest
+	(*ResetRpkiResponse)(nil),                // 122: api.ResetRpkiResponse
+	(*ListRpkiTableRequest)(nil),             // 123: api.ListRpkiTableRequest
+	(*ListRpkiTableResponse)(nil),            // 124: api.ListRpkiTableResponse
+	(*EnableZebraRequest)(nil),               // 125: api.EnableZebraRequest
+	(*EnableZebraResponse)(nil),              // 126: api.EnableZebraResponse
+	(*EnableMrtRequest)(nil),                 // 127: api.EnableMrtRequest
+	(*EnableMrtResponse)(nil),                // 128: api.EnableMrtResponse
+	(*DisableMrtRequest)(nil),                // 129: api.DisableMrtRequest
+	(*DisableMrtResponse)(nil),               // 130: api.DisableMrtResponse
+	(*AddBmpRequest)(nil),                    // 131: api.AddBmpRequest
+	(*AddBmpResponse)(nil),                   // 132: api.AddBmpResponse
+	(*DeleteBmpRequest)(nil),                 // 133: api.DeleteBmpRequest
+	(*DeleteBmpResponse)(nil),                // 134: api.DeleteBmpResponse
+	(*ListBmpRequest)(nil),                   // 135: api.ListBmpRequest
+	(*ListBmpResponse)(nil),                  // 136: api.ListBmpResponse
+	(*Validation)(nil),                       // 137: api.Validation
+	(*Path)(nil),                             // 138: api.Path
+	(*Destination)(nil),                      // 139: api.Destination
+	(*Peer)(nil),                             // 140: api.Peer
+	(*PeerGroup)(nil),                        // 141: api.PeerGroup
+	(*DynamicNeighbor)(nil),                  // 142: api.DynamicNeighbor
+	(*ApplyPolicy)(nil),                      // 143: api.ApplyPolicy
+	(*PrefixLimit)(nil),                      // 144: api.PrefixLimit
+	(*PeerConf)(nil),                         // 145: api.PeerConf
+	(*PeerGroupConf)(nil),                    // 146: api.PeerGroupConf
+	(*PeerGroupState)(nil),                   // 147: api.PeerGroupState
+	(*TtlSecurity)(nil),                      // 148: api.TtlSecurity
+	(*EbgpMultihop)(nil),                     // 149: api.EbgpMultihop
+	(*RouteReflector)(nil),                   // 150: api.RouteReflector
+	(*PeerState)(nil),                        // 151: api.PeerState
+	(*Messages)(nil),                         // 152: api.Messages
+	(*Message)(nil),                          // 153: api.Message
+	(*Queues)(nil),                           // 154: api.Queues
+	(*Timers)(nil),                           // 155: api.Timers
+	(*TimersConfig)(nil),                     // 156: api.TimersConfig
+	(*TimersState)(nil),                      // 157: api.TimersState
+	(*Transport)(nil),                        // 158: api.Transport
+	(*RouteServer)(nil),                      // 159: api.RouteServer
+	(*GracefulRestart)(nil),                  // 160: api.GracefulRestart
+	(*MpGracefulRestartConfig)(nil),          // 161: api.MpGracefulRestartConfig
+	(*MpGracefulRestartState)(nil),           // 162: api.MpGracefulRestartState
+	(*MpGracefulRestart)(nil),                // 163: api.MpGracefulRestart
+	(*AfiSafiConfig)(nil),                    // 164: api.AfiSafiConfig
+	(*AfiSafiState)(nil),                     // 165: api.AfiSafiState
+	(*RouteSelectionOptionsConfig)(nil),      // 166: api.RouteSelectionOptionsConfig
+	(*RouteSelectionOptionsState)(nil),       // 167: api.RouteSelectionOptionsState
+	(*RouteSelectionOptions)(nil),            // 168: api.RouteSelectionOptions
+	(*UseMultiplePathsConfig)(nil),           // 169: api.UseMultiplePathsConfig
+	(*UseMultiplePathsState)(nil),            // 170: api.UseMultiplePathsState
+	(*EbgpConfig)(nil),                       // 171: api.EbgpConfig
+	(*EbgpState)(nil),                        // 172: api.EbgpState
+	(*Ebgp)(nil),                             // 173: api.Ebgp
+	(*IbgpConfig)(nil),                       // 174: api.IbgpConfig
+	(*IbgpState)(nil),                        // 175: api.IbgpState
+	(*Ibgp)(nil),                             // 176: api.Ibgp
+	(*UseMultiplePaths)(nil),                 // 177: api.UseMultiplePaths
+	(*RouteTargetMembershipConfig)(nil),      // 178: api.RouteTargetMembershipConfig
+	(*RouteTargetMembershipState)(nil),       // 179: api.RouteTargetMembershipState
+	(*RouteTargetMembership)(nil),            // 180: api.RouteTargetMembership
+	(*LongLivedGracefulRestartConfig)(nil),   // 181: api.LongLivedGracefulRestartConfig
+	(*LongLivedGracefulRestartState)(nil),    // 182: api.LongLivedGracefulRestartState
+	(*LongLivedGracefulRestart)(nil),         // 183: api.LongLivedGracefulRestart
+	(*AfiSafi)(nil),                          // 184: api.AfiSafi
+	(*AddPathsConfig)(nil),                   // 185: api.AddPathsConfig
+	(*AddPathsState)(nil),                    // 186: api.AddPathsState
+	(*AddPaths)(nil),                         // 187: api.AddPaths
+	(*Prefix)(nil),                           // 188: api.Prefix
+	(*DefinedSet)(nil),                       // 189: api.DefinedSet
+	(*MatchSet)(nil),                         // 190: api.MatchSet
+	(*AsPathLength)(nil),                     // 191: api.AsPathLength
+	(*CommunityCount)(nil),                   // 192: api.CommunityCount
+	(*LocalPrefEq)(nil),                      // 193: api.LocalPrefEq
+	(*MedEq)(nil),                            // 194: api.MedEq
+	(*Conditions)(nil),                       // 195: api.Conditions
+	(*CommunityAction)(nil),                  // 196: api.CommunityAction
+	(*MedAction)(nil),                        // 197: api.MedAction
+	(*AsPrependAction)(nil),                  // 198: api.AsPrependAction
+	(*NexthopAction)(nil),                    // 199: api.NexthopAction
+	(*LocalPrefAction)(nil),                  // 200: api.LocalPrefAction
+	(*OriginAction)(nil),                     // 201: api.OriginAction
+	(*Actions)(nil),                          // 202: api.Actions
+	(*Statement)(nil),                        // 203: api.Statement
+	(*Policy)(nil),                           // 204: api.Policy
+	(*PolicyAssignment)(nil),                 // 205: api.PolicyAssignment
+	(*RoutingPolicy)(nil),                    // 206: api.RoutingPolicy
+	(*Roa)(nil),                              // 207: api.Roa
+	(*Vrf)(nil),                              // 208: api.Vrf
+	(*DefaultRouteDistance)(nil),             // 209: api.DefaultRouteDistance
+	(*Global)(nil),                           // 210: api.Global
+	(*Confederation)(nil),                    // 211: api.Confederation
+	(*RPKIConf)(nil),                         // 212: api.RPKIConf
+	(*RPKIState)(nil),                        // 213: api.RPKIState
+	(*Rpki)(nil),                             // 214: api.Rpki
+	(*SetLogLevelRequest)(nil),               // 215: api.SetLogLevelRequest
+	(*SetLogLevelResponse)(nil),              // 216: api.SetLogLevelResponse
+	(*BfdAsyncCounters)(nil),                 // 217: api.BfdAsyncCounters
+	(*BfdPeerState)(nil),                     // 218: api.BfdPeerState
+	(*BfdPeerConfig)(nil),                    // 219: api.BfdPeerConfig
+	(*BfdState)(nil),                         // 220: api.BfdState
+	(*TcpAoKey)(nil),                         // 221: api.TcpAoKey
+	(*TcpAoKeychain)(nil),                    // 222: api.TcpAoKeychain
+	(*AddTcpAoKeychainRequest)(nil),          // 223: api.AddTcpAoKeychainRequest
+	(*AddTcpAoKeychainResponse)(nil),         // 224: api.AddTcpAoKeychainResponse
+	(*UpdateTcpAoKeychainRequest)(nil),       // 225: api.UpdateTcpAoKeychainRequest
+	(*UpdateTcpAoKeychainResponse)(nil),      // 226: api.UpdateTcpAoKeychainResponse
+	(*DeleteTcpAoKeychainRequest)(nil),       // 227: api.DeleteTcpAoKeychainRequest
+	(*DeleteTcpAoKeychainResponse)(nil),      // 228: api.DeleteTcpAoKeychainResponse
+	(*ListTcpAoKeychainRequest)(nil),         // 229: api.ListTcpAoKeychainRequest
+	(*ListTcpAoKeychainResponse)(nil),        // 230: api.ListTcpAoKeychainResponse
+	(*WatchEventRequest_Peer)(nil),           // 231: api.WatchEventRequest.Peer
+	(*WatchEventRequest_Table)(nil),          // 232: api.WatchEventRequest.Table
+	(*WatchEventRequest_Table_Filter)(nil),   // 233: api.WatchEventRequest.Table.Filter
+	(*WatchEventResponse_PeerEvent)(nil),     // 234: api.WatchEventResponse.PeerEvent
+	(*WatchEventResponse_TableEvent)(nil),    // 235: api.WatchEventResponse.TableEvent
+	(*ListBmpResponse_BmpStation)(nil),       // 236: api.ListBmpResponse.BmpStation
+	(*ListBmpResponse_BmpStation_Conf)(nil),  // 237: api.ListBmpResponse.BmpStation.Conf
+	(*ListBmpResponse_BmpStation_State)(nil), // 238: api.ListBmpResponse.BmpStation.State
+	(*Family)(nil),                           // 239: api.Family
+	(*NLRI)(nil),                             // 240: api.NLRI
+	(*Attribute)(nil),                        // 241: api.Attribute
+	(*timestamppb.Timestamp)(nil),            // 242: google.protobuf.Timestamp
+	(*Capability)(nil),                       // 243: api.Capability
+	(*RouteDistinguisher)(nil),               // 244: api.RouteDistinguisher
+	(*RouteTarget)(nil),                      // 245: api.RouteTarget
 }
 var file_api_gobgp_proto_depIdxs = []int32{
-	209, // 0: api.StartBgpRequest.global:type_name -> api.Global
-	209, // 1: api.GetBgpResponse.global:type_name -> api.Global
-	220, // 2: api.WatchEventRequest.peer:type_name -> api.WatchEventRequest.Peer
-	221, // 3: api.WatchEventRequest.table:type_name -> api.WatchEventRequest.Table
-	223, // 4: api.WatchEventResponse.peer:type_name -> api.WatchEventResponse.PeerEvent
-	224, // 5: api.WatchEventResponse.table:type_name -> api.WatchEventResponse.TableEvent
-	139, // 6: api.AddPeerRequest.peer:type_name -> api.Peer
-	139, // 7: api.ListPeerResponse.peer:type_name -> api.Peer
-	139, // 8: api.UpdatePeerRequest.peer:type_name -> api.Peer
-	13,  // 9: api.ResetPeerRequest.direction:type_name -> api.ResetPeerRequest.Direction
-	140, // 10: api.AddPeerGroupRequest.peer_group:type_name -> api.PeerGroup
-	140, // 11: api.UpdatePeerGroupRequest.peer_group:type_name -> api.PeerGroup
-	140, // 12: api.ListPeerGroupResponse.peer_group:type_name -> api.PeerGroup
-	141, // 13: api.AddDynamicNeighborRequest.dynamic_neighbor:type_name -> api.DynamicNeighbor
-	141, // 14: api.ListDynamicNeighborResponse.dynamic_neighbor:type_name -> api.DynamicNeighbor
+	210, // 0: api.StartBgpRequest.global:type_name -> api.Global
+	210, // 1: api.GetBgpResponse.global:type_name -> api.Global
+	231, // 2: api.WatchEventRequest.peer:type_name -> api.WatchEventRequest.Peer
+	232, // 3: api.WatchEventRequest.table:type_name -> api.WatchEventRequest.Table
+	234, // 4: api.WatchEventResponse.peer:type_name -> api.WatchEventResponse.PeerEvent
+	235, // 5: api.WatchEventResponse.table:type_name -> api.WatchEventResponse.TableEvent
+	140, // 6: api.AddPeerRequest.peer:type_name -> api.Peer
+	140, // 7: api.ListPeerResponse.peer:type_name -> api.Peer
+	140, // 8: api.UpdatePeerRequest.peer:type_name -> api.Peer
+	14,  // 9: api.ResetPeerRequest.direction:type_name -> api.ResetPeerRequest.Direction
+	141, // 10: api.AddPeerGroupRequest.peer_group:type_name -> api.PeerGroup
+	141, // 11: api.UpdatePeerGroupRequest.peer_group:type_name -> api.PeerGroup
+	141, // 12: api.ListPeerGroupResponse.peer_group:type_name -> api.PeerGroup
+	142, // 13: api.AddDynamicNeighborRequest.dynamic_neighbor:type_name -> api.DynamicNeighbor
+	142, // 14: api.ListDynamicNeighborResponse.dynamic_neighbor:type_name -> api.DynamicNeighbor
 	0,   // 15: api.AddPathRequest.table_type:type_name -> api.TableType
-	137, // 16: api.AddPathRequest.path:type_name -> api.Path
+	138, // 16: api.AddPathRequest.path:type_name -> api.Path
 	0,   // 17: api.DeletePathRequest.table_type:type_name -> api.TableType
-	228, // 18: api.DeletePathRequest.family:type_name -> api.Family
-	137, // 19: api.DeletePathRequest.path:type_name -> api.Path
-	14,  // 20: api.TableLookupPrefix.type:type_name -> api.TableLookupPrefix.Type
+	239, // 18: api.DeletePathRequest.family:type_name -> api.Family
+	138, // 19: api.DeletePathRequest.path:type_name -> api.Path
+	15,  // 20: api.TableLookupPrefix.type:type_name -> api.TableLookupPrefix.Type
 	0,   // 21: api.ListPathRequest.table_type:type_name -> api.TableType
-	228, // 22: api.ListPathRequest.family:type_name -> api.Family
-	69,  // 23: api.ListPathRequest.prefixes:type_name -> api.TableLookupPrefix
-	15,  // 24: api.ListPathRequest.sort_type:type_name -> api.ListPathRequest.SortType
-	138, // 25: api.ListPathResponse.destination:type_name -> api.Destination
+	239, // 22: api.ListPathRequest.family:type_name -> api.Family
+	70,  // 23: api.ListPathRequest.prefixes:type_name -> api.TableLookupPrefix
+	16,  // 24: api.ListPathRequest.sort_type:type_name -> api.ListPathRequest.SortType
+	139, // 25: api.ListPathResponse.destination:type_name -> api.Destination
 	0,   // 26: api.AddPathStreamRequest.table_type:type_name -> api.TableType
-	137, // 27: api.AddPathStreamRequest.paths:type_name -> api.Path
+	138, // 27: api.AddPathStreamRequest.paths:type_name -> api.Path
 	0,   // 28: api.GetTableRequest.table_type:type_name -> api.TableType
-	228, // 29: api.GetTableRequest.family:type_name -> api.Family
-	207, // 30: api.AddVrfRequest.vrf:type_name -> api.Vrf
-	207, // 31: api.ListVrfResponse.vrf:type_name -> api.Vrf
-	203, // 32: api.AddPolicyRequest.policy:type_name -> api.Policy
-	203, // 33: api.DeletePolicyRequest.policy:type_name -> api.Policy
-	203, // 34: api.ListPolicyResponse.policy:type_name -> api.Policy
-	188, // 35: api.SetPoliciesRequest.defined_sets:type_name -> api.DefinedSet
-	203, // 36: api.SetPoliciesRequest.policies:type_name -> api.Policy
-	204, // 37: api.SetPoliciesRequest.assignments:type_name -> api.PolicyAssignment
-	188, // 38: api.AddDefinedSetRequest.defined_set:type_name -> api.DefinedSet
-	188, // 39: api.DeleteDefinedSetRequest.defined_set:type_name -> api.DefinedSet
+	239, // 29: api.GetTableRequest.family:type_name -> api.Family
+	208, // 30: api.AddVrfRequest.vrf:type_name -> api.Vrf
+	208, // 31: api.ListVrfResponse.vrf:type_name -> api.Vrf
+	204, // 32: api.AddPolicyRequest.policy:type_name -> api.Policy
+	204, // 33: api.DeletePolicyRequest.policy:type_name -> api.Policy
+	204, // 34: api.ListPolicyResponse.policy:type_name -> api.Policy
+	189, // 35: api.SetPoliciesRequest.defined_sets:type_name -> api.DefinedSet
+	204, // 36: api.SetPoliciesRequest.policies:type_name -> api.Policy
+	205, // 37: api.SetPoliciesRequest.assignments:type_name -> api.PolicyAssignment
+	189, // 38: api.AddDefinedSetRequest.defined_set:type_name -> api.DefinedSet
+	189, // 39: api.DeleteDefinedSetRequest.defined_set:type_name -> api.DefinedSet
 	4,   // 40: api.ListDefinedSetRequest.defined_type:type_name -> api.DefinedType
-	188, // 41: api.ListDefinedSetResponse.defined_set:type_name -> api.DefinedSet
-	202, // 42: api.AddStatementRequest.statement:type_name -> api.Statement
-	202, // 43: api.DeleteStatementRequest.statement:type_name -> api.Statement
-	202, // 44: api.ListStatementResponse.statement:type_name -> api.Statement
-	204, // 45: api.AddPolicyAssignmentRequest.assignment:type_name -> api.PolicyAssignment
-	204, // 46: api.DeletePolicyAssignmentRequest.assignment:type_name -> api.PolicyAssignment
+	189, // 41: api.ListDefinedSetResponse.defined_set:type_name -> api.DefinedSet
+	203, // 42: api.AddStatementRequest.statement:type_name -> api.Statement
+	203, // 43: api.DeleteStatementRequest.statement:type_name -> api.Statement
+	203, // 44: api.ListStatementResponse.statement:type_name -> api.Statement
+	205, // 45: api.AddPolicyAssignmentRequest.assignment:type_name -> api.PolicyAssignment
+	205, // 46: api.DeletePolicyAssignmentRequest.assignment:type_name -> api.PolicyAssignment
 	8,   // 47: api.ListPolicyAssignmentRequest.direction:type_name -> api.PolicyDirection
-	204, // 48: api.ListPolicyAssignmentResponse.assignment:type_name -> api.PolicyAssignment
-	204, // 49: api.SetPolicyAssignmentRequest.assignment:type_name -> api.PolicyAssignment
-	228, // 50: api.ListRpkiRequest.family:type_name -> api.Family
-	213, // 51: api.ListRpkiResponse.server:type_name -> api.Rpki
-	228, // 52: api.ListRpkiTableRequest.family:type_name -> api.Family
-	206, // 53: api.ListRpkiTableResponse.roa:type_name -> api.Roa
-	16,  // 54: api.EnableMrtRequest.dump_type:type_name -> api.EnableMrtRequest.DumpType
-	17,  // 55: api.AddBmpRequest.policy:type_name -> api.AddBmpRequest.MonitoringPolicy
-	225, // 56: api.ListBmpResponse.station:type_name -> api.ListBmpResponse.BmpStation
+	205, // 48: api.ListPolicyAssignmentResponse.assignment:type_name -> api.PolicyAssignment
+	205, // 49: api.SetPolicyAssignmentRequest.assignment:type_name -> api.PolicyAssignment
+	239, // 50: api.ListRpkiRequest.family:type_name -> api.Family
+	214, // 51: api.ListRpkiResponse.server:type_name -> api.Rpki
+	239, // 52: api.ListRpkiTableRequest.family:type_name -> api.Family
+	207, // 53: api.ListRpkiTableResponse.roa:type_name -> api.Roa
+	17,  // 54: api.EnableMrtRequest.dump_type:type_name -> api.EnableMrtRequest.DumpType
+	18,  // 55: api.AddBmpRequest.policy:type_name -> api.AddBmpRequest.MonitoringPolicy
+	236, // 56: api.ListBmpResponse.station:type_name -> api.ListBmpResponse.BmpStation
 	1,   // 57: api.Validation.state:type_name -> api.ValidationState
-	18,  // 58: api.Validation.reason:type_name -> api.Validation.Reason
-	206, // 59: api.Validation.matched:type_name -> api.Roa
-	206, // 60: api.Validation.unmatched_asn:type_name -> api.Roa
-	206, // 61: api.Validation.unmatched_length:type_name -> api.Roa
-	229, // 62: api.Path.nlri:type_name -> api.NLRI
-	230, // 63: api.Path.pattrs:type_name -> api.Attribute
-	231, // 64: api.Path.age:type_name -> google.protobuf.Timestamp
-	136, // 65: api.Path.validation:type_name -> api.Validation
-	228, // 66: api.Path.family:type_name -> api.Family
-	137, // 67: api.Destination.paths:type_name -> api.Path
-	142, // 68: api.Peer.apply_policy:type_name -> api.ApplyPolicy
-	144, // 69: api.Peer.conf:type_name -> api.PeerConf
-	148, // 70: api.Peer.ebgp_multihop:type_name -> api.EbgpMultihop
-	149, // 71: api.Peer.route_reflector:type_name -> api.RouteReflector
-	150, // 72: api.Peer.state:type_name -> api.PeerState
-	154, // 73: api.Peer.timers:type_name -> api.Timers
-	157, // 74: api.Peer.transport:type_name -> api.Transport
-	158, // 75: api.Peer.route_server:type_name -> api.RouteServer
-	159, // 76: api.Peer.graceful_restart:type_name -> api.GracefulRestart
-	183, // 77: api.Peer.afi_safis:type_name -> api.AfiSafi
-	147, // 78: api.Peer.ttl_security:type_name -> api.TtlSecurity
-	218, // 79: api.Peer.bfd:type_name -> api.BfdPeerConfig
-	142, // 80: api.PeerGroup.apply_policy:type_name -> api.ApplyPolicy
-	145, // 81: api.PeerGroup.conf:type_name -> api.PeerGroupConf
-	148, // 82: api.PeerGroup.ebgp_multihop:type_name -> api.EbgpMultihop
-	149, // 83: api.PeerGroup.route_reflector:type_name -> api.RouteReflector
-	146, // 84: api.PeerGroup.info:type_name -> api.PeerGroupState
-	154, // 85: api.PeerGroup.timers:type_name -> api.Timers
-	157, // 86: api.PeerGroup.transport:type_name -> api.Transport
-	158, // 87: api.PeerGroup.route_server:type_name -> api.RouteServer
-	159, // 88: api.PeerGroup.graceful_restart:type_name -> api.GracefulRestart
-	183, // 89: api.PeerGroup.afi_safis:type_name -> api.AfiSafi
-	147, // 90: api.PeerGroup.ttl_security:type_name -> api.TtlSecurity
-	218, // 91: api.PeerGroup.bfd:type_name -> api.BfdPeerConfig
-	204, // 92: api.ApplyPolicy.export_policy:type_name -> api.PolicyAssignment
-	204, // 93: api.ApplyPolicy.import_policy:type_name -> api.PolicyAssignment
-	228, // 94: api.PrefixLimit.family:type_name -> api.Family
+	19,  // 58: api.Validation.reason:type_name -> api.Validation.Reason
+	207, // 59: api.Validation.matched:type_name -> api.Roa
+	207, // 60: api.Validation.unmatched_asn:type_name -> api.Roa
+	207, // 61: api.Validation.unmatched_length:type_name -> api.Roa
+	240, // 62: api.Path.nlri:type_name -> api.NLRI
+	241, // 63: api.Path.pattrs:type_name -> api.Attribute
+	242, // 64: api.Path.age:type_name -> google.protobuf.Timestamp
+	137, // 65: api.Path.validation:type_name -> api.Validation
+	239, // 66: api.Path.family:type_name -> api.Family
+	138, // 67: api.Destination.paths:type_name -> api.Path
+	143, // 68: api.Peer.apply_policy:type_name -> api.ApplyPolicy
+	145, // 69: api.Peer.conf:type_name -> api.PeerConf
+	149, // 70: api.Peer.ebgp_multihop:type_name -> api.EbgpMultihop
+	150, // 71: api.Peer.route_reflector:type_name -> api.RouteReflector
+	151, // 72: api.Peer.state:type_name -> api.PeerState
+	155, // 73: api.Peer.timers:type_name -> api.Timers
+	158, // 74: api.Peer.transport:type_name -> api.Transport
+	159, // 75: api.Peer.route_server:type_name -> api.RouteServer
+	160, // 76: api.Peer.graceful_restart:type_name -> api.GracefulRestart
+	184, // 77: api.Peer.afi_safis:type_name -> api.AfiSafi
+	148, // 78: api.Peer.ttl_security:type_name -> api.TtlSecurity
+	219, // 79: api.Peer.bfd:type_name -> api.BfdPeerConfig
+	143, // 80: api.PeerGroup.apply_policy:type_name -> api.ApplyPolicy
+	146, // 81: api.PeerGroup.conf:type_name -> api.PeerGroupConf
+	149, // 82: api.PeerGroup.ebgp_multihop:type_name -> api.EbgpMultihop
+	150, // 83: api.PeerGroup.route_reflector:type_name -> api.RouteReflector
+	147, // 84: api.PeerGroup.info:type_name -> api.PeerGroupState
+	155, // 85: api.PeerGroup.timers:type_name -> api.Timers
+	158, // 86: api.PeerGroup.transport:type_name -> api.Transport
+	159, // 87: api.PeerGroup.route_server:type_name -> api.RouteServer
+	160, // 88: api.PeerGroup.graceful_restart:type_name -> api.GracefulRestart
+	184, // 89: api.PeerGroup.afi_safis:type_name -> api.AfiSafi
+	148, // 90: api.PeerGroup.ttl_security:type_name -> api.TtlSecurity
+	219, // 91: api.PeerGroup.bfd:type_name -> api.BfdPeerConfig
+	205, // 92: api.ApplyPolicy.export_policy:type_name -> api.PolicyAssignment
+	205, // 93: api.ApplyPolicy.import_policy:type_name -> api.PolicyAssignment
+	239, // 94: api.PrefixLimit.family:type_name -> api.Family
 	2,   // 95: api.PeerConf.type:type_name -> api.PeerType
 	3,   // 96: api.PeerConf.remove_private:type_name -> api.RemovePrivate
 	2,   // 97: api.PeerGroupConf.type:type_name -> api.PeerType
 	3,   // 98: api.PeerGroupConf.remove_private:type_name -> api.RemovePrivate
 	2,   // 99: api.PeerGroupState.type:type_name -> api.PeerType
 	3,   // 100: api.PeerGroupState.remove_private:type_name -> api.RemovePrivate
-	151, // 101: api.PeerState.messages:type_name -> api.Messages
+	152, // 101: api.PeerState.messages:type_name -> api.Messages
 	2,   // 102: api.PeerState.type:type_name -> api.PeerType
-	153, // 103: api.PeerState.queues:type_name -> api.Queues
+	154, // 103: api.PeerState.queues:type_name -> api.Queues
 	3,   // 104: api.PeerState.remove_private:type_name -> api.RemovePrivate
-	19,  // 105: api.PeerState.session_state:type_name -> api.PeerState.SessionState
-	20,  // 106: api.PeerState.admin_state:type_name -> api.PeerState.AdminState
-	232, // 107: api.PeerState.remote_cap:type_name -> api.Capability
-	232, // 108: api.PeerState.local_cap:type_name -> api.Capability
-	21,  // 109: api.PeerState.disconnect_reason:type_name -> api.PeerState.DisconnectReason
-	217, // 110: api.PeerState.bfd_state:type_name -> api.BfdPeerState
-	152, // 111: api.Messages.received:type_name -> api.Message
-	152, // 112: api.Messages.sent:type_name -> api.Message
-	155, // 113: api.Timers.config:type_name -> api.TimersConfig
-	156, // 114: api.Timers.state:type_name -> api.TimersState
-	231, // 115: api.TimersState.uptime:type_name -> google.protobuf.Timestamp
-	231, // 116: api.TimersState.downtime:type_name -> google.protobuf.Timestamp
-	160, // 117: api.MpGracefulRestart.config:type_name -> api.MpGracefulRestartConfig
-	161, // 118: api.MpGracefulRestart.state:type_name -> api.MpGracefulRestartState
-	228, // 119: api.AfiSafiConfig.family:type_name -> api.Family
-	228, // 120: api.AfiSafiState.family:type_name -> api.Family
-	165, // 121: api.RouteSelectionOptions.config:type_name -> api.RouteSelectionOptionsConfig
-	166, // 122: api.RouteSelectionOptions.state:type_name -> api.RouteSelectionOptionsState
-	170, // 123: api.Ebgp.config:type_name -> api.EbgpConfig
-	171, // 124: api.Ebgp.state:type_name -> api.EbgpState
-	173, // 125: api.Ibgp.config:type_name -> api.IbgpConfig
-	174, // 126: api.Ibgp.state:type_name -> api.IbgpState
-	168, // 127: api.UseMultiplePaths.config:type_name -> api.UseMultiplePathsConfig
-	169, // 128: api.UseMultiplePaths.state:type_name -> api.UseMultiplePathsState
-	172, // 129: api.UseMultiplePaths.ebgp:type_name -> api.Ebgp
-	175, // 130: api.UseMultiplePaths.ibgp:type_name -> api.Ibgp
-	177, // 131: api.RouteTargetMembership.config:type_name -> api.RouteTargetMembershipConfig
-	178, // 132: api.RouteTargetMembership.state:type_name -> api.RouteTargetMembershipState
-	180, // 133: api.LongLivedGracefulRestart.config:type_name -> api.LongLivedGracefulRestartConfig
-	181, // 134: api.LongLivedGracefulRestart.state:type_name -> api.LongLivedGracefulRestartState
-	162, // 135: api.AfiSafi.mp_graceful_restart:type_name -> api.MpGracefulRestart
-	163, // 136: api.AfiSafi.config:type_name -> api.AfiSafiConfig
-	164, // 137: api.AfiSafi.state:type_name -> api.AfiSafiState
-	142, // 138: api.AfiSafi.apply_policy:type_name -> api.ApplyPolicy
-	167, // 139: api.AfiSafi.route_selection_options:type_name -> api.RouteSelectionOptions
-	176, // 140: api.AfiSafi.use_multiple_paths:type_name -> api.UseMultiplePaths
-	143, // 141: api.AfiSafi.prefix_limits:type_name -> api.PrefixLimit
-	179, // 142: api.AfiSafi.route_target_membership:type_name -> api.RouteTargetMembership
-	182, // 143: api.AfiSafi.long_lived_graceful_restart:type_name -> api.LongLivedGracefulRestart
-	186, // 144: api.AfiSafi.add_paths:type_name -> api.AddPaths
-	184, // 145: api.AddPaths.config:type_name -> api.AddPathsConfig
-	185, // 146: api.AddPaths.state:type_name -> api.AddPathsState
+	20,  // 105: api.PeerState.session_state:type_name -> api.PeerState.SessionState
+	21,  // 106: api.PeerState.admin_state:type_name -> api.PeerState.AdminState
+	243, // 107: api.PeerState.remote_cap:type_name -> api.Capability
+	243, // 108: api.PeerState.local_cap:type_name -> api.Capability
+	22,  // 109: api.PeerState.disconnect_reason:type_name -> api.PeerState.DisconnectReason
+	218, // 110: api.PeerState.bfd_state:type_name -> api.BfdPeerState
+	153, // 111: api.Messages.received:type_name -> api.Message
+	153, // 112: api.Messages.sent:type_name -> api.Message
+	156, // 113: api.Timers.config:type_name -> api.TimersConfig
+	157, // 114: api.Timers.state:type_name -> api.TimersState
+	242, // 115: api.TimersState.uptime:type_name -> google.protobuf.Timestamp
+	242, // 116: api.TimersState.downtime:type_name -> google.protobuf.Timestamp
+	161, // 117: api.MpGracefulRestart.config:type_name -> api.MpGracefulRestartConfig
+	162, // 118: api.MpGracefulRestart.state:type_name -> api.MpGracefulRestartState
+	239, // 119: api.AfiSafiConfig.family:type_name -> api.Family
+	239, // 120: api.AfiSafiState.family:type_name -> api.Family
+	166, // 121: api.RouteSelectionOptions.config:type_name -> api.RouteSelectionOptionsConfig
+	167, // 122: api.RouteSelectionOptions.state:type_name -> api.RouteSelectionOptionsState
+	171, // 123: api.Ebgp.config:type_name -> api.EbgpConfig
+	172, // 124: api.Ebgp.state:type_name -> api.EbgpState
+	174, // 125: api.Ibgp.config:type_name -> api.IbgpConfig
+	175, // 126: api.Ibgp.state:type_name -> api.IbgpState
+	169, // 127: api.UseMultiplePaths.config:type_name -> api.UseMultiplePathsConfig
+	170, // 128: api.UseMultiplePaths.state:type_name -> api.UseMultiplePathsState
+	173, // 129: api.UseMultiplePaths.ebgp:type_name -> api.Ebgp
+	176, // 130: api.UseMultiplePaths.ibgp:type_name -> api.Ibgp
+	178, // 131: api.RouteTargetMembership.config:type_name -> api.RouteTargetMembershipConfig
+	179, // 132: api.RouteTargetMembership.state:type_name -> api.RouteTargetMembershipState
+	181, // 133: api.LongLivedGracefulRestart.config:type_name -> api.LongLivedGracefulRestartConfig
+	182, // 134: api.LongLivedGracefulRestart.state:type_name -> api.LongLivedGracefulRestartState
+	163, // 135: api.AfiSafi.mp_graceful_restart:type_name -> api.MpGracefulRestart
+	164, // 136: api.AfiSafi.config:type_name -> api.AfiSafiConfig
+	165, // 137: api.AfiSafi.state:type_name -> api.AfiSafiState
+	143, // 138: api.AfiSafi.apply_policy:type_name -> api.ApplyPolicy
+	168, // 139: api.AfiSafi.route_selection_options:type_name -> api.RouteSelectionOptions
+	177, // 140: api.AfiSafi.use_multiple_paths:type_name -> api.UseMultiplePaths
+	144, // 141: api.AfiSafi.prefix_limits:type_name -> api.PrefixLimit
+	180, // 142: api.AfiSafi.route_target_membership:type_name -> api.RouteTargetMembership
+	183, // 143: api.AfiSafi.long_lived_graceful_restart:type_name -> api.LongLivedGracefulRestart
+	187, // 144: api.AfiSafi.add_paths:type_name -> api.AddPaths
+	185, // 145: api.AddPaths.config:type_name -> api.AddPathsConfig
+	186, // 146: api.AddPaths.state:type_name -> api.AddPathsState
 	4,   // 147: api.DefinedSet.defined_type:type_name -> api.DefinedType
-	187, // 148: api.DefinedSet.prefixes:type_name -> api.Prefix
-	22,  // 149: api.MatchSet.type:type_name -> api.MatchSet.Type
+	188, // 148: api.DefinedSet.prefixes:type_name -> api.Prefix
+	23,  // 149: api.MatchSet.type:type_name -> api.MatchSet.Type
 	5,   // 150: api.AsPathLength.type:type_name -> api.Comparison
 	5,   // 151: api.CommunityCount.type:type_name -> api.Comparison
-	189, // 152: api.Conditions.prefix_set:type_name -> api.MatchSet
-	189, // 153: api.Conditions.neighbor_set:type_name -> api.MatchSet
-	190, // 154: api.Conditions.as_path_length:type_name -> api.AsPathLength
-	189, // 155: api.Conditions.as_path_set:type_name -> api.MatchSet
-	189, // 156: api.Conditions.community_set:type_name -> api.MatchSet
-	189, // 157: api.Conditions.ext_community_set:type_name -> api.MatchSet
+	190, // 152: api.Conditions.prefix_set:type_name -> api.MatchSet
+	190, // 153: api.Conditions.neighbor_set:type_name -> api.MatchSet
+	191, // 154: api.Conditions.as_path_length:type_name -> api.AsPathLength
+	190, // 155: api.Conditions.as_path_set:type_name -> api.MatchSet
+	190, // 156: api.Conditions.community_set:type_name -> api.MatchSet
+	190, // 157: api.Conditions.ext_community_set:type_name -> api.MatchSet
 	1,   // 158: api.Conditions.rpki_result:type_name -> api.ValidationState
-	23,  // 159: api.Conditions.route_type:type_name -> api.Conditions.RouteType
-	189, // 160: api.Conditions.large_community_set:type_name -> api.MatchSet
-	228, // 161: api.Conditions.afi_safi_in:type_name -> api.Family
-	191, // 162: api.Conditions.community_count:type_name -> api.CommunityCount
+	24,  // 159: api.Conditions.route_type:type_name -> api.Conditions.RouteType
+	190, // 160: api.Conditions.large_community_set:type_name -> api.MatchSet
+	239, // 161: api.Conditions.afi_safi_in:type_name -> api.Family
+	192, // 162: api.Conditions.community_count:type_name -> api.CommunityCount
 	6,   // 163: api.Conditions.origin:type_name -> api.OriginType
-	192, // 164: api.Conditions.local_pref_eq:type_name -> api.LocalPrefEq
-	193, // 165: api.Conditions.med_eq:type_name -> api.MedEq
-	24,  // 166: api.CommunityAction.type:type_name -> api.CommunityAction.Type
-	25,  // 167: api.MedAction.type:type_name -> api.MedAction.Type
+	193, // 164: api.Conditions.local_pref_eq:type_name -> api.LocalPrefEq
+	194, // 165: api.Conditions.med_eq:type_name -> api.MedEq
+	25,  // 166: api.CommunityAction.type:type_name -> api.CommunityAction.Type
+	26,  // 167: api.MedAction.type:type_name -> api.MedAction.Type
 	6,   // 168: api.OriginAction.origin:type_name -> api.OriginType
 	7,   // 169: api.Actions.route_action:type_name -> api.RouteAction
-	195, // 170: api.Actions.community:type_name -> api.CommunityAction
-	196, // 171: api.Actions.med:type_name -> api.MedAction
-	197, // 172: api.Actions.as_prepend:type_name -> api.AsPrependAction
-	195, // 173: api.Actions.ext_community:type_name -> api.CommunityAction
-	198, // 174: api.Actions.nexthop:type_name -> api.NexthopAction
-	199, // 175: api.Actions.local_pref:type_name -> api.LocalPrefAction
-	195, // 176: api.Actions.large_community:type_name -> api.CommunityAction
-	200, // 177: api.Actions.origin_action:type_name -> api.OriginAction
-	194, // 178: api.Statement.conditions:type_name -> api.Conditions
-	201, // 179: api.Statement.actions:type_name -> api.Actions
-	202, // 180: api.Policy.statements:type_name -> api.Statement
+	196, // 170: api.Actions.community:type_name -> api.CommunityAction
+	197, // 171: api.Actions.med:type_name -> api.MedAction
+	198, // 172: api.Actions.as_prepend:type_name -> api.AsPrependAction
+	196, // 173: api.Actions.ext_community:type_name -> api.CommunityAction
+	199, // 174: api.Actions.nexthop:type_name -> api.NexthopAction
+	200, // 175: api.Actions.local_pref:type_name -> api.LocalPrefAction
+	196, // 176: api.Actions.large_community:type_name -> api.CommunityAction
+	201, // 177: api.Actions.origin_action:type_name -> api.OriginAction
+	195, // 178: api.Statement.conditions:type_name -> api.Conditions
+	202, // 179: api.Statement.actions:type_name -> api.Actions
+	203, // 180: api.Policy.statements:type_name -> api.Statement
 	8,   // 181: api.PolicyAssignment.direction:type_name -> api.PolicyDirection
-	203, // 182: api.PolicyAssignment.policies:type_name -> api.Policy
+	204, // 182: api.PolicyAssignment.policies:type_name -> api.Policy
 	7,   // 183: api.PolicyAssignment.default_action:type_name -> api.RouteAction
-	188, // 184: api.RoutingPolicy.defined_sets:type_name -> api.DefinedSet
-	203, // 185: api.RoutingPolicy.policies:type_name -> api.Policy
-	211, // 186: api.Roa.conf:type_name -> api.RPKIConf
-	233, // 187: api.Vrf.rd:type_name -> api.RouteDistinguisher
-	234, // 188: api.Vrf.import_rt:type_name -> api.RouteTarget
-	234, // 189: api.Vrf.export_rt:type_name -> api.RouteTarget
-	165, // 190: api.Global.route_selection_options:type_name -> api.RouteSelectionOptionsConfig
-	208, // 191: api.Global.default_route_distance:type_name -> api.DefaultRouteDistance
-	210, // 192: api.Global.confederation:type_name -> api.Confederation
-	159, // 193: api.Global.graceful_restart:type_name -> api.GracefulRestart
-	231, // 194: api.RPKIState.uptime:type_name -> google.protobuf.Timestamp
-	231, // 195: api.RPKIState.downtime:type_name -> google.protobuf.Timestamp
-	211, // 196: api.Rpki.conf:type_name -> api.RPKIConf
-	212, // 197: api.Rpki.state:type_name -> api.RPKIState
-	26,  // 198: api.SetLogLevelRequest.level:type_name -> api.SetLogLevelRequest.Level
+	189, // 184: api.RoutingPolicy.defined_sets:type_name -> api.DefinedSet
+	204, // 185: api.RoutingPolicy.policies:type_name -> api.Policy
+	212, // 186: api.Roa.conf:type_name -> api.RPKIConf
+	244, // 187: api.Vrf.rd:type_name -> api.RouteDistinguisher
+	245, // 188: api.Vrf.import_rt:type_name -> api.RouteTarget
+	245, // 189: api.Vrf.export_rt:type_name -> api.RouteTarget
+	166, // 190: api.Global.route_selection_options:type_name -> api.RouteSelectionOptionsConfig
+	209, // 191: api.Global.default_route_distance:type_name -> api.DefaultRouteDistance
+	211, // 192: api.Global.confederation:type_name -> api.Confederation
+	160, // 193: api.Global.graceful_restart:type_name -> api.GracefulRestart
+	242, // 194: api.RPKIState.uptime:type_name -> google.protobuf.Timestamp
+	242, // 195: api.RPKIState.downtime:type_name -> google.protobuf.Timestamp
+	212, // 196: api.Rpki.conf:type_name -> api.RPKIConf
+	213, // 197: api.Rpki.state:type_name -> api.RPKIState
+	27,  // 198: api.SetLogLevelRequest.level:type_name -> api.SetLogLevelRequest.Level
 	9,   // 199: api.BfdPeerState.session_state:type_name -> api.BfdSessionState
 	9,   // 200: api.BfdPeerState.remote_session_state:type_name -> api.BfdSessionState
 	10,  // 201: api.BfdPeerState.local_diagnostic_code:type_name -> api.BfdDiagnosticCode
 	10,  // 202: api.BfdPeerState.remote_diagnostic_code:type_name -> api.BfdDiagnosticCode
-	216, // 203: api.BfdPeerState.bfd_async:type_name -> api.BfdAsyncCounters
-	222, // 204: api.WatchEventRequest.Table.filters:type_name -> api.WatchEventRequest.Table.Filter
-	11,  // 205: api.WatchEventRequest.Table.Filter.type:type_name -> api.WatchEventRequest.Table.Filter.Type
-	12,  // 206: api.WatchEventResponse.PeerEvent.type:type_name -> api.WatchEventResponse.PeerEvent.Type
-	139, // 207: api.WatchEventResponse.PeerEvent.peer:type_name -> api.Peer
-	137, // 208: api.WatchEventResponse.TableEvent.paths:type_name -> api.Path
-	226, // 209: api.ListBmpResponse.BmpStation.conf:type_name -> api.ListBmpResponse.BmpStation.Conf
-	227, // 210: api.ListBmpResponse.BmpStation.state:type_name -> api.ListBmpResponse.BmpStation.State
-	231, // 211: api.ListBmpResponse.BmpStation.State.uptime:type_name -> google.protobuf.Timestamp
-	231, // 212: api.ListBmpResponse.BmpStation.State.downtime:type_name -> google.protobuf.Timestamp
-	27,  // 213: api.GoBgpService.StartBgp:input_type -> api.StartBgpRequest
-	29,  // 214: api.GoBgpService.StopBgp:input_type -> api.StopBgpRequest
-	31,  // 215: api.GoBgpService.GetBgp:input_type -> api.GetBgpRequest
-	33,  // 216: api.GoBgpService.WatchEvent:input_type -> api.WatchEventRequest
-	35,  // 217: api.GoBgpService.AddPeer:input_type -> api.AddPeerRequest
-	37,  // 218: api.GoBgpService.DeletePeer:input_type -> api.DeletePeerRequest
-	39,  // 219: api.GoBgpService.ListPeer:input_type -> api.ListPeerRequest
-	41,  // 220: api.GoBgpService.UpdatePeer:input_type -> api.UpdatePeerRequest
-	43,  // 221: api.GoBgpService.ResetPeer:input_type -> api.ResetPeerRequest
-	45,  // 222: api.GoBgpService.ShutdownPeer:input_type -> api.ShutdownPeerRequest
-	47,  // 223: api.GoBgpService.EnablePeer:input_type -> api.EnablePeerRequest
-	49,  // 224: api.GoBgpService.DisablePeer:input_type -> api.DisablePeerRequest
-	51,  // 225: api.GoBgpService.AddPeerGroup:input_type -> api.AddPeerGroupRequest
-	53,  // 226: api.GoBgpService.DeletePeerGroup:input_type -> api.DeletePeerGroupRequest
-	57,  // 227: api.GoBgpService.ListPeerGroup:input_type -> api.ListPeerGroupRequest
-	55,  // 228: api.GoBgpService.UpdatePeerGroup:input_type -> api.UpdatePeerGroupRequest
-	59,  // 229: api.GoBgpService.AddDynamicNeighbor:input_type -> api.AddDynamicNeighborRequest
-	63,  // 230: api.GoBgpService.ListDynamicNeighbor:input_type -> api.ListDynamicNeighborRequest
-	61,  // 231: api.GoBgpService.DeleteDynamicNeighbor:input_type -> api.DeleteDynamicNeighborRequest
-	65,  // 232: api.GoBgpService.AddPath:input_type -> api.AddPathRequest
-	67,  // 233: api.GoBgpService.DeletePath:input_type -> api.DeletePathRequest
-	70,  // 234: api.GoBgpService.ListPath:input_type -> api.ListPathRequest
-	72,  // 235: api.GoBgpService.AddPathStream:input_type -> api.AddPathStreamRequest
-	74,  // 236: api.GoBgpService.GetTable:input_type -> api.GetTableRequest
-	76,  // 237: api.GoBgpService.AddVrf:input_type -> api.AddVrfRequest
-	78,  // 238: api.GoBgpService.DeleteVrf:input_type -> api.DeleteVrfRequest
-	80,  // 239: api.GoBgpService.ListVrf:input_type -> api.ListVrfRequest
-	82,  // 240: api.GoBgpService.AddPolicy:input_type -> api.AddPolicyRequest
-	84,  // 241: api.GoBgpService.DeletePolicy:input_type -> api.DeletePolicyRequest
-	86,  // 242: api.GoBgpService.ListPolicy:input_type -> api.ListPolicyRequest
-	88,  // 243: api.GoBgpService.SetPolicies:input_type -> api.SetPoliciesRequest
-	90,  // 244: api.GoBgpService.AddDefinedSet:input_type -> api.AddDefinedSetRequest
-	92,  // 245: api.GoBgpService.DeleteDefinedSet:input_type -> api.DeleteDefinedSetRequest
-	94,  // 246: api.GoBgpService.ListDefinedSet:input_type -> api.ListDefinedSetRequest
-	96,  // 247: api.GoBgpService.AddStatement:input_type -> api.AddStatementRequest
-	98,  // 248: api.GoBgpService.DeleteStatement:input_type -> api.DeleteStatementRequest
-	100, // 249: api.GoBgpService.ListStatement:input_type -> api.ListStatementRequest
-	102, // 250: api.GoBgpService.AddPolicyAssignment:input_type -> api.AddPolicyAssignmentRequest
-	104, // 251: api.GoBgpService.DeletePolicyAssignment:input_type -> api.DeletePolicyAssignmentRequest
-	106, // 252: api.GoBgpService.ListPolicyAssignment:input_type -> api.ListPolicyAssignmentRequest
-	108, // 253: api.GoBgpService.SetPolicyAssignment:input_type -> api.SetPolicyAssignmentRequest
-	110, // 254: api.GoBgpService.AddRpki:input_type -> api.AddRpkiRequest
-	112, // 255: api.GoBgpService.DeleteRpki:input_type -> api.DeleteRpkiRequest
-	114, // 256: api.GoBgpService.ListRpki:input_type -> api.ListRpkiRequest
-	116, // 257: api.GoBgpService.EnableRpki:input_type -> api.EnableRpkiRequest
-	118, // 258: api.GoBgpService.DisableRpki:input_type -> api.DisableRpkiRequest
-	120, // 259: api.GoBgpService.ResetRpki:input_type -> api.ResetRpkiRequest
-	122, // 260: api.GoBgpService.ListRpkiTable:input_type -> api.ListRpkiTableRequest
-	124, // 261: api.GoBgpService.EnableZebra:input_type -> api.EnableZebraRequest
-	126, // 262: api.GoBgpService.EnableMrt:input_type -> api.EnableMrtRequest
-	128, // 263: api.GoBgpService.DisableMrt:input_type -> api.DisableMrtRequest
-	130, // 264: api.GoBgpService.AddBmp:input_type -> api.AddBmpRequest
-	132, // 265: api.GoBgpService.DeleteBmp:input_type -> api.DeleteBmpRequest
-	134, // 266: api.GoBgpService.ListBmp:input_type -> api.ListBmpRequest
-	214, // 267: api.GoBgpService.SetLogLevel:input_type -> api.SetLogLevelRequest
-	28,  // 268: api.GoBgpService.StartBgp:output_type -> api.StartBgpResponse
-	30,  // 269: api.GoBgpService.StopBgp:output_type -> api.StopBgpResponse
-	32,  // 270: api.GoBgpService.GetBgp:output_type -> api.GetBgpResponse
-	34,  // 271: api.GoBgpService.WatchEvent:output_type -> api.WatchEventResponse
-	36,  // 272: api.GoBgpService.AddPeer:output_type -> api.AddPeerResponse
-	38,  // 273: api.GoBgpService.DeletePeer:output_type -> api.DeletePeerResponse
-	40,  // 274: api.GoBgpService.ListPeer:output_type -> api.ListPeerResponse
-	42,  // 275: api.GoBgpService.UpdatePeer:output_type -> api.UpdatePeerResponse
-	44,  // 276: api.GoBgpService.ResetPeer:output_type -> api.ResetPeerResponse
-	46,  // 277: api.GoBgpService.ShutdownPeer:output_type -> api.ShutdownPeerResponse
-	48,  // 278: api.GoBgpService.EnablePeer:output_type -> api.EnablePeerResponse
-	50,  // 279: api.GoBgpService.DisablePeer:output_type -> api.DisablePeerResponse
-	52,  // 280: api.GoBgpService.AddPeerGroup:output_type -> api.AddPeerGroupResponse
-	54,  // 281: api.GoBgpService.DeletePeerGroup:output_type -> api.DeletePeerGroupResponse
-	58,  // 282: api.GoBgpService.ListPeerGroup:output_type -> api.ListPeerGroupResponse
-	56,  // 283: api.GoBgpService.UpdatePeerGroup:output_type -> api.UpdatePeerGroupResponse
-	60,  // 284: api.GoBgpService.AddDynamicNeighbor:output_type -> api.AddDynamicNeighborResponse
-	64,  // 285: api.GoBgpService.ListDynamicNeighbor:output_type -> api.ListDynamicNeighborResponse
-	62,  // 286: api.GoBgpService.DeleteDynamicNeighbor:output_type -> api.DeleteDynamicNeighborResponse
-	66,  // 287: api.GoBgpService.AddPath:output_type -> api.AddPathResponse
-	68,  // 288: api.GoBgpService.DeletePath:output_type -> api.DeletePathResponse
-	71,  // 289: api.GoBgpService.ListPath:output_type -> api.ListPathResponse
-	73,  // 290: api.GoBgpService.AddPathStream:output_type -> api.AddPathStreamResponse
-	75,  // 291: api.GoBgpService.GetTable:output_type -> api.GetTableResponse
-	77,  // 292: api.GoBgpService.AddVrf:output_type -> api.AddVrfResponse
-	79,  // 293: api.GoBgpService.DeleteVrf:output_type -> api.DeleteVrfResponse
-	81,  // 294: api.GoBgpService.ListVrf:output_type -> api.ListVrfResponse
-	83,  // 295: api.GoBgpService.AddPolicy:output_type -> api.AddPolicyResponse
-	85,  // 296: api.GoBgpService.DeletePolicy:output_type -> api.DeletePolicyResponse
-	87,  // 297: api.GoBgpService.ListPolicy:output_type -> api.ListPolicyResponse
-	89,  // 298: api.GoBgpService.SetPolicies:output_type -> api.SetPoliciesResponse
-	91,  // 299: api.GoBgpService.AddDefinedSet:output_type -> api.AddDefinedSetResponse
-	93,  // 300: api.GoBgpService.DeleteDefinedSet:output_type -> api.DeleteDefinedSetResponse
-	95,  // 301: api.GoBgpService.ListDefinedSet:output_type -> api.ListDefinedSetResponse
-	97,  // 302: api.GoBgpService.AddStatement:output_type -> api.AddStatementResponse
-	99,  // 303: api.GoBgpService.DeleteStatement:output_type -> api.DeleteStatementResponse
-	101, // 304: api.GoBgpService.ListStatement:output_type -> api.ListStatementResponse
-	103, // 305: api.GoBgpService.AddPolicyAssignment:output_type -> api.AddPolicyAssignmentResponse
-	105, // 306: api.GoBgpService.DeletePolicyAssignment:output_type -> api.DeletePolicyAssignmentResponse
-	107, // 307: api.GoBgpService.ListPolicyAssignment:output_type -> api.ListPolicyAssignmentResponse
-	109, // 308: api.GoBgpService.SetPolicyAssignment:output_type -> api.SetPolicyAssignmentResponse
-	111, // 309: api.GoBgpService.AddRpki:output_type -> api.AddRpkiResponse
-	113, // 310: api.GoBgpService.DeleteRpki:output_type -> api.DeleteRpkiResponse
-	115, // 311: api.GoBgpService.ListRpki:output_type -> api.ListRpkiResponse
-	117, // 312: api.GoBgpService.EnableRpki:output_type -> api.EnableRpkiResponse
-	119, // 313: api.GoBgpService.DisableRpki:output_type -> api.DisableRpkiResponse
-	121, // 314: api.GoBgpService.ResetRpki:output_type -> api.ResetRpkiResponse
-	123, // 315: api.GoBgpService.ListRpkiTable:output_type -> api.ListRpkiTableResponse
-	125, // 316: api.GoBgpService.EnableZebra:output_type -> api.EnableZebraResponse
-	127, // 317: api.GoBgpService.EnableMrt:output_type -> api.EnableMrtResponse
-	129, // 318: api.GoBgpService.DisableMrt:output_type -> api.DisableMrtResponse
-	131, // 319: api.GoBgpService.AddBmp:output_type -> api.AddBmpResponse
-	133, // 320: api.GoBgpService.DeleteBmp:output_type -> api.DeleteBmpResponse
-	135, // 321: api.GoBgpService.ListBmp:output_type -> api.ListBmpResponse
-	215, // 322: api.GoBgpService.SetLogLevel:output_type -> api.SetLogLevelResponse
-	268, // [268:323] is the sub-list for method output_type
-	213, // [213:268] is the sub-list for method input_type
-	213, // [213:213] is the sub-list for extension type_name
-	213, // [213:213] is the sub-list for extension extendee
-	0,   // [0:213] is the sub-list for field type_name
+	217, // 203: api.BfdPeerState.bfd_async:type_name -> api.BfdAsyncCounters
+	11,  // 204: api.TcpAoKey.algorithm:type_name -> api.TcpAoAlgorithm
+	221, // 205: api.TcpAoKeychain.keys:type_name -> api.TcpAoKey
+	222, // 206: api.AddTcpAoKeychainRequest.keychain:type_name -> api.TcpAoKeychain
+	222, // 207: api.AddTcpAoKeychainResponse.keychain:type_name -> api.TcpAoKeychain
+	221, // 208: api.UpdateTcpAoKeychainRequest.add_keys:type_name -> api.TcpAoKey
+	221, // 209: api.UpdateTcpAoKeychainRequest.delete_keys:type_name -> api.TcpAoKey
+	222, // 210: api.UpdateTcpAoKeychainResponse.keychain:type_name -> api.TcpAoKeychain
+	222, // 211: api.ListTcpAoKeychainResponse.keychain:type_name -> api.TcpAoKeychain
+	233, // 212: api.WatchEventRequest.Table.filters:type_name -> api.WatchEventRequest.Table.Filter
+	12,  // 213: api.WatchEventRequest.Table.Filter.type:type_name -> api.WatchEventRequest.Table.Filter.Type
+	13,  // 214: api.WatchEventResponse.PeerEvent.type:type_name -> api.WatchEventResponse.PeerEvent.Type
+	140, // 215: api.WatchEventResponse.PeerEvent.peer:type_name -> api.Peer
+	138, // 216: api.WatchEventResponse.TableEvent.paths:type_name -> api.Path
+	237, // 217: api.ListBmpResponse.BmpStation.conf:type_name -> api.ListBmpResponse.BmpStation.Conf
+	238, // 218: api.ListBmpResponse.BmpStation.state:type_name -> api.ListBmpResponse.BmpStation.State
+	242, // 219: api.ListBmpResponse.BmpStation.State.uptime:type_name -> google.protobuf.Timestamp
+	242, // 220: api.ListBmpResponse.BmpStation.State.downtime:type_name -> google.protobuf.Timestamp
+	28,  // 221: api.GoBgpService.StartBgp:input_type -> api.StartBgpRequest
+	30,  // 222: api.GoBgpService.StopBgp:input_type -> api.StopBgpRequest
+	32,  // 223: api.GoBgpService.GetBgp:input_type -> api.GetBgpRequest
+	34,  // 224: api.GoBgpService.WatchEvent:input_type -> api.WatchEventRequest
+	36,  // 225: api.GoBgpService.AddPeer:input_type -> api.AddPeerRequest
+	38,  // 226: api.GoBgpService.DeletePeer:input_type -> api.DeletePeerRequest
+	40,  // 227: api.GoBgpService.ListPeer:input_type -> api.ListPeerRequest
+	42,  // 228: api.GoBgpService.UpdatePeer:input_type -> api.UpdatePeerRequest
+	44,  // 229: api.GoBgpService.ResetPeer:input_type -> api.ResetPeerRequest
+	46,  // 230: api.GoBgpService.ShutdownPeer:input_type -> api.ShutdownPeerRequest
+	48,  // 231: api.GoBgpService.EnablePeer:input_type -> api.EnablePeerRequest
+	50,  // 232: api.GoBgpService.DisablePeer:input_type -> api.DisablePeerRequest
+	52,  // 233: api.GoBgpService.AddPeerGroup:input_type -> api.AddPeerGroupRequest
+	54,  // 234: api.GoBgpService.DeletePeerGroup:input_type -> api.DeletePeerGroupRequest
+	58,  // 235: api.GoBgpService.ListPeerGroup:input_type -> api.ListPeerGroupRequest
+	56,  // 236: api.GoBgpService.UpdatePeerGroup:input_type -> api.UpdatePeerGroupRequest
+	60,  // 237: api.GoBgpService.AddDynamicNeighbor:input_type -> api.AddDynamicNeighborRequest
+	64,  // 238: api.GoBgpService.ListDynamicNeighbor:input_type -> api.ListDynamicNeighborRequest
+	62,  // 239: api.GoBgpService.DeleteDynamicNeighbor:input_type -> api.DeleteDynamicNeighborRequest
+	66,  // 240: api.GoBgpService.AddPath:input_type -> api.AddPathRequest
+	68,  // 241: api.GoBgpService.DeletePath:input_type -> api.DeletePathRequest
+	71,  // 242: api.GoBgpService.ListPath:input_type -> api.ListPathRequest
+	73,  // 243: api.GoBgpService.AddPathStream:input_type -> api.AddPathStreamRequest
+	75,  // 244: api.GoBgpService.GetTable:input_type -> api.GetTableRequest
+	77,  // 245: api.GoBgpService.AddVrf:input_type -> api.AddVrfRequest
+	79,  // 246: api.GoBgpService.DeleteVrf:input_type -> api.DeleteVrfRequest
+	81,  // 247: api.GoBgpService.ListVrf:input_type -> api.ListVrfRequest
+	83,  // 248: api.GoBgpService.AddPolicy:input_type -> api.AddPolicyRequest
+	85,  // 249: api.GoBgpService.DeletePolicy:input_type -> api.DeletePolicyRequest
+	87,  // 250: api.GoBgpService.ListPolicy:input_type -> api.ListPolicyRequest
+	89,  // 251: api.GoBgpService.SetPolicies:input_type -> api.SetPoliciesRequest
+	91,  // 252: api.GoBgpService.AddDefinedSet:input_type -> api.AddDefinedSetRequest
+	93,  // 253: api.GoBgpService.DeleteDefinedSet:input_type -> api.DeleteDefinedSetRequest
+	95,  // 254: api.GoBgpService.ListDefinedSet:input_type -> api.ListDefinedSetRequest
+	97,  // 255: api.GoBgpService.AddStatement:input_type -> api.AddStatementRequest
+	99,  // 256: api.GoBgpService.DeleteStatement:input_type -> api.DeleteStatementRequest
+	101, // 257: api.GoBgpService.ListStatement:input_type -> api.ListStatementRequest
+	103, // 258: api.GoBgpService.AddPolicyAssignment:input_type -> api.AddPolicyAssignmentRequest
+	105, // 259: api.GoBgpService.DeletePolicyAssignment:input_type -> api.DeletePolicyAssignmentRequest
+	107, // 260: api.GoBgpService.ListPolicyAssignment:input_type -> api.ListPolicyAssignmentRequest
+	109, // 261: api.GoBgpService.SetPolicyAssignment:input_type -> api.SetPolicyAssignmentRequest
+	111, // 262: api.GoBgpService.AddRpki:input_type -> api.AddRpkiRequest
+	113, // 263: api.GoBgpService.DeleteRpki:input_type -> api.DeleteRpkiRequest
+	115, // 264: api.GoBgpService.ListRpki:input_type -> api.ListRpkiRequest
+	117, // 265: api.GoBgpService.EnableRpki:input_type -> api.EnableRpkiRequest
+	119, // 266: api.GoBgpService.DisableRpki:input_type -> api.DisableRpkiRequest
+	121, // 267: api.GoBgpService.ResetRpki:input_type -> api.ResetRpkiRequest
+	123, // 268: api.GoBgpService.ListRpkiTable:input_type -> api.ListRpkiTableRequest
+	125, // 269: api.GoBgpService.EnableZebra:input_type -> api.EnableZebraRequest
+	127, // 270: api.GoBgpService.EnableMrt:input_type -> api.EnableMrtRequest
+	129, // 271: api.GoBgpService.DisableMrt:input_type -> api.DisableMrtRequest
+	131, // 272: api.GoBgpService.AddBmp:input_type -> api.AddBmpRequest
+	133, // 273: api.GoBgpService.DeleteBmp:input_type -> api.DeleteBmpRequest
+	135, // 274: api.GoBgpService.ListBmp:input_type -> api.ListBmpRequest
+	215, // 275: api.GoBgpService.SetLogLevel:input_type -> api.SetLogLevelRequest
+	223, // 276: api.GoBgpService.AddTcpAoKeychain:input_type -> api.AddTcpAoKeychainRequest
+	225, // 277: api.GoBgpService.UpdateTcpAoKeychain:input_type -> api.UpdateTcpAoKeychainRequest
+	227, // 278: api.GoBgpService.DeleteTcpAoKeychain:input_type -> api.DeleteTcpAoKeychainRequest
+	229, // 279: api.GoBgpService.ListTcpAoKeychain:input_type -> api.ListTcpAoKeychainRequest
+	29,  // 280: api.GoBgpService.StartBgp:output_type -> api.StartBgpResponse
+	31,  // 281: api.GoBgpService.StopBgp:output_type -> api.StopBgpResponse
+	33,  // 282: api.GoBgpService.GetBgp:output_type -> api.GetBgpResponse
+	35,  // 283: api.GoBgpService.WatchEvent:output_type -> api.WatchEventResponse
+	37,  // 284: api.GoBgpService.AddPeer:output_type -> api.AddPeerResponse
+	39,  // 285: api.GoBgpService.DeletePeer:output_type -> api.DeletePeerResponse
+	41,  // 286: api.GoBgpService.ListPeer:output_type -> api.ListPeerResponse
+	43,  // 287: api.GoBgpService.UpdatePeer:output_type -> api.UpdatePeerResponse
+	45,  // 288: api.GoBgpService.ResetPeer:output_type -> api.ResetPeerResponse
+	47,  // 289: api.GoBgpService.ShutdownPeer:output_type -> api.ShutdownPeerResponse
+	49,  // 290: api.GoBgpService.EnablePeer:output_type -> api.EnablePeerResponse
+	51,  // 291: api.GoBgpService.DisablePeer:output_type -> api.DisablePeerResponse
+	53,  // 292: api.GoBgpService.AddPeerGroup:output_type -> api.AddPeerGroupResponse
+	55,  // 293: api.GoBgpService.DeletePeerGroup:output_type -> api.DeletePeerGroupResponse
+	59,  // 294: api.GoBgpService.ListPeerGroup:output_type -> api.ListPeerGroupResponse
+	57,  // 295: api.GoBgpService.UpdatePeerGroup:output_type -> api.UpdatePeerGroupResponse
+	61,  // 296: api.GoBgpService.AddDynamicNeighbor:output_type -> api.AddDynamicNeighborResponse
+	65,  // 297: api.GoBgpService.ListDynamicNeighbor:output_type -> api.ListDynamicNeighborResponse
+	63,  // 298: api.GoBgpService.DeleteDynamicNeighbor:output_type -> api.DeleteDynamicNeighborResponse
+	67,  // 299: api.GoBgpService.AddPath:output_type -> api.AddPathResponse
+	69,  // 300: api.GoBgpService.DeletePath:output_type -> api.DeletePathResponse
+	72,  // 301: api.GoBgpService.ListPath:output_type -> api.ListPathResponse
+	74,  // 302: api.GoBgpService.AddPathStream:output_type -> api.AddPathStreamResponse
+	76,  // 303: api.GoBgpService.GetTable:output_type -> api.GetTableResponse
+	78,  // 304: api.GoBgpService.AddVrf:output_type -> api.AddVrfResponse
+	80,  // 305: api.GoBgpService.DeleteVrf:output_type -> api.DeleteVrfResponse
+	82,  // 306: api.GoBgpService.ListVrf:output_type -> api.ListVrfResponse
+	84,  // 307: api.GoBgpService.AddPolicy:output_type -> api.AddPolicyResponse
+	86,  // 308: api.GoBgpService.DeletePolicy:output_type -> api.DeletePolicyResponse
+	88,  // 309: api.GoBgpService.ListPolicy:output_type -> api.ListPolicyResponse
+	90,  // 310: api.GoBgpService.SetPolicies:output_type -> api.SetPoliciesResponse
+	92,  // 311: api.GoBgpService.AddDefinedSet:output_type -> api.AddDefinedSetResponse
+	94,  // 312: api.GoBgpService.DeleteDefinedSet:output_type -> api.DeleteDefinedSetResponse
+	96,  // 313: api.GoBgpService.ListDefinedSet:output_type -> api.ListDefinedSetResponse
+	98,  // 314: api.GoBgpService.AddStatement:output_type -> api.AddStatementResponse
+	100, // 315: api.GoBgpService.DeleteStatement:output_type -> api.DeleteStatementResponse
+	102, // 316: api.GoBgpService.ListStatement:output_type -> api.ListStatementResponse
+	104, // 317: api.GoBgpService.AddPolicyAssignment:output_type -> api.AddPolicyAssignmentResponse
+	106, // 318: api.GoBgpService.DeletePolicyAssignment:output_type -> api.DeletePolicyAssignmentResponse
+	108, // 319: api.GoBgpService.ListPolicyAssignment:output_type -> api.ListPolicyAssignmentResponse
+	110, // 320: api.GoBgpService.SetPolicyAssignment:output_type -> api.SetPolicyAssignmentResponse
+	112, // 321: api.GoBgpService.AddRpki:output_type -> api.AddRpkiResponse
+	114, // 322: api.GoBgpService.DeleteRpki:output_type -> api.DeleteRpkiResponse
+	116, // 323: api.GoBgpService.ListRpki:output_type -> api.ListRpkiResponse
+	118, // 324: api.GoBgpService.EnableRpki:output_type -> api.EnableRpkiResponse
+	120, // 325: api.GoBgpService.DisableRpki:output_type -> api.DisableRpkiResponse
+	122, // 326: api.GoBgpService.ResetRpki:output_type -> api.ResetRpkiResponse
+	124, // 327: api.GoBgpService.ListRpkiTable:output_type -> api.ListRpkiTableResponse
+	126, // 328: api.GoBgpService.EnableZebra:output_type -> api.EnableZebraResponse
+	128, // 329: api.GoBgpService.EnableMrt:output_type -> api.EnableMrtResponse
+	130, // 330: api.GoBgpService.DisableMrt:output_type -> api.DisableMrtResponse
+	132, // 331: api.GoBgpService.AddBmp:output_type -> api.AddBmpResponse
+	134, // 332: api.GoBgpService.DeleteBmp:output_type -> api.DeleteBmpResponse
+	136, // 333: api.GoBgpService.ListBmp:output_type -> api.ListBmpResponse
+	216, // 334: api.GoBgpService.SetLogLevel:output_type -> api.SetLogLevelResponse
+	224, // 335: api.GoBgpService.AddTcpAoKeychain:output_type -> api.AddTcpAoKeychainResponse
+	226, // 336: api.GoBgpService.UpdateTcpAoKeychain:output_type -> api.UpdateTcpAoKeychainResponse
+	228, // 337: api.GoBgpService.DeleteTcpAoKeychain:output_type -> api.DeleteTcpAoKeychainResponse
+	230, // 338: api.GoBgpService.ListTcpAoKeychain:output_type -> api.ListTcpAoKeychainResponse
+	280, // [280:339] is the sub-list for method output_type
+	221, // [221:280] is the sub-list for method input_type
+	221, // [221:221] is the sub-list for extension type_name
+	221, // [221:221] is the sub-list for extension extendee
+	0,   // [0:221] is the sub-list for field type_name
 }
 
 func init() { file_api_gobgp_proto_init() }
@@ -14855,8 +15456,8 @@ func file_api_gobgp_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_gobgp_proto_rawDesc), len(file_api_gobgp_proto_rawDesc)),
-			NumEnums:      27,
-			NumMessages:   201,
+			NumEnums:      28,
+			NumMessages:   211,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gobgp_grpc.pb.go
+++ b/api/gobgp_grpc.pb.go
@@ -95,6 +95,10 @@ const (
 	GoBgpService_DeleteBmp_FullMethodName              = "/api.GoBgpService/DeleteBmp"
 	GoBgpService_ListBmp_FullMethodName                = "/api.GoBgpService/ListBmp"
 	GoBgpService_SetLogLevel_FullMethodName            = "/api.GoBgpService/SetLogLevel"
+	GoBgpService_AddTcpAoKeychain_FullMethodName       = "/api.GoBgpService/AddTcpAoKeychain"
+	GoBgpService_UpdateTcpAoKeychain_FullMethodName    = "/api.GoBgpService/UpdateTcpAoKeychain"
+	GoBgpService_DeleteTcpAoKeychain_FullMethodName    = "/api.GoBgpService/DeleteTcpAoKeychain"
+	GoBgpService_ListTcpAoKeychain_FullMethodName      = "/api.GoBgpService/ListTcpAoKeychain"
 )
 
 // GoBgpServiceClient is the client API for GoBgpService service.
@@ -158,6 +162,10 @@ type GoBgpServiceClient interface {
 	DeleteBmp(ctx context.Context, in *DeleteBmpRequest, opts ...grpc.CallOption) (*DeleteBmpResponse, error)
 	ListBmp(ctx context.Context, in *ListBmpRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListBmpResponse], error)
 	SetLogLevel(ctx context.Context, in *SetLogLevelRequest, opts ...grpc.CallOption) (*SetLogLevelResponse, error)
+	AddTcpAoKeychain(ctx context.Context, in *AddTcpAoKeychainRequest, opts ...grpc.CallOption) (*AddTcpAoKeychainResponse, error)
+	UpdateTcpAoKeychain(ctx context.Context, in *UpdateTcpAoKeychainRequest, opts ...grpc.CallOption) (*UpdateTcpAoKeychainResponse, error)
+	DeleteTcpAoKeychain(ctx context.Context, in *DeleteTcpAoKeychainRequest, opts ...grpc.CallOption) (*DeleteTcpAoKeychainResponse, error)
+	ListTcpAoKeychain(ctx context.Context, in *ListTcpAoKeychainRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListTcpAoKeychainResponse], error)
 }
 
 type goBgpServiceClient struct {
@@ -838,6 +846,55 @@ func (c *goBgpServiceClient) SetLogLevel(ctx context.Context, in *SetLogLevelReq
 	return out, nil
 }
 
+func (c *goBgpServiceClient) AddTcpAoKeychain(ctx context.Context, in *AddTcpAoKeychainRequest, opts ...grpc.CallOption) (*AddTcpAoKeychainResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AddTcpAoKeychainResponse)
+	err := c.cc.Invoke(ctx, GoBgpService_AddTcpAoKeychain_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *goBgpServiceClient) UpdateTcpAoKeychain(ctx context.Context, in *UpdateTcpAoKeychainRequest, opts ...grpc.CallOption) (*UpdateTcpAoKeychainResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpdateTcpAoKeychainResponse)
+	err := c.cc.Invoke(ctx, GoBgpService_UpdateTcpAoKeychain_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *goBgpServiceClient) DeleteTcpAoKeychain(ctx context.Context, in *DeleteTcpAoKeychainRequest, opts ...grpc.CallOption) (*DeleteTcpAoKeychainResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteTcpAoKeychainResponse)
+	err := c.cc.Invoke(ctx, GoBgpService_DeleteTcpAoKeychain_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *goBgpServiceClient) ListTcpAoKeychain(ctx context.Context, in *ListTcpAoKeychainRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ListTcpAoKeychainResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &GoBgpService_ServiceDesc.Streams[14], GoBgpService_ListTcpAoKeychain_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[ListTcpAoKeychainRequest, ListTcpAoKeychainResponse]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type GoBgpService_ListTcpAoKeychainClient = grpc.ServerStreamingClient[ListTcpAoKeychainResponse]
+
 // GoBgpServiceServer is the server API for GoBgpService service.
 // All implementations must embed UnimplementedGoBgpServiceServer
 // for forward compatibility.
@@ -899,6 +956,10 @@ type GoBgpServiceServer interface {
 	DeleteBmp(context.Context, *DeleteBmpRequest) (*DeleteBmpResponse, error)
 	ListBmp(*ListBmpRequest, grpc.ServerStreamingServer[ListBmpResponse]) error
 	SetLogLevel(context.Context, *SetLogLevelRequest) (*SetLogLevelResponse, error)
+	AddTcpAoKeychain(context.Context, *AddTcpAoKeychainRequest) (*AddTcpAoKeychainResponse, error)
+	UpdateTcpAoKeychain(context.Context, *UpdateTcpAoKeychainRequest) (*UpdateTcpAoKeychainResponse, error)
+	DeleteTcpAoKeychain(context.Context, *DeleteTcpAoKeychainRequest) (*DeleteTcpAoKeychainResponse, error)
+	ListTcpAoKeychain(*ListTcpAoKeychainRequest, grpc.ServerStreamingServer[ListTcpAoKeychainResponse]) error
 	mustEmbedUnimplementedGoBgpServiceServer()
 }
 
@@ -1073,6 +1134,18 @@ func (UnimplementedGoBgpServiceServer) ListBmp(*ListBmpRequest, grpc.ServerStrea
 }
 func (UnimplementedGoBgpServiceServer) SetLogLevel(context.Context, *SetLogLevelRequest) (*SetLogLevelResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SetLogLevel not implemented")
+}
+func (UnimplementedGoBgpServiceServer) AddTcpAoKeychain(context.Context, *AddTcpAoKeychainRequest) (*AddTcpAoKeychainResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddTcpAoKeychain not implemented")
+}
+func (UnimplementedGoBgpServiceServer) UpdateTcpAoKeychain(context.Context, *UpdateTcpAoKeychainRequest) (*UpdateTcpAoKeychainResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateTcpAoKeychain not implemented")
+}
+func (UnimplementedGoBgpServiceServer) DeleteTcpAoKeychain(context.Context, *DeleteTcpAoKeychainRequest) (*DeleteTcpAoKeychainResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteTcpAoKeychain not implemented")
+}
+func (UnimplementedGoBgpServiceServer) ListTcpAoKeychain(*ListTcpAoKeychainRequest, grpc.ServerStreamingServer[ListTcpAoKeychainResponse]) error {
+	return status.Errorf(codes.Unimplemented, "method ListTcpAoKeychain not implemented")
 }
 func (UnimplementedGoBgpServiceServer) mustEmbedUnimplementedGoBgpServiceServer() {}
 func (UnimplementedGoBgpServiceServer) testEmbeddedByValue()                      {}
@@ -1983,6 +2056,71 @@ func _GoBgpService_SetLogLevel_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _GoBgpService_AddTcpAoKeychain_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AddTcpAoKeychainRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GoBgpServiceServer).AddTcpAoKeychain(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GoBgpService_AddTcpAoKeychain_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GoBgpServiceServer).AddTcpAoKeychain(ctx, req.(*AddTcpAoKeychainRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _GoBgpService_UpdateTcpAoKeychain_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateTcpAoKeychainRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GoBgpServiceServer).UpdateTcpAoKeychain(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GoBgpService_UpdateTcpAoKeychain_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GoBgpServiceServer).UpdateTcpAoKeychain(ctx, req.(*UpdateTcpAoKeychainRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _GoBgpService_DeleteTcpAoKeychain_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteTcpAoKeychainRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GoBgpServiceServer).DeleteTcpAoKeychain(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GoBgpService_DeleteTcpAoKeychain_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GoBgpServiceServer).DeleteTcpAoKeychain(ctx, req.(*DeleteTcpAoKeychainRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _GoBgpService_ListTcpAoKeychain_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(ListTcpAoKeychainRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(GoBgpServiceServer).ListTcpAoKeychain(m, &grpc.GenericServerStream[ListTcpAoKeychainRequest, ListTcpAoKeychainResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type GoBgpService_ListTcpAoKeychainServer = grpc.ServerStreamingServer[ListTcpAoKeychainResponse]
+
 // GoBgpService_ServiceDesc is the grpc.ServiceDesc for GoBgpService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -2154,6 +2292,18 @@ var GoBgpService_ServiceDesc = grpc.ServiceDesc{
 			MethodName: "SetLogLevel",
 			Handler:    _GoBgpService_SetLogLevel_Handler,
 		},
+		{
+			MethodName: "AddTcpAoKeychain",
+			Handler:    _GoBgpService_AddTcpAoKeychain_Handler,
+		},
+		{
+			MethodName: "UpdateTcpAoKeychain",
+			Handler:    _GoBgpService_UpdateTcpAoKeychain_Handler,
+		},
+		{
+			MethodName: "DeleteTcpAoKeychain",
+			Handler:    _GoBgpService_DeleteTcpAoKeychain_Handler,
+		},
 	},
 	Streams: []grpc.StreamDesc{
 		{
@@ -2224,6 +2374,11 @@ var GoBgpService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "ListBmp",
 			Handler:       _GoBgpService_ListBmp_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "ListTcpAoKeychain",
+			Handler:       _GoBgpService_ListTcpAoKeychain_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -2491,3 +2491,34 @@ func (s *server) GetTable(ctx context.Context, r *api.GetTableRequest) (*api.Get
 func (s *server) SetLogLevel(ctx context.Context, r *api.SetLogLevelRequest) (*api.SetLogLevelResponse, error) {
 	return &api.SetLogLevelResponse{}, s.bgpServer.SetLogLevel(ctx, r)
 }
+
+func (s *server) AddTcpAoKeychain(ctx context.Context, r *api.AddTcpAoKeychainRequest) (*api.AddTcpAoKeychainResponse, error) {
+	return s.bgpServer.AddTcpAoKeychain(ctx, r)
+}
+
+func (s *server) UpdateTcpAoKeychain(ctx context.Context, r *api.UpdateTcpAoKeychainRequest) (*api.UpdateTcpAoKeychainResponse, error) {
+	return s.bgpServer.UpdateTcpAoKeychain(ctx, r)
+}
+
+func (s *server) DeleteTcpAoKeychain(ctx context.Context, r *api.DeleteTcpAoKeychainRequest) (*api.DeleteTcpAoKeychainResponse, error) {
+	if err := s.bgpServer.DeleteTcpAoKeychain(ctx, r); err != nil {
+		return nil, err
+	}
+	return &api.DeleteTcpAoKeychainResponse{}, nil
+}
+
+func (s *server) ListTcpAoKeychain(r *api.ListTcpAoKeychainRequest, stream api.GoBgpService_ListTcpAoKeychainServer) error {
+	ctx, cancel := context.WithCancel(stream.Context())
+	defer cancel()
+	var sendErr error
+	fn := func(chain *api.TcpAoKeychain) {
+		if sendErr = stream.Send(&api.ListTcpAoKeychainResponse{Keychain: chain}); sendErr != nil {
+			cancel()
+		}
+	}
+	err := s.bgpServer.ListTcpAoKeychain(ctx, r, fn)
+	if sendErr != nil {
+		return sendErr
+	}
+	return err
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -133,30 +133,31 @@ func (d *sharedData) propagateBucket(path *table.Path) *sync.Mutex {
 }
 
 type BgpServer struct {
-	shared       *sharedData
-	apiServer    *server
-	bgpConfig    oc.Bgp
-	acceptCh     chan net.Conn
-	mgmtCh       chan *mgmtOp
-	closeCh      chan struct{}
-	policy       *table.RoutingPolicy
-	listeners    []*netutils.TCPListener
-	neighborMap  map[netip.Addr]*peer
-	peerGroupMap map[string]*peerGroup
-	globalRib    *table.TableManager
-	rsRib        *table.TableManager
-	roaManager   *roaManager
-	watcherMap   map[watchEventType][]*watcher
-	watcherMu    sync.RWMutex
-	zclient      *zebraClient
-	bmpManager   *bmpClientManager
-	mrtManager   *mrtManager
-	roaTable     *table.ROATable
-	uuidMap      map[string]uuid.UUID
-	bfdServer    *bfdServer
-	logger       *slog.Logger
-	logLevelVar  *slog.LevelVar
-	timingHook   FSMTimingHook
+	shared        *sharedData
+	apiServer     *server
+	bgpConfig     oc.Bgp
+	acceptCh      chan net.Conn
+	mgmtCh        chan *mgmtOp
+	closeCh       chan struct{}
+	policy        *table.RoutingPolicy
+	listeners     []*netutils.TCPListener
+	neighborMap   map[netip.Addr]*peer
+	peerGroupMap  map[string]*peerGroup
+	globalRib     *table.TableManager
+	rsRib         *table.TableManager
+	roaManager    *roaManager
+	watcherMap    map[watchEventType][]*watcher
+	watcherMu     sync.RWMutex
+	zclient       *zebraClient
+	bmpManager    *bmpClientManager
+	mrtManager    *mrtManager
+	roaTable      *table.ROATable
+	uuidMap       map[string]uuid.UUID
+	bfdServer     *bfdServer
+	keyChainStore *tcpAoKeychainStore
+	logger        *slog.Logger
+	logLevelVar   *slog.LevelVar
+	timingHook    FSMTimingHook
 	// manage lifecycle of the server
 	isServing     atomic.Bool
 	shutdownWG    *sync.WaitGroup
@@ -199,6 +200,7 @@ func NewBgpServer(opt ...ServerOption) *BgpServer {
 	s.bmpManager = newBmpClientManager(s)
 	s.mrtManager = newMrtManager(s)
 	s.bfdServer = NewBfdServer(s, logger)
+	s.keyChainStore = newTcpAoKeychainStore()
 	if len(opts.grpcAddress) != 0 {
 		grpc.EnableTracing = false
 		s.apiServer = newAPIserver(s, shared, grpc.NewServer(opts.grpcOption...), opts.grpcAddress)
@@ -2209,6 +2211,7 @@ func (s *BgpServer) StopBgp(ctx context.Context, r *api.StopBgpRequest) error {
 		for _, l := range s.listeners {
 			l.Close()
 		}
+		s.keyChainStore.clearAllKeychains()
 		s.bgpConfig.Global = oc.Global{}
 		return nil
 	}, false)
@@ -5316,4 +5319,175 @@ func (s *BgpServer) ListBfdPeer(ctx context.Context, fn func(string, *api.BfdPee
 	for _, state := range list {
 		fn(state.peerAddress.String(), &state.state)
 	}
+}
+
+func (s *BgpServer) AddTcpAoKeychain(_ context.Context, r *api.AddTcpAoKeychainRequest) (*api.AddTcpAoKeychainResponse, error) {
+	if r == nil {
+		return nil, status.Error(codes.InvalidArgument, "nil request")
+	}
+	if r.Keychain == nil {
+		return nil, status.Error(codes.InvalidArgument, "TCP-AO keychain is required")
+	}
+	if r.Keychain.Name == "" {
+		return nil, status.Error(codes.InvalidArgument, "TCP-AO keychain name is required")
+	}
+
+	var response *api.AddTcpAoKeychainResponse
+	err := s.mgmtOperation(func() error {
+		chain, err := newTcpAoKeychain(r.Keychain)
+		if err != nil {
+			return err
+		}
+		if _, exists := s.keyChainStore.getKeychain(chain.name); exists {
+			return status.Errorf(codes.AlreadyExists, "TCP-AO keychain %q already exists", chain.name)
+		}
+		s.keyChainStore.addKeychain(chain)
+		response = &api.AddTcpAoKeychainResponse{Keychain: chain.toAPIKeychain()}
+		return nil
+	}, false)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (s *BgpServer) UpdateTcpAoKeychain(_ context.Context, r *api.UpdateTcpAoKeychainRequest) (*api.UpdateTcpAoKeychainResponse, error) {
+	if r == nil {
+		return nil, status.Error(codes.InvalidArgument, "nil request")
+	}
+	if r.Name == "" {
+		return nil, status.Error(codes.InvalidArgument, "TCP-AO keychain name is required")
+	}
+
+	var response *api.UpdateTcpAoKeychainResponse
+	err := s.mgmtOperation(func() error {
+		keychain, ok := s.keyChainStore.getKeychain(r.Name)
+		if !ok {
+			return status.Errorf(codes.NotFound, "TCP-AO keychain %q does not exist", r.Name)
+		}
+		added, deleted, err := s.validateTcpAoKeychainUpdate(keychain, r)
+		if err != nil {
+			return err
+		}
+		keychain.updateKeys(added, deleted)
+		response = &api.UpdateTcpAoKeychainResponse{Keychain: keychain.toAPIKeychain()}
+		return nil
+	}, false)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (s *BgpServer) DeleteTcpAoKeychain(_ context.Context, r *api.DeleteTcpAoKeychainRequest) error {
+	if r == nil {
+		return status.Error(codes.InvalidArgument, "nil request")
+	}
+	if r.Name == "" {
+		return status.Error(codes.InvalidArgument, "TCP-AO keychain name is required")
+	}
+
+	return s.mgmtOperation(func() error {
+		if _, exists := s.keyChainStore.getKeychain(r.Name); !exists {
+			return status.Errorf(codes.NotFound, "TCP-AO keychain %q does not exist", r.Name)
+		}
+		if !s.keyChainStore.deleteKeychain(r.Name) {
+			return status.Errorf(codes.NotFound, "TCP-AO keychain %q does not exist", r.Name)
+		}
+		return nil
+	}, false)
+}
+
+func (s *BgpServer) ListTcpAoKeychain(ctx context.Context, r *api.ListTcpAoKeychainRequest, fn func(*api.TcpAoKeychain)) error {
+	if r == nil {
+		return status.Error(codes.InvalidArgument, "nil request")
+	}
+	if fn == nil {
+		return status.Error(codes.InvalidArgument, "nil callback")
+	}
+
+	var chains []*api.TcpAoKeychain
+	err := s.mgmtOperation(func() error {
+		if r.Name != "" {
+			keychain, ok := s.keyChainStore.getKeychain(r.Name)
+			if !ok {
+				return status.Errorf(codes.NotFound, "TCP-AO keychain %q does not exist", r.Name)
+			}
+			chains = []*api.TcpAoKeychain{keychain.toAPIKeychain()}
+			return nil
+		}
+		for _, chain := range s.keyChainStore.getAllKeychains() {
+			chains = append(chains, chain.toAPIKeychain())
+		}
+		return nil
+	}, false)
+	if err != nil {
+		return err
+	}
+	for _, chain := range chains {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		fn(chain)
+	}
+	return nil
+}
+
+func (s *BgpServer) validateTcpAoKeychainUpdate(keychain *tcpAoKeychain, request *api.UpdateTcpAoKeychainRequest) (added, deleted []netutils.TCPAOKey, err error) {
+	sendIDs := make(map[uint8]struct{}, len(keychain.keys))
+	receiveIDs := make(map[uint8]struct{}, len(keychain.keys))
+	for _, key := range keychain.keys {
+		sendIDs[key.SendID] = struct{}{}
+		receiveIDs[key.ReceiveID] = struct{}{}
+	}
+	for i, delKey := range request.DeleteKeys {
+		if delKey == nil {
+			err = status.Errorf(codes.InvalidArgument, "TCP-AO delete key request %q contains a nil key at index %d", keychain.name, i)
+			return
+		}
+		if delKey.SendId > 255 {
+			err = status.Errorf(codes.InvalidArgument, "TCP-AO keychain %q delete key %d has send ID %d outside 0..255", keychain.name, i, delKey.SendId)
+			return
+		}
+		if delKey.ReceiveId > 255 {
+			err = status.Errorf(codes.InvalidArgument, "TCP-AO keychain %q delete key %d has receive ID %d outside 0..255", keychain.name, i, delKey.ReceiveId)
+			return
+		}
+		key, exists := keychain.getKey(uint8(delKey.SendId), uint8(delKey.ReceiveId))
+		if !exists {
+			err = status.Errorf(codes.NotFound, "TCP-AO keychain %q does not contain key with send ID %d and receive ID %d", request.Name, delKey.SendId, delKey.ReceiveId)
+			return
+		}
+		if _, exists := sendIDs[key.SendID]; !exists {
+			err = status.Errorf(codes.InvalidArgument, "TCP-AO keychain %q delete request contains duplicate key with send ID %d and receive ID %d", request.Name, delKey.SendId, delKey.ReceiveId)
+			return
+		}
+		delete(sendIDs, key.SendID)
+		delete(receiveIDs, key.ReceiveID)
+		deleted = append(deleted, key)
+	}
+	for i, addKey := range request.AddKeys {
+		if addKey == nil {
+			err = status.Errorf(codes.InvalidArgument, "TCP-AO add key request %q contains a nil key at index %d", keychain.name, i)
+			return
+		}
+		if _, ok := sendIDs[uint8(addKey.SendId)]; ok {
+			err = status.Errorf(codes.AlreadyExists, "TCP-AO keychain %q already contains send ID %d", keychain.name, addKey.SendId)
+			return
+		}
+		if _, ok := receiveIDs[uint8(addKey.ReceiveId)]; ok {
+			err = status.Errorf(codes.AlreadyExists, "TCP-AO keychain %q already contains receive ID %d", keychain.name, addKey.ReceiveId)
+			return
+		}
+		sendIDs[uint8(addKey.SendId)] = struct{}{}
+		receiveIDs[uint8(addKey.ReceiveId)] = struct{}{}
+	}
+	if len(sendIDs) < 1 || len(sendIDs) > 256 {
+		err = status.Errorf(codes.InvalidArgument, "TCP-AO keychain %q must contain between 1 and 256 keys", request.Name)
+		return
+	}
+	if len(request.AddKeys) > 0 {
+		added, err = newTcpAoKeys(keychain.name, request.AddKeys)
+	}
+	return
 }

--- a/pkg/server/tcp_ao.go
+++ b/pkg/server/tcp_ao.go
@@ -1,0 +1,199 @@
+// Copyright (C) 2026 The GoBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"maps"
+	"slices"
+	"sync"
+
+	"github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/internal/pkg/netutils"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// tcpAoMaxMasterKeyBytes matches TCP_AO_MAXKEYLEN from Linux's include/uapi/linux/tcp.h.
+const tcpAoMaxMasterKeyBytes = 80
+
+type tcpAoKeychain struct {
+	mu   sync.RWMutex
+	name string
+	keys map[uint8]netutils.TCPAOKey
+}
+
+type tcpAoKeychainStore struct {
+	// keychains must only be accessed from mgmtOperation callbacks while shared.mu is held.
+	keychains map[string]*tcpAoKeychain
+}
+
+func newTcpAoKeychainStore() *tcpAoKeychainStore {
+	return &tcpAoKeychainStore{keychains: make(map[string]*tcpAoKeychain)}
+}
+
+func (s *tcpAoKeychainStore) addKeychain(chain *tcpAoKeychain) {
+	s.keychains[chain.name] = chain
+}
+
+func (s *tcpAoKeychainStore) getKeychain(name string) (*tcpAoKeychain, bool) {
+	chain, ok := s.keychains[name]
+	return chain, ok
+}
+
+func (s *tcpAoKeychainStore) getAllKeychains() []*tcpAoKeychain {
+	return slices.Collect(maps.Values(s.keychains))
+}
+
+func (s *tcpAoKeychainStore) deleteKeychain(name string) bool {
+	chain, ok := s.keychains[name]
+	if !ok {
+		return false
+	}
+	chain.clearKeys()
+	delete(s.keychains, name)
+	return true
+}
+
+func (s *tcpAoKeychainStore) clearAllKeychains() {
+	for _, chain := range s.keychains {
+		chain.clearKeys()
+	}
+	clear(s.keychains)
+}
+
+func newTcpAoKeychain(a *api.TcpAoKeychain) (*tcpAoKeychain, error) {
+	keys, err := newTcpAoKeys(a.Name, a.Keys)
+	if err != nil {
+		return nil, err
+	}
+	keyMap := make(map[uint8]netutils.TCPAOKey, len(keys))
+	for _, key := range keys {
+		keyMap[key.SendID] = key
+	}
+	return &tcpAoKeychain{name: a.Name, keys: keyMap}, nil
+}
+
+func newTcpAoKeys(chainName string, keys []*api.TcpAoKey) ([]netutils.TCPAOKey, error) {
+	if len(keys) == 0 || len(keys) > 256 {
+		return nil, status.Errorf(codes.InvalidArgument, "TCP-AO keychain %q must contain between 1 and 256 keys", chainName)
+	}
+	sendIDs := make(map[uint32]struct{}, len(keys))
+	receiveIDs := make(map[uint32]struct{}, len(keys))
+	for i, key := range keys {
+		if key == nil {
+			return nil, status.Errorf(codes.InvalidArgument, "TCP-AO keychain %q contains a nil key at index %d", chainName, i)
+		}
+		if key.SendId > 255 {
+			return nil, status.Errorf(codes.InvalidArgument, "TCP-AO keychain %q key %d has send ID %d outside 0..255", chainName, i, key.SendId)
+		}
+		if key.ReceiveId > 255 {
+			return nil, status.Errorf(codes.InvalidArgument, "TCP-AO keychain %q key %d has receive ID %d outside 0..255", chainName, i, key.ReceiveId)
+		}
+		if _, ok := sendIDs[key.SendId]; ok {
+			return nil, status.Errorf(codes.InvalidArgument, "TCP-AO keychain %q has duplicate send ID %d", chainName, key.SendId)
+		}
+		if _, ok := receiveIDs[key.ReceiveId]; ok {
+			return nil, status.Errorf(codes.InvalidArgument, "TCP-AO keychain %q has duplicate receive ID %d", chainName, key.ReceiveId)
+		}
+		switch key.Algorithm {
+		case api.TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96,
+			api.TcpAoAlgorithm_TCP_AO_ALGORITHM_AES_128_CMAC_96:
+		default:
+			return nil, status.Errorf(codes.InvalidArgument, "TCP-AO keychain %q key %d has unsupported algorithm %s", chainName, i, key.Algorithm)
+		}
+		if len(key.MasterKey) == 0 || len(key.MasterKey) > tcpAoMaxMasterKeyBytes {
+			return nil, status.Errorf(codes.InvalidArgument, "TCP-AO keychain %q key %d master key must contain between 1 and %d bytes", chainName, i, tcpAoMaxMasterKeyBytes)
+		}
+		sendIDs[key.SendId] = struct{}{}
+		receiveIDs[key.ReceiveId] = struct{}{}
+	}
+
+	result := make([]netutils.TCPAOKey, 0, len(keys))
+	for _, apiKey := range keys {
+		key := netutils.TCPAOKey{
+			SendID:            uint8(apiKey.SendId),
+			ReceiveID:         uint8(apiKey.ReceiveId),
+			Algorithm:         netutils.TCPAOAlgorithm(apiKey.Algorithm),
+			ExcludeTCPOptions: apiKey.ExcludeTcpOptions,
+			MasterKey:         append([]byte{}, apiKey.MasterKey...),
+		}
+		result = append(result, key)
+	}
+	return result, nil
+}
+
+func (c *tcpAoKeychain) toAPIKeychain() *api.TcpAoKeychain {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	result := &api.TcpAoKeychain{
+		Name: c.name,
+		Keys: make([]*api.TcpAoKey, 0, len(c.keys)),
+	}
+	sendIDs := make([]uint8, 0, len(c.keys))
+	for sendID := range c.keys {
+		sendIDs = append(sendIDs, sendID)
+	}
+	slices.Sort(sendIDs)
+	for _, sendID := range sendIDs {
+		key := c.keys[sendID]
+		result.Keys = append(result.Keys, &api.TcpAoKey{
+			SendId:            uint32(key.SendID),
+			ReceiveId:         uint32(key.ReceiveID),
+			Algorithm:         api.TcpAoAlgorithm(key.Algorithm),
+			ExcludeTcpOptions: key.ExcludeTCPOptions,
+			// MasterKey is intentionally omitted
+		})
+	}
+	return result
+}
+
+func (c *tcpAoKeychain) getKey(sendID, receiveID uint8) (netutils.TCPAOKey, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	key, ok := c.keys[sendID]
+	if !ok || key.ReceiveID != receiveID {
+		return netutils.TCPAOKey{}, false
+	}
+	return key, true
+}
+
+func (c *tcpAoKeychain) updateKeys(added, deleted []netutils.TCPAOKey) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, deletedKey := range deleted {
+		key, ok := c.keys[deletedKey.SendID]
+		if !ok || key.ReceiveID != deletedKey.ReceiveID {
+			continue
+		}
+		clear(key.MasterKey)
+		delete(c.keys, deletedKey.SendID)
+	}
+	for _, key := range added {
+		c.keys[key.SendID] = key
+	}
+}
+
+func (c *tcpAoKeychain) clearKeys() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, key := range c.keys {
+		clear(key.MasterKey)
+	}
+	clear(c.keys)
+}

--- a/pkg/server/tcp_ao_test.go
+++ b/pkg/server/tcp_ao_test.go
@@ -1,0 +1,272 @@
+// Copyright (C) 2026 The GoBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/osrg/gobgp/v4/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+func testTcpAoKeychain(name string) *api.TcpAoKeychain {
+	return &api.TcpAoKeychain{
+		Name: name,
+		Keys: []*api.TcpAoKey{{
+			SendId:            1,
+			ReceiveId:         2,
+			Algorithm:         api.TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96,
+			ExcludeTcpOptions: true,
+			MasterKey:         []byte("secret"),
+		}},
+	}
+}
+
+func TestTcpAoKeychainValidation(t *testing.T) {
+	s := NewBgpServer()
+	go s.Serve()
+	t.Cleanup(func() {
+		require.NoError(t, s.StopBgp(context.Background(), &api.StopBgpRequest{}))
+	})
+	add := func(keychain *api.TcpAoKeychain) error {
+		_, err := s.AddTcpAoKeychain(context.Background(), &api.AddTcpAoKeychainRequest{Keychain: keychain})
+		return err
+	}
+	update := func(request *api.UpdateTcpAoKeychainRequest) error {
+		_, err := s.UpdateTcpAoKeychain(context.Background(), request)
+		return err
+	}
+	tests := []struct {
+		name string
+		err  error
+		code codes.Code
+	}{
+		{
+			name: "missing keychain",
+			err:  add(nil),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "missing name",
+			err:  add(testTcpAoKeychain("")),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "no keys",
+			err:  add(&api.TcpAoKeychain{Name: "chain"}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "nil key",
+			err:  add(&api.TcpAoKeychain{Name: "chain", Keys: []*api.TcpAoKey{nil}}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "send ID overflow",
+			err:  add(&api.TcpAoKeychain{Name: "chain", Keys: []*api.TcpAoKey{{SendId: 256, Algorithm: api.TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96, MasterKey: []byte{1}}}}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "receive ID overflow",
+			err:  add(&api.TcpAoKeychain{Name: "chain", Keys: []*api.TcpAoKey{{ReceiveId: 256, Algorithm: api.TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96, MasterKey: []byte{1}}}}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "duplicate send ID",
+			err: add(&api.TcpAoKeychain{Name: "chain", Keys: []*api.TcpAoKey{
+				{SendId: 1, ReceiveId: 1, Algorithm: api.TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96, MasterKey: []byte{1}},
+				{SendId: 1, ReceiveId: 2, Algorithm: api.TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96, MasterKey: []byte{2}},
+			}}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "duplicate receive ID",
+			err: add(&api.TcpAoKeychain{Name: "chain", Keys: []*api.TcpAoKey{
+				{SendId: 1, ReceiveId: 1, Algorithm: api.TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96, MasterKey: []byte{1}},
+				{SendId: 2, ReceiveId: 1, Algorithm: api.TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96, MasterKey: []byte{2}},
+			}}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "unspecified algorithm",
+			err:  add(&api.TcpAoKeychain{Name: "chain", Keys: []*api.TcpAoKey{{MasterKey: []byte{1}}}}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "unknown algorithm",
+			err:  add(&api.TcpAoKeychain{Name: "chain", Keys: []*api.TcpAoKey{{Algorithm: api.TcpAoAlgorithm(99), MasterKey: []byte{1}}}}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "empty master key",
+			err:  add(&api.TcpAoKeychain{Name: "chain", Keys: []*api.TcpAoKey{{Algorithm: api.TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96}}}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "long master key",
+			err:  add(&api.TcpAoKeychain{Name: "chain", Keys: []*api.TcpAoKey{{Algorithm: api.TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96, MasterKey: make([]byte, tcpAoMaxMasterKeyBytes+1)}}}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "nil update request",
+			err:  update(nil),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "missing update name",
+			err:  update(&api.UpdateTcpAoKeychainRequest{}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "nil delete request",
+			err:  s.DeleteTcpAoKeychain(context.Background(), nil),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "missing delete name",
+			err:  s.DeleteTcpAoKeychain(context.Background(), &api.DeleteTcpAoKeychainRequest{}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "nil list request",
+			err:  s.ListTcpAoKeychain(context.Background(), nil, func(*api.TcpAoKeychain) {}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "nil list callback",
+			err:  s.ListTcpAoKeychain(context.Background(), &api.ListTcpAoKeychainRequest{}, nil),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "valid keychain for update",
+			err: add(&api.TcpAoKeychain{
+				Name: "update-chain",
+				Keys: []*api.TcpAoKey{
+					{SendId: 5, ReceiveId: 15, Algorithm: api.TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96, MasterKey: []byte("five")},
+					{SendId: 9, ReceiveId: 19, Algorithm: api.TcpAoAlgorithm_TCP_AO_ALGORITHM_AES_128_CMAC_96, MasterKey: []byte("nine")},
+				},
+			}),
+			code: codes.OK,
+		},
+		{
+			name: "delete missing key",
+			err:  update(&api.UpdateTcpAoKeychainRequest{Name: "update-chain", DeleteKeys: []*api.TcpAoKey{{SendId: 5, ReceiveId: 99}}}),
+			code: codes.NotFound,
+		},
+		{
+			name: "delete key twice",
+			err: update(&api.UpdateTcpAoKeychainRequest{Name: "update-chain", DeleteKeys: []*api.TcpAoKey{
+				{SendId: 5, ReceiveId: 15},
+				{SendId: 5, ReceiveId: 15},
+			}}),
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "add duplicate send ID",
+			err: update(&api.UpdateTcpAoKeychainRequest{Name: "update-chain", AddKeys: []*api.TcpAoKey{{
+				SendId: 9, ReceiveId: 29, Algorithm: api.TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96, MasterKey: []byte("duplicate"),
+			}}}),
+			code: codes.AlreadyExists,
+		},
+		{
+			name: "add duplicate receive ID",
+			err: update(&api.UpdateTcpAoKeychainRequest{Name: "update-chain", AddKeys: []*api.TcpAoKey{{
+				SendId: 29, ReceiveId: 19, Algorithm: api.TcpAoAlgorithm_TCP_AO_ALGORITHM_HMAC_SHA1_96, MasterKey: []byte("duplicate"),
+			}}}),
+			code: codes.AlreadyExists,
+		},
+		{
+			name: "delete every key",
+			err: update(&api.UpdateTcpAoKeychainRequest{Name: "update-chain", DeleteKeys: []*api.TcpAoKey{
+				{SendId: 5, ReceiveId: 15},
+				{SendId: 9, ReceiveId: 19},
+			}}),
+			code: codes.InvalidArgument,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.code, status.Code(tt.err))
+		})
+	}
+}
+
+func TestTcpAoKeychainOperations(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "gobgp.sock")
+	socketAddr := "unix://" + socketPath
+	s := NewBgpServer(GrpcListenAddress(socketAddr))
+	go s.Serve()
+	t.Cleanup(s.Stop)
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(socketPath)
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
+
+	conn, err := grpc.NewClient(socketAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	client := api.NewGoBgpServiceClient(conn)
+
+	added, err := client.AddTcpAoKeychain(context.Background(), &api.AddTcpAoKeychainRequest{
+		Keychain: testTcpAoKeychain("chain"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, added.Keychain)
+	require.Len(t, added.Keychain.Keys, 1)
+	assert.Empty(t, added.Keychain.Keys[0].MasterKey)
+
+	updated, err := client.UpdateTcpAoKeychain(context.Background(), &api.UpdateTcpAoKeychainRequest{
+		Name: "chain",
+		DeleteKeys: []*api.TcpAoKey{{
+			SendId:    1,
+			ReceiveId: 2,
+		}},
+		AddKeys: []*api.TcpAoKey{{
+			SendId: 1, ReceiveId: 2, Algorithm: api.TcpAoAlgorithm_TCP_AO_ALGORITHM_AES_128_CMAC_96, MasterKey: []byte("replacement"),
+		}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated.Keychain)
+	require.Len(t, updated.Keychain.Keys, 1)
+	assert.Equal(t, uint32(1), updated.Keychain.Keys[0].SendId)
+	assert.Equal(t, uint32(2), updated.Keychain.Keys[0].ReceiveId)
+	assert.Equal(t, api.TcpAoAlgorithm_TCP_AO_ALGORITHM_AES_128_CMAC_96, updated.Keychain.Keys[0].Algorithm)
+	assert.Empty(t, updated.Keychain.Keys[0].MasterKey)
+
+	stream, err := client.ListTcpAoKeychain(context.Background(), &api.ListTcpAoKeychainRequest{Name: "chain"})
+	require.NoError(t, err)
+	listed, err := stream.Recv()
+	require.NoError(t, err)
+	assert.Equal(t, updated.Keychain, listed.Keychain)
+	_, err = stream.Recv()
+	assert.ErrorIs(t, err, io.EOF)
+
+	_, err = client.DeleteTcpAoKeychain(context.Background(), &api.DeleteTcpAoKeychainRequest{Name: "chain"})
+	require.NoError(t, err)
+	stream, err = client.ListTcpAoKeychain(context.Background(), &api.ListTcpAoKeychainRequest{Name: "chain"})
+	require.NoError(t, err)
+	_, err = stream.Recv()
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}

--- a/proto/api/gobgp.proto
+++ b/proto/api/gobgp.proto
@@ -105,6 +105,11 @@ service GoBgpService {
   rpc ListBmp(ListBmpRequest) returns (stream ListBmpResponse);
 
   rpc SetLogLevel(SetLogLevelRequest) returns (SetLogLevelResponse);
+
+  rpc AddTcpAoKeychain(AddTcpAoKeychainRequest) returns (AddTcpAoKeychainResponse);
+  rpc UpdateTcpAoKeychain(UpdateTcpAoKeychainRequest) returns (UpdateTcpAoKeychainResponse);
+  rpc DeleteTcpAoKeychain(DeleteTcpAoKeychainRequest) returns (DeleteTcpAoKeychainResponse);
+  rpc ListTcpAoKeychain(ListTcpAoKeychainRequest) returns (stream ListTcpAoKeychainResponse);
 }
 
 message StartBgpRequest {
@@ -1441,4 +1446,55 @@ message BfdState {
   uint64 received_error = 3;
   uint64 invalid_packet = 4;
   uint64 unknown_peer = 5;
+}
+
+enum TcpAoAlgorithm {
+  TCP_AO_ALGORITHM_UNSPECIFIED = 0;
+  TCP_AO_ALGORITHM_HMAC_SHA1_96 = 1;
+  TCP_AO_ALGORITHM_AES_128_CMAC_96 = 2;
+}
+
+message TcpAoKey {
+  uint32 send_id = 1;
+  uint32 receive_id = 2;
+  TcpAoAlgorithm algorithm = 3;
+  bytes master_key = 4 [debug_redact = true]; // write-only
+  bool exclude_tcp_options = 5;
+}
+
+message TcpAoKeychain {
+  string name = 1;
+  repeated TcpAoKey keys = 2;
+}
+
+message AddTcpAoKeychainRequest {
+  TcpAoKeychain keychain = 1;
+}
+
+message AddTcpAoKeychainResponse {
+  TcpAoKeychain keychain = 1;
+}
+
+message UpdateTcpAoKeychainRequest {
+  string name = 1;
+  repeated TcpAoKey add_keys = 2;
+  repeated TcpAoKey delete_keys = 3; // only send_id and receive_id are used
+}
+
+message UpdateTcpAoKeychainResponse {
+  TcpAoKeychain keychain = 1;
+}
+
+message DeleteTcpAoKeychainRequest {
+  string name = 1;
+}
+
+message DeleteTcpAoKeychainResponse {}
+
+message ListTcpAoKeychainRequest {
+  string name = 1;
+}
+
+message ListTcpAoKeychainResponse {
+  TcpAoKeychain keychain = 1;
 }


### PR DESCRIPTION
The is the first part of the TCP-AO implementation (https://github.com/osrg/gobgp/issues/3493) which adds the proto API for TCP-AO keychain configuration and implementation of the keychain store.

The configured keychains do not have any use for now, this will be added in follow-up changes as part of https://github.com/osrg/gobgp/issues/3493.