### PR TITLE
netutils: add TCP-AO socket helpers

### DIFF
--- a/internal/pkg/netutils/tcp_ao.go
+++ b/internal/pkg/netutils/tcp_ao.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 The GoBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netutils
+
+import (
+	"errors"
+	"net/netip"
+)
+
+// tcpAOMaxKeyLen defines maximum TCP-AO key length, matching Linux TCP_AO_MAXKEYLEN:
+// https://github.com/torvalds/linux/blob/v6.7/include/uapi/linux/tcp.h#L369
+const tcpAOMaxKeyLen = 80
+
+// ErrTCPAONotSupported is returned when TCP-AO is requested on a platform for which GoBGP does not provide support.
+var ErrTCPAONotSupported = errors.New("TCP-AO is not supported on this platform")
+
+// TCPAOAlgorithm identifies an RFC 5926 TCP-AO algorithm profile.
+type TCPAOAlgorithm uint8
+
+const (
+	TCPAOAlgorithmUnspecified TCPAOAlgorithm = iota
+	TCPAOAlgorithmHMACSHA1
+	TCPAOAlgorithmAES128CMAC
+)
+
+// TCPAOKey contains socket-level properties of one TCP-AO key.
+type TCPAOKey struct {
+	SendID            uint8
+	ReceiveID         uint8
+	Algorithm         TCPAOAlgorithm
+	MasterKey         []byte
+	ExcludeTCPOptions bool
+}
+
+// TCPAOConfig contains all keys used by a TCP-AO socket operation.
+// PreferredSendID optionally selects a key from Keys.
+type TCPAOConfig struct {
+	Keys            []TCPAOKey
+	PreferredSendID *uint8
+}
+
+// TCPAOKeyState contains the operational state for one TCP-AO key installed on a socket.
+type TCPAOKeyState struct {
+	Peer           netip.Prefix
+	InterfaceIndex int32
+	SendID         uint8
+	ReceiveID      uint8
+	Current        bool
+	ReceiveNext    bool
+	PacketsGood    uint64
+	PacketsBad     uint64
+}
+
+// TCPAOSocketCounters contains operational counters maintained for a TCP-AO socket.
+type TCPAOSocketCounters struct {
+	PacketsKeyNotFound uint64
+	PacketsAORequired  uint64
+	PacketsDroppedICMP uint64
+}

