### PR TITLE
packet/bgp: handle absent Multi-Topology ID in SRv6 SID NLRI

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -5798,8 +5798,17 @@ type LsSrv6SIDNLRI struct {
 }
 
 func (l *LsSrv6SIDNLRI) String() string {
+	if l.LocalNodeDesc == nil || l.Srv6SIDInfo == nil {
+		return "SRv6SID { EMPTY }"
+	}
+
 	local := l.LocalNodeDesc.(*LsTLVNodeDescriptor).Extract()
 	srv6SID := l.Srv6SIDInfo.(*LsTLVSrv6SIDInfo)
+
+	// The Multi-Topology Identifier TLV is optional (RFC 9514, Section 6).
+	if l.MultiTopoID == nil {
+		return fmt.Sprintf("SRv6SID { LOCAL_NODE: %s SRv6_SID: %v}", local, srv6SID.String())
+	}
 	multiTopo := l.MultiTopoID.(*LsTLVMultiTopoID)
 
 	return fmt.Sprintf("SRv6SID { LOCAL_NODE: %s SRv6_SID: %v MULTI_TOPO_IDs: %v}", local, srv6SID.String(), multiTopo.String())
@@ -5878,26 +5887,35 @@ func (l *LsSrv6SIDNLRI) Serialize() ([]byte, error) {
 	}
 	buf = append(buf, s...)
 
-	s, err = l.MultiTopoID.Serialize()
-	if err != nil {
-		return nil, err
+	// The Multi-Topology Identifier TLV is optional (RFC 9514, Section 6), so
+	// it may legitimately be absent from a decoded NLRI.
+	if l.MultiTopoID != nil {
+		s, err = l.MultiTopoID.Serialize()
+		if err != nil {
+			return nil, err
+		}
+		buf = append(buf, s...)
 	}
-	buf = append(buf, s...)
 
 	return l.LsNLRI.Serialize(buf)
 }
 
 func (l *LsSrv6SIDNLRI) MarshalJSON() ([]byte, error) {
+	var multiTopoID *LsTLVMultiTopoID
+	if l.MultiTopoID != nil {
+		multiTopoID = l.MultiTopoID.(*LsTLVMultiTopoID)
+	}
+
 	return json.Marshal(struct {
-		Type        LsNLRIType       `json:"type"`
-		LocalNode   LsNodeDescriptor `json:"local_node_desc"`
-		Srv6SID     LsTLVSrv6SIDInfo `json:"srv6_sid_info"`
-		MultiTopoID LsTLVMultiTopoID `json:"multi_topo"`
+		Type        LsNLRIType        `json:"type"`
+		LocalNode   LsNodeDescriptor  `json:"local_node_desc"`
+		Srv6SID     LsTLVSrv6SIDInfo  `json:"srv6_sid_info"`
+		MultiTopoID *LsTLVMultiTopoID `json:"multi_topo,omitempty"`
 	}{
 		Type:        l.Type(),
 		LocalNode:   *l.LocalNodeDesc.(*LsTLVNodeDescriptor).Extract(),
 		Srv6SID:     *l.Srv6SIDInfo.(*LsTLVSrv6SIDInfo),
-		MultiTopoID: *l.MultiTopoID.(*LsTLVMultiTopoID),
+		MultiTopoID: multiTopoID,
 	})
 }
 

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -4517,6 +4517,71 @@ func Test_LsTLVSrv6SIDInfo(t *testing.T) {
 	}
 }
 
+// The Multi-Topology Identifier TLV is optional in an SRv6 SID NLRI (RFC 9514,
+// Section 6), so an NLRI decoded without it must still serialize and render.
+func Test_LsSrv6SIDNLRIMultiTopoID(t *testing.T) {
+	base := []byte{
+		0x02,                                           // Protocol ID: IS-IS Level 2
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Identifier
+		0x01, 0x00, 0x00, 0x10, // TLV Local Node Descriptor
+		0x02, 0x00, 0x00, 0x04, // Sub-TLV Autonomous System
+		0x00, 0x00, 0xfd, 0xe8, // AS: 65000
+		0x02, 0x03, 0x00, 0x04, // Sub-TLV IGP Router ID
+		0x0a, 0x00, 0x00, 0x01, // IGP Router ID: 10.0.0.1
+		0x02, 0x06, 0x00, 0x10, // TLV SRv6 SID Information
+		0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // SID: fd00::1
+	}
+	multiTopoID := []byte{
+		0x01, 0x07, 0x00, 0x02, // TLV Multi-Topology Identifier
+		0x00, 0x02, // Multi-Topology ID: 2
+	}
+
+	tests := []struct {
+		name    string
+		nlri    []byte
+		present bool
+	}{
+		{"without Multi-Topology ID", base, false},
+		{"with Multi-Topology ID", append(append([]byte{}, base...), multiTopoID...), true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			data := append([]byte{
+				0x00, 0x06, // NLRI Type: SRv6 SID
+				0x00, byte(len(test.nlri)), // Length
+			}, test.nlri...)
+
+			prefix := &LsAddrPrefix{}
+			assert.NoError(prefix.decodeFromBytes(data))
+
+			srv6 := prefix.NLRI.(*LsSrv6SIDNLRI)
+			if test.present {
+				assert.NotNil(srv6.MultiTopoID)
+			} else {
+				assert.Nil(srv6.MultiTopoID)
+			}
+
+			got, err := prefix.Serialize()
+			assert.NoError(err)
+			assert.Equal(data, got)
+
+			buf, err := json.Marshal(srv6)
+			assert.NoError(err)
+
+			if test.present {
+				assert.Contains(srv6.String(), "MULTI_TOPO_IDs")
+				assert.Contains(string(buf), "multi_topo")
+			} else {
+				assert.NotContains(srv6.String(), "MULTI_TOPO_IDs")
+				assert.NotContains(string(buf), "multi_topo")
+			}
+		})
+	}
+}
+
 func Test_PathAttributeLs(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
RFC 9514, Section 6 says the SRv6 SID Descriptors field "MUST contain a single SRv6 SID Information TLV (Section 6.1) and MAY contain the Multi-Topology Identifier TLV [RFC7752]".  LsSrv6SIDNLRI.DecodeFromBytes follows that and only requires LS_TLV_LOCAL_NODE_DESC and LS_TLV_SRV6_SID_INFO, so a successfully decoded NLRI can leave MultiTopoID nil.

The output methods assumed otherwise.  Serialize called l.MultiTopoID.Serialize() on a nil interface, while String and MarshalJSON type-asserted it without comma-ok.  A BGP-LS peer can therefore crash the process with a single UPDATE: tableKey serializes every LsAddrPrefix to derive its destination key, so the panic fires while the route is being stored, not only on a later re-advertisement, and neither pkg/server nor internal/pkg/table recovers.

Emit the TLV only when it is present and guard the two rendering paths. The JSON representation now omits "multi_topo" instead of carrying a zero-valued object; nothing could have consumed that field before, since reaching it panicked.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>