### PR TITLE
fix(server): prevent watcher leaks during shutdown

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -185,7 +185,7 @@ func NewBgpServer(opt ...ServerOption) *BgpServer {
 		neighborMap:  make(map[netip.Addr]*peer),
 		peerGroupMap: make(map[string]*peerGroup),
 		policy:       table.NewRoutingPolicy(logger),
-		mgmtCh:       make(chan *mgmtOp, 1),
+		mgmtCh:       make(chan *mgmtOp),
 		closeCh:      make(chan struct{}),
 		watcherMap:   make(map[watchEventType][]*watcher),
 		uuidMap:      make(map[string]uuid.UUID),
@@ -5016,6 +5016,7 @@ type watcher struct {
 	realCh chan watchEvent
 	ch     *channels.InfiniteChannel
 	s      *BgpServer
+	stop   sync.Once
 	// filters are used for notifyWatcher by using the filter for the given watchEvent,
 	// call notify method for skipping filtering.
 	filters map[watchEventType]func(w watchEvent) bool
@@ -5039,27 +5040,35 @@ func (w *watcher) loop() {
 	close(w.realCh)
 }
 
-//nolint:errcheck // we don't care about the error here.
 func (w *watcher) Stop() {
-	w.s.mgmtOperation(func() error {
-		w.s.watcherMu.Lock()
-		for k, l := range w.s.watcherMap {
-			for i, v := range l {
-				if w == v {
-					w.s.watcherMap[k] = append(l[:i], l[i+1:]...)
-					break
+	cleanup := func() error {
+		w.stop.Do(func() {
+			w.s.watcherMu.Lock()
+			for k, l := range w.s.watcherMap {
+				for i, v := range l {
+					if w == v {
+						w.s.watcherMap[k] = append(l[:i], l[i+1:]...)
+						break
+					}
 				}
 			}
-		}
-		w.s.watcherMu.Unlock()
+			w.s.watcherMu.Unlock()
 
-		cleanInfiniteChannel(w.ch)
-		// the loop function goroutine might be blocked for
-		// writing to realCh. make sure it finishes.
-		for range w.realCh {
-		}
+			cleanInfiniteChannel(w.ch)
+			// the loop function goroutine might be blocked for
+			// writing to realCh. make sure it finishes.
+			for range w.realCh {
+			}
+		})
+
 		return nil
-	}, false)
+	}
+
+	if err := w.s.mgmtOperation(cleanup, false); err != nil {
+		// Serve has stopped, so there is no management loop left to serialize cleanup.
+		// No new watcher notifications can be produced after the server has stopped.
+		_ = cleanup()
+	}
 }
 
 func (s *BgpServer) isWatched(typ watchEventType) bool {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -179,6 +179,64 @@ func TestStop(t *testing.T) {
 	assert.Error(err)
 }
 
+func TestMgmtOperationReturnsAfterServerStops(t *testing.T) {
+	s := NewBgpServer()
+
+	result := make(chan error, 1)
+	started := make(chan struct{})
+
+	go func() {
+		close(started)
+		result <- s.mgmtOperation(func() error { return nil }, false)
+	}()
+
+	<-started
+	close(s.closeCh)
+
+	select {
+	case err := <-result:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("management operation did not return after server stopped")
+	}
+}
+
+func TestWatcherStopAfterServerStops(t *testing.T) {
+	s := runNewServer(t, 1, "1.1.1.1", -1)
+	w := s.watch(WatchPeer())
+
+	require.NoError(t, s.StopBgp(context.Background(), &api.StopBgpRequest{}))
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		w.Stop()
+		w.Stop()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watcher cleanup did not finish after server stopped")
+	}
+
+	s.watcherMu.RLock()
+	defer s.watcherMu.RUnlock()
+
+	for _, watchers := range s.watcherMap {
+		assert.NotContains(t, watchers, w)
+	}
+
+	select {
+	case _, ok := <-w.Event():
+		assert.False(t, ok)
+	default:
+		t.Fatal("watcher event channel is not closed")
+	}
+}
+
 func TestWatchUpdateCurrentDeliversInitBeforeLiveEvents(t *testing.T) {
 	ctx := context.Background()
 	s1 := runNewServer(t, 1, "1.1.1.1", 10179)


### PR DESCRIPTION
Ensure queued management operations and watcher cleanup can complete after the server loop exits instead of leaving blocked goroutines.