--- a/internal/pkg/netutils/tcp_ao_linux.go
+++ b/internal/pkg/netutils/tcp_ao_linux.go
@@ -1,0 +1,293 @@
+// Copyright (C) 2026 The GoBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package netutils
+
+import (
+	"fmt"
+	"net/netip"
+	"os"
+	"runtime"
+	"syscall"
+	"unsafe"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// AddTCPAOKeysSockopt installs all provided keys on a TCP socket.
+// A nil PreferredSendID leaves the existing CurrentKey and RNextKey selection unchanged,
+// as required when installing keys on a listening socket. A non-nil value selects the matching key.
+func AddTCPAOKeysSockopt(sc syscall.RawConn, peer netip.Prefix, interfaceName string, config TCPAOConfig) error {
+	vrfIfIndex, err := vrfInterfaceIndex(interfaceName)
+	if err != nil {
+		return err
+	}
+	if err := validateTCPAOPeerScope(peer, vrfIfIndex); err != nil {
+		return err
+	}
+	if err := validateTCPAOAddKeys(config.Keys); err != nil {
+		return err
+	}
+	preferredKey, err := getPreferredTCPAOKey(config)
+	if err != nil {
+		return err
+	}
+	for _, key := range config.Keys {
+		command, err := marshalTCPAOAdd(peer, vrfIfIndex, key, preferredKey != nil && preferredKey.SendID == key.SendID)
+		if err != nil {
+			return err
+		}
+		if err := setTCPAOSockopt(sc, tcpAOAddKeyOption, command); err != nil {
+			return fmt.Errorf("failed to add TCP-AO key SendID %d ReceiveID %d: %w", key.SendID, key.ReceiveID, err)
+		}
+	}
+	return nil
+}
+
+// DeleteTCPAOKeysSockopt removes all configured keys from a TCP socket.
+func DeleteTCPAOKeysSockopt(sc syscall.RawConn, peer netip.Prefix, interfaceName string, config TCPAOConfig) error {
+	vrfIfIndex, err := vrfInterfaceIndex(interfaceName)
+	if err != nil {
+		return err
+	}
+	if err := validateTCPAOPeerScope(peer, vrfIfIndex); err != nil {
+		return err
+	}
+	if err := validateTCPAOKeyIDs(config.Keys); err != nil {
+		return err
+	}
+	for _, key := range config.Keys {
+		command, err := marshalTCPAODel(peer, vrfIfIndex, key)
+		if err != nil {
+			return err
+		}
+		if err := setTCPAOSockopt(sc, tcpAODelKeyOption, command); err != nil {
+			return fmt.Errorf("failed to delete TCP-AO key SendID %d ReceiveID %d: %w", key.SendID, key.ReceiveID, err)
+		}
+	}
+	return nil
+}
+
+// SetTCPAOKeySockopt sets CurrentKey and/or RNextKey to the key selected by PreferredSendID on a connected TCP-AO socket.
+func SetTCPAOKeySockopt(sc syscall.RawConn, config TCPAOConfig, setRNext, setCurrent bool) error {
+	if err := validateTCPAOKeyIDs(config.Keys); err != nil {
+		return err
+	}
+	preferredKey, err := getPreferredTCPAOKey(config)
+	if err != nil {
+		return err
+	}
+	if preferredKey == nil {
+		return fmt.Errorf("TCP-AO key selection requires PreferredSendID")
+	}
+	command, err := marshalTCPAOInfo(preferredKey, setRNext, setCurrent)
+	if err != nil {
+		return err
+	}
+	if err := setTCPAOSockopt(sc, tcpAOInfoOption, command); err != nil {
+		return fmt.Errorf("failed to select TCP-AO key %d: %w", *config.PreferredSendID, err)
+	}
+	return nil
+}
+
+// GetTCPAOKeyStateSockopt returns the keys installed on a TCP-AO socket and their kernel-maintained operational state.
+func GetTCPAOKeyStateSockopt(sc syscall.RawConn) ([]TCPAOKeyState, error) {
+	// Initially allocate one record for every possible key ID.
+	// The kernel reports the total matching count, so larger listener key sets will be retried with larger capacity.
+	keyCapacity := uint32(tcpAOKeyIDCount)
+	for {
+		buffer, length, err := marshalTCPAOGetKeys(keyCapacity)
+		if err != nil {
+			return nil, err
+		}
+		if err := getTCPAOSockopt(sc, tcpAOGetKeysOption, buffer, &length); err != nil {
+			clear(buffer)
+			return nil, fmt.Errorf("failed to get TCP-AO keys: %w", err)
+		}
+		keyCount, err := unmarshalTCPAOGetKeyCount(buffer, length)
+		if err != nil {
+			clear(buffer)
+			return nil, err
+		}
+		if keyCount > keyCapacity {
+			clear(buffer)
+			keyCapacity = keyCount
+			continue // retry with larger capacity fitting the actual key count
+		}
+		states, err := unmarshalTCPAOGetKeys(buffer, length, keyCount)
+		clear(buffer)
+		return states, err
+	}
+}
+
+// GetTCPAOSocketCountersSockopt returns the operational counters maintained for a TCP-AO socket.
+func GetTCPAOSocketCountersSockopt(sc syscall.RawConn) (TCPAOSocketCounters, error) {
+	buffer, length, err := marshalTCPAOGetInfo()
+	if err != nil {
+		return TCPAOSocketCounters{}, err
+	}
+	if err := getTCPAOSockopt(sc, tcpAOInfoOption, buffer, &length); err != nil {
+		return TCPAOSocketCounters{}, fmt.Errorf("failed to get TCP-AO info: %w", err)
+	}
+	return unmarshalTCPAOGetInfo(buffer, length)
+}
+
+// vrfInterfaceIndex returns the VRF interface index used to scope a TCP-AO key.
+// It accepts either the VRF device or one of its enslaved devices.
+func vrfInterfaceIndex(interfaceName string) (int32, error) {
+	if interfaceName == "" {
+		return 0, nil
+	}
+	link, err := netlink.LinkByName(interfaceName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get link for interface %s: %w", interfaceName, err)
+	}
+	if link.Type() != "vrf" {
+		masterIndex := link.Attrs().MasterIndex
+		if masterIndex == 0 {
+			return 0, nil
+		}
+		link, err = netlink.LinkByIndex(masterIndex)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get master link for interface %s: %w", interfaceName, err)
+		}
+		if link.Type() != "vrf" {
+			return 0, nil
+		}
+	}
+	return int32(link.Attrs().Index), nil
+}
+
+func validateTCPAOPeerScope(prefix netip.Prefix, ifIndex int32) error {
+	if !prefix.IsValid() {
+		return fmt.Errorf("invalid TCP-AO peer scope")
+	}
+	if ifIndex < 0 {
+		return fmt.Errorf("invalid TCP-AO interface index %d", ifIndex)
+	}
+	addr := prefix.Addr()
+	if addr.Zone() != "" {
+		return fmt.Errorf("TCP-AO peer scope must not contain an IPv6 zone")
+	}
+	if addr.Is4In6() {
+		return fmt.Errorf("TCP-AO peer scope must use an unmapped IPv4 address")
+	}
+	if prefix != prefix.Masked() {
+		return fmt.Errorf("TCP-AO peer scope %s has host bits set", prefix)
+	}
+	if prefix.Bits() != 0 && addr.IsUnspecified() {
+		return fmt.Errorf("TCP-AO unspecified peer address requires a zero-length prefix")
+	}
+	return nil
+}
+
+func validateTCPAOAddKeys(keys []TCPAOKey) error {
+	if err := validateTCPAOKeyIDs(keys); err != nil {
+		return err
+	}
+	for _, key := range keys {
+		if len(key.MasterKey) == 0 || len(key.MasterKey) > tcpAOMaxKeyLen {
+			return fmt.Errorf("TCP-AO key with SendID %d must contain 1-%d master-key bytes", key.SendID, tcpAOMaxKeyLen)
+		}
+		switch key.Algorithm {
+		case TCPAOAlgorithmHMACSHA1, TCPAOAlgorithmAES128CMAC:
+		default:
+			return fmt.Errorf("unsupported TCP-AO algorithm for SendID %d", key.SendID)
+		}
+	}
+	return nil
+}
+
+func validateTCPAOKeyIDs(keys []TCPAOKey) error {
+	if len(keys) == 0 {
+		return fmt.Errorf("TCP-AO requires at least one key")
+	}
+	if len(keys) > tcpAOKeyIDCount {
+		return fmt.Errorf("TCP-AO supports at most %d keys per peer scope", tcpAOKeyIDCount)
+	}
+	var sendIDs, receiveIDs [tcpAOKeyIDCount]bool
+	for _, key := range keys {
+		if sendIDs[key.SendID] {
+			return fmt.Errorf("duplicate TCP-AO SendID %d", key.SendID)
+		}
+		if receiveIDs[key.ReceiveID] {
+			return fmt.Errorf("duplicate TCP-AO ReceiveID %d", key.ReceiveID)
+		}
+		sendIDs[key.SendID] = true
+		receiveIDs[key.ReceiveID] = true
+	}
+	return nil
+}
+
+func getPreferredTCPAOKey(config TCPAOConfig) (*TCPAOKey, error) {
+	if config.PreferredSendID == nil {
+		return nil, nil
+	}
+	for i := range config.Keys {
+		if config.Keys[i].SendID == *config.PreferredSendID {
+			return &config.Keys[i], nil
+		}
+	}
+	return nil, fmt.Errorf("TCP-AO preferred SendID %d does not exist", *config.PreferredSendID)
+}
+
+func setTCPAOSockopt(sc syscall.RawConn, option int, value []byte) error {
+	var sockerr error
+	controlErr := sc.Control(func(fd uintptr) {
+		_, _, errno := unix.Syscall6(
+			unix.SYS_SETSOCKOPT,
+			fd,
+			uintptr(unix.IPPROTO_TCP),
+			uintptr(option),
+			uintptr(unsafe.Pointer(&value[0])),
+			uintptr(len(value)),
+			0,
+		)
+		if errno != 0 {
+			sockerr = os.NewSyscallError("setsockopt(TCP_AO)", errno)
+		}
+	})
+	runtime.KeepAlive(value)
+	if sockerr != nil {
+		return sockerr
+	}
+	return controlErr
+}
+
+func getTCPAOSockopt(sc syscall.RawConn, option int, value []byte, length *uint32) error {
+	var sockerr error
+	controlErr := sc.Control(func(fd uintptr) {
+		_, _, errno := unix.Syscall6(
+			unix.SYS_GETSOCKOPT,
+			fd,
+			uintptr(unix.IPPROTO_TCP),
+			uintptr(option),
+			uintptr(unsafe.Pointer(&value[0])),
+			uintptr(unsafe.Pointer(length)),
+			0,
+		)
+		if errno != 0 {
+			sockerr = os.NewSyscallError("getsockopt(TCP_AO)", errno)
+		}
+	})
+	runtime.KeepAlive(value)
+	runtime.KeepAlive(length)
+	if sockerr != nil {
+		return sockerr
+	}
+	return controlErr
+}

