### PR TITLE
packet/rtr: bound RTRIPPrefix prefix and max length to address family

### DIFF
--- a/pkg/packet/rtr/rtr.go
+++ b/pkg/packet/rtr/rtr.go
@@ -229,11 +229,17 @@ func (m *RTRIPPrefix) DecodeFromBytes(data []byte) error {
 	m.PrefixLen = data[9]
 	m.MaxLen = data[10]
 	if m.Type == RTR_IPV4_PREFIX {
+		if m.PrefixLen > 32 || m.MaxLen > 32 {
+			return errors.New("prefix or max length out of range for IPv4 RTRIPPrefix")
+		}
 		m.Prefix, _ = netip.AddrFromSlice(data[12:16])
 		m.AS = binary.BigEndian.Uint32(data[16:20])
 	} else {
 		if len(data) < RTR_IPV6_PREFIX_LEN {
 			return errors.New("data too short for RTRIPPrefix")
+		}
+		if m.PrefixLen > 128 || m.MaxLen > 128 {
+			return errors.New("prefix or max length out of range for IPv6 RTRIPPrefix")
 		}
 		m.Prefix, _ = netip.AddrFromSlice(data[12:28])
 		m.AS = binary.BigEndian.Uint32(data[28:32])

--- a/pkg/packet/rtr/rtr.go
+++ b/pkg/packet/rtr/rtr.go
@@ -229,7 +229,7 @@ func (m *RTRIPPrefix) DecodeFromBytes(data []byte) error {
 	m.PrefixLen = data[9]
 	m.MaxLen = data[10]
 	if m.Type == RTR_IPV4_PREFIX {
-		if m.PrefixLen > 32 || m.MaxLen > 32 {
+		if m.MaxLen > 32 || m.PrefixLen > m.MaxLen {
 			return errors.New("prefix or max length out of range for IPv4 RTRIPPrefix")
 		}
 		m.Prefix, _ = netip.AddrFromSlice(data[12:16])
@@ -238,7 +238,7 @@ func (m *RTRIPPrefix) DecodeFromBytes(data []byte) error {
 		if len(data) < RTR_IPV6_PREFIX_LEN {
 			return errors.New("data too short for RTRIPPrefix")
 		}
-		if m.PrefixLen > 128 || m.MaxLen > 128 {
+		if m.MaxLen > 128 || m.PrefixLen > m.MaxLen {
 			return errors.New("prefix or max length out of range for IPv6 RTRIPPrefix")
 		}
 		m.Prefix, _ = netip.AddrFromSlice(data[12:28])

--- a/pkg/packet/rtr/rtr_test.go
+++ b/pkg/packet/rtr/rtr_test.go
@@ -137,6 +137,40 @@ func Test_ParseRTR_ErrorReportRejectsOversizedTextLen(t *testing.T) {
 	require.Error(t, err)
 }
 
+func Test_ParseRTR_IPPrefixRejectsOutOfRangeLength(t *testing.T) {
+	// RFC8210 5.7/5.8 bound Prefix Length and Max Length to the address
+	// family maximum (0..32 for IPv4, 0..128 for IPv6). A length past the
+	// maximum reaches net.CIDRMask via table.NewROA, which returns a nil
+	// mask, so the ROA is stored with a bogus default-route network.
+	ipv4PDU := func(prefixLen, maxLen uint8) []byte {
+		data := make([]byte, RTR_IPV4_PREFIX_LEN)
+		data[1] = RTR_IPV4_PREFIX
+		putUint32BE(data[4:8], RTR_IPV4_PREFIX_LEN)
+		data[9] = prefixLen
+		data[10] = maxLen
+		return data
+	}
+	ipv6PDU := func(prefixLen, maxLen uint8) []byte {
+		data := make([]byte, RTR_IPV6_PREFIX_LEN)
+		data[1] = RTR_IPV6_PREFIX
+		putUint32BE(data[4:8], RTR_IPV6_PREFIX_LEN)
+		data[9] = prefixLen
+		data[10] = maxLen
+		return data
+	}
+
+	_, err := ParseRTR(ipv4PDU(33, 32))
+	require.Error(t, err)
+	_, err = ParseRTR(ipv4PDU(24, 33))
+	require.Error(t, err)
+	_, err = ParseRTR(ipv6PDU(129, 128))
+	require.Error(t, err)
+
+	// A prefix within range still decodes.
+	_, err = ParseRTR(ipv4PDU(24, 32))
+	require.NoError(t, err)
+}
+
 func putUint32BE(b []byte, v uint32) {
 	b[0] = byte(v >> 24)
 	b[1] = byte(v >> 16)

--- a/pkg/packet/rtr/rtr_test.go
+++ b/pkg/packet/rtr/rtr_test.go
@@ -138,10 +138,11 @@ func Test_ParseRTR_ErrorReportRejectsOversizedTextLen(t *testing.T) {
 }
 
 func Test_ParseRTR_IPPrefixRejectsOutOfRangeLength(t *testing.T) {
-	// RFC8210 5.7/5.8 bound Prefix Length and Max Length to the address
-	// family maximum (0..32 for IPv4, 0..128 for IPv6). A length past the
-	// maximum reaches net.CIDRMask via table.NewROA, which returns a nil
-	// mask, so the ROA is stored with a bogus default-route network.
+	// RFC8210 5.1 bounds Prefix Length and Max Length to the address
+	// family maximum (0..32 for IPv4, 0..128 for IPv6) and requires Max
+	// Length to be no less than Prefix Length. A length past the maximum
+	// reaches net.CIDRMask via table.NewROA, which returns a nil mask, so
+	// the ROA is stored with a bogus default-route network.
 	ipv4PDU := func(prefixLen, maxLen uint8) []byte {
 		data := make([]byte, RTR_IPV4_PREFIX_LEN)
 		data[1] = RTR_IPV4_PREFIX
@@ -164,6 +165,12 @@ func Test_ParseRTR_IPPrefixRejectsOutOfRangeLength(t *testing.T) {
 	_, err = ParseRTR(ipv4PDU(24, 33))
 	require.Error(t, err)
 	_, err = ParseRTR(ipv6PDU(129, 128))
+	require.Error(t, err)
+
+	// Max Length must not be less than Prefix Length.
+	_, err = ParseRTR(ipv4PDU(24, 16))
+	require.Error(t, err)
+	_, err = ParseRTR(ipv6PDU(64, 48))
 	require.Error(t, err)
 
 	// A prefix within range still decodes.


### PR DESCRIPTION
A crafted RTR IPv4 Prefix PDU with Prefix Length 33 (RFC 8210 5.1 bounds it to
0..32) decodes without complaint, and the ROA built from it comes out as:

    ROA.Network = "<nil>"   // net.CIDRMask(33, 32) returned nil

RTRIPPrefix.DecodeFromBytes takes PrefixLen and MaxLen straight from the wire.
roaManager.handleRTRMsg hands the length to table.NewROA, and net.CIDRMask
returns a nil mask once the length is past the address size, so the ROA lands
in the critbit tree keyed as a /0 default route that matches every prefix
during origin validation. NewRTRIPPrefix already rejects these lengths on the
send side; apply the same bound in the decoder, and also reject Max Length
below Prefix Length per RFC 8210 5.1.
