### PR TITLE
packet/bgp: keep extended community decoders inside their community

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -183,6 +183,16 @@ const (
 	EC_TYPE_GENERIC_TRANSITIVE_EXPERIMENTAL3      ExtendedCommunityAttrType = 0x82 // RFC7674
 )
 
+const (
+	// RFC4360 2. BGP Extended Communities Attribute
+	// Each Extended Community is encoded as an 8-octet quantity
+	ExtendedCommunityLen = 8
+	// RFC5701 2. IPv6 Address Specific BGP Extended Community Attribute
+	// Each IPv6 Address Specific extended community is encoded as a
+	// 20-octet quantity
+	IP6ExtendedCommunityLen = 20
+)
+
 // RFC7153 5.2. Registries for the "Sub-Type" Field
 // RANGE	REGISTRATION PROCEDURES
 // 0x00-0xBF	First Come First Served
@@ -14591,14 +14601,12 @@ func parseGenericTransitiveExperimentalExtended(data []byte) (ExtendedCommunityI
 	case EC_SUBTYPE_FLOWSPEC_TRAFFIC_REMARK:
 		dscp := data[7]
 		return NewTrafficRemarkExtended(dscp), nil
-	case EC_SUBTYPE_FLOWSPEC_REDIRECT_IP6:
-		if len(data) < 20 {
-			return nil, NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "not all extended community bytes for IPv6 FlowSpec are available")
-		}
-
-		ipv6, _ := netip.AddrFromSlice(data[2:18])
-		localAdmin := binary.BigEndian.Uint16(data[18:20])
-		return NewRedirectIPv6AddressSpecificExtended(ipv6, localAdmin)
+	// EC_SUBTYPE_FLOWSPEC_REDIRECT_IP6 is deliberately absent here. The
+	// redirect to IPv6 action is an IPv6 Address Specific Extended
+	// Community, which is 20 octets long and travels in its own path
+	// attribute (RFC5701 Section 2 and 3), so it cannot appear in this
+	// 8-octet attribute. It is decoded by parseIP6FlowSpecExtended instead.
+	// Falling through to UnknownExtended keeps the 8 octets intact.
 	case EC_SUBTYPE_L2_INFO:
 		switch data[2] {
 		case byte(LAYER2ENCAPSULATION_TYPE_VPLS):
@@ -14741,9 +14749,13 @@ type PathAttributeExtendedCommunities struct {
 }
 
 func ParseExtended(data []byte) (ExtendedCommunityInterface, error) {
-	if len(data) < 8 {
+	if len(data) < ExtendedCommunityLen {
 		return nil, NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "not all extended community bytes are available")
 	}
+	// Callers hand over the rest of the enclosing attribute or NLRI, so
+	// bound the buffer to this community. A sub-type decoder must not be
+	// able to read into the community that follows.
+	data = data[:ExtendedCommunityLen]
 	attrType := ExtendedCommunityAttrType(data[0])
 	subtype := ExtendedCommunityAttrSubType(data[1])
 	transitive := false
@@ -14798,18 +14810,18 @@ func (p *PathAttributeExtendedCommunities) DecodeFromBytes(data []byte, options 
 	if err != nil {
 		return err
 	}
-	if p.Length%8 != 0 {
+	if p.Length%ExtendedCommunityLen != 0 {
 		eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
 		eSubCode := uint8(BGP_ERROR_SUB_ATTRIBUTE_LENGTH_ERROR)
 		return NewMessageError(eCode, eSubCode, nil, "extendedcommunities length isn't correct")
 	}
-	for len(value) >= 8 {
+	for len(value) >= ExtendedCommunityLen {
 		e, err := ParseExtended(value)
 		if err != nil {
 			return err
 		}
 		p.Value = append(p.Value, e)
-		value = value[8:]
+		value = value[ExtendedCommunityLen:]
 	}
 	return nil
 }
@@ -15787,9 +15799,11 @@ type PathAttributeIP6ExtendedCommunities struct {
 }
 
 func ParseIP6Extended(data []byte) (ExtendedCommunityInterface, error) {
-	if len(data) < 20 {
+	if len(data) < IP6ExtendedCommunityLen {
 		return nil, NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "not all extended community bytes are available")
 	}
+	// Bound the buffer to this community, like ParseExtended does.
+	data = data[:IP6ExtendedCommunityLen]
 	attrType := ExtendedCommunityAttrType(data[0])
 	subtype := ExtendedCommunityAttrSubType(data[1])
 	transitive := false
@@ -15818,18 +15832,18 @@ func (p *PathAttributeIP6ExtendedCommunities) DecodeFromBytes(data []byte, optio
 	if err != nil {
 		return err
 	}
-	if p.Length%20 != 0 {
+	if p.Length%IP6ExtendedCommunityLen != 0 {
 		eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
 		eSubCode := uint8(BGP_ERROR_SUB_ATTRIBUTE_LENGTH_ERROR)
 		return NewMessageError(eCode, eSubCode, nil, "extendedcommunities length isn't correct")
 	}
-	for len(value) >= 20 {
+	for len(value) >= IP6ExtendedCommunityLen {
 		e, err := ParseIP6Extended(value)
 		if err != nil {
 			return err
 		}
 		p.Value = append(p.Value, e)
-		value = value[20:]
+		value = value[IP6ExtendedCommunityLen:]
 	}
 	return nil
 }

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -647,6 +647,56 @@ func Test_IP6FlowSpecExtended(t *testing.T) {
 	assert.Equal(t, m1, m2)
 }
 
+func Test_ExtendedCommunityDoesNotCrossCommunityBoundary(t *testing.T) {
+	assert := assert.New(t)
+
+	// RFC4360 Section 2 fixes every community in this attribute at 8
+	// octets, so a sub-type decoder must stay inside its own community. The
+	// first community below is the one sub-type that used to read 20 bytes,
+	// which took the two route targets that follow it and made the attribute
+	// re-serialize to 36 bytes.
+	value := []byte{
+		byte(EC_TYPE_GENERIC_TRANSITIVE_EXPERIMENTAL), 0x0b, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00,
+		byte(EC_TYPE_TRANSITIVE_TWO_OCTET_AS_SPECIFIC), byte(EC_SUBTYPE_ROUTE_TARGET), 0xfe, 0x4c, 0x00, 0x00, 0x00, 0x01,
+		byte(EC_TYPE_TRANSITIVE_TWO_OCTET_AS_SPECIFIC), byte(EC_SUBTYPE_ROUTE_TARGET), 0xfe, 0xb0, 0x00, 0x00, 0x00, 0x02,
+	}
+	buf := append([]byte{byte(BGP_ATTR_FLAG_OPTIONAL | BGP_ATTR_FLAG_TRANSITIVE), byte(BGP_ATTR_TYPE_EXTENDED_COMMUNITIES), byte(len(value))}, value...)
+
+	p := NewPathAttributeExtendedCommunities(nil)
+	require.NoError(t, p.DecodeFromBytes(buf))
+	require.Len(t, p.Value, 3)
+	assert.IsType(&UnknownExtended{}, p.Value[0])
+	assert.Equal("65100:1", p.Value[1].String())
+	assert.Equal("65200:2", p.Value[2].String())
+
+	out, err := p.Serialize()
+	require.NoError(t, err)
+	assert.Equal(buf, out)
+}
+
+func Test_RouteTargetMembershipNLRIDoesNotCrossNLRIBoundary(t *testing.T) {
+	assert := assert.New(t)
+
+	// The route target of a 96-bit RT membership NLRI is an 8-octet
+	// extended community, so decoding the first NLRI below must not reach
+	// into the second one.
+	buf := []byte{
+		96, 0x00, 0x00, 0xfd, 0xe8,
+		byte(EC_TYPE_GENERIC_TRANSITIVE_EXPERIMENTAL), 0x0b, 0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00,
+		96, 0x00, 0x00, 0xfd, 0xe9,
+		byte(EC_TYPE_TRANSITIVE_TWO_OCTET_AS_SPECIFIC), byte(EC_SUBTYPE_ROUTE_TARGET), 0xfe, 0x4c, 0x00, 0x00, 0x00, 0x01,
+	}
+
+	r := &RouteTargetMembershipNLRI{}
+	require.NoError(t, r.decodeFromBytes(buf))
+	assert.IsType(&UnknownExtended{}, r.RouteTarget)
+
+	out, err := r.Serialize()
+	require.NoError(t, err)
+	assert.Equal(r.Len(), len(out))
+	assert.Equal(buf[:13], out)
+}
+
 func Test_UnknownIP6Extended_RoundTrip(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
ParseExtended() receives the rest of the enclosing attribute or NLRI while its callers advance eight octets at a time, so nothing stops a sub-type decoder from reading into the community that follows. The flowspec redirect-IPv6 sub-type did exactly that: it read 20 octets out of an 8-octet community.

RFC 4360 Section 2 encodes every community of this attribute as an 8-octet quantity, and the 20-octet IPv6 Address Specific Extended Community needs an attribute of its own for that very reason (RFC 5701 Sections 1 and 3), so this sub-type cannot appear here at all. Drop the case and let it fall through to UnknownExtended, which keeps the eight octets intact and forwards them unchanged, the same way BIRD and FRR treat a sub-type they do not decode.

The damage was not confined to the decode. The attribute re-serialized to a length that is no longer a multiple of eight, which RFC 7606 Section 7.14 makes malformed, so receivers withdraw the route. Reached through a route target membership NLRI, the same sub-type made Len() and Serialize() disagree by twelve octets and desynchronised the NLRI framing for the peer, with no length check anywhere to catch it.

Bound the buffer in ParseExtended() and ParseIP6Extended() as well, so a sub-type decoder added later cannot reintroduce the same class of bug, and name the two unit sizes rather than spelling 8 and 20 across six places.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>