### PR TITLE
packet/bgp: validate declared lengths in Prefix-SID SRv6 TLVs

### DIFF
--- a/internal/pkg/netutils/sockopt_linux_test.go
+++ b/internal/pkg/netutils/sockopt_linux_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 )
 
@@ -102,9 +103,7 @@ func Test_buildTcpMD5Sig_bindInterface(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Don't confuse IPv6 zone with ifindex
 			s := buildTcpMD5Sig(tt.bindInterface, "fe80::4850:31ff:fe01:fc55%456", "helloworld")
-			if s == nil {
-				t.Fatal("Gen md5 sig failed")
-			}
+			require.NotNil(t, s, "Gen md5 sig failed")
 			if s.Ifindex != tt.expectedIfindex {
 				t.Errorf("Unexpected ifindex value for %T: got %d, want %d", tt.bindInterface, s.Ifindex, tt.expectedIfindex)
 			}

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -5225,14 +5225,37 @@ func FuzzDecodeFromBytes(f *testing.F) {
 		(&TunnelEncapSubTLVSRSegmentList{}).DecodeFromBytes(data)
 		(&VPLSNLRI{}).decodeFromBytes(data)
 		(&TLV{}).DecodeFromBytes(data)
-		(&PathAttributePrefixSID{}).DecodeFromBytes(data)
-		(&SRv6L3ServiceAttribute{}).DecodeFromBytes(data)
 		(&SubTLV{}).DecodeFromBytes(data)
-		(&SRv6InformationSubTLV{}).DecodeFromBytes(data)
 		(&SubSubTLV{}).DecodeFromBytes(data)
-		(&SRv6SIDStructureSubSubTLV{}).DecodeFromBytes(data)
-		(&SRv6ServiceTLV{}).DecodeFromBytes(data)
+
+		// The BGP Prefix-SID TLVs carry a declared Length that the
+		// serializers size their buffers from, so decoding alone does
+		// not exercise the decode/serialize contract. Re-serialize
+		// whatever decoded successfully: an accepted object must never
+		// panic on the way back out.
+		psid := &PathAttributePrefixSID{}
+		if psid.DecodeFromBytes(data) == nil {
+			psid.Serialize()
+		}
+		fuzzPrefixSIDRoundTrip(data,
+			&SRv6L3ServiceAttribute{},
+			&SRv6ServiceTLV{},
+			&SRv6InformationSubTLV{},
+			&SRv6SIDStructureSubSubTLV{},
+		)
 	})
