### PR TITLE
ci: run buf generate from proto so the diff check has an effect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,16 @@ jobs:
       - name: buf format check
         run: buf format --diff --exit-code
 
+      # buf.gen.yaml sets "out: ../", which buf resolves against the working
+      # directory, so this has to run from proto/ as CONTRIBUTING.md documents.
+      # Running it from the repository root wrote the generated code to the
+      # parent of the checkout, leaving the diff check below nothing to compare.
+      - name: buf generate
+        working-directory: proto
+        run: buf generate
+
       - name: buf generate check
-        run: |
-          buf generate --template proto/buf.gen.yaml proto
-          git diff --exit-code
+        run: git diff --exit-code
 
   golangci:
     name: lint


### PR DESCRIPTION
The generate check ran buf from the repository root. buf resolves the "out: ../" in proto/buf.gen.yaml against the working directory, not against the config file, so the generated code was written to the parent of the checkout instead of into it. The git diff that follows therefore compared a tree buf had never touched and passed unconditionally, including when the committed .pb.go files were stale with respect to the .proto sources.

Run it from proto/, which is what CONTRIBUTING.md tells contributors to do and what "out: ../" is written for. The template and input arguments go away with the move: buf picks up buf.gen.yaml and the module from the working directory, so CI now runs the exact command the documentation gives, removing the divergence that hid this in the first place.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>