--- a/internal/pkg/netutils/tcp_ao_linux_test.go
+++ b/internal/pkg/netutils/tcp_ao_linux_test.go
@@ -1,0 +1,238 @@
+// Copyright (C) 2026 The GoBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package netutils
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func skipTCPAONotSupported(t *testing.T, err error) {
+	t.Helper()
+	if errors.Is(err, unix.ENOPROTOOPT) || errors.Is(err, unix.EOPNOTSUPP) {
+		t.Skipf("running kernel does not support TCP-AO: %v", err)
+	}
+	require.NoError(t, err)
+}
+
+func TestTCPAOKeyLifecycle(t *testing.T) {
+	// create listener socket with one TCP-AO key
+	peer := netip.MustParsePrefix("127.0.0.1/32")
+	config := TCPAOConfig{Keys: []TCPAOKey{{
+		SendID: 7, ReceiveID: 9, Algorithm: TCPAOAlgorithmHMACSHA1, MasterKey: []byte("secret"),
+	}}}
+	listenConfig := net.ListenConfig{Control: func(_, _ string, raw syscall.RawConn) error {
+		return AddTCPAOKeysSockopt(raw, peer, "", config)
+	}}
+	listenConfig.SetMultipathTCP(false)
+	listener, err := listenConfig.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	skipTCPAONotSupported(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	tcpListener, ok := listener.(*net.TCPListener)
+	require.True(t, ok)
+	raw, err := tcpListener.SyscallConn()
+	require.NoError(t, err)
+	counters, err := GetTCPAOSocketCountersSockopt(raw)
+	require.NoError(t, err)
+	require.Equal(t, TCPAOSocketCounters{}, counters)
+
+	// add another key
+	addConfig := TCPAOConfig{Keys: []TCPAOKey{{
+		SendID: 8, ReceiveID: 10, Algorithm: TCPAOAlgorithmHMACSHA1, MasterKey: []byte("secret"),
+	}}}
+	err = AddTCPAOKeysSockopt(raw, peer, "", addConfig)
+	require.NoError(t, err)
+
+	// get both keys
+	states, err := GetTCPAOKeyStateSockopt(raw)
+	require.NoError(t, err)
+	require.Len(t, states, 2)
+	statesBySendID := make(map[uint8]TCPAOKeyState, len(states))
+	for _, state := range states {
+		statesBySendID[state.SendID] = state
+	}
+	for _, key := range append(config.Keys, addConfig.Keys...) {
+		state, ok := statesBySendID[key.SendID]
+		require.True(t, ok)
+		require.Equal(t, peer, state.Peer)
+		require.Zero(t, state.InterfaceIndex)
+		require.Equal(t, key.ReceiveID, state.ReceiveID)
+	}
+
+	// delete the first key
+	err = DeleteTCPAOKeysSockopt(raw, peer, "", TCPAOConfig{Keys: []TCPAOKey{{
+		SendID: 7, ReceiveID: 9,
+	}}})
+	require.NoError(t, err)
+	states, err = GetTCPAOKeyStateSockopt(raw)
+	require.NoError(t, err)
+	require.Len(t, states, 1)
+	require.Equal(t, uint8(8), states[0].SendID)
+	require.Equal(t, uint8(10), states[0].ReceiveID)
+
+	// delete the remaining key
+	err = DeleteTCPAOKeysSockopt(raw, peer, "", TCPAOConfig{Keys: []TCPAOKey{{
+		SendID: 8, ReceiveID: 10,
+	}}})
+	require.NoError(t, err)
+	states, err = GetTCPAOKeyStateSockopt(raw)
+	require.NoError(t, err)
+	require.Empty(t, states)
+}
+
+func TestTCPAOKeyStateListenSocketManyKeys(t *testing.T) {
+	keyForIndex := func(i int) (netip.Prefix, TCPAOConfig) {
+		peer := netip.PrefixFrom(netip.AddrFrom4([4]byte{
+			127, byte(i >> 16), byte(i >> 8), byte(i),
+		}), 32)
+		id := uint8(i)
+		return peer, TCPAOConfig{Keys: []TCPAOKey{{
+			SendID: id, ReceiveID: id, Algorithm: TCPAOAlgorithmHMACSHA1, MasterKey: []byte("secret"),
+		}}}
+	}
+
+	peer, config := keyForIndex(0)
+	listenConfig := net.ListenConfig{Control: func(_, _ string, raw syscall.RawConn) error {
+		return AddTCPAOKeysSockopt(raw, peer, "", config)
+	}}
+	listenConfig.SetMultipathTCP(false)
+	listener, err := listenConfig.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	skipTCPAONotSupported(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	raw, err := listener.(*net.TCPListener).SyscallConn()
+	require.NoError(t, err)
+	for i := 1; i <= tcpAOKeyIDCount; i++ {
+		peer, config := keyForIndex(i)
+		require.NoError(t, AddTCPAOKeysSockopt(raw, peer, "", config))
+	}
+
+	states, err := GetTCPAOKeyStateSockopt(raw)
+	require.NoError(t, err)
+	require.Len(t, states, tcpAOKeyIDCount+1)
+	statesByPeer := make(map[netip.Prefix]TCPAOKeyState, len(states))
+	for _, state := range states {
+		statesByPeer[state.Peer] = state
+		require.Zero(t, state.InterfaceIndex)
+	}
+	require.Len(t, statesByPeer, tcpAOKeyIDCount+1)
+	for i := range tcpAOKeyIDCount + 1 {
+		peer, config := keyForIndex(i)
+		state, ok := statesByPeer[peer]
+		require.True(t, ok)
+		require.Equal(t, config.Keys[0].SendID, state.SendID)
+		require.Equal(t, config.Keys[0].ReceiveID, state.ReceiveID)
+	}
+}
+
+func TestTCPAOKeySelection(t *testing.T) {
+	// create server socket with two TCP-AO keys
+	peer := netip.MustParsePrefix("127.0.0.1/32")
+	serverConfig := TCPAOConfig{Keys: []TCPAOKey{
+		{SendID: 20, ReceiveID: 10, Algorithm: TCPAOAlgorithmHMACSHA1, MasterKey: []byte("secret")},
+		{SendID: 21, ReceiveID: 11, Algorithm: TCPAOAlgorithmHMACSHA1, MasterKey: []byte("secret")},
+	}}
+	listenConfig := net.ListenConfig{Control: func(_, _ string, raw syscall.RawConn) error {
+		return AddTCPAOKeysSockopt(raw, peer, "", serverConfig)
+	}}
+	listenConfig.SetMultipathTCP(false)
+	listener, err := listenConfig.Listen(context.Background(), "tcp4", "127.0.0.1:0")
+	skipTCPAONotSupported(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	// create client socket with two TCP-AO keys
+	current := uint8(10)
+	clientConfig := TCPAOConfig{
+		Keys: []TCPAOKey{
+			{SendID: 10, ReceiveID: 20, Algorithm: TCPAOAlgorithmHMACSHA1, MasterKey: []byte("secret")},
+			{SendID: 11, ReceiveID: 21, Algorithm: TCPAOAlgorithmHMACSHA1, MasterKey: []byte("secret")},
+		},
+		PreferredSendID: &current,
+	}
+	dialer := net.Dialer{Timeout: time.Second}
+	dialer.SetMultipathTCP(false)
+	dialer.Control = func(_, _ string, raw syscall.RawConn) error {
+		return AddTCPAOKeysSockopt(raw, peer, "", clientConfig)
+	}
+	clientConn, err := dialer.DialContext(context.Background(), "tcp4", listener.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() { clientConn.Close() })
+	clientRaw, err := clientConn.(*net.TCPConn).SyscallConn()
+	require.NoError(t, err)
+
+	// accept client connection
+	accepted := make(chan *net.TCPConn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.(*net.TCPListener).AcceptTCP()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		accepted <- conn
+	}()
+	var serverConn *net.TCPConn
+	select {
+	case serverConn = <-accepted:
+	case err := <-acceptErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out accepting TCP-AO connection")
+	}
+	t.Cleanup(func() { serverConn.Close() })
+	serverRaw, err := serverConn.SyscallConn()
+	require.NoError(t, err)
+
+	// set & verify ReceiveNext on client
+	clientNext := uint8(11)
+	clientConfig.PreferredSendID = &clientNext
+	err = SetTCPAOKeySockopt(clientRaw, clientConfig, true, false)
+	require.NoError(t, err)
+
+	states, err := GetTCPAOKeyStateSockopt(clientRaw)
+	require.NoError(t, err)
+	require.Len(t, states, 2)
+	statesBySendID := make(map[uint8]TCPAOKeyState, len(states))
+	for _, state := range states {
+		statesBySendID[state.SendID] = state
+	}
+	require.True(t, statesBySendID[current].Current)
+	require.True(t, statesBySendID[clientNext].ReceiveNext)
+
+	// set & verify Current on server
+	serverNext := uint8(21)
+	serverConfig.PreferredSendID = &serverNext
+	err = SetTCPAOKeySockopt(serverRaw, serverConfig, false, true)
+	require.NoError(t, err)
+
+	states, err = GetTCPAOKeyStateSockopt(serverRaw)
+	require.NoError(t, err)
+	statesBySendID = make(map[uint8]TCPAOKeyState, len(states))
+	for _, state := range states {
+		statesBySendID[state.SendID] = state
+	}
+	require.True(t, statesBySendID[serverNext].Current)
+}

--- a/internal/pkg/netutils/tcp_ao_stub.go
+++ b/internal/pkg/netutils/tcp_ao_stub.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 The GoBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package netutils
+
+import (
+	"net/netip"
+	"syscall"
+)
+
+func AddTCPAOKeysSockopt(_ syscall.RawConn, _ netip.Prefix, _ string, _ TCPAOConfig) error {
+	return ErrTCPAONotSupported
+}
+
+func DeleteTCPAOKeysSockopt(_ syscall.RawConn, _ netip.Prefix, _ string, _ TCPAOConfig) error {
+	return ErrTCPAONotSupported
+}
+
+func SetTCPAOKeySockopt(_ syscall.RawConn, _ TCPAOConfig, _, _ bool) error {
+	return ErrTCPAONotSupported
+}
+
+func GetTCPAOKeyStateSockopt(_ syscall.RawConn) ([]TCPAOKeyState, error) {
+	return nil, ErrTCPAONotSupported
+}
+
+func GetTCPAOSocketCountersSockopt(_ syscall.RawConn) (TCPAOSocketCounters, error) {
+	return TCPAOSocketCounters{}, ErrTCPAONotSupported
+}

--- a/internal/pkg/netutils/tcp_ao_uapi.go
+++ b/internal/pkg/netutils/tcp_ao_uapi.go
@@ -1,0 +1,414 @@
+// Copyright (C) 2026 The GoBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netutils
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net/netip"
+)
+
+// TCP-AO was added to the Linux UAPI in Linux 6.7.
+// Its scalar fields use native byte order.
+const (
+	// Linux TCP-AO socket option numbers:
+	// https://github.com/torvalds/linux/blob/v6.7/include/uapi/linux/tcp.h#L132-L135
+	tcpAOAddKeyOption  = 38
+	tcpAODelKeyOption  = 39
+	tcpAOInfoOption    = 40
+	tcpAOGetKeysOption = 41
+
+	// tcpAOSockaddrStorageSize matches sizeof(struct __kernel_sockaddr_storage):
+	// https://github.com/torvalds/linux/blob/v6.7/include/uapi/linux/socket.h#L16-L27
+	tcpAOSockaddrStorageSize = 128
+
+	// tcpAOAlgorithmNameSize matches the alg_name fields in the Linux TCP-AO
+	// UAPI structures:
+	// https://github.com/torvalds/linux/blob/v6.7/include/uapi/linux/tcp.h#L369-L458
+	tcpAOAlgorithmNameSize = 64
+
+	// tcpAOKeyIDCount is the number of distinct values representable by an 8-bit TCP-AO key ID.
+	// A listening socket can contain more keys when their peer scopes do not overlap.
+	tcpAOKeyIDCount = 1 << 8
+
+	// tcpAOAFInet and tcpAOAFInet6 match Linux AF_INET and AF_INET6:
+	// https://github.com/torvalds/linux/blob/v6.7/include/linux/socket.h#L189-L200
+	tcpAOAFInet  = 2
+	tcpAOAFInet6 = 10
+
+	// tcpAOKeyFlagIfindex and tcpAOKeyFlagExcludeOpt match Linux
+	// TCP_AO_KEYF_IFINDEX and TCP_AO_KEYF_EXCLUDE_OPT:
+	// https://github.com/torvalds/linux/blob/v6.7/include/uapi/linux/tcp.h#L371-L376
+	tcpAOKeyFlagIfindex    = 1 << 0
+	tcpAOKeyFlagExcludeOpt = 1 << 1
+
+	// tcpAOMACLength is the 96-bit MAC length in bytes
+	// specified for TCP-AO algorithms by RFC 5926, Section 3.2.
+	// https://www.rfc-editor.org/rfc/rfc5926.html#section-3.2
+	tcpAOMACLength = 12
+)
+
+// Linux C ABIs allocate the first declared bitfield from the low-order bit on
+// little-endian systems and from the high-order bit on big-endian systems.
+var (
+	nativeIsBigEndian   = binary.NativeEndian.Uint16([]byte{1, 2}) == 0x0102
+	tcpAOFlagSetCurrent = nativeCBitfield32Mask(0)
+	tcpAOFlagSetRNext   = nativeCBitfield32Mask(1)
+	tcpAOGetFlagCurrent = nativeCBitfield16Mask(0)
+	tcpAOGetFlagRNext   = nativeCBitfield16Mask(1)
+	tcpAOGetFlagAll     = nativeCBitfield16Mask(2)
+)
+
+func nativeCBitfield32Mask(fieldIndex uint) uint32 {
+	if nativeIsBigEndian {
+		return 1 << (31 - fieldIndex)
+	}
+	return 1 << fieldIndex
+}
+
+func nativeCBitfield16Mask(fieldIndex uint) uint16 {
+	if nativeIsBigEndian {
+		return 1 << (15 - fieldIndex)
+	}
+	return 1 << fieldIndex
+}
+
+// tcpAOSockaddrStorage mirrors Linux struct __kernel_sockaddr_storage:
+// https://github.com/torvalds/linux/blob/v6.7/include/uapi/linux/socket.h#L16-L27
+type tcpAOSockaddrStorage [tcpAOSockaddrStorageSize]byte
+
+// tcpAOAddABI mirrors Linux struct tcp_ao_add:
+// https://github.com/torvalds/linux/blob/v6.7/include/uapi/linux/tcp.h#L378-L393
+type tcpAOAddABI struct {
+	Address        tcpAOSockaddrStorage
+	Algorithm      [tcpAOAlgorithmNameSize]byte
+	InterfaceIndex int32
+	Flags          uint32
+	Reserved2      uint16
+	PrefixLength   uint8
+	SendID         uint8
+	ReceiveID      uint8
+	MACLength      uint8
+	KeyFlags       uint8
+	KeyLength      uint8
+	Key            [tcpAOMaxKeyLen]byte
+}
+
+// tcpAODelABI mirrors Linux struct tcp_ao_del:
+// https://github.com/torvalds/linux/blob/v6.7/include/uapi/linux/tcp.h#L395-L409
+type tcpAODelABI struct {
+	Address        tcpAOSockaddrStorage
+	InterfaceIndex int32
+	Flags          uint32
+	Reserved2      uint16
+	PrefixLength   uint8
+	SendID         uint8
+	ReceiveID      uint8
+	CurrentKey     uint8
+	RNextKey       uint8
+	KeyFlags       uint8
+}
+
+// tcpAOInfoABI mirrors Linux struct tcp_ao_info_opt:
+// https://github.com/torvalds/linux/blob/v6.7/include/uapi/linux/tcp.h#L411-L427
+type tcpAOInfoABI struct {
+	Flags             uint32
+	Reserved2         uint16
+	CurrentKey        uint8
+	RNextKey          uint8
+	PacketGood        uint64
+	PacketBad         uint64
+	PacketKeyNotFound uint64
+	PacketAORequired  uint64
+	PacketDroppedICMP uint64
+}
+
+// tcpAOGetKeyABI mirrors Linux struct tcp_ao_getsockopt:
+// https://github.com/torvalds/linux/blob/v6.7/include/uapi/linux/tcp.h#L429-L460
+type tcpAOGetKeyABI struct {
+	Address        tcpAOSockaddrStorage
+	Algorithm      [tcpAOAlgorithmNameSize]byte
+	Key            [tcpAOMaxKeyLen]byte
+	KeyCount       uint32
+	Flags          uint16
+	SendID         uint8
+	ReceiveID      uint8
+	PrefixLength   uint8
+	MACLength      uint8
+	KeyFlags       uint8
+	KeyLength      uint8
+	InterfaceIndex int32
+	PacketsGood    uint64
+	PacketsBad     uint64
+}
+
+// tcpAOSockaddrInet4ABI mirrors Linux struct sockaddr_in:
+// https://github.com/torvalds/linux/blob/v6.7/include/uapi/linux/in.h#L256-L265
+type tcpAOSockaddrInet4ABI struct {
+	Family  uint16
+	Port    [2]byte
+	Address [4]byte
+	Zero    [8]byte
+}
+
+// tcpAOSockaddrInet6ABI mirrors Linux struct sockaddr_in6:
+// https://github.com/torvalds/linux/blob/v6.7/include/uapi/linux/in6.h#L50-L56
+type tcpAOSockaddrInet6ABI struct {
+	Family   uint16
+	Port     [2]byte
+	FlowInfo [4]byte
+	Address  [16]byte
+	ScopeID  uint32
+}
+
+// tcpAOAlgorithmName returns a Linux TCP-AO algorithm name:
+// https://github.com/torvalds/linux/blob/v7.2-rc1/net/ipv4/tcp_ao.c#L26-L42
+func tcpAOAlgorithmName(algorithm TCPAOAlgorithm) string {
+	switch algorithm {
+	case TCPAOAlgorithmHMACSHA1:
+		return "hmac(sha1)"
+	case TCPAOAlgorithmAES128CMAC:
+		return "cmac(aes128)"
+	default:
+		return ""
+	}
+}
+
+func marshalTCPAOAdd(scope netip.Prefix, ifindex int32, key TCPAOKey, selected bool) ([]byte, error) {
+	address, err := marshalTCPAOSockaddr(scope)
+	if err != nil {
+		return nil, err
+	}
+	abi := tcpAOAddABI{
+		Address:        address,
+		InterfaceIndex: ifindex,
+		PrefixLength:   uint8(scope.Bits()),
+		SendID:         key.SendID,
+		ReceiveID:      key.ReceiveID,
+		MACLength:      tcpAOMACLength,
+		KeyLength:      uint8(len(key.MasterKey)),
+	}
+	copy(abi.Algorithm[:], tcpAOAlgorithmName(key.Algorithm))
+	if selected {
+		abi.Flags = tcpAOFlagSetCurrent | tcpAOFlagSetRNext
+	}
+	if ifindex != 0 {
+		abi.KeyFlags |= tcpAOKeyFlagIfindex
+	}
+	if key.ExcludeTCPOptions {
+		abi.KeyFlags |= tcpAOKeyFlagExcludeOpt
+	}
+	copy(abi.Key[:], key.MasterKey)
+	return encodeTCPAOABI(&abi)
+}
+
+func marshalTCPAODel(scope netip.Prefix, ifindex int32, key TCPAOKey) ([]byte, error) {
+	address, err := marshalTCPAOSockaddr(scope)
+	if err != nil {
+		return nil, err
+	}
+	abi := tcpAODelABI{
+		Address:        address,
+		InterfaceIndex: ifindex,
+		PrefixLength:   uint8(scope.Bits()),
+		SendID:         key.SendID,
+		ReceiveID:      key.ReceiveID,
+	}
+	if ifindex != 0 {
+		abi.KeyFlags = tcpAOKeyFlagIfindex
+	}
+	return encodeTCPAOABI(&abi)
+}
+
+func marshalTCPAOInfo(key *TCPAOKey, setRNext, setCurrent bool) ([]byte, error) {
+	abi := tcpAOInfoABI{}
+	if setRNext {
+		abi.Flags = tcpAOFlagSetRNext
+		abi.RNextKey = key.ReceiveID
+	}
+	if setCurrent {
+		abi.Flags |= tcpAOFlagSetCurrent
+		abi.CurrentKey = key.SendID
+	}
+	return encodeTCPAOABI(&abi)
+}
+
+func marshalTCPAOGetInfo() ([]byte, uint32, error) {
+	buffer, err := encodeTCPAOABI(&tcpAOInfoABI{})
+	if err != nil {
+		return nil, 0, err
+	}
+	return buffer, uint32(len(buffer)), nil
+}
+
+func unmarshalTCPAOGetInfo(buffer []byte, size uint32) (TCPAOSocketCounters, error) {
+	expectedSize := binary.Size(tcpAOInfoABI{})
+	if size != uint32(expectedSize) {
+		return TCPAOSocketCounters{}, fmt.Errorf("TCP-AO info size is %d, want %d", size, expectedSize)
+	}
+	var abi tcpAOInfoABI
+	if _, err := binary.Decode(buffer[:size], binary.NativeEndian, &abi); err != nil {
+		return TCPAOSocketCounters{}, fmt.Errorf("failed to decode TCP-AO info: %w", err)
+	}
+	return TCPAOSocketCounters{
+		PacketsKeyNotFound: abi.PacketKeyNotFound,
+		PacketsAORequired:  abi.PacketAORequired,
+		PacketsDroppedICMP: abi.PacketDroppedICMP,
+	}, nil
+}
+
+func marshalTCPAOGetKeys(keyCount uint32) ([]byte, uint32, error) {
+	if keyCount == 0 {
+		return nil, 0, fmt.Errorf("TCP-AO key state buffer requires at least one record")
+	}
+	request := tcpAOGetKeyABI{
+		KeyCount: keyCount,
+		Flags:    tcpAOGetFlagAll,
+	}
+	requestBytes, err := encodeTCPAOABI(&request)
+	if err != nil {
+		return nil, 0, err
+	}
+	buffer := make([]byte, int(keyCount)*len(requestBytes))
+	copy(buffer, requestBytes)
+	return buffer, uint32(len(requestBytes)), nil
+}
+
+func unmarshalTCPAOGetKeyCount(buffer []byte, recordSize uint32) (uint32, error) {
+	expectedRecordSize := binary.Size(tcpAOGetKeyABI{})
+	if recordSize != uint32(expectedRecordSize) {
+		return 0, fmt.Errorf("TCP-AO key state record size is %d, need %d", recordSize, expectedRecordSize)
+	}
+	if len(buffer) < int(recordSize) {
+		return 0, fmt.Errorf("TCP-AO key state buffer size is %d, need at least %d", len(buffer), recordSize)
+	}
+
+	var abi tcpAOGetKeyABI
+	if _, err := binary.Decode(buffer[:recordSize], binary.NativeEndian, &abi); err != nil {
+		return 0, fmt.Errorf("failed to decode TCP-AO key count: %w", err)
+	}
+	return abi.KeyCount, nil
+}
+
+func unmarshalTCPAOGetKeys(buffer []byte, recordSize, keyCount uint32) ([]TCPAOKeyState, error) {
+	bufferCapacity := uint32(len(buffer) / int(recordSize))
+	if keyCount > bufferCapacity {
+		return nil, fmt.Errorf("TCP-AO key buffer capacity is %d keys, need %d keys", bufferCapacity, keyCount)
+	}
+
+	states := make([]TCPAOKeyState, 0, keyCount)
+	for i := range keyCount {
+		offset := i * recordSize
+		var abi tcpAOGetKeyABI
+		n, err := binary.Decode(buffer[offset:offset+recordSize], binary.NativeEndian, &abi)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode TCP-AO key state: %w", err)
+		}
+		if recordSize != uint32(n) {
+			return nil, fmt.Errorf("decoded %d TCP-AO key state bytes, want %d", n, recordSize)
+		}
+		peer, err := unmarshalTCPAOSockaddr(abi.Address, abi.PrefixLength)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode TCP-AO key state peer: %w", err)
+		}
+		states = append(states, TCPAOKeyState{
+			Peer:           peer,
+			InterfaceIndex: abi.InterfaceIndex,
+			SendID:         abi.SendID,
+			ReceiveID:      abi.ReceiveID,
+			Current:        abi.Flags&tcpAOGetFlagCurrent != 0,
+			ReceiveNext:    abi.Flags&tcpAOGetFlagRNext != 0,
+			PacketsGood:    abi.PacketsGood,
+			PacketsBad:     abi.PacketsBad,
+		})
+	}
+	return states, nil
+}
+
+func unmarshalTCPAOSockaddr(storage tcpAOSockaddrStorage, prefixLength uint8) (netip.Prefix, error) {
+	switch family := binary.NativeEndian.Uint16(storage[:2]); family {
+	case tcpAOAFInet:
+		if prefixLength > 32 {
+			return netip.Prefix{}, fmt.Errorf("invalid TCP-AO IPv4 prefix length %d", prefixLength)
+		}
+		var abi tcpAOSockaddrInet4ABI
+		if _, err := binary.Decode(storage[:binary.Size(abi)], binary.NativeEndian, &abi); err != nil {
+			return netip.Prefix{}, fmt.Errorf("failed to decode TCP-AO IPv4 address: %w", err)
+		}
+		return netip.PrefixFrom(netip.AddrFrom4(abi.Address), int(prefixLength)), nil
+	case tcpAOAFInet6:
+		if prefixLength > 128 {
+			return netip.Prefix{}, fmt.Errorf("invalid TCP-AO IPv6 prefix length %d", prefixLength)
+		}
+		var abi tcpAOSockaddrInet6ABI
+		if _, err := binary.Decode(storage[:binary.Size(abi)], binary.NativeEndian, &abi); err != nil {
+			return netip.Prefix{}, fmt.Errorf("failed to decode TCP-AO IPv6 address: %w", err)
+		}
+		return netip.PrefixFrom(netip.AddrFrom16(abi.Address), int(prefixLength)), nil
+	default:
+		return netip.Prefix{}, fmt.Errorf("unsupported TCP-AO address family %d", family)
+	}
+}
+
+func marshalTCPAOSockaddr(scope netip.Prefix) (tcpAOSockaddrStorage, error) {
+	var storage tcpAOSockaddrStorage
+	addr := scope.Addr()
+	if addr.Is4() {
+		abi := tcpAOSockaddrInet4ABI{
+			Family:  tcpAOAFInet,
+			Address: addr.As4(),
+		}
+		if err := encodeTCPAOSockaddr(&storage, &abi); err != nil {
+			return storage, fmt.Errorf("failed to encode TCP-AO IPv4 address: %w", err)
+		}
+		return storage, nil
+	}
+	abi := tcpAOSockaddrInet6ABI{
+		Family:  tcpAOAFInet6,
+		Address: addr.As16(),
+	}
+	if err := encodeTCPAOSockaddr(&storage, &abi); err != nil {
+		return storage, fmt.Errorf("failed to encode TCP-AO IPv6 address: %w", err)
+	}
+	return storage, nil
+}
+
+func encodeTCPAOSockaddr(storage *tcpAOSockaddrStorage, abi any) error {
+	encoded, err := encodeTCPAOABI(abi)
+	if err != nil {
+		return err
+	}
+	if len(encoded) > len(storage) {
+		return fmt.Errorf("TCP-AO socket address ABI record size is %d, maximum %d", len(encoded), len(storage))
+	}
+	copy(storage[:], encoded)
+	return nil
+}
+
+func encodeTCPAOABI(abi any) ([]byte, error) {
+	abiSize := binary.Size(abi)
+	if abiSize < 0 {
+		return nil, fmt.Errorf("TCP-AO ABI record has a variable-size field")
+	}
+	dst := make([]byte, abiSize)
+	n, err := binary.Encode(dst, binary.NativeEndian, abi)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode TCP-AO ABI record: %w", err)
+	}
+	if n != abiSize {
+		return nil, fmt.Errorf("encoded %d TCP-AO ABI bytes, want %d", n, abiSize)
+	}
+	return dst, nil
+}


### PR DESCRIPTION
Add helpers that will be used to attach and control TCP-AO keys to TCP sockets of BGP peers.

Right now they do not have any use except for tests, this will be added in a follow-up change.

(part of the TCP-AO implementation tracked in https://github.com/osrg/gobgp/issues/3493)