### PR TITLE
bfd: discard received packets with an unbound discriminator

### DIFF
--- a/pkg/server/bfd_peer.go
+++ b/pkg/server/bfd_peer.go
@@ -285,16 +285,42 @@ func (p *bfdPeer) startClient() {
 }
 
 func (p *bfdPeer) rxPacket(h *bfd.BFDHeader) {
-	if h.YourDiscriminator != 0 && h.YourDiscriminator != p.myDiscriminator {
-		p.stats.invalidDiscriminator.Add(1)
-		return
-	}
-
 	// RFC 5880 Section 6.8.6: if the Detect Mult field is zero, the packet
 	// MUST be discarded.
 	if h.DetectTimeMultiplier == 0 {
 		p.stats.invalidMultiplier.Add(1)
 		return
+	}
+
+	// RFC 5880 Section 6.8.6: if the My Discriminator field is zero, the
+	// packet MUST be discarded.
+	if h.MyDiscriminator == 0 {
+		p.stats.invalidDiscriminator.Add(1)
+		return
+	}
+
+	// RFC 5880 Section 6.8.6: a nonzero Your Discriminator selects the
+	// session and MUST match ours. A zero Your Discriminator carries no
+	// session binding, so it is only accepted from a remote system that has
+	// not learned our discriminator yet, i.e. one in Down or AdminDown.
+	if h.YourDiscriminator != 0 {
+		if h.YourDiscriminator != p.myDiscriminator {
+			p.stats.invalidDiscriminator.Add(1)
+			return
+		}
+	} else {
+		if h.State != bfd.StateDown && h.State != bfd.StateAdminDown {
+			p.stats.invalidDiscriminator.Add(1)
+			return
+		}
+
+		// Once the remote discriminator is bound, a packet that omits Your
+		// Discriminator still has to come from that same remote system, or
+		// it can tear the session down without ever having seen it.
+		if p.yourDiscriminator != 0 && h.MyDiscriminator != p.yourDiscriminator {
+			p.stats.invalidDiscriminator.Add(1)
+			return
+		}
 	}
 
 	p.stats.rxPacket.Add(1)

--- a/pkg/server/bfd_peer_test.go
+++ b/pkg/server/bfd_peer_test.go
@@ -99,7 +99,7 @@ func Test_RxPacket(t *testing.T) {
 
 	assert.Equal(p.stats.rxPacket.Load(), uint64(0))
 
-	p.Rx(&bfd.BFDHeader{DetectTimeMultiplier: 5})
+	p.Rx(&bfd.BFDHeader{MyDiscriminator: 111, DetectTimeMultiplier: 5})
 
 	time.Sleep(2 * time.Second)
 	p.Stop()
@@ -246,6 +246,97 @@ func Test_RxPacketZeroMultiplierDiscarded(t *testing.T) {
 	assert.Equal(uint64(1), p.stats.invalidMultiplier.Load())
 	assert.Equal(uint64(0), p.stats.rxPacket.Load())
 	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_DOWN, p.sessionState())
+}
+
+func Test_RxPacketUnboundDiscriminatorDiscarded(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
+		Port:                     13784,
+		Enabled:                  true,
+		DetectionMultiplier:      3,
+		RequiredMinimumReceive:   300000,
+		DesiredMinimumTxInterval: 300000,
+	}, "")
+	defer p.Stop()
+
+	// RFC 5880 Section 6.8.6: a zero Your Discriminator is only meaningful
+	// from a remote system in Down or AdminDown. Init carries no session
+	// binding here, so it must not drive the session Up.
+	p.rxPacket(&bfd.BFDHeader{
+		State:                bfd.StateInit,
+		MyDiscriminator:      111,
+		YourDiscriminator:    0,
+		DetectTimeMultiplier: 3,
+	})
+	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_DOWN, p.sessionState())
+	assert.Equal(uint64(1), p.stats.invalidDiscriminator.Load())
+
+	// RFC 5880 Section 6.8.6: a zero My Discriminator MUST be discarded. It
+	// is also the value setStateDown uses to mean "no remote session".
+	p.rxPacket(&bfd.BFDHeader{
+		State:                bfd.StateDown,
+		MyDiscriminator:      0,
+		YourDiscriminator:    p.myDiscriminator,
+		DetectTimeMultiplier: 3,
+	})
+	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_DOWN, p.sessionState())
+	assert.Equal(uint32(0), p.yourDiscriminator)
+	assert.Equal(uint64(2), p.stats.invalidDiscriminator.Load())
+
+	// A Down packet with a zero Your Discriminator is still accepted: that is
+	// how a remote system that has not learned our discriminator starts up.
+	p.rxPacket(&bfd.BFDHeader{
+		State:                bfd.StateDown,
+		MyDiscriminator:      222,
+		YourDiscriminator:    0,
+		DetectTimeMultiplier: 3,
+	})
+	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_INIT, p.sessionState())
+	assert.Equal(uint32(222), p.yourDiscriminator)
+}
+
+func Test_RxPacketZeroYourDiscriminatorForeignRemoteDiscarded(t *testing.T) {
+	assert := assert.New(t)
+
+	ps := &mockPeerState{}
+	p := NewBfdPeer(ps, slog.Default(), netip.MustParseAddr("127.0.0.1"), oc.BfdConfig{
+		Port:                     13784,
+		Enabled:                  true,
+		DetectionMultiplier:      3,
+		RequiredMinimumReceive:   300000,
+		DesiredMinimumTxInterval: 300000,
+	}, "")
+	defer p.Stop()
+
+	p.state.Store(int32(api.BfdSessionState_BFD_SESSION_STATE_UP))
+	p.yourDiscriminator = 12345
+
+	// The remote discriminator is already bound, so a Down packet that omits
+	// Your Discriminator and carries a different My Discriminator did not come
+	// from that remote system. Accepting it would reset the BGP peer.
+	p.rxPacket(&bfd.BFDHeader{
+		State:                bfd.StateDown,
+		MyDiscriminator:      67890,
+		YourDiscriminator:    0,
+		DetectTimeMultiplier: 3,
+	})
+	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_UP, p.sessionState())
+	assert.Equal(uint32(12345), p.yourDiscriminator)
+	assert.Equal(int64(0), atomic.LoadInt64(&ps.resetPeerCount))
+	assert.Equal(uint64(1), p.stats.invalidDiscriminator.Load())
+
+	// The bound remote system may still omit Your Discriminator when it
+	// signals Down, and that packet has to be honored.
+	p.rxPacket(&bfd.BFDHeader{
+		State:                bfd.StateDown,
+		MyDiscriminator:      12345,
+		YourDiscriminator:    0,
+		DetectTimeMultiplier: 3,
+	})
+	assert.Equal(api.BfdSessionState_BFD_SESSION_STATE_DOWN, p.sessionState())
+	assert.Equal(int64(1), atomic.LoadInt64(&ps.resetPeerCount))
 }
 
 func Test_ExpiryDoesNotResetAlreadyDownPeer(t *testing.T) {


### PR DESCRIPTION
go test with the session in Down, fed a control packet whose sender never
observed our My Discriminator:

    state after blind Init packet: BFD_SESSION_STATE_UP

rxPacket compares Your Discriminator only when it is nonzero, so State Init
with a zero Your Discriminator walks the session Down -> Up with nothing tying
the packet to it. RFC 5880 6.8.6 accepts a zero Your Discriminator only from a
remote in Down or AdminDown, and separately requires discarding a zero My
Discriminator, which rxPacket currently stores as p.yourDiscriminator, the same
value setStateDown uses to mean "no session", and then echoes back on the wire.

With no BFD authentication and no receive-side TTL check, that echo is the only
evidence a packet came from the peer, so both checks are applied in rxPacket
next to the existing Detect Mult one.