### PR TITLE
table: send IPv6 extended communities in their own attribute

### DIFF
--- a/cmd/gobgp/vrf.go
+++ b/cmd/gobgp/vrf.go
@@ -167,9 +167,18 @@ func modVrf(typ string, args []string) error {
 				return err
 			}
 		}
-		v, _ := apiutil.MarshalRD(rd)
-		irt, _ := apiutil.MarshalRTs(importRt)
-		ert, _ := apiutil.MarshalRTs(exportRt)
+		v, err := apiutil.MarshalRD(rd)
+		if err != nil {
+			return err
+		}
+		irt, err := apiutil.MarshalRTs(importRt)
+		if err != nil {
+			return err
+		}
+		ert, err := apiutil.MarshalRTs(exportRt)
+		if err != nil {
+			return err
+		}
 
 		_, err = client.AddVrf(ctx, &api.AddVrfRequest{
 			Vrf: &api.Vrf{

--- a/internal/pkg/table/path.go
+++ b/internal/pkg/table/path.go
@@ -919,18 +919,45 @@ func (path *Path) GetExtCommunities() []bgp.ExtendedCommunityInterface {
 }
 
 func (path *Path) SetExtCommunities(exts []bgp.ExtendedCommunityInterface, doReplace bool) {
-	attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_EXTENDED_COMMUNITIES)
-	if attr != nil {
-		l := attr.(*bgp.PathAttributeExtendedCommunities).Value
+	if len(exts) == 0 {
 		if doReplace {
-			l = exts
-		} else {
-			l = append(l, exts...)
+			// RFC7606 Section 7.14 considers the attribute malformed unless
+			// its length is a non-zero multiple of 8, so drop it rather than
+			// advertising an empty one.
+			path.delPathAttr(bgp.BGP_ATTR_TYPE_EXTENDED_COMMUNITIES)
 		}
-		path.setPathAttr(bgp.NewPathAttributeExtendedCommunities(l))
-	} else {
-		path.setPathAttr(bgp.NewPathAttributeExtendedCommunities(exts))
+		return
 	}
+	if attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_EXTENDED_COMMUNITIES); attr != nil && !doReplace {
+		// Concat rather than append, so growing this path's list cannot write
+		// into the backing array of an attribute shared with another path.
+		exts = slices.Concat(attr.(*bgp.PathAttributeExtendedCommunities).Value, exts)
+	}
+	path.setPathAttr(bgp.NewPathAttributeExtendedCommunities(exts))
+}
+
+func (path *Path) GetIP6ExtCommunities() []bgp.ExtendedCommunityInterface {
+	if attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_IP6_EXTENDED_COMMUNITIES); attr != nil {
+		return attr.(*bgp.PathAttributeIP6ExtendedCommunities).Value
+	}
+	return nil
+}
+
+// SetIP6ExtCommunities is the counterpart of SetExtCommunities for the IPv6
+// Address Specific Extended Community attribute (RFC5701 Section 3). The two
+// attributes carry communities of different sizes and neither reaches into the
+// other.
+func (path *Path) SetIP6ExtCommunities(exts []bgp.ExtendedCommunityInterface, doReplace bool) {
+	if len(exts) == 0 {
+		if doReplace {
+			path.delPathAttr(bgp.BGP_ATTR_TYPE_IP6_EXTENDED_COMMUNITIES)
+		}
+		return
+	}
+	if attr := path.getPathAttr(bgp.BGP_ATTR_TYPE_IP6_EXTENDED_COMMUNITIES); attr != nil && !doReplace {
+		exts = slices.Concat(attr.(*bgp.PathAttributeIP6ExtendedCommunities).Value, exts)
+	}
+	path.setPathAttr(bgp.NewPathAttributeIP6ExtendedCommunities(exts))
 }
 
 func (path *Path) GetRouteTargets() []bgp.ExtendedCommunityInterface {

--- a/internal/pkg/table/policy.go
+++ b/internal/pkg/table/policy.go
@@ -2930,8 +2930,14 @@ func NewCommunityAction(c oc.SetCommunity) (*CommunityAction, error) {
 }
 
 type ExtCommunityAction struct {
-	action      oc.BgpSetCommunityOptionType
+	action oc.BgpSetCommunityOptionType
+	// list keeps every community in configuration order, which ToConfig
+	// relies on to index subtypeList. list8 and list6 are the partitions
+	// actually applied to a path: the two attributes take communities of
+	// different sizes, so a community can only go to one of them.
 	list        []bgp.ExtendedCommunityInterface
+	list8       []bgp.ExtendedCommunityInterface
+	list6       []bgp.ExtendedCommunityInterface
 	removeList  []*regexp.Regexp
 	subtypeList []bgp.ExtendedCommunityAttrSubType
 }
@@ -2943,11 +2949,13 @@ func (a *ExtCommunityAction) Type() ActionType {
 func (a *ExtCommunityAction) Apply(path *Path, _ *PolicyOptions) (*Path, error) {
 	switch a.action {
 	case oc.BGP_SET_COMMUNITY_OPTION_TYPE_ADD:
-		path.SetExtCommunities(a.list, false)
+		path.SetExtCommunities(a.list8, false)
+		path.SetIP6ExtCommunities(a.list6, false)
 	case oc.BGP_SET_COMMUNITY_OPTION_TYPE_REMOVE:
 		RegexpRemoveExtCommunities(path, a.removeList, a.subtypeList)
 	case oc.BGP_SET_COMMUNITY_OPTION_TYPE_REPLACE:
-		path.SetExtCommunities(a.list, true)
+		path.SetExtCommunities(a.list8, true)
+		path.SetIP6ExtCommunities(a.list6, true)
 	}
 	return path, nil
 }
@@ -3002,7 +3010,7 @@ func NewExtCommunityAction(c oc.SetExtCommunity) (*ExtCommunityAction, error) {
 		}
 		return nil, fmt.Errorf("invalid option name: %s", c.Options)
 	}
-	var list []bgp.ExtendedCommunityInterface
+	var list, list8, list6 []bgp.ExtendedCommunityInterface
 	var removeList []*regexp.Regexp
 	subtypeList := make([]bgp.ExtendedCommunityAttrSubType, 0, len(c.SetExtCommunityMethod.CommunitiesList))
 	if a == oc.BGP_SET_COMMUNITY_OPTION_TYPE_REMOVE {
@@ -3023,6 +3031,25 @@ func NewExtCommunityAction(c oc.SetExtCommunity) (*ExtCommunityAction, error) {
 			if err != nil {
 				return nil, err
 			}
+			// Pick the attribute by encoded size, done once here rather than
+			// per path. RFC4360 Section 2 fixes every community of the
+			// Extended Communities attribute at 8 octets, and RFC5701
+			// Section 2 encodes the IPv6 address specific ones as 20 octets
+			// in an attribute of their own. Size is the reliable
+			// discriminator: RedirectIPv6AddressSpecificExtended reports the
+			// same type octet as the 8-octet experimental communities.
+			buf, err := comm.Serialize()
+			if err != nil {
+				return nil, err
+			}
+			switch len(buf) {
+			case bgp.ExtendedCommunityLen:
+				list8 = append(list8, comm)
+			case bgp.IP6ExtendedCommunityLen:
+				list6 = append(list6, comm)
+			default:
+				return nil, fmt.Errorf("ext-community %q encodes to %d octets, which fits neither the %d-octet nor the %d-octet attribute", x, len(buf), bgp.ExtendedCommunityLen, bgp.IP6ExtendedCommunityLen)
+			}
 			list = append(list, comm)
 			_, subtype := comm.GetTypes()
 			subtypeList = append(subtypeList, subtype)
@@ -3031,6 +3058,8 @@ func NewExtCommunityAction(c oc.SetExtCommunity) (*ExtCommunityAction, error) {
 	return &ExtCommunityAction{
 		action:      a,
 		list:        list,
+		list8:       list8,
+		list6:       list6,
 		removeList:  removeList,
 		subtypeList: subtypeList,
 	}, nil

--- a/internal/pkg/table/policy_test.go
+++ b/internal/pkg/table/policy_test.go
@@ -2562,6 +2562,129 @@ func TestPolicyMatchAndClearCommunities(t *testing.T) {
 	// assert.Equal(t, []uint32{}, newPath.GetCommunities())
 }
 
+func TestExtCommunityActionSplitsByAttribute(t *testing.T) {
+	// RFC4360 Section 2 fixes every community of the Extended Communities
+	// attribute at 8 octets, so an IPv6 address specific route target, which
+	// RFC5701 Section 2 encodes as 20 octets, has to go to the attribute
+	// RFC5701 Section 3 defines for it. Mixing them into one attribute made
+	// its length stop being a multiple of 8.
+	newAction := func(option string, comms ...string) (*ExtCommunityAction, error) {
+		return NewExtCommunityAction(oc.SetExtCommunity{
+			Options: option,
+			SetExtCommunityMethod: oc.SetExtCommunityMethod{
+				CommunitiesList: comms,
+			},
+		})
+	}
+	newPath := func() *Path {
+		nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.0/24"))
+		return NewPath(bgp.RF_IPv4_UC, &PeerInfo{AS: 65001}, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}, time.Now(), false)
+	}
+
+	for _, comm := range []string{"rt:65001:200", "rt:10.0.0.1:300", "soo:65001:200", "encap:vxlan", "valid"} {
+		a, err := newAction("add", comm)
+		require.NoError(t, err, comm)
+		assert.Len(t, a.list8, 1, comm)
+		assert.Empty(t, a.list6, comm)
+	}
+
+	a, err := newAction("add", "rt:65001:200", "rt:2001:db8::1:100", "rt:10.0.0.1:300")
+	require.NoError(t, err)
+	require.Len(t, a.list8, 2)
+	require.Len(t, a.list6, 1)
+
+	path, err := a.Apply(newPath(), nil)
+	require.NoError(t, err)
+
+	ext := path.getPathAttr(bgp.BGP_ATTR_TYPE_EXTENDED_COMMUNITIES)
+	require.NotNil(t, ext)
+	buf, err := ext.Serialize()
+	require.NoError(t, err)
+	assert.Zero(t, (len(buf)-3)%bgp.ExtendedCommunityLen)
+
+	ip6 := path.getPathAttr(bgp.BGP_ATTR_TYPE_IP6_EXTENDED_COMMUNITIES)
+	require.NotNil(t, ip6)
+	buf, err = ip6.Serialize()
+	require.NoError(t, err)
+	assert.Zero(t, (len(buf)-3)%bgp.IP6ExtendedCommunityLen)
+	assert.Equal(t, "2001:db8::1:100", path.GetIP6ExtCommunities()[0].String())
+}
+
+func TestExtCommunityActionReplaceKeepsAttributesSeparate(t *testing.T) {
+	// Each list replaces only its own attribute. Replacing with 8-octet
+	// communities alone must not leave a stale IPv6 attribute behind, and
+	// vice versa.
+	newPath := func() *Path {
+		nlri, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("10.10.0.0/24"))
+		path := NewPath(bgp.RF_IPv4_UC, &PeerInfo{AS: 65001}, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}, time.Now(), false)
+		a, err := NewExtCommunityAction(oc.SetExtCommunity{
+			Options: "add",
+			SetExtCommunityMethod: oc.SetExtCommunityMethod{
+				CommunitiesList: []string{"rt:65001:200", "rt:2001:db8::1:100"},
+			},
+		})
+		require.NoError(t, err)
+		path, err = a.Apply(path, nil)
+		require.NoError(t, err)
+		return path
+	}
+
+	replace := func(path *Path, comms ...string) *Path {
+		a, err := NewExtCommunityAction(oc.SetExtCommunity{
+			Options: "replace",
+			SetExtCommunityMethod: oc.SetExtCommunityMethod{
+				CommunitiesList: comms,
+			},
+		})
+		require.NoError(t, err)
+		path, err = a.Apply(path, nil)
+		require.NoError(t, err)
+		return path
+	}
+
+	// Replacing with only an 8-octet community clears the IPv6 attribute.
+	path := replace(newPath(), "rt:65002:300")
+	assert.Equal(t, "65002:300", path.GetExtCommunities()[0].String())
+	assert.Empty(t, path.GetIP6ExtCommunities())
+
+	// Replacing with only a 20-octet community clears the 8-octet attribute.
+	path = replace(newPath(), "rt:2001:db8::2:200")
+	assert.Empty(t, path.GetExtCommunities())
+	assert.Equal(t, "2001:db8::2:200", path.GetIP6ExtCommunities()[0].String())
+}
+
+func TestExtCommunityActionConfigRoundTrip(t *testing.T) {
+	// Splitting the communities by attribute must not disturb the
+	// configuration view: ToConfig indexes subtypeList by the position in
+	// list, so list has to stay whole and in configuration order. Were it
+	// partitioned, the subtype prefixes would be taken from the wrong
+	// entries and "soo:" would come back as "rt:".
+	in := []string{"rt:65001:200", "rt:2001:db8::1:100", "soo:10.0.0.1:300", "valid"}
+	newAction := func(comms []string) (*ExtCommunityAction, error) {
+		return NewExtCommunityAction(oc.SetExtCommunity{
+			Options: "add",
+			SetExtCommunityMethod: oc.SetExtCommunityMethod{
+				CommunitiesList: comms,
+			},
+		})
+	}
+
+	a, err := newAction(in)
+	require.NoError(t, err)
+	require.Len(t, a.list, len(in))
+	require.Len(t, a.list8, 3)
+	require.Len(t, a.list6, 1)
+
+	out := a.ToConfig().SetExtCommunityMethod.CommunitiesList
+	assert.Equal(t, in, out)
+	assert.Equal(t, "add["+strings.Join(in, ", ")+"]", a.String())
+
+	b, err := newAction(out)
+	require.NoError(t, err)
+	assert.Equal(t, a.list8, b.list8)
+	assert.Equal(t, a.list6, b.list6)
+}
+
 func TestExtCommunityConditionEvaluate(t *testing.T) {
 	// setup
 	// create path


### PR DESCRIPTION
ParseExtCommunity() returns a 20-octet IPv6 address specific community whenever the configured value parses as an IPv6 address, and the set action handed whatever it got to the Extended Communities attribute. RFC 4360 Section 2 fixes every community of that attribute at 8 octets, and RFC 5701 Sections 1 and 3 gave the 20-octet form an attribute of its own because it does not fit, so the attribute length stopped being a multiple of eight. RFC 7606 Section 7.14 calls that malformed and has receivers withdraw the route, so a policy that looked accepted made the routes it touched disappear.

Pick the attribute by encoded size rather than by community type, since the type is ambiguous where the length is not:
RedirectIPv6AddressSpecificExtended reports the same type octet as the 8-octet experimental communities. Replace acts on each attribute independently, because leaving the other one alone would keep route targets the operator just replaced. An empty list deletes its attribute rather than building one of length zero, which Section 7.14 rejects too since it demands a non-zero multiple of eight.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>