### PR TITLE
packet/bgp: reject a zero length next hop for families that require one

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -12751,7 +12751,18 @@ func (p *PathAttributeMpReachNLRI) DecodeFromBytes(data []byte, options ...*Mars
 	}
 
 	switch nexthoplen {
-	case 0: // no nexthop, skip (FlowSpec)
+	case 0:
+		// A zero-length next hop is only valid for the families that do
+		// not carry a next hop: the FlowSpec families and the gobgp opaque
+		// key/value family. It is malformed for any other family (e.g.
+		// IPv4/IPv6 unicast). The AFI/SAFI is not decoded on the MRT-only
+		// next hop path, so that path is left unchanged.
+		if !onlyNexthop &&
+			p.SAFI != SAFI_FLOW_SPEC_UNICAST &&
+			p.SAFI != SAFI_FLOW_SPEC_VPN &&
+			p.SAFI != SAFI_KEY_VALUE {
+			return NewMessageError(eCode, eSubCode, eData, "mpreach nexthop length is zero for a family that requires a next hop")
+		}
 	case BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL: // 16 bytes IPv6 Global + 16 bytes IPv6 Link Local
 		p.LinkLocalNexthop, _ = netip.AddrFromSlice(nexthopbin[BGP_ATTR_NHLEN_IPV6_GLOBAL:BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL])
 		fallthrough

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -1227,6 +1227,55 @@ func TestMpReachDecodeDoesNotMutateInputWhenDeletingSecondRD(t *testing.T) {
 	require.Equal(t, before, data, "DecodeFromBytes must not mutate the input buffer")
 }
 
+func TestMpReachZeroNexthopFamilyValidation(t *testing.T) {
+	// A zero-length next hop is only valid for families that carry no next
+	// hop (FlowSpec, and gobgp's opaque family); it is malformed for any
+	// other family. See RFC 4760 section 3 and GH #3450.
+	// Build an otherwise well-formed MP_REACH_NLRI attribute with a
+	// zero-length next hop, so the only reason to reject it is the family
+	// check (without the fix the message decodes cleanly).
+	mpReachZeroNexthop := func(afi uint16, safi uint8, nlri []byte) []byte {
+		// AFI(2) + SAFI(1) + NextHopLength(1)=0 + reserved(1) + NLRI
+		value := []byte{byte(afi >> 8), byte(afi), safi, 0x00, 0x00}
+		value = append(value, nlri...)
+		attr := []byte{0x80, byte(BGP_ATTR_TYPE_MP_REACH_NLRI), byte(len(value))}
+		return append(attr, value...)
+	}
+
+	rejected := []struct {
+		name string
+		afi  uint16
+		safi uint8
+		nlri []byte
+	}{
+		{"ipv4-unicast", AFI_IP, SAFI_UNICAST, []byte{0x18, 0x0a, 0x00, 0x00}},        // 10.0.0.0/24
+		{"ipv6-unicast", AFI_IP6, SAFI_UNICAST, []byte{0x20, 0x20, 0x01, 0x0d, 0xb8}}, // 2001:db8::/32
+	}
+	for _, tc := range rejected {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &PathAttributeMpReachNLRI{}
+			err := p.DecodeFromBytes(mpReachZeroNexthop(tc.afi, tc.safi, tc.nlri))
+			require.Error(t, err, "zero-length next hop must be rejected for %s", tc.name)
+		})
+	}
+
+	// FlowSpec carries no next hop, so a zero-length next hop is valid and
+	// must still round-trip.
+	t.Run("flowspec-accepted", func(t *testing.T) {
+		destPrefix, err := NewIPAddrPrefix(netip.MustParsePrefix("10.0.0.0/24"))
+		require.NoError(t, err)
+		nlri, err := NewFlowSpecUnicast(RF_FS_IPv4_UC, []FlowSpecComponentInterface{
+			NewFlowSpecDestinationPrefix(destPrefix),
+		})
+		require.NoError(t, err)
+		mp, err := NewPathAttributeMpReachNLRI(RF_FS_IPv4_UC, []PathNLRI{{NLRI: nlri}})
+		require.NoError(t, err)
+		buf, err := mp.Serialize()
+		require.NoError(t, err)
+		require.NoError(t, (&PathAttributeMpReachNLRI{}).DecodeFromBytes(buf))
+	})
+}
+
 func Test_MpReachNLRIWithIPv4MappedIPv6Prefix(t *testing.T) {
 	assert := assert.New(t)
 	n1, _ := NewIPAddrPrefix(netip.MustParsePrefix("::ffff:10.0.0.0/120"))


### PR DESCRIPTION
Fixes #3450

PathAttributeMpReachNLRI.DecodeFromBytes accepted a next hop length of zero for every AFI and SAFI. Per RFC 4760 section 3 that is only valid for families that carry no next hop, so for IPv4 or IPv6 unicast it is malformed. gobgp accepted it silently.

This rejects a zero length next hop except for the families that legitimately omit one: the FlowSpec families and gobgp's opaque key/value family. A flowspec only check would wrongly reject opaque (caught by Test_AddPath). The MRT only path is unchanged.

Testing: new test TestMpReachZeroNexthopFamilyValidation (unicast rejected, FlowSpec still round trips; passes with the fix, fails without). Full unit suite, gofmt, and go vet are clean.
