### PR TITLE
server: reject an unknown peer group in the dynamic neighbor API

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3625,6 +3625,9 @@ func (s *BgpServer) AddDynamicNeighbor(ctx context.Context, r *api.AddDynamicNei
 	if r == nil || r.DynamicNeighbor == nil {
 		return fmt.Errorf("nil request")
 	}
+	if r.DynamicNeighbor.PeerGroup == "" {
+		return fmt.Errorf("dynamic neighbor requires the peer group config")
+	}
 	p, err := netip.ParsePrefix(r.DynamicNeighbor.Prefix)
 	if err != nil {
 		return fmt.Errorf("invalid prefix: %v", err)
@@ -3637,9 +3640,13 @@ func (s *BgpServer) AddDynamicNeighbor(ctx context.Context, r *api.AddDynamicNei
 				PeerGroup: r.DynamicNeighbor.PeerGroup,
 			},
 		}
-		s.peerGroupMap[c.Config.PeerGroup].AddDynamicNeighbor(c)
+		pg, ok := s.peerGroupMap[c.Config.PeerGroup]
+		if !ok {
+			return fmt.Errorf("no such peer-group: %s", c.Config.PeerGroup)
+		}
+		pg.AddDynamicNeighbor(c)
 
-		pConf := s.peerGroupMap[c.Config.PeerGroup].Conf
+		pConf := pg.Conf
 		if pConf.Config.AuthPassword != "" {
 			prefix := r.DynamicNeighbor.Prefix
 			addr, _, _ := net.ParseCIDR(prefix)
@@ -3749,30 +3756,35 @@ func (s *BgpServer) DeleteDynamicNeighbor(ctx context.Context, r *api.DeleteDyna
 	if r == nil {
 		return fmt.Errorf("nil request")
 	}
+	if r.PeerGroup == "" {
+		return fmt.Errorf("dynamic neighbor requires the peer group config")
+	}
 	return s.mgmtOperation(func() error {
-		s.peerGroupMap[r.PeerGroup].DeleteDynamicNeighbor(r.Prefix)
+		pg, ok := s.peerGroupMap[r.PeerGroup]
+		if !ok {
+			return fmt.Errorf("no such peer-group: %s", r.PeerGroup)
+		}
+		pg.DeleteDynamicNeighbor(r.Prefix)
 
-		if pg, ok := s.peerGroupMap[r.PeerGroup]; ok {
-			pConf := pg.Conf
-			if pConf.Config.AuthPassword != "" {
-				prefix := r.Prefix
-				addr, _, perr := net.ParseCIDR(prefix)
-				if perr == nil {
-					for _, l := range s.listListeners(addr.String()) {
-						if err := netutils.SetTCPMD5SigSockopt(l, pConf.Transport.Config.BindInterface, prefix, ""); err != nil {
-							s.logger.Warn("failed to clear md5",
-								slog.String("Topic", "Peer"),
-								slog.String("Key", prefix),
-								slog.String("Err", err.Error()))
-						}
+		pConf := pg.Conf
+		if pConf.Config.AuthPassword != "" {
+			prefix := r.Prefix
+			addr, _, perr := net.ParseCIDR(prefix)
+			if perr == nil {
+				for _, l := range s.listListeners(addr.String()) {
+					if err := netutils.SetTCPMD5SigSockopt(l, pConf.Transport.Config.BindInterface, prefix, ""); err != nil {
+						s.logger.Warn("failed to clear md5",
+							slog.String("Topic", "Peer"),
+							slog.String("Key", prefix),
+							slog.String("Err", err.Error()))
 					}
-				} else {
-					s.logger.Warn("Cannot clear up dynamic MD5, invalid prefix",
-						slog.String("Topic", "Peer"),
-						slog.String("Key", prefix),
-						slog.String("Err", perr.Error()),
-					)
 				}
+			} else {
+				s.logger.Warn("Cannot clear up dynamic MD5, invalid prefix",
+					slog.String("Topic", "Peer"),
+					slog.String("Key", prefix),
+					slog.String("Err", perr.Error()),
+				)
 			}
 		}
 		return nil

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1949,6 +1949,63 @@ func TestDynamicNeighbor(t *testing.T) {
 	establisedWaiter.Wait(t, 10*time.Second)
 }
 
+// TestDynamicNeighborUnknownPeerGroup verifies that the dynamic neighbor API rejects a peer group
+// that does not exist instead of dereferencing a nil peerGroup and killing the daemon. The config
+// file path validates this in oc.DynamicNeighbor.validate; the API path must do the same.
+func TestDynamicNeighborUnknownPeerGroup(t *testing.T) {
+	assert := assert.New(t)
+	s := NewBgpServer()
+	go s.Serve()
+	err := s.StartBgp(context.Background(), &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        1,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	assert.NoError(err)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	err = s.addPeerGroup(&oc.PeerGroup{
+		Config: oc.PeerGroupConfig{
+			PeerAs:        2,
+			PeerGroupName: "g",
+		},
+	})
+	assert.NoError(err)
+
+	for _, name := range []string{"missing-pg", ""} {
+		err = s.AddDynamicNeighbor(context.Background(), &api.AddDynamicNeighborRequest{
+			DynamicNeighbor: &api.DynamicNeighbor{
+				Prefix:    "127.0.0.0/24",
+				PeerGroup: name,
+			},
+		})
+		assert.Error(err, "peer group %q", name)
+
+		err = s.DeleteDynamicNeighbor(context.Background(), &api.DeleteDynamicNeighborRequest{
+			Prefix:    "127.0.0.0/24",
+			PeerGroup: name,
+		})
+		assert.Error(err, "peer group %q", name)
+	}
+
+	// The existing peer group is still usable for both operations.
+	err = s.AddDynamicNeighbor(context.Background(), &api.AddDynamicNeighborRequest{
+		DynamicNeighbor: &api.DynamicNeighbor{
+			Prefix:    "127.0.0.0/24",
+			PeerGroup: "g",
+		},
+	})
+	assert.NoError(err)
+
+	err = s.DeleteDynamicNeighbor(context.Background(), &api.DeleteDynamicNeighborRequest{
+		Prefix:    "127.0.0.0/24",
+		PeerGroup: "g",
+	})
+	assert.NoError(err)
+}
+
 // TestDynamicNeighborBfd verifies that BFD is registered for a dynamic neighbor when the peer group has
 // BFD enabled (the accept path), and deregistered when the neighbor goes away (the stop path). Without
 // the fix, BFD never runs for dynamic peers.


### PR DESCRIPTION
Adding or deleting a dynamic neighbor through the API indexed peerGroupMap without checking the result, so an unknown peer group name yielded a nil *peerGroup that was dereferenced immediately. The config file path is safe because oc.DynamicNeighbor.validate rejects a missing or empty peer group while reading the configuration, but nothing did so for the runtime path, which meant a single AddDynamicNeighbor or DeleteDynamicNeighbor request naming a group that does not exist panicked the management goroutine and terminated gobgpd. As gobgpd listens for API requests on :50051 by default, that turns a configuration mistake into a lost daemon.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>