### PR TITLE
packet/bgp: bound MUP Type 2 endpoint address length to address family

### DIFF
--- a/pkg/packet/bgp/mup.go
+++ b/pkg/packet/bgp/mup.go
@@ -810,7 +810,14 @@ func (r *MUPType2SessionTransformedRoute) DecodeFromBytes(data []byte, afi uint1
 		return malformedAttrListErr("invalid 3GPP 5G specific Type 2 Session Transformed Route length")
 	}
 	r.EndpointAddressLength = data[p]
-	if afi == AFI_IP && r.EndpointAddressLength > 64 || afi == AFI_IP6 && r.EndpointAddressLength > 160 {
+	// Endpoint Address Length covers the endpoint address plus the
+	// architecture-specific endpoint identifier (TEID), so it must be at
+	// least the endpoint address size (32 for IPv4, 128 for IPv6). Without
+	// the lower bound a too-small value makes teidLen negative, so the on-wire
+	// TEID octets are handed to parseMUPTLVs and the TEID recorded in the
+	// route key is wrong.
+	if afi == AFI_IP && (r.EndpointAddressLength < 32 || r.EndpointAddressLength > 64) ||
+		afi == AFI_IP6 && (r.EndpointAddressLength < 128 || r.EndpointAddressLength > 160) {
 		return malformedAttrListErr(fmt.Sprintf("Invalid Endpoint Address Length: %d", r.EndpointAddressLength))
 	}
 	p += 1

--- a/pkg/packet/bgp/mup_test.go
+++ b/pkg/packet/bgp/mup_test.go
@@ -333,6 +333,47 @@ func Test_MUPType2SessionTransformedRouteIPv6(t *testing.T) {
 	}
 }
 
+func Test_MUPType2SessionTransformedRouteRejectsShortEndpointAddressLength(t *testing.T) {
+	assert := assert.New(t)
+	rd, _ := ParseRouteDistinguisher("100:100")
+
+	// ArchType(1) + RouteType(2) + Length(1) + RD(8), so the Endpoint Address
+	// Length octet sits at index 12.
+	const ealOffset = 1 + 2 + 1 + 8
+
+	v4 := NewMUPNLRI(AFI_IP, MUP_ARCH_TYPE_3GPP_5G, MUP_ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED,
+		&MUPType2SessionTransformedRoute{
+			RD:                    rd,
+			EndpointAddressLength: 32,
+			EndpointAddress:       netip.MustParseAddr("10.10.10.1"),
+			TEID:                  netip.MustParseAddr("0.0.0.0"),
+		})
+	buf, err := v4.Serialize()
+	assert.NoError(err)
+	buf[ealOffset] = 16 // below the 32-bit IPv4 endpoint address size
+	_, err = NLRIFromSlice(RF_MUP_IPv4, buf)
+	assert.Error(err)
+	buf[ealOffset] = 32 // a legal length still decodes
+	_, err = NLRIFromSlice(RF_MUP_IPv4, buf)
+	assert.NoError(err)
+
+	v6 := NewMUPNLRI(AFI_IP6, MUP_ARCH_TYPE_3GPP_5G, MUP_ROUTE_TYPE_TYPE_2_SESSION_TRANSFORMED,
+		&MUPType2SessionTransformedRoute{
+			RD:                    rd,
+			EndpointAddressLength: 128,
+			EndpointAddress:       netip.MustParseAddr("2001::1"),
+			TEID:                  netip.MustParseAddr("0.0.0.0"),
+		})
+	buf6, err := v6.Serialize()
+	assert.NoError(err)
+	buf6[ealOffset] = 64 // below the 128-bit IPv6 endpoint address size
+	_, err = NLRIFromSlice(RF_MUP_IPv6, buf6)
+	assert.Error(err)
+	buf6[ealOffset] = 128 // a legal length still decodes
+	_, err = NLRIFromSlice(RF_MUP_IPv6, buf6)
+	assert.NoError(err)
+}
+
 func Test_MUPType1SessionTransformedRouteTLVs(t *testing.T) {
 	assert := assert.New(t)
 	rd, _ := ParseRouteDistinguisher("100:100")


### PR DESCRIPTION
MUP Type 2 ST route, AFI=IPv4, with the Endpoint Address Length octet set below 32 in a peer-supplied RF_MUP UPDATE:

    [type:t2st][rd:100:100][endpoint-address-length:16][endpoint:10.10.10.1][teid:0.0.0.0]

MUPType2SessionTransformedRoute.DecodeFromBytes bounds Endpoint Address Length only from above (>64 for IPv4, >160 for IPv6). That field is the endpoint address plus the architecture-specific endpoint identifier, so it must be at least the endpoint address size. The endpoint is always consumed at its fixed 4/16 bytes and teidLen is EndpointAddressLength minus that size, so a value below it goes negative: the TEID is recorded as 0.0.0.0 and the octets the peer placed after the endpoint (its intended TEID) are handed to parseMUPTLVs. EndpointAddressLength and TEID are both part of the Type 2 route key, so the same endpoint decodes under several distinct keys, and other trailing layouts fail parseMUPTLVs and drop the whole UPDATE.

The sibling Type 1 decoder already restricts its length fields; this adds the matching lower bound (32 for IPv4, 128 for IPv6).
