### PR TITLE
server: resolve unnumbered NeighborInterface before validating neighbor address

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3453,15 +3453,14 @@ func (s *BgpServer) addPeerGroup(c *oc.PeerGroup) error {
 }
 
 func (s *BgpServer) addNeighbor(c *oc.Neighbor) error {
-	addr, err := c.ExtractNeighborAddress()
-	if err != nil {
-		return err
-	}
-
-	if _, y := s.neighborMap[netip.MustParseAddr(addr)]; y {
-		return fmt.Errorf("can't overwrite the existing peer: %s", addr)
-	}
-
+	// Resolve config defaults BEFORE extracting/validating the neighbor address.
+	// For an unnumbered (interface-only) neighbor added via the gRPC AddPeer API
+	// - NeighborInterface set, NeighborAddress empty - SetDefaultNeighborConfigValues
+	// resolves the peer's IPv6 link-local from the interface into
+	// State.NeighborAddress and derives the local link-local as the transport
+	// source address. ExtractNeighborAddress would otherwise reject the addressless
+	// neighbor up front with "NeighborAddress is not configured". The config-file
+	// path already defaults before addNeighbor; this makes the gRPC path match.
 	var pgConf *oc.PeerGroup
 	if c.Config.PeerGroup != "" {
 		pg, ok := s.peerGroupMap[c.Config.PeerGroup]
@@ -3473,6 +3472,15 @@ func (s *BgpServer) addNeighbor(c *oc.Neighbor) error {
 
 	if err := oc.SetDefaultNeighborConfigValues(c, pgConf, &s.bgpConfig.Global); err != nil {
 		return err
+	}
+
+	addr, err := c.ExtractNeighborAddress()
+	if err != nil {
+		return err
+	}
+
+	if _, y := s.neighborMap[netip.MustParseAddr(addr)]; y {
+		return fmt.Errorf("can't overwrite the existing peer: %s", addr)
 	}
 
 	if vrf := c.Config.Vrf; vrf != "" {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -179,6 +179,49 @@ func TestStop(t *testing.T) {
 	assert.Error(err)
 }
 
+// TestAddPeerUnnumberedInterface verifies that an unnumbered (interface-only)
+// neighbor added via the AddPeer API is not rejected before its interface is
+// resolved. Such a neighbor carries NeighborInterface with an empty
+// NeighborAddress; the address is derived from the interface's IPv6 link-local
+// by SetDefaultNeighborConfigValues. Previously addNeighbor validated the
+// address via ExtractNeighborAddress *before* defaulting ran, rejecting the
+// peer with "NeighborAddress is not configured" and making unnumbered peering
+// unreachable over the API (only the config-file path worked). See #3023.
+//
+// Driving the peer to establishment would require a real interface with a
+// discovered IPv6 link-local neighbor in the netlink table, which is not
+// available in a unit test. Instead we assert that the peer gets past the
+// premature address gate: with a non-existent interface, AddPeer must fail at
+// interface resolution, not at address validation.
+func TestAddPeerUnnumberedInterface(t *testing.T) {
+	assert := assert.New(t)
+	s := NewBgpServer()
+	go s.Serve()
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        1,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	p := &api.Peer{
+		Conf: &api.PeerConf{
+			NeighborInterface: "gobgp-nonexistent0",
+			PeerAsn:           2,
+		},
+	}
+	err = s.AddPeer(context.Background(), &api.AddPeerRequest{Peer: p})
+	// Resolution of a non-existent interface cannot succeed in a unit test, so
+	// an error is expected - but it must come from interface resolution, not
+	// from the address-validation gate that used to run first.
+	require.Error(t, err)
+	assert.NotContains(err.Error(), "NeighborAddress is not configured",
+		"interface-only neighbor must reach interface resolution, not be rejected by the address gate")
+}
+
 func TestWatchUpdateCurrentDeliversInitBeforeLiveEvents(t *testing.T) {
 	ctx := context.Background()
 	s1 := runNewServer(t, 1, "1.1.1.1", 10179)


### PR DESCRIPTION
Fixes #3023.

Problem

Adding an unnumbered (interface-only) neighbor via the gRPC AddPeer API — NeighborInterface set, NeighborAddress empty — is rejected up front with:

NeighborAddress is not configured

so gobgp's native unnumbered support is unreachable over gRPC. Only the config-file path works.

Cause

In (*BgpServer).addNeighbor the order was:

1. c.ExtractNeighborAddress() — errors on an addressless neighbor
2. peer-group lookup
3. oc.SetDefaultNeighborConfigValues(...)

But step 3 is what resolves the interface's link-local: SetDefaultNeighborConfigValues calls GetIPv6LinkLocalNeighborAddress(NeighborInterface) and stores the result in State.NeighborAddress (pkg/config/oc/default.go). ExtractNeighborAddress reads State.NeighborAddress first (pkg/config/oc/util.go) — but it ran before that field was populated. The config-file/CLI path defaults the neighbor config before reaching addNeighbor, which is why it doesn't hit this.

Fix

Reorder addNeighbor so peer-group lookup + SetDefaultNeighborConfigValues run first, then ExtractNeighborAddress sees the resolved zoned link-local. This makes the gRPC path behave identically to the config-file path, and reuses the existing defaulting routine rather than adding a second resolution call site.

Re #3023's question of whether the ordering was intentional: it reads as an ordering oversight — the resolution logic already lives in SetDefaultNeighborConfigValues; addNeighbor just validated before invoking it.

Testing

Added a unit test (TestAddPeerUnnumberedInterface) that adds an interface-only neighbor via AddPeer and asserts it reaches interface resolution rather than being rejected by the address-validation gate. Verified it fails on the pre-fix ordering with "NeighborAddress is not configured" and passes with the fix. A full end-to-end unnumbered session was validated separately against an FRR peer — interface resolution needs a real IPv6 link-local neighbor in the netlink table, so it isn't reproducible in a hermetic unit test (matching where gobgp's existing unnumbered coverage lives, the scenario_test integration suite).