+}
+
+// fuzzPrefixSIDRoundTrip decodes data into each TLV and re-serializes the ones
+// that accepted it.
+//
+//nolint:errcheck
+func fuzzPrefixSIDRoundTrip(data []byte, tlvs ...PrefixSIDTLVInterface) {
+	for _, tlv := range tlvs {
+		if tlv.DecodeFromBytes(data) == nil {
+			tlv.Serialize()
+		}
+	}
 }
 
 func Test_LsTLVSrv6EndXSID(t *testing.T) {

--- a/pkg/packet/bgp/prefix_sid.go
+++ b/pkg/packet/bgp/prefix_sid.go
@@ -194,12 +194,15 @@ func (s *SRv6L3ServiceAttribute) Serialize() ([]byte, error) {
 	buf := make([]byte, s.Length+3)
 	p := 4
 	for _, tlv := range s.SubTLVs {
-		s, err := tlv.Serialize()
+		b, err := tlv.Serialize()
 		if err != nil {
 			return nil, err
 		}
-		copy(buf[p:p+len(s)], s)
-		p += len(s)
+		if p+len(b) > len(buf) {
+			return nil, malformedAttrListErr("serialization failed: Prefix SID TLV malformed")
+		}
+		copy(buf[p:p+len(b)], b)
+		p += len(b)
 	}
 	return s.TLV.Serialize(buf)
 }
@@ -280,6 +283,12 @@ func (s *SRv6L3ServiceAttribute) Extract() *SRv6L3Service {
 
 const (
 	subTLVHdrLen = 3
+
+	// Minimum value length of an SRv6 SID Information Sub-TLV: RESERVED1(1)
+	// + SRv6 SID Value(16) + Svc SID Flags(1) + SRv6 Endpoint Behavior(2) +
+	// RESERVED2(1), per RFC 9252 Section 3.1. RFC 9252 Section 7 declares
+	// the sub-TLV malformed when "The Sub-TLV Length is less than 21".
+	srv6InformationSubTLVMinValueLen = 21
 )
 
 type SubTLVType uint8
@@ -360,6 +369,12 @@ func (s *SRv6InformationSubTLV) Len() int {
 }
 
 func (s *SRv6InformationSubTLV) Serialize() ([]byte, error) {
+	// The buffer is sized from s.Length, so it must leave room for the
+	// fixed fields written below: SID + Flags(1) + Endpoint Behavior(2) +
+	// RESERVED2(1).
+	if s.Length < srv6InformationSubTLVMinValueLen || len(s.SID)+4 > int(s.Length) {
+		return nil, malformedAttrListErr("serialization failed: Prefix SID TLV malformed")
+	}
 	buf := make([]byte, s.Length)
 	p := 0
 	copy(buf[p:], s.SID)
@@ -376,6 +391,9 @@ func (s *SRv6InformationSubTLV) Serialize() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
+		if p+len(sbuf) > len(buf) {
+			return nil, malformedAttrListErr("serialization failed: Prefix SID TLV malformed")
+		}
 		copy(buf[p:], sbuf)
 		p += len(sbuf)
 	}
@@ -389,20 +407,12 @@ func (s *SRv6InformationSubTLV) DecodeFromBytes(data []byte) error {
 	}
 	s.Type = SubTLVType(data[0])
 	s.Length = binary.BigEndian.Uint16(data[1:3])
-	// 4th reserved byte
-	p := 4
-	s.SID = make([]byte, 16)
-	if len(data) < p+16+1+2+1 {
+	// The declared Length must cover the fixed fields decoded below.
+	// Accepting a shorter one would leave Length inconsistent with the
+	// decoded object, and Serialize sizes its buffer from Length.
+	if s.Length < srv6InformationSubTLVMinValueLen {
 		return malformedAttrListErr("decoding failed: Prefix SID TLV malformed")
 	}
-	copy(s.SID, data[p:p+16])
-	p += 16
-	s.Flags = data[p]
-	p++
-	s.EndpointBehavior = binary.BigEndian.Uint16(data[p : p+2])
-	p += 2
-	// reserved byte
-	p++
 	// Sub-Sub-TLVs are bounded by this sub-TLV's declared Length, not by
 	// the caller's remaining buffer, which may still hold sibling
 	// sub-TLVs of the enclosing Service TLV. subTLVHdrLen + Length is the
@@ -411,7 +421,20 @@ func (s *SRv6InformationSubTLV) DecodeFromBytes(data []byte) error {
 	if end > len(data) {
 		return malformedAttrListErr("decoding failed: Prefix SID TLV malformed")
 	}
-	if p+3 > end {
+	// The fixed fields are read within end, which the minimum Length above
+	// guarantees is at least subTLVHdrLen + 21.
+	// 4th reserved byte
+	p := 4
+	s.SID = make([]byte, 16)
+	copy(s.SID, data[p:p+16])
+	p += 16
+	s.Flags = data[p]
+	p++
+	s.EndpointBehavior = binary.BigEndian.Uint16(data[p : p+2])
+	p += 2
+	// reserved byte
+	p++
+	if p+subSubTLVHdrLen > end {
 		// There is no Sub Sub TLVs detected, returning
 		return nil
 	}
@@ -479,6 +502,10 @@ func (s *SRv6InformationSubTLV) Extract() *SRv6InformationSTLV {
 
 const (
 	subSubTLVHdrLen = 3
+
+	// Value length of an SRv6 SID Structure Sub-Sub-TLV. RFC 9252 Section
+	// 3.2.1 fixes it: "This field contains a total length of 6 octets."
+	srv6SIDStructureSubSubTLVValueLen = 6
 )
 
 type SubSubTLVType uint8
@@ -509,17 +536,19 @@ func (s *SubSubTLV) Serialize(value []byte) ([]byte, error) {
 }
 
 func (s *SubSubTLV) DecodeFromBytes(data []byte) ([]byte, error) {
-	if len(data) < prefixSIDtlvHdrLen {
+	// A Sub-Sub-TLV header is Type(1) + Length(2); it has no reserved byte,
+	// unlike the TLV and Sub-TLV headers.
+	if len(data) < subSubTLVHdrLen {
 		return nil, malformedAttrListErr("decoding failed: Prefix SID Sub Sub TLV malformed")
 	}
 	s.Type = SubSubTLVType(data[0])
 	s.Length = binary.BigEndian.Uint16(data[1:3])
 
-	if len(data) < s.Len() || s.Len() < prefixSIDtlvHdrLen {
+	if len(data) < s.Len() {
 		return nil, malformedAttrListErr("decoding failed: Prefix SID Sub Sub TLV malformed")
 	}
 
-	return data[prefixSIDtlvHdrLen:s.Len()], nil
+	return data[subSubTLVHdrLen:s.Len()], nil
 }
 
 // SRv6SIDStructureSubSubTLV defines a structure of SRv6 SID Structure Sub Sub TLV (type 1) object
@@ -554,7 +583,10 @@ func (s *SRv6SIDStructureSubSubTLV) Len() int {
 }
 
 func (s *SRv6SIDStructureSubSubTLV) Serialize() ([]byte, error) {
-	buf := make([]byte, s.Length)
+	// Size the buffer from the fixed structure length rather than from
+	// s.Length, so an inconsistent Length is reported by
+	// SubSubTLV.Serialize instead of overflowing the buffer here.
+	buf := make([]byte, srv6SIDStructureSubSubTLVValueLen)
 	p := 0
 	buf[p] = s.LocatorBlockLength
 	p++
@@ -572,11 +604,17 @@ func (s *SRv6SIDStructureSubSubTLV) Serialize() ([]byte, error) {
 }
 
 func (s *SRv6SIDStructureSubSubTLV) DecodeFromBytes(data []byte) error {
-	if len(data) < 9 {
+	if len(data) < subSubTLVHdrLen+srv6SIDStructureSubSubTLVValueLen {
 		return malformedAttrListErr("decoding failed: Prefix SID Sub Sub TLV malformed")
 	}
 	s.Type = SubSubTLVType(data[0])
 	s.Length = binary.BigEndian.Uint16(data[1:3])
+	// The six structure fields below are fixed, so any other Length leaves
+	// Length inconsistent with the decoded object. Serialize sizes its
+	// buffer from Length, so a shorter one must not be accepted here.
+	if s.Length != srv6SIDStructureSubSubTLVValueLen {
+		return malformedAttrListErr("decoding failed: Prefix SID Sub Sub TLV malformed")
+	}
 
 	s.LocatorBlockLength = data[3]
 	s.LocatorNodeLength = data[4]
@@ -651,6 +689,9 @@ func (t *SRv6ServiceTLV) Serialize() ([]byte, error) {
 		b, err := tlv.Serialize()
 		if err != nil {
 			return nil, err
+		}
+		if p+len(b) > len(buf) {
+			return nil, malformedAttrListErr("serialization failed: Prefix SID TLV malformed")
 		}
 		copy(buf[p:p+len(b)], b)
 		p += len(b)

--- a/pkg/packet/bgp/prefix_sid_test.go
+++ b/pkg/packet/bgp/prefix_sid_test.go
@@ -2,6 +2,8 @@ package bgp
 
 import (
 	"bytes"
+	"encoding/hex"
+	"fmt"
 	"net/netip"
 	"testing"
 
@@ -159,6 +161,113 @@ func TestSRv6ServiceTLVUnknownSubTLV(t *testing.T) {
 	err := s.DecodeFromBytes(input)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(s.SubTLVs))
+}
+
+func TestSRv6SIDStructureSubSubTLVLength(t *testing.T) {
+	// RFC 9252 Section 3.2.1 fixes the SRv6 SID Structure Sub-Sub-TLV
+	// Length at 6 octets. A shorter one used to be accepted while the
+	// decoder still consumed the six structure bytes, and Serialize then
+	// wrote those six bytes into a buffer sized from Length.
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "length 1",
+			input: []byte{0x01, 0x00, 0x01, 0x28, 0x18, 0x10, 0x00, 0x10, 0x40},
+		},
+		{
+			name:  "length 5",
+			input: []byte{0x01, 0x00, 0x05, 0x28, 0x18, 0x10, 0x00, 0x10, 0x40},
+		},
+		{
+			name:  "length 7",
+			input: []byte{0x01, 0x00, 0x07, 0x28, 0x18, 0x10, 0x00, 0x10, 0x40, 0x00},
+		},
+		{
+			name:  "truncated value",
+			input: []byte{0x01, 0x00, 0x06, 0x28, 0x18, 0x10, 0x00, 0x10},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sstlv := &SRv6SIDStructureSubSubTLV{}
+			assert.Error(t, sstlv.DecodeFromBytes(tt.input))
+		})
+	}
+}
+
+func TestSRv6InformationSubTLVLength(t *testing.T) {
+	// RFC 9252 Section 7: the SRv6 SID Information Sub-TLV is malformed
+	// when "The Sub-TLV Length is less than 21". A shorter one used to be
+	// accepted while the decoder still consumed the 24 fixed bytes, and
+	// Serialize then wrote them into a buffer sized from Length.
+	sid := []byte{
+		0x20, 0x01, 0x00, 0x00, 0x00, 0x05, 0x00, 0x03,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+	for _, length := range []uint16{0, 1, 16, 20} {
+		t.Run(fmt.Sprintf("length %d", length), func(t *testing.T) {
+			input := []byte{0x01, byte(length >> 8), byte(length), 0x00}
+			input = append(input, sid...)
+			input = append(input, 0x00, 0x00, 0x13, 0x00)
+
+			stlv := &SRv6InformationSubTLV{}
+			assert.Error(t, stlv.DecodeFromBytes(input))
+		})
+	}
+}
+
+func TestPathAttributePrefixSIDMalformedLength(t *testing.T) {
+	// Both TLVs are reached through a full Prefix-SID attribute here: a
+	// malformed length must be rejected at decode time, because the
+	// attribute is re-serialized on the receive path (the attrs hash in
+	// table.ProcessMessage) and any panic there takes down the daemon.
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			// SRv6 SID Structure Sub-Sub-TLV Length = 5.
+			name:  "sub-sub-tlv length 5",
+			input: []byte{0xc0, 0x28, 0x25, 0x05, 0x00, 0x22, 0x00, 0x01, 0x00, 0x1e, 0x00, 0x20, 0x01, 0x00, 0x00, 0x00, 0x05, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x13, 0x00, 0x01, 0x00, 0x05, 0x28, 0x18, 0x10, 0x00, 0x10, 0x40},
+		},
+		{
+			// SRv6 SID Information Sub-TLV Length = 16.
+			name:  "sub-tlv length 16",
+			input: []byte{0xc0, 0x28, 0x1c, 0x05, 0x00, 0x19, 0x00, 0x01, 0x00, 0x10, 0x00, 0x20, 0x01, 0x00, 0x00, 0x00, 0x05, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x13, 0x00},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attribute, err := GetPathAttribute(tt.input)
+			assert.NoError(t, err)
+			assert.Error(t, attribute.DecodeFromBytes(tt.input))
+
+			// Serializing the partially decoded attribute must not
+			// panic either. Whether it errors is not interesting; the
+			// malformed TLV was never appended, so it may well succeed.
+			assert.NotPanics(t, func() {
+				_, _ = attribute.Serialize()
+			})
+		})
+	}
+}
+
+func TestBGPUpdatePrefixSIDMalformedSubSubTLVLength(t *testing.T) {
+	// A full UPDATE carrying an SRv6 SID Structure Sub-Sub-TLV that
+	// declares Length = 5 while carrying the six structure bytes.
+	raw, err := hex.DecodeString("ffffffffffffffffffffffffffffffff0073020000005c4001010040020602010000fdea800e2400015504c00002fe0001000317000000640000006418c000020000006409200a00000100c028250500220001001e002001000000050003000000000000000000001300010005281810001040")
+	assert.NoError(t, err)
+
+	msg, err := ParseBGPMessage(raw)
+	assert.Error(t, err)
+	if msg == nil {
+		return
+	}
+	assert.NotPanics(t, func() {
+		_, _ = msg.Serialize()
+	})
 }
 
 // to make label with bottom of stack


### PR DESCRIPTION
The SRv6 SID Structure Sub-Sub-TLV decoder took Length straight off the wire and then read the six fixed structure fields regardless, so an attacker-declared Length of 1 to 5 was accepted for an object whose six fields were already populated. Serialize sizes its buffer from Length and writes those six bytes unconditionally, so the accepted attribute panicked with an index out of range on the way back out. The SRv6 SID Information Sub-TLV had the same mismatch: it never checked a lower bound on Length and bounded its 24 fixed bytes by the caller's remaining buffer instead of the declared length, so any Length up to 16 panicked in the same way.

This is remotely reachable from an established peer. Serialize is not only called when re-advertising: ProcessMessage hashes every received path attribute by serializing it, so the panic fires on the receive path with a single peer configured, and nothing in pkg/server recovers it.

RFC 9252 fixes both lengths. Section 3.2.1 says of the SRv6 SID Structure Sub-Sub-TLV Length that "This field contains a total length of 6 octets", and Section 7 declares the SRv6 SID Information Sub-TLV malformed when "The Sub-TLV Length is less than 21". FRR enforces both, rejecting the attribute when length differs from 6 or is below 21. Enforce them at decode time so an inconsistent object is never built.

Harden the serializers as well, so a future decoder gap degrades to an error instead of a panic: size the structure buffer from the fixed length rather than from Length, reject an Information Sub-TLV that cannot hold its own fixed fields, and bounds-check the sub-TLV copies in both service TLV serializers. Correct SubSubTLV.DecodeFromBytes to use the 3-byte sub-sub-TLV header length; the 4-byte value it used was what accidentally rejected Length 0, and that guard is now explicit.

The fuzz target only decoded these TLVs, which is why a decode-accepted, serialize-panicking object went unnoticed. Re-serialize whatever decoded successfully so the contract between the two is actually exercised.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>