### PR TITLE
flowspec: add the redirect-to-IP action (draft-ietf-idr-flowspec-redirect-ip-16)

### DIFF
--- a/api/attribute.pb.go
+++ b/api/attribute.pb.go
@@ -5620,6 +5620,7 @@ type IP6ExtendedCommunitiesAttribute_Community struct {
 	//
 	//	*IP6ExtendedCommunitiesAttribute_Community_Ipv6AddressSpecific
 	//	*IP6ExtendedCommunitiesAttribute_Community_RedirectIpv6AddressSpecific
+	//	*IP6ExtendedCommunitiesAttribute_Community_FlowSpecRedirectToIpv6
 	Extcom        isIP6ExtendedCommunitiesAttribute_Community_Extcom `protobuf_oneof:"extcom"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -5680,6 +5681,15 @@ func (x *IP6ExtendedCommunitiesAttribute_Community) GetRedirectIpv6AddressSpecif
 	return nil
 }
 
+func (x *IP6ExtendedCommunitiesAttribute_Community) GetFlowSpecRedirectToIpv6() *FlowSpecRedirectToIPv6Extended {
+	if x != nil {
+		if x, ok := x.Extcom.(*IP6ExtendedCommunitiesAttribute_Community_FlowSpecRedirectToIpv6); ok {
+			return x.FlowSpecRedirectToIpv6
+		}
+	}
+	return nil
+}
+
 type isIP6ExtendedCommunitiesAttribute_Community_Extcom interface {
 	isIP6ExtendedCommunitiesAttribute_Community_Extcom()
 }
@@ -5692,10 +5702,17 @@ type IP6ExtendedCommunitiesAttribute_Community_RedirectIpv6AddressSpecific struc
 	RedirectIpv6AddressSpecific *RedirectIPv6AddressSpecificExtended `protobuf:"bytes,2,opt,name=redirect_ipv6_address_specific,json=redirectIpv6AddressSpecific,proto3,oneof"`
 }
 
+type IP6ExtendedCommunitiesAttribute_Community_FlowSpecRedirectToIpv6 struct {
+	FlowSpecRedirectToIpv6 *FlowSpecRedirectToIPv6Extended `protobuf:"bytes,3,opt,name=flow_spec_redirect_to_ipv6,json=flowSpecRedirectToIpv6,proto3,oneof"`
+}
+
 func (*IP6ExtendedCommunitiesAttribute_Community_Ipv6AddressSpecific) isIP6ExtendedCommunitiesAttribute_Community_Extcom() {
 }
 
 func (*IP6ExtendedCommunitiesAttribute_Community_RedirectIpv6AddressSpecific) isIP6ExtendedCommunitiesAttribute_Community_Extcom() {
+}
+
+func (*IP6ExtendedCommunitiesAttribute_Community_FlowSpecRedirectToIpv6) isIP6ExtendedCommunitiesAttribute_Community_Extcom() {
 }
 
 type AigpAttribute_TLV struct {
@@ -6049,12 +6066,13 @@ const file_api_attribute_proto_rawDesc = "" +
 	"#RedirectIPv6AddressSpecificExtended\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x1f\n" +
 	"\vlocal_admin\x18\x02 \x01(\rR\n" +
-	"localAdmin\"\xd4\x02\n" +
+	"localAdmin\"\xb7\x03\n" +
 	"\x1fIP6ExtendedCommunitiesAttribute\x12P\n" +
-	"\vcommunities\x18\x01 \x03(\v2..api.IP6ExtendedCommunitiesAttribute.CommunityR\vcommunities\x1a\xde\x01\n" +
+	"\vcommunities\x18\x01 \x03(\v2..api.IP6ExtendedCommunitiesAttribute.CommunityR\vcommunities\x1a\xc1\x02\n" +
 	"\tCommunity\x12V\n" +
 	"\x15ipv6_address_specific\x18\x01 \x01(\v2 .api.IPv6AddressSpecificExtendedH\x00R\x13ipv6AddressSpecific\x12o\n" +
-	"\x1eredirect_ipv6_address_specific\x18\x02 \x01(\v2(.api.RedirectIPv6AddressSpecificExtendedH\x00R\x1bredirectIpv6AddressSpecificB\b\n" +
+	"\x1eredirect_ipv6_address_specific\x18\x02 \x01(\v2(.api.RedirectIPv6AddressSpecificExtendedH\x00R\x1bredirectIpv6AddressSpecific\x12a\n" +
+	"\x1aflow_spec_redirect_to_ipv6\x18\x03 \x01(\v2#.api.FlowSpecRedirectToIPv6ExtendedH\x00R\x16flowSpecRedirectToIpv6B\b\n" +
 	"\x06extcom\"*\n" +
 	"\x10AigpTLVIGPMetric\x12\x16\n" +
 	"\x06metric\x18\x01 \x01(\x04R\x06metric\":\n" +
@@ -6422,6 +6440,7 @@ var file_api_attribute_proto_goTypes = []any{
 	(*Family)(nil),                                    // 89: api.Family
 	(*NLRI)(nil),                                      // 90: api.NLRI
 	(*ExtendedCommunity)(nil),                         // 91: api.ExtendedCommunity
+	(*FlowSpecRedirectToIPv6Extended)(nil),            // 92: api.FlowSpecRedirectToIPv6Extended
 }
 var file_api_attribute_proto_depIdxs = []int32{
 	70,  // 0: api.Attribute.unknown:type_name -> api.UnknownAttribute
@@ -6518,18 +6537,19 @@ var file_api_attribute_proto_depIdxs = []int32{
 	36,  // 91: api.TunnelEncapTLV.TLV.sr_segment_list:type_name -> api.TunnelEncapSubTLVSRSegmentList
 	42,  // 92: api.IP6ExtendedCommunitiesAttribute.Community.ipv6_address_specific:type_name -> api.IPv6AddressSpecificExtended
 	43,  // 93: api.IP6ExtendedCommunitiesAttribute.Community.redirect_ipv6_address_specific:type_name -> api.RedirectIPv6AddressSpecificExtended
-	46,  // 94: api.AigpAttribute.TLV.unknown:type_name -> api.AigpTLVUnknown
-	45,  // 95: api.AigpAttribute.TLV.igp_metric:type_name -> api.AigpTLVIGPMetric
-	73,  // 96: api.SRv6InformationSubTLV.SubSubTlvsEntry.value:type_name -> api.SRv6SubSubTLVs
-	77,  // 97: api.SRv6L3ServiceTLV.SubTlvsEntry.value:type_name -> api.SRv6SubTLVs
-	77,  // 98: api.SRv6L2ServiceTLV.SubTlvsEntry.value:type_name -> api.SRv6SubTLVs
-	78,  // 99: api.PrefixSID.TLV.l3_service:type_name -> api.SRv6L3ServiceTLV
-	79,  // 100: api.PrefixSID.TLV.l2_service:type_name -> api.SRv6L2ServiceTLV
-	101, // [101:101] is the sub-list for method output_type
-	101, // [101:101] is the sub-list for method input_type
-	101, // [101:101] is the sub-list for extension type_name
-	101, // [101:101] is the sub-list for extension extendee
-	0,   // [0:101] is the sub-list for field type_name
+	92,  // 94: api.IP6ExtendedCommunitiesAttribute.Community.flow_spec_redirect_to_ipv6:type_name -> api.FlowSpecRedirectToIPv6Extended
+	46,  // 95: api.AigpAttribute.TLV.unknown:type_name -> api.AigpTLVUnknown
+	45,  // 96: api.AigpAttribute.TLV.igp_metric:type_name -> api.AigpTLVIGPMetric
+	73,  // 97: api.SRv6InformationSubTLV.SubSubTlvsEntry.value:type_name -> api.SRv6SubSubTLVs
+	77,  // 98: api.SRv6L3ServiceTLV.SubTlvsEntry.value:type_name -> api.SRv6SubTLVs
+	77,  // 99: api.SRv6L2ServiceTLV.SubTlvsEntry.value:type_name -> api.SRv6SubTLVs
+	78,  // 100: api.PrefixSID.TLV.l3_service:type_name -> api.SRv6L3ServiceTLV
+	79,  // 101: api.PrefixSID.TLV.l2_service:type_name -> api.SRv6L2ServiceTLV
+	102, // [102:102] is the sub-list for method output_type
+	102, // [102:102] is the sub-list for method input_type
+	102, // [102:102] is the sub-list for extension type_name
+	102, // [102:102] is the sub-list for extension extendee
+	0,   // [0:102] is the sub-list for field type_name
 }
 
 func init() { file_api_attribute_proto_init() }
@@ -6596,6 +6616,7 @@ func file_api_attribute_proto_init() {
 	file_api_attribute_proto_msgTypes[80].OneofWrappers = []any{
 		(*IP6ExtendedCommunitiesAttribute_Community_Ipv6AddressSpecific)(nil),
 		(*IP6ExtendedCommunitiesAttribute_Community_RedirectIpv6AddressSpecific)(nil),
+		(*IP6ExtendedCommunitiesAttribute_Community_FlowSpecRedirectToIpv6)(nil),
 	}
 	file_api_attribute_proto_msgTypes[81].OneofWrappers = []any{
 		(*AigpAttribute_TLV_Unknown)(nil),

--- a/api/extcom.pb.go
+++ b/api/extcom.pb.go
@@ -897,6 +897,112 @@ func (x *RedirectIPv4AddressSpecificExtended) GetLocalAdmin() uint32 {
 	return 0
 }
 
+// draft-ietf-idr-flowspec-redirect-ip-16, type 0x01 sub-type 0x0c.
+type FlowSpecRedirectToIPv4Extended struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Address       string                 `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	Copy          bool                   `protobuf:"varint,2,opt,name=copy,proto3" json:"copy,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FlowSpecRedirectToIPv4Extended) Reset() {
+	*x = FlowSpecRedirectToIPv4Extended{}
+	mi := &file_api_extcom_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FlowSpecRedirectToIPv4Extended) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FlowSpecRedirectToIPv4Extended) ProtoMessage() {}
+
+func (x *FlowSpecRedirectToIPv4Extended) ProtoReflect() protoreflect.Message {
+	mi := &file_api_extcom_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FlowSpecRedirectToIPv4Extended.ProtoReflect.Descriptor instead.
+func (*FlowSpecRedirectToIPv4Extended) Descriptor() ([]byte, []int) {
+	return file_api_extcom_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *FlowSpecRedirectToIPv4Extended) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *FlowSpecRedirectToIPv4Extended) GetCopy() bool {
+	if x != nil {
+		return x.Copy
+	}
+	return false
+}
+
+// The IPv6 form of the same draft, RFC 5701 type 0x000c.
+type FlowSpecRedirectToIPv6Extended struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Address       string                 `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	Copy          bool                   `protobuf:"varint,2,opt,name=copy,proto3" json:"copy,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FlowSpecRedirectToIPv6Extended) Reset() {
+	*x = FlowSpecRedirectToIPv6Extended{}
+	mi := &file_api_extcom_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FlowSpecRedirectToIPv6Extended) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FlowSpecRedirectToIPv6Extended) ProtoMessage() {}
+
+func (x *FlowSpecRedirectToIPv6Extended) ProtoReflect() protoreflect.Message {
+	mi := &file_api_extcom_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FlowSpecRedirectToIPv6Extended.ProtoReflect.Descriptor instead.
+func (*FlowSpecRedirectToIPv6Extended) Descriptor() ([]byte, []int) {
+	return file_api_extcom_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *FlowSpecRedirectToIPv6Extended) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *FlowSpecRedirectToIPv6Extended) GetCopy() bool {
+	if x != nil {
+		return x.Copy
+	}
+	return false
+}
+
 type RedirectFourOctetAsSpecificExtended struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Asn           uint32                 `protobuf:"varint,1,opt,name=asn,proto3" json:"asn,omitempty"`
@@ -907,7 +1013,7 @@ type RedirectFourOctetAsSpecificExtended struct {
 
 func (x *RedirectFourOctetAsSpecificExtended) Reset() {
 	*x = RedirectFourOctetAsSpecificExtended{}
-	mi := &file_api_extcom_proto_msgTypes[17]
+	mi := &file_api_extcom_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -919,7 +1025,7 @@ func (x *RedirectFourOctetAsSpecificExtended) String() string {
 func (*RedirectFourOctetAsSpecificExtended) ProtoMessage() {}
 
 func (x *RedirectFourOctetAsSpecificExtended) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[17]
+	mi := &file_api_extcom_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -932,7 +1038,7 @@ func (x *RedirectFourOctetAsSpecificExtended) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use RedirectFourOctetAsSpecificExtended.ProtoReflect.Descriptor instead.
 func (*RedirectFourOctetAsSpecificExtended) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{17}
+	return file_api_extcom_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *RedirectFourOctetAsSpecificExtended) GetAsn() uint32 {
@@ -958,7 +1064,7 @@ type TrafficRemarkExtended struct {
 
 func (x *TrafficRemarkExtended) Reset() {
 	*x = TrafficRemarkExtended{}
-	mi := &file_api_extcom_proto_msgTypes[18]
+	mi := &file_api_extcom_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -970,7 +1076,7 @@ func (x *TrafficRemarkExtended) String() string {
 func (*TrafficRemarkExtended) ProtoMessage() {}
 
 func (x *TrafficRemarkExtended) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[18]
+	mi := &file_api_extcom_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -983,7 +1089,7 @@ func (x *TrafficRemarkExtended) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TrafficRemarkExtended.ProtoReflect.Descriptor instead.
 func (*TrafficRemarkExtended) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{18}
+	return file_api_extcom_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *TrafficRemarkExtended) GetDscp() uint32 {
@@ -1004,7 +1110,7 @@ type MUPTwoOctetAsSpecificExtended struct {
 
 func (x *MUPTwoOctetAsSpecificExtended) Reset() {
 	*x = MUPTwoOctetAsSpecificExtended{}
-	mi := &file_api_extcom_proto_msgTypes[19]
+	mi := &file_api_extcom_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1016,7 +1122,7 @@ func (x *MUPTwoOctetAsSpecificExtended) String() string {
 func (*MUPTwoOctetAsSpecificExtended) ProtoMessage() {}
 
 func (x *MUPTwoOctetAsSpecificExtended) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[19]
+	mi := &file_api_extcom_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1029,7 +1135,7 @@ func (x *MUPTwoOctetAsSpecificExtended) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MUPTwoOctetAsSpecificExtended.ProtoReflect.Descriptor instead.
 func (*MUPTwoOctetAsSpecificExtended) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{19}
+	return file_api_extcom_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *MUPTwoOctetAsSpecificExtended) GetSubType() uint32 {
@@ -1064,7 +1170,7 @@ type MUPIPv4AddressSpecificExtended struct {
 
 func (x *MUPIPv4AddressSpecificExtended) Reset() {
 	*x = MUPIPv4AddressSpecificExtended{}
-	mi := &file_api_extcom_proto_msgTypes[20]
+	mi := &file_api_extcom_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1076,7 +1182,7 @@ func (x *MUPIPv4AddressSpecificExtended) String() string {
 func (*MUPIPv4AddressSpecificExtended) ProtoMessage() {}
 
 func (x *MUPIPv4AddressSpecificExtended) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[20]
+	mi := &file_api_extcom_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1089,7 +1195,7 @@ func (x *MUPIPv4AddressSpecificExtended) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MUPIPv4AddressSpecificExtended.ProtoReflect.Descriptor instead.
 func (*MUPIPv4AddressSpecificExtended) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{20}
+	return file_api_extcom_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *MUPIPv4AddressSpecificExtended) GetSubType() uint32 {
@@ -1124,7 +1230,7 @@ type MUPFourOctetAsSpecificExtended struct {
 
 func (x *MUPFourOctetAsSpecificExtended) Reset() {
 	*x = MUPFourOctetAsSpecificExtended{}
-	mi := &file_api_extcom_proto_msgTypes[21]
+	mi := &file_api_extcom_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1136,7 +1242,7 @@ func (x *MUPFourOctetAsSpecificExtended) String() string {
 func (*MUPFourOctetAsSpecificExtended) ProtoMessage() {}
 
 func (x *MUPFourOctetAsSpecificExtended) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[21]
+	mi := &file_api_extcom_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1149,7 +1255,7 @@ func (x *MUPFourOctetAsSpecificExtended) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MUPFourOctetAsSpecificExtended.ProtoReflect.Descriptor instead.
 func (*MUPFourOctetAsSpecificExtended) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{21}
+	return file_api_extcom_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *MUPFourOctetAsSpecificExtended) GetSubType() uint32 {
@@ -1183,7 +1289,7 @@ type VPLSExtended struct {
 
 func (x *VPLSExtended) Reset() {
 	*x = VPLSExtended{}
-	mi := &file_api_extcom_proto_msgTypes[22]
+	mi := &file_api_extcom_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1195,7 +1301,7 @@ func (x *VPLSExtended) String() string {
 func (*VPLSExtended) ProtoMessage() {}
 
 func (x *VPLSExtended) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[22]
+	mi := &file_api_extcom_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1208,7 +1314,7 @@ func (x *VPLSExtended) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VPLSExtended.ProtoReflect.Descriptor instead.
 func (*VPLSExtended) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{22}
+	return file_api_extcom_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *VPLSExtended) GetControlFlags() uint32 {
@@ -1235,7 +1341,7 @@ type ETreeExtended struct {
 
 func (x *ETreeExtended) Reset() {
 	*x = ETreeExtended{}
-	mi := &file_api_extcom_proto_msgTypes[23]
+	mi := &file_api_extcom_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1247,7 +1353,7 @@ func (x *ETreeExtended) String() string {
 func (*ETreeExtended) ProtoMessage() {}
 
 func (x *ETreeExtended) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[23]
+	mi := &file_api_extcom_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1260,7 +1366,7 @@ func (x *ETreeExtended) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ETreeExtended.ProtoReflect.Descriptor instead.
 func (*ETreeExtended) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{23}
+	return file_api_extcom_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ETreeExtended) GetIsLeaf() bool {
@@ -1287,7 +1393,7 @@ type MulticastFlagsExtended struct {
 
 func (x *MulticastFlagsExtended) Reset() {
 	*x = MulticastFlagsExtended{}
-	mi := &file_api_extcom_proto_msgTypes[24]
+	mi := &file_api_extcom_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1299,7 +1405,7 @@ func (x *MulticastFlagsExtended) String() string {
 func (*MulticastFlagsExtended) ProtoMessage() {}
 
 func (x *MulticastFlagsExtended) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[24]
+	mi := &file_api_extcom_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1312,7 +1418,7 @@ func (x *MulticastFlagsExtended) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MulticastFlagsExtended.ProtoReflect.Descriptor instead.
 func (*MulticastFlagsExtended) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{24}
+	return file_api_extcom_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *MulticastFlagsExtended) GetIsIgmpProxy() bool {
@@ -1339,7 +1445,7 @@ type UnknownExtended struct {
 
 func (x *UnknownExtended) Reset() {
 	*x = UnknownExtended{}
-	mi := &file_api_extcom_proto_msgTypes[25]
+	mi := &file_api_extcom_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1351,7 +1457,7 @@ func (x *UnknownExtended) String() string {
 func (*UnknownExtended) ProtoMessage() {}
 
 func (x *UnknownExtended) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[25]
+	mi := &file_api_extcom_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1364,7 +1470,7 @@ func (x *UnknownExtended) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnknownExtended.ProtoReflect.Descriptor instead.
 func (*UnknownExtended) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{25}
+	return file_api_extcom_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *UnknownExtended) GetType() uint32 {
@@ -1411,6 +1517,7 @@ type ExtendedCommunity struct {
 	//	*ExtendedCommunity_MupTwoOctetAsSpecific
 	//	*ExtendedCommunity_MupIpv4AddressSpecific
 	//	*ExtendedCommunity_MupFourOctetAsSpecific
+	//	*ExtendedCommunity_FlowSpecRedirectToIpv4
 	Extcom        isExtendedCommunity_Extcom `protobuf_oneof:"extcom"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1418,7 +1525,7 @@ type ExtendedCommunity struct {
 
 func (x *ExtendedCommunity) Reset() {
 	*x = ExtendedCommunity{}
-	mi := &file_api_extcom_proto_msgTypes[26]
+	mi := &file_api_extcom_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1430,7 +1537,7 @@ func (x *ExtendedCommunity) String() string {
 func (*ExtendedCommunity) ProtoMessage() {}
 
 func (x *ExtendedCommunity) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[26]
+	mi := &file_api_extcom_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1443,7 +1550,7 @@ func (x *ExtendedCommunity) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtendedCommunity.ProtoReflect.Descriptor instead.
 func (*ExtendedCommunity) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{26}
+	return file_api_extcom_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ExtendedCommunity) GetExtcom() isExtendedCommunity_Extcom {
@@ -1687,6 +1794,15 @@ func (x *ExtendedCommunity) GetMupFourOctetAsSpecific() *MUPFourOctetAsSpecificE
 	return nil
 }
 
+func (x *ExtendedCommunity) GetFlowSpecRedirectToIpv4() *FlowSpecRedirectToIPv4Extended {
+	if x != nil {
+		if x, ok := x.Extcom.(*ExtendedCommunity_FlowSpecRedirectToIpv4); ok {
+			return x.FlowSpecRedirectToIpv4
+		}
+	}
+	return nil
+}
+
 type isExtendedCommunity_Extcom interface {
 	isExtendedCommunity_Extcom()
 }
@@ -1795,6 +1911,10 @@ type ExtendedCommunity_MupFourOctetAsSpecific struct {
 	MupFourOctetAsSpecific *MUPFourOctetAsSpecificExtended `protobuf:"bytes,27,opt,name=mup_four_octet_as_specific,json=mupFourOctetAsSpecific,proto3,oneof"`
 }
 
+type ExtendedCommunity_FlowSpecRedirectToIpv4 struct {
+	FlowSpecRedirectToIpv4 *FlowSpecRedirectToIPv4Extended `protobuf:"bytes,28,opt,name=flow_spec_redirect_to_ipv4,json=flowSpecRedirectToIpv4,proto3,oneof"` // The IPv6 form lives in IP6ExtendedCommunitiesAttribute.
+}
+
 func (*ExtendedCommunity_Unknown) isExtendedCommunity_Extcom() {}
 
 func (*ExtendedCommunity_TwoOctetAsSpecific) isExtendedCommunity_Extcom() {}
@@ -1847,6 +1967,8 @@ func (*ExtendedCommunity_MupIpv4AddressSpecific) isExtendedCommunity_Extcom() {}
 
 func (*ExtendedCommunity_MupFourOctetAsSpecific) isExtendedCommunity_Extcom() {}
 
+func (*ExtendedCommunity_FlowSpecRedirectToIpv4) isExtendedCommunity_Extcom() {}
+
 type RouteTarget struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Rt:
@@ -1861,7 +1983,7 @@ type RouteTarget struct {
 
 func (x *RouteTarget) Reset() {
 	*x = RouteTarget{}
-	mi := &file_api_extcom_proto_msgTypes[27]
+	mi := &file_api_extcom_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1873,7 +1995,7 @@ func (x *RouteTarget) String() string {
 func (*RouteTarget) ProtoMessage() {}
 
 func (x *RouteTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_api_extcom_proto_msgTypes[27]
+	mi := &file_api_extcom_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1886,7 +2008,7 @@ func (x *RouteTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteTarget.ProtoReflect.Descriptor instead.
 func (*RouteTarget) Descriptor() ([]byte, []int) {
-	return file_api_extcom_proto_rawDescGZIP(), []int{27}
+	return file_api_extcom_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *RouteTarget) GetRt() isRouteTarget_Rt {
@@ -2005,7 +2127,13 @@ const file_api_extcom_proto_rawDesc = "" +
 	"#RedirectIPv4AddressSpecificExtended\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x1f\n" +
 	"\vlocal_admin\x18\x02 \x01(\rR\n" +
-	"localAdmin\"X\n" +
+	"localAdmin\"N\n" +
+	"\x1eFlowSpecRedirectToIPv4Extended\x12\x18\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x12\n" +
+	"\x04copy\x18\x02 \x01(\bR\x04copy\"N\n" +
+	"\x1eFlowSpecRedirectToIPv6Extended\x12\x18\n" +
+	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x12\n" +
+	"\x04copy\x18\x02 \x01(\bR\x04copy\"X\n" +
 	"#RedirectFourOctetAsSpecificExtended\x12\x10\n" +
 	"\x03asn\x18\x01 \x01(\rR\x03asn\x12\x1f\n" +
 	"\vlocal_admin\x18\x02 \x01(\rR\n" +
@@ -2039,7 +2167,7 @@ const file_api_extcom_proto_rawDesc = "" +
 	"isMldProxy\";\n" +
 	"\x0fUnknownExtended\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\rR\x04type\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value\"\xf4\x0e\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value\"\xd7\x0f\n" +
 	"\x11ExtendedCommunity\x120\n" +
 	"\aunknown\x18\x01 \x01(\v2\x14.api.UnknownExtendedH\x00R\aunknown\x12T\n" +
 	"\x15two_octet_as_specific\x18\x02 \x01(\v2\x1f.api.TwoOctetAsSpecificExtendedH\x00R\x12twoOctetAsSpecific\x12V\n" +
@@ -2070,7 +2198,8 @@ const file_api_extcom_proto_rawDesc = "" +
 	"\x0fmulticast_flags\x18\x18 \x01(\v2\x1b.api.MulticastFlagsExtendedH\x00R\x0emulticastFlags\x12^\n" +
 	"\x19mup_two_octet_as_specific\x18\x19 \x01(\v2\".api.MUPTwoOctetAsSpecificExtendedH\x00R\x15mupTwoOctetAsSpecific\x12`\n" +
 	"\x19mup_ipv4_address_specific\x18\x1a \x01(\v2#.api.MUPIPv4AddressSpecificExtendedH\x00R\x16mupIpv4AddressSpecific\x12a\n" +
-	"\x1amup_four_octet_as_specific\x18\x1b \x01(\v2#.api.MUPFourOctetAsSpecificExtendedH\x00R\x16mupFourOctetAsSpecificB\b\n" +
+	"\x1amup_four_octet_as_specific\x18\x1b \x01(\v2#.api.MUPFourOctetAsSpecificExtendedH\x00R\x16mupFourOctetAsSpecific\x12a\n" +
+	"\x1aflow_spec_redirect_to_ipv4\x18\x1c \x01(\v2#.api.FlowSpecRedirectToIPv4ExtendedH\x00R\x16flowSpecRedirectToIpv4B\b\n" +
 	"\x06extcomJ\x04\b\x15\x10\x16R\x03mup\"\x9a\x02\n" +
 	"\vRouteTarget\x12T\n" +
 	"\x15two_octet_as_specific\x18\x01 \x01(\v2\x1f.api.TwoOctetAsSpecificExtendedH\x00R\x12twoOctetAsSpecific\x12V\n" +
@@ -2090,7 +2219,7 @@ func file_api_extcom_proto_rawDescGZIP() []byte {
 	return file_api_extcom_proto_rawDescData
 }
 
-var file_api_extcom_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_api_extcom_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_api_extcom_proto_goTypes = []any{
 	(*TwoOctetAsSpecificExtended)(nil),          // 0: api.TwoOctetAsSpecificExtended
 	(*IPv4AddressSpecificExtended)(nil),         // 1: api.IPv4AddressSpecificExtended
@@ -2109,20 +2238,22 @@ var file_api_extcom_proto_goTypes = []any{
 	(*TrafficActionExtended)(nil),               // 14: api.TrafficActionExtended
 	(*RedirectTwoOctetAsSpecificExtended)(nil),  // 15: api.RedirectTwoOctetAsSpecificExtended
 	(*RedirectIPv4AddressSpecificExtended)(nil), // 16: api.RedirectIPv4AddressSpecificExtended
-	(*RedirectFourOctetAsSpecificExtended)(nil), // 17: api.RedirectFourOctetAsSpecificExtended
-	(*TrafficRemarkExtended)(nil),               // 18: api.TrafficRemarkExtended
-	(*MUPTwoOctetAsSpecificExtended)(nil),       // 19: api.MUPTwoOctetAsSpecificExtended
-	(*MUPIPv4AddressSpecificExtended)(nil),      // 20: api.MUPIPv4AddressSpecificExtended
-	(*MUPFourOctetAsSpecificExtended)(nil),      // 21: api.MUPFourOctetAsSpecificExtended
-	(*VPLSExtended)(nil),                        // 22: api.VPLSExtended
-	(*ETreeExtended)(nil),                       // 23: api.ETreeExtended
-	(*MulticastFlagsExtended)(nil),              // 24: api.MulticastFlagsExtended
-	(*UnknownExtended)(nil),                     // 25: api.UnknownExtended
-	(*ExtendedCommunity)(nil),                   // 26: api.ExtendedCommunity
-	(*RouteTarget)(nil),                         // 27: api.RouteTarget
+	(*FlowSpecRedirectToIPv4Extended)(nil),      // 17: api.FlowSpecRedirectToIPv4Extended
+	(*FlowSpecRedirectToIPv6Extended)(nil),      // 18: api.FlowSpecRedirectToIPv6Extended
+	(*RedirectFourOctetAsSpecificExtended)(nil), // 19: api.RedirectFourOctetAsSpecificExtended
+	(*TrafficRemarkExtended)(nil),               // 20: api.TrafficRemarkExtended
+	(*MUPTwoOctetAsSpecificExtended)(nil),       // 21: api.MUPTwoOctetAsSpecificExtended
+	(*MUPIPv4AddressSpecificExtended)(nil),      // 22: api.MUPIPv4AddressSpecificExtended
+	(*MUPFourOctetAsSpecificExtended)(nil),      // 23: api.MUPFourOctetAsSpecificExtended
+	(*VPLSExtended)(nil),                        // 24: api.VPLSExtended
+	(*ETreeExtended)(nil),                       // 25: api.ETreeExtended
+	(*MulticastFlagsExtended)(nil),              // 26: api.MulticastFlagsExtended
+	(*UnknownExtended)(nil),                     // 27: api.UnknownExtended
+	(*ExtendedCommunity)(nil),                   // 28: api.ExtendedCommunity
+	(*RouteTarget)(nil),                         // 29: api.RouteTarget
 }
 var file_api_extcom_proto_depIdxs = []int32{
-	25, // 0: api.ExtendedCommunity.unknown:type_name -> api.UnknownExtended
+	27, // 0: api.ExtendedCommunity.unknown:type_name -> api.UnknownExtended
 	0,  // 1: api.ExtendedCommunity.two_octet_as_specific:type_name -> api.TwoOctetAsSpecificExtended
 	1,  // 2: api.ExtendedCommunity.ipv4_address_specific:type_name -> api.IPv4AddressSpecificExtended
 	2,  // 3: api.ExtendedCommunity.four_octet_as_specific:type_name -> api.FourOctetAsSpecificExtended
@@ -2140,22 +2271,23 @@ var file_api_extcom_proto_depIdxs = []int32{
 	14, // 15: api.ExtendedCommunity.traffic_action:type_name -> api.TrafficActionExtended
 	15, // 16: api.ExtendedCommunity.redirect_two_octet_as_specific:type_name -> api.RedirectTwoOctetAsSpecificExtended
 	16, // 17: api.ExtendedCommunity.redirect_ipv4_address_specific:type_name -> api.RedirectIPv4AddressSpecificExtended
-	17, // 18: api.ExtendedCommunity.redirect_four_octet_as_specific:type_name -> api.RedirectFourOctetAsSpecificExtended
-	18, // 19: api.ExtendedCommunity.traffic_remark:type_name -> api.TrafficRemarkExtended
-	22, // 20: api.ExtendedCommunity.vpls:type_name -> api.VPLSExtended
-	23, // 21: api.ExtendedCommunity.etree:type_name -> api.ETreeExtended
-	24, // 22: api.ExtendedCommunity.multicast_flags:type_name -> api.MulticastFlagsExtended
-	19, // 23: api.ExtendedCommunity.mup_two_octet_as_specific:type_name -> api.MUPTwoOctetAsSpecificExtended
-	20, // 24: api.ExtendedCommunity.mup_ipv4_address_specific:type_name -> api.MUPIPv4AddressSpecificExtended
-	21, // 25: api.ExtendedCommunity.mup_four_octet_as_specific:type_name -> api.MUPFourOctetAsSpecificExtended
-	0,  // 26: api.RouteTarget.two_octet_as_specific:type_name -> api.TwoOctetAsSpecificExtended
-	1,  // 27: api.RouteTarget.ipv4_address_specific:type_name -> api.IPv4AddressSpecificExtended
-	2,  // 28: api.RouteTarget.four_octet_as_specific:type_name -> api.FourOctetAsSpecificExtended
-	29, // [29:29] is the sub-list for method output_type
-	29, // [29:29] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	19, // 18: api.ExtendedCommunity.redirect_four_octet_as_specific:type_name -> api.RedirectFourOctetAsSpecificExtended
+	20, // 19: api.ExtendedCommunity.traffic_remark:type_name -> api.TrafficRemarkExtended
+	24, // 20: api.ExtendedCommunity.vpls:type_name -> api.VPLSExtended
+	25, // 21: api.ExtendedCommunity.etree:type_name -> api.ETreeExtended
+	26, // 22: api.ExtendedCommunity.multicast_flags:type_name -> api.MulticastFlagsExtended
+	21, // 23: api.ExtendedCommunity.mup_two_octet_as_specific:type_name -> api.MUPTwoOctetAsSpecificExtended
+	22, // 24: api.ExtendedCommunity.mup_ipv4_address_specific:type_name -> api.MUPIPv4AddressSpecificExtended
+	23, // 25: api.ExtendedCommunity.mup_four_octet_as_specific:type_name -> api.MUPFourOctetAsSpecificExtended
+	17, // 26: api.ExtendedCommunity.flow_spec_redirect_to_ipv4:type_name -> api.FlowSpecRedirectToIPv4Extended
+	0,  // 27: api.RouteTarget.two_octet_as_specific:type_name -> api.TwoOctetAsSpecificExtended
+	1,  // 28: api.RouteTarget.ipv4_address_specific:type_name -> api.IPv4AddressSpecificExtended
+	2,  // 29: api.RouteTarget.four_octet_as_specific:type_name -> api.FourOctetAsSpecificExtended
+	30, // [30:30] is the sub-list for method output_type
+	30, // [30:30] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_api_extcom_proto_init() }
@@ -2163,7 +2295,7 @@ func file_api_extcom_proto_init() {
 	if File_api_extcom_proto != nil {
 		return
 	}
-	file_api_extcom_proto_msgTypes[26].OneofWrappers = []any{
+	file_api_extcom_proto_msgTypes[28].OneofWrappers = []any{
 		(*ExtendedCommunity_Unknown)(nil),
 		(*ExtendedCommunity_TwoOctetAsSpecific)(nil),
 		(*ExtendedCommunity_Ipv4AddressSpecific)(nil),
@@ -2190,8 +2322,9 @@ func file_api_extcom_proto_init() {
 		(*ExtendedCommunity_MupTwoOctetAsSpecific)(nil),
 		(*ExtendedCommunity_MupIpv4AddressSpecific)(nil),
 		(*ExtendedCommunity_MupFourOctetAsSpecific)(nil),
+		(*ExtendedCommunity_FlowSpecRedirectToIpv4)(nil),
 	}
-	file_api_extcom_proto_msgTypes[27].OneofWrappers = []any{
+	file_api_extcom_proto_msgTypes[29].OneofWrappers = []any{
 		(*RouteTarget_TwoOctetAsSpecific)(nil),
 		(*RouteTarget_Ipv4AddressSpecific)(nil),
 		(*RouteTarget_FourOctetAsSpecific)(nil),
@@ -2202,7 +2335,7 @@ func file_api_extcom_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_extcom_proto_rawDesc), len(file_api_extcom_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   28,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -59,6 +59,7 @@ const (
 	ctColor
 	ctLb
 	ctMup
+	ctRedirectIP
 )
 
 var extCommNameMap = map[extCommType]string{
@@ -66,6 +67,7 @@ var extCommNameMap = map[extCommType]string{
 	ctDiscard:        "discard",
 	ctRate:           "rate-limit",
 	ctRedirect:       "redirect",
+	ctRedirectIP:     "redirect-to-ip",
 	ctMark:           "mark",
 	ctAction:         "action",
 	ctRT:             "rt",
@@ -88,6 +90,7 @@ var extCommValueMap = map[string]extCommType{
 	extCommNameMap[ctDiscard]:        ctDiscard,
 	extCommNameMap[ctRate]:           ctRate,
 	extCommNameMap[ctRedirect]:       ctRedirect,
+	extCommNameMap[ctRedirectIP]:     ctRedirectIP,
 	extCommNameMap[ctMark]:           ctMark,
 	extCommNameMap[ctAction]:         ctAction,
 	extCommNameMap[ctRT]:             ctRT,
@@ -151,6 +154,42 @@ func redirectParser(args []string) ([]bgp.ExtendedCommunityInterface, error) {
 		return []bgp.ExtendedCommunityInterface{ex}, nil
 	}
 	return nil, fmt.Errorf("invalid redirect")
+}
+
+// redirectIPParser parses "redirect-to-ip <address> [copy]". Unlike
+// redirectParser, the argument is a forwarding target, not a route target.
+func redirectIPParser(args []string) ([]bgp.ExtendedCommunityInterface, error) {
+	if len(args) < 2 || args[0] != extCommNameMap[ctRedirectIP] {
+		return nil, fmt.Errorf("invalid redirect-to-ip")
+	}
+	isCopy := false
+	switch len(args) {
+	case 2:
+	case 3:
+		if args[2] != "copy" {
+			return nil, fmt.Errorf("invalid redirect-to-ip: unexpected %q, want \"copy\"", args[2])
+		}
+		isCopy = true
+	default:
+		return nil, fmt.Errorf("invalid redirect-to-ip: want <address> [copy]")
+	}
+	addr, err := netip.ParseAddr(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid redirect-to-ip target %q: %w", args[1], err)
+	}
+	addr = addr.Unmap()
+	if addr.Is4() {
+		ext, err := bgp.NewFlowSpecRedirectToIPv4Extended(addr, isCopy)
+		if err != nil {
+			return nil, err
+		}
+		return []bgp.ExtendedCommunityInterface{ext}, nil
+	}
+	ext, err := bgp.NewFlowSpecRedirectToIPv6Extended(addr, isCopy)
+	if err != nil {
+		return nil, err
+	}
+	return []bgp.ExtendedCommunityInterface{ext}, nil
 }
 
 func markParser(args []string) ([]bgp.ExtendedCommunityInterface, error) {
@@ -469,6 +508,7 @@ var extCommParserMap = map[extCommType]func([]string) ([]bgp.ExtendedCommunityIn
 	ctDiscard:        rateLimitParser,
 	ctRate:           rateLimitParser,
 	ctRedirect:       redirectParser,
+	ctRedirectIP:     redirectIPParser,
 	ctMark:           markParser,
 	ctAction:         actionParser,
 	ctRT:             rtParser,
@@ -3232,7 +3272,7 @@ func parsePath(rf bgp.Family, args []string) (*api.Path, error) {
 		ipv6extcomms := make([]bgp.ExtendedCommunityInterface, 0)
 		for _, com := range extcomms {
 			switch com.(type) {
-			case *bgp.RedirectIPv6AddressSpecificExtended:
+			case *bgp.RedirectIPv6AddressSpecificExtended, *bgp.FlowSpecRedirectToIPv6Extended:
 				ipv6extcomms = append(ipv6extcomms, com)
 			default:
 				normalextcomms = append(normalextcomms, com)
@@ -3320,6 +3360,7 @@ usage: %s rib -a %%s %s%%s match <MATCH> then <THEN>%%s%%s%%s
                %s |
                %s <RATE> [as <AS>] |
                %s <RT> [color <color>] [prefix <prefix>] [locator-node-length <length>] [function-length <length>] [behavior <behavior>] |
+               %s <ADDRESS> [copy] |
                %s <DEC_NUM> |
                %s { sample | terminal | sample-terminal } }...
     <RT> : xxx:yyy, xxx.xxx.xxx.xxx:yyy, xxxx::xxxx:yyy, xxx.xxx:yyy`,
@@ -3335,6 +3376,7 @@ usage: %s rib -a %%s %s%%s match <MATCH> then <THEN>%%s%%s%%s
 			extCommNameMap[ctDiscard],
 			extCommNameMap[ctRate],
 			extCommNameMap[ctRedirect],
+			extCommNameMap[ctRedirectIP],
 			extCommNameMap[ctMark],
 			extCommNameMap[ctAction],
 		)

--- a/cmd/gobgp/global_test.go
+++ b/cmd/gobgp/global_test.go
@@ -305,3 +305,51 @@ func Test_ParseRtcArgs(t *testing.T) {
 		})
 	}
 }
+
+func Test_ParseFlowSpecRedirectToIP(t *testing.T) {
+	assert := assert.New(t)
+
+	for _, tc := range []struct {
+		name string
+		args string
+		copy bool
+		want string
+	}{
+		{"IPv4", "redirect-to-ip 198.51.100.11", false, "redirect-to-ip: 198.51.100.11"},
+		{"IPv4 copy", "redirect-to-ip 198.51.100.11 copy", true, "copy-to-ip: 198.51.100.11"},
+		{"IPv6", "redirect-to-ip 2001:db8:1::1", false, "redirect-to-ip: 2001:db8:1::1"},
+		{"IPv6 copy", "redirect-to-ip 2001:db8:1::1 copy", true, "copy-to-ip: 2001:db8:1::1"},
+		{"IPv4-mapped is an IPv4 target", "redirect-to-ip ::ffff:198.51.100.11", false, "redirect-to-ip: 198.51.100.11"},
+	} {
+		exts, err := parseExtendedCommunities(strings.Split(tc.args, " "))
+		assert.NoError(err, tc.name)
+		assert.Len(exts, 1, tc.name)
+		switch e := exts[0].(type) {
+		case *bgp.FlowSpecRedirectToIPv4Extended:
+			assert.Equal(tc.copy, e.IsCopy(), tc.name)
+			assert.Equal(tc.want, e.String(), tc.name)
+		case *bgp.FlowSpecRedirectToIPv6Extended:
+			assert.Equal(tc.copy, e.IsCopy(), tc.name)
+			assert.Equal(tc.want, e.String(), tc.name)
+		default:
+			assert.Fail("unexpected type", "%s: %T", tc.name, exts[0])
+		}
+	}
+
+	for _, bad := range []string{
+		"redirect-to-ip",
+		"redirect-to-ip not-an-address",
+		"redirect-to-ip 198.51.100.11 mirror",
+		"redirect-to-ip 198.51.100.11 copy extra",
+	} {
+		_, err := parseExtendedCommunities(strings.Split(bad, " "))
+		assert.Error(err, bad)
+	}
+
+	// "redirect" must keep meaning rt-redirect.
+	exts, err := parseExtendedCommunities(strings.Split("redirect 10.0.0.1:100", " "))
+	assert.NoError(err)
+	assert.Len(exts, 1)
+	_, isNew := exts[0].(*bgp.FlowSpecRedirectToIPv4Extended)
+	assert.False(isNew, "plain redirect must not produce the redirect-to-ip action")
+}

--- a/docs/sources/flowspec.md
+++ b/docs/sources/flowspec.md
@@ -505,7 +505,7 @@ $ gobgp global rib -a ipv4-flowspec
 #### Example - redirect-to-ip
 
 `redirect-to-ip` is not the same action as `redirect`.
-`redirect` carries a route target and selects a VRF (rt-redirect, RFC 7674), while `redirect-to-ip` carries the address the matching traffic is forwarded toward.
+`redirect` carries a route target and selects a VRF (redirect-to-VRF, RFC 8955 section 7.4), while `redirect-to-ip` carries the address the matching traffic is forwarded toward.
 It is defined in [draft-ietf-idr-flowspec-redirect-ip-16](https://datatracker.ietf.org/doc/html/draft-ietf-idr-flowspec-redirect-ip-16), which this implementation follows, as type 0x01 sub-type 0x0c for IPv4 and type 0x000c for IPv6.
 The code points are IANA-assigned; the draft is in the RFC Editor queue.
 The trailing `copy` is optional and sets the C bit, which mirrors the matching traffic to the target instead of diverting it.

--- a/docs/sources/flowspec.md
+++ b/docs/sources/flowspec.md
@@ -417,6 +417,7 @@ $ gobgp global rib -a l2vpn-flowspec
 | 0x8007 | action terminal                | Specify the termination of the traffic filter.                           |
 | 0x8007 | action sample-terminal         | Specify both of sample and terminal.                                     |
 | 0x8008 | redirect \<RT>                 | Redirect to VRF which has the given RT in its import policy.             |
+| 0x010c / 0x000c | redirect-to-ip \<ADDRESS> \[copy] | Redirect the traffic to the given address; `copy` mirrors it instead. The first code is the IPv4 form, the second the IPv6 form. |
 | 0x8009 | mark \<VALUE>                  | Modifies the DSCP in IPv4 or Traffic Class in IPv6 with the given value. |
 
 #### Example - accept/discard
@@ -500,6 +501,37 @@ $ gobgp global rib -a ipv4-flowspec
    Network                    Next Hop             AS_PATH              Age        Attrs
 *> [destination: 10.0.0.0/24] fictitious                                00:00:00   [{Origin: ?} {Extcomms: [redirect: 200.200:100]}]
 ```
+
+#### Example - redirect-to-ip
+
+`redirect-to-ip` is not the same action as `redirect`.
+`redirect` carries a route target and selects a VRF (rt-redirect, RFC 7674), while `redirect-to-ip` carries the address the matching traffic is forwarded toward.
+It is defined in [draft-ietf-idr-flowspec-redirect-ip-16](https://datatracker.ietf.org/doc/html/draft-ietf-idr-flowspec-redirect-ip-16), which this implementation follows, as type 0x01 sub-type 0x0c for IPv4 and type 0x000c for IPv6.
+The code points are IANA-assigned; the draft is in the RFC Editor queue.
+The trailing `copy` is optional and sets the C bit, which mirrors the matching traffic to the target instead of diverting it.
+
+```bash
+# redirect flows destined to 192.0.2.1:61001 to 198.51.100.11
+$ gobgp global rib -a ipv4-flowspec add match destination 192.0.2.1/32 destination-port '==61001' then redirect-to-ip 198.51.100.11
+$ gobgp global rib -a ipv4-flowspec
+   Network                                                Next Hop             AS_PATH              Age        Attrs
+*> [destination: 192.0.2.1/32][destination-port: ==61001] fictitious                                00:00:00   [{Origin: ?} {Extcomms: [redirect-to-ip: 198.51.100.11]}]
+
+# mirror (copy) instead of divert
+$ gobgp global rib -a ipv4-flowspec add match destination 192.0.2.1/32 destination-port '==61002' then redirect-to-ip 198.51.100.99 copy
+$ gobgp global rib -a ipv4-flowspec
+   Network                                                Next Hop             AS_PATH              Age        Attrs
+*> [destination: 192.0.2.1/32][destination-port: ==61002] fictitious                                00:00:00   [{Origin: ?} {Extcomms: [copy-to-ip: 198.51.100.99]}]
+
+# IPv6 form
+$ gobgp global rib -a ipv6-flowspec add match destination 2001:db8:1::/64 then redirect-to-ip 2001:db8:2::1
+$ gobgp global rib -a ipv6-flowspec
+   Network                          Next Hop             AS_PATH              Age        Attrs
+*> [destination: 2001:db8:1::/64/0] fictitious                                00:00:00   [{Origin: ?} {Extcomms: [redirect-to-ip: 2001:db8:2::1]}]
+```
+
+A receiver given several redirect-to-IP targets for one flow load-shares across them, following its ECMP configuration.
+Advertise exactly one `redirect-to-ip` community per flow-spec NLRI where every matching packet has to reach the same target, such as per-flow steering to one server.
 
 #### Example - mark
 

--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -248,6 +248,16 @@ func UnmarshalAttribute(attr *api.Attribute) (bgp.PathAttributeInterface, error)
 					return nil, fmt.Errorf("invalid ipv6 address: %s", v.Address)
 				}
 				community, _ = bgp.NewRedirectIPv6AddressSpecificExtended(addr, uint16(v.LocalAdmin))
+			case *api.IP6ExtendedCommunitiesAttribute_Community_FlowSpecRedirectToIpv6:
+				v := an.GetFlowSpecRedirectToIpv6()
+				addr, err := netip.ParseAddr(v.Address)
+				if err != nil {
+					return nil, fmt.Errorf("invalid redirect-to-ipv6 address: %s", v.Address)
+				}
+				community, err = bgp.NewFlowSpecRedirectToIPv6Extended(addr, v.Copy)
+				if err != nil {
+					return nil, err
+				}
 			}
 			if community == nil {
 				return nil, fmt.Errorf("invalid ipv6 extended community: %T", an.GetExtcom())
@@ -2483,6 +2493,13 @@ func NewExtendedCommunitiesAttributeFromNative(a *bgp.PathAttributeExtendedCommu
 					LocalAdmin: uint32(v.LocalAdmin),
 				},
 			}
+		case *bgp.FlowSpecRedirectToIPv4Extended:
+			community.Extcom = &api.ExtendedCommunity_FlowSpecRedirectToIpv4{
+				FlowSpecRedirectToIpv4: &api.FlowSpecRedirectToIPv4Extended{
+					Address: v.Target.String(),
+					Copy:    v.Copy,
+				},
+			}
 		case *bgp.RedirectFourOctetAsSpecificExtended:
 			community.Extcom = &api.ExtendedCommunity_RedirectFourOctetAsSpecific{
 				RedirectFourOctetAsSpecific: &api.RedirectFourOctetAsSpecificExtended{
@@ -2621,6 +2638,16 @@ func unmarshalExComm(a *api.ExtendedCommunitiesAttribute) (*bgp.PathAttributeExt
 				return nil, fmt.Errorf("invalid address: %s", v.Address)
 			}
 			community, _ = bgp.NewRedirectIPv4AddressSpecificExtended(addr, uint16(v.LocalAdmin))
+		case *api.ExtendedCommunity_FlowSpecRedirectToIpv4:
+			v := comm.FlowSpecRedirectToIpv4
+			addr, err := netip.ParseAddr(v.Address)
+			if err != nil {
+				return nil, fmt.Errorf("invalid redirect-to-ipv4 address: %s", v.Address)
+			}
+			community, err = bgp.NewFlowSpecRedirectToIPv4Extended(addr, v.Copy)
+			if err != nil {
+				return nil, err
+			}
 		case *api.ExtendedCommunity_RedirectFourOctetAsSpecific:
 			v := comm.RedirectFourOctetAsSpecific
 			community = bgp.NewRedirectFourOctetAsSpecificExtended(v.Asn, uint16(v.LocalAdmin))
@@ -2841,6 +2868,13 @@ func NewIP6ExtendedCommunitiesAttributeFromNative(a *bgp.PathAttributeIP6Extende
 				RedirectIpv6AddressSpecific: &api.RedirectIPv6AddressSpecificExtended{
 					Address:    v.IPv6.String(),
 					LocalAdmin: uint32(v.LocalAdmin),
+				},
+			}
+		case *bgp.FlowSpecRedirectToIPv6Extended:
+			community.Extcom = &api.IP6ExtendedCommunitiesAttribute_Community_FlowSpecRedirectToIpv6{
+				FlowSpecRedirectToIpv6: &api.FlowSpecRedirectToIPv6Extended{
+					Address: v.Target.String(),
+					Copy:    v.Copy,
 				},
 			}
 		default:

--- a/pkg/apiutil/attribute_test.go
+++ b/pkg/apiutil/attribute_test.go
@@ -2435,3 +2435,49 @@ func Test_LsNodeNLRIWithoutBgpRouterIDRoundTrip(t *testing.T) {
 	_, err = UnmarshalNLRI(bgp.RF_LS, marshalled)
 	assert.NoError(t, err)
 }
+
+func Test_ExtendedCommunitiesAttribute_FlowSpecRedirectToIP(t *testing.T) {
+	assert := assert.New(t)
+
+	for _, isCopy := range []bool{false, true} {
+		input := &api.ExtendedCommunitiesAttribute{
+			Communities: []*api.ExtendedCommunity{
+				{Extcom: &api.ExtendedCommunity_FlowSpecRedirectToIpv4{FlowSpecRedirectToIpv4: &api.FlowSpecRedirectToIPv4Extended{
+					Address: "198.51.100.11",
+					Copy:    isCopy,
+				}}},
+			},
+		}
+
+		a := &api.Attribute{Attr: &api.Attribute_ExtendedCommunities{ExtendedCommunities: input}}
+		n, err := UnmarshalAttribute(a)
+		assert.NoError(err)
+
+		output, err := NewExtendedCommunitiesAttributeFromNative(n.(*bgp.PathAttributeExtendedCommunities))
+		assert.NoError(err)
+		assert.True(proto.Equal(input, output))
+	}
+}
+
+func Test_IP6ExtendedCommunitiesAttribute_FlowSpecRedirectToIP(t *testing.T) {
+	assert := assert.New(t)
+
+	for _, isCopy := range []bool{false, true} {
+		input := &api.IP6ExtendedCommunitiesAttribute{
+			Communities: []*api.IP6ExtendedCommunitiesAttribute_Community{
+				{Extcom: &api.IP6ExtendedCommunitiesAttribute_Community_FlowSpecRedirectToIpv6{FlowSpecRedirectToIpv6: &api.FlowSpecRedirectToIPv6Extended{
+					Address: "2001:db8::1",
+					Copy:    isCopy,
+				}}},
+			},
+		}
+
+		a := &api.Attribute{Attr: &api.Attribute_Ip6ExtendedCommunities{Ip6ExtendedCommunities: input}}
+		n, err := UnmarshalAttribute(a)
+		assert.NoError(err)
+
+		output, err := NewIP6ExtendedCommunitiesAttributeFromNative(n.(*bgp.PathAttributeIP6ExtendedCommunities))
+		assert.NoError(err)
+		assert.True(proto.Equal(input, output))
+	}
+}

--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -233,6 +233,8 @@ const (
 	EC_SUBTYPE_L2_INFO                 ExtendedCommunityAttrSubType = 0x0A // EC_TYPE: 0x80
 	EC_SUBTYPE_FLOWSPEC_REDIRECT_IP6   ExtendedCommunityAttrSubType = 0x0B // EC_TYPE: 0x80
 
+	EC_SUBTYPE_FLOWSPEC_REDIRECT_IP ExtendedCommunityAttrSubType = 0x0C // EC_TYPE: 0x01 (IPv4), 0x00 (IPv6)
+
 	EC_SUBTYPE_MAC_MOBILITY    ExtendedCommunityAttrSubType = 0x00 // EC_TYPE: 0x06
 	EC_SUBTYPE_ESI_LABEL       ExtendedCommunityAttrSubType = 0x01 // EC_TYPE: 0x06
 	EC_SUBTYPE_ES_IMPORT       ExtendedCommunityAttrSubType = 0x02 // EC_TYPE: 0x06
@@ -14589,6 +14591,124 @@ func NewRedirectIPv4AddressSpecificExtended(ipv4 netip.Addr, localAdmin uint16) 
 	return &RedirectIPv4AddressSpecificExtended{*e}, nil
 }
 
+// FlowSpecRedirectToIPv4Extended is the redirect-to-IPv4 action of
+// draft-ietf-idr-flowspec-redirect-ip-16. Unlike the Redirect* types,
+// which carry a route target (redirect-to-VRF, RFC 8955 section 7.4),
+// the value is a forwarding target. Copy is the C bit.
+type FlowSpecRedirectToIPv4Extended struct {
+	Target netip.Addr
+	Copy   bool
+}
+
+const flowSpecRedirectToIPCopyBit uint16 = 0x0001
+
+func flowSpecRedirectLocalAdmin(isCopy bool) uint16 {
+	if isCopy {
+		return flowSpecRedirectToIPCopyBit
+	}
+	return 0
+}
+
+func (e *FlowSpecRedirectToIPv4Extended) Serialize() ([]byte, error) {
+	if !e.Target.Is4() {
+		return nil, fmt.Errorf("redirect-to-ipv4 target must be an IPv4 address: %s", e.Target)
+	}
+	buf := make([]byte, 8)
+	buf[0] = byte(EC_TYPE_TRANSITIVE_IP4_SPECIFIC)
+	buf[1] = byte(EC_SUBTYPE_FLOWSPEC_REDIRECT_IP)
+	copy(buf[2:6], e.Target.AsSlice())
+	binary.BigEndian.PutUint16(buf[6:8], flowSpecRedirectLocalAdmin(e.Copy))
+	return buf, nil
+}
+
+func (e *FlowSpecRedirectToIPv4Extended) IsCopy() bool { return e.Copy }
+
+func (e *FlowSpecRedirectToIPv4Extended) String() string {
+	if e.Copy {
+		return "copy-to-ip: " + e.Target.String()
+	}
+	return "redirect-to-ip: " + e.Target.String()
+}
+
+func (e *FlowSpecRedirectToIPv4Extended) MarshalJSON() ([]byte, error) {
+	t, s := e.GetTypes()
+	return json.Marshal(struct {
+		Type    ExtendedCommunityAttrType    `json:"type"`
+		Subtype ExtendedCommunityAttrSubType `json:"subtype"`
+		Target  string                       `json:"target"`
+		Copy    bool                         `json:"copy"`
+	}{t, s, e.Target.String(), e.Copy})
+}
+
+func (e *FlowSpecRedirectToIPv4Extended) GetTypes() (ExtendedCommunityAttrType, ExtendedCommunityAttrSubType) {
+	return EC_TYPE_TRANSITIVE_IP4_SPECIFIC, EC_SUBTYPE_FLOWSPEC_REDIRECT_IP
+}
+
+func (e *FlowSpecRedirectToIPv4Extended) Flat() map[string]string {
+	return map[string]string{}
+}
+
+func NewFlowSpecRedirectToIPv4Extended(target netip.Addr, isCopy bool) (*FlowSpecRedirectToIPv4Extended, error) {
+	if !target.Is4() {
+		return nil, fmt.Errorf("redirect-to-ipv4 target must be an IPv4 address: %s", target)
+	}
+	return &FlowSpecRedirectToIPv4Extended{Target: target, Copy: isCopy}, nil
+}
+
+// FlowSpecRedirectToIPv6Extended is the IPv6 counterpart, carried in an
+// RFC 5701 IPv6 address-specific community.
+type FlowSpecRedirectToIPv6Extended struct {
+	Target netip.Addr
+	Copy   bool
+}
+
+func (e *FlowSpecRedirectToIPv6Extended) Serialize() ([]byte, error) {
+	// Is6 admits the IPv4-mapped form, which the decoder can produce.
+	if !e.Target.Is6() {
+		return nil, fmt.Errorf("redirect-to-ipv6 target must be an IPv6 address: %s", e.Target)
+	}
+	buf := make([]byte, 20)
+	buf[0] = byte(EC_TYPE_TRANSITIVE_IP6_SPECIFIC)
+	buf[1] = byte(EC_SUBTYPE_FLOWSPEC_REDIRECT_IP)
+	copy(buf[2:18], e.Target.AsSlice())
+	binary.BigEndian.PutUint16(buf[18:20], flowSpecRedirectLocalAdmin(e.Copy))
+	return buf, nil
+}
+
+func (e *FlowSpecRedirectToIPv6Extended) IsCopy() bool { return e.Copy }
+
+func (e *FlowSpecRedirectToIPv6Extended) String() string {
+	if e.Copy {
+		return "copy-to-ip: " + e.Target.String()
+	}
+	return "redirect-to-ip: " + e.Target.String()
+}
+
+func (e *FlowSpecRedirectToIPv6Extended) MarshalJSON() ([]byte, error) {
+	t, s := e.GetTypes()
+	return json.Marshal(struct {
+		Type    ExtendedCommunityAttrType    `json:"type"`
+		Subtype ExtendedCommunityAttrSubType `json:"subtype"`
+		Target  string                       `json:"target"`
+		Copy    bool                         `json:"copy"`
+	}{t, s, e.Target.String(), e.Copy})
+}
+
+func (e *FlowSpecRedirectToIPv6Extended) GetTypes() (ExtendedCommunityAttrType, ExtendedCommunityAttrSubType) {
+	return EC_TYPE_TRANSITIVE_IP6_SPECIFIC, EC_SUBTYPE_FLOWSPEC_REDIRECT_IP
+}
+
+func (e *FlowSpecRedirectToIPv6Extended) Flat() map[string]string {
+	return map[string]string{}
+}
+
+func NewFlowSpecRedirectToIPv6Extended(target netip.Addr, isCopy bool) (*FlowSpecRedirectToIPv6Extended, error) {
+	if !target.Is6() {
+		return nil, fmt.Errorf("redirect-to-ipv6 target must be an IPv6 address: %s", target)
+	}
+	return &FlowSpecRedirectToIPv6Extended{Target: target, Copy: isCopy}, nil
+}
+
 type RedirectIPv6AddressSpecificExtended struct {
 	IPv6AddressSpecificExtended
 }
@@ -14899,6 +15019,15 @@ func ParseExtended(data []byte) (ExtendedCommunityInterface, error) {
 			return NewTwoOctetAsSpecificExtended(subtype, as, localAdmin, transitive), nil
 		}
 	case EC_TYPE_TRANSITIVE_IP4_SPECIFIC:
+		if subtype == EC_SUBTYPE_FLOWSPEC_REDIRECT_IP {
+			target, _ := netip.AddrFromSlice(data[2:6])
+			// Reserved bits are ignored on receipt.
+			la := binary.BigEndian.Uint16(data[6:8])
+			return &FlowSpecRedirectToIPv4Extended{
+				Target: target,
+				Copy:   la&flowSpecRedirectToIPCopyBit != 0,
+			}, nil
+		}
 		transitive = true
 		fallthrough
 	case EC_TYPE_NON_TRANSITIVE_IP4_SPECIFIC:
@@ -15959,6 +16088,15 @@ func ParseIP6Extended(data []byte) (ExtendedCommunityInterface, error) {
 	transitive := false
 	switch attrType {
 	case EC_TYPE_TRANSITIVE_IP6_SPECIFIC:
+		if subtype == EC_SUBTYPE_FLOWSPEC_REDIRECT_IP {
+			target, _ := netip.AddrFromSlice(data[2:18])
+			// Reserved bits are ignored on receipt.
+			la := binary.BigEndian.Uint16(data[18:20])
+			return &FlowSpecRedirectToIPv6Extended{
+				Target: target,
+				Copy:   la&flowSpecRedirectToIPCopyBit != 0,
+			}, nil
+		}
 		transitive = true
 		fallthrough
 	case EC_TYPE_NON_TRANSITIVE_IP6_SPECIFIC:

--- a/pkg/packet/bgp/flowspec_redirect_ip_test.go
+++ b/pkg/packet/bgp/flowspec_redirect_ip_test.go
@@ -1,0 +1,178 @@
+package bgp
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlowSpecRedirectToIPv4Serialize(t *testing.T) {
+	ec, err := NewFlowSpecRedirectToIPv4Extended(netip.MustParseAddr("203.0.113.10"), false)
+	assert.NoError(t, err)
+	buf, err := ec.Serialize()
+	assert.NoError(t, err)
+	// type 0x01, subtype 0x0c, GA = target, LA = 0 (C flag clear).
+	assert.Equal(t, []byte{0x01, 0x0c, 203, 0, 113, 10, 0x00, 0x00}, buf)
+	assert.Equal(t, "redirect-to-ip: 203.0.113.10", ec.String())
+}
+
+func TestFlowSpecRedirectToIPv4CopyFlag(t *testing.T) {
+	ec, err := NewFlowSpecRedirectToIPv4Extended(netip.MustParseAddr("203.0.113.10"), true)
+	assert.NoError(t, err)
+	buf, err := ec.Serialize()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0x01, 0x0c, 203, 0, 113, 10, 0x00, 0x01}, buf)
+	assert.True(t, ec.IsCopy())
+	assert.Equal(t, "copy-to-ip: 203.0.113.10", ec.String())
+}
+
+func TestFlowSpecRedirectToIPv4ParseRoundTrip(t *testing.T) {
+	for _, isCopy := range []bool{false, true} {
+		orig, err := NewFlowSpecRedirectToIPv4Extended(netip.MustParseAddr("10.0.0.42"), isCopy)
+		assert.NoError(t, err)
+		buf, err := orig.Serialize()
+		assert.NoError(t, err)
+
+		parsed, err := ParseExtended(buf)
+		assert.NoError(t, err)
+		got, ok := parsed.(*FlowSpecRedirectToIPv4Extended)
+		assert.True(t, ok, "parsed as %T", parsed)
+		assert.Equal(t, orig.Target, got.Target)
+		assert.Equal(t, isCopy, got.Copy)
+	}
+}
+
+// Reserved bits must be ignored on receipt and never re-originated.
+func TestFlowSpecRedirectToIPv4IgnoresReservedBits(t *testing.T) {
+	wire := []byte{0x01, 0x0c, 203, 0, 113, 10, 0xff, 0xfe} // reserved set, C clear
+	parsed, err := ParseExtended(wire)
+	assert.NoError(t, err)
+	got, ok := parsed.(*FlowSpecRedirectToIPv4Extended)
+	assert.True(t, ok, "parsed as %T", parsed)
+	assert.False(t, got.IsCopy())
+
+	out, err := got.Serialize()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{0x01, 0x0c, 203, 0, 113, 10, 0x00, 0x00}, out,
+		"reserved bits must not be re-originated")
+
+	wire[7] = 0xff // reserved set, C set
+	parsed, err = ParseExtended(wire)
+	assert.NoError(t, err)
+	assert.True(t, parsed.(*FlowSpecRedirectToIPv4Extended).IsCopy())
+}
+
+func TestFlowSpecRedirectToIPv4RejectsNonIPv4(t *testing.T) {
+	_, err := NewFlowSpecRedirectToIPv4Extended(netip.MustParseAddr("2001:db8::1"), false)
+	assert.Error(t, err)
+}
+
+// Only 0x0c is the redirect action; other subtypes stay generic.
+func TestFlowSpecRedirectToIPv4DoesNotShadowRT(t *testing.T) {
+	rt, err := NewIPv4AddressSpecificExtended(EC_SUBTYPE_ROUTE_TARGET, netip.MustParseAddr("10.0.0.1"), 100, true)
+	assert.NoError(t, err)
+	buf, err := rt.Serialize()
+	assert.NoError(t, err)
+	parsed, err := ParseExtended(buf)
+	assert.NoError(t, err)
+	_, isRedirect := parsed.(*FlowSpecRedirectToIPv4Extended)
+	assert.False(t, isRedirect)
+}
+
+func TestFlowSpecRedirectToIPv6Serialize(t *testing.T) {
+	ec, err := NewFlowSpecRedirectToIPv6Extended(netip.MustParseAddr("2001:db8::1"), false)
+	assert.NoError(t, err)
+	buf, err := ec.Serialize()
+	assert.NoError(t, err)
+	assert.Len(t, buf, 20)
+	// IPv6 address-specific EC (RFC 5701) type 0x00, subtype 0x0c.
+	assert.Equal(t, byte(0x00), buf[0])
+	assert.Equal(t, byte(0x0c), buf[1])
+	assert.Equal(t, netip.MustParseAddr("2001:db8::1").AsSlice(), buf[2:18])
+	assert.Equal(t, []byte{0x00, 0x00}, buf[18:20])
+	assert.Equal(t, "redirect-to-ip: 2001:db8::1", ec.String())
+}
+
+func TestFlowSpecRedirectToIPv6ParseRoundTrip(t *testing.T) {
+	for _, isCopy := range []bool{false, true} {
+		orig, err := NewFlowSpecRedirectToIPv6Extended(netip.MustParseAddr("2001:db8::42"), isCopy)
+		assert.NoError(t, err)
+		buf, err := orig.Serialize()
+		assert.NoError(t, err)
+
+		parsed, err := ParseIP6Extended(buf)
+		assert.NoError(t, err)
+		got, ok := parsed.(*FlowSpecRedirectToIPv6Extended)
+		assert.True(t, ok, "parsed as %T", parsed)
+		assert.Equal(t, orig.Target, got.Target)
+		assert.Equal(t, isCopy, got.Copy)
+	}
+}
+
+func TestFlowSpecRedirectToIPv6RejectsNonIPv6(t *testing.T) {
+	_, err := NewFlowSpecRedirectToIPv6Extended(netip.MustParseAddr("192.0.2.1"), false)
+	assert.Error(t, err)
+}
+
+// Same for the IPv6 dispatch.
+func TestFlowSpecRedirectToIPv6DoesNotShadowRT(t *testing.T) {
+	rt, err := NewIPv6AddressSpecificExtended(EC_SUBTYPE_ROUTE_TARGET, netip.MustParseAddr("2001:db8::1"), 100, true)
+	assert.NoError(t, err)
+	buf, err := rt.Serialize()
+	assert.NoError(t, err)
+	parsed, err := ParseIP6Extended(buf)
+	assert.NoError(t, err)
+	_, isRedirect := parsed.(*FlowSpecRedirectToIPv6Extended)
+	assert.False(t, isRedirect)
+}
+
+// What the decoder accepts, the encoder must be able to re-originate.
+func TestFlowSpecRedirectToIPv6UnmapsV4MappedTarget(t *testing.T) {
+	wire := make([]byte, 20)
+	wire[0] = 0x00 // transitive IPv6-address-specific
+	wire[1] = 0x0c
+	copy(wire[2:18], netip.MustParseAddr("::ffff:198.51.100.11").AsSlice())
+
+	parsed, err := ParseIP6Extended(wire)
+	assert.NoError(t, err)
+	got, ok := parsed.(*FlowSpecRedirectToIPv6Extended)
+	assert.True(t, ok, "parsed as %T", parsed)
+
+	_, err = got.Serialize()
+	assert.NoError(t, err, "a parsed target must be re-serializable")
+}
+
+// A truncated community must be refused by the length guard rather
+// than reaching the fixed-offset reads in the redirect branches.
+func TestFlowSpecRedirectToIPRejectsShortBuffers(t *testing.T) {
+	v4 := []byte{0x01, 0x0c, 203, 0, 113, 10, 0x00, 0x00}
+	for n := range v4 {
+		_, err := ParseExtended(v4[:n])
+		assert.Error(t, err, "ParseExtended accepted %d bytes", n)
+	}
+
+	v6 := make([]byte, 20)
+	v6[0], v6[1] = 0x00, 0x0c
+	for n := range v6 {
+		_, err := ParseIP6Extended(v6[:n])
+		assert.Error(t, err, "ParseIP6Extended accepted %d bytes", n)
+	}
+}
+
+// type and subtype already name the action, so the remaining fields
+// carry only the value, as the other action communities do.
+func TestFlowSpecRedirectToIPMarshalJSON(t *testing.T) {
+	v4, err := NewFlowSpecRedirectToIPv4Extended(netip.MustParseAddr("198.51.100.11"), true)
+	assert.NoError(t, err)
+	b, err := json.Marshal(v4)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"type":1,"subtype":12,"target":"198.51.100.11","copy":true}`, string(b))
+
+	v6, err := NewFlowSpecRedirectToIPv6Extended(netip.MustParseAddr("2001:db8::1"), false)
+	assert.NoError(t, err)
+	b, err = json.Marshal(v6)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"type":0,"subtype":12,"target":"2001:db8::1","copy":false}`, string(b))
+}

--- a/proto/api/attribute.proto
+++ b/proto/api/attribute.proto
@@ -342,6 +342,7 @@ message IP6ExtendedCommunitiesAttribute {
     oneof extcom {
       IPv6AddressSpecificExtended ipv6_address_specific = 1;
       RedirectIPv6AddressSpecificExtended redirect_ipv6_address_specific = 2;
+      FlowSpecRedirectToIPv6Extended flow_spec_redirect_to_ipv6 = 3;
     }
   }
   repeated Community communities = 1;

--- a/proto/api/extcom.proto
+++ b/proto/api/extcom.proto
@@ -89,6 +89,18 @@ message RedirectIPv4AddressSpecificExtended {
   uint32 local_admin = 2;
 }
 
+// draft-ietf-idr-flowspec-redirect-ip-16, type 0x01 sub-type 0x0c.
+message FlowSpecRedirectToIPv4Extended {
+  string address = 1;
+  bool copy = 2;
+}
+
+// The IPv6 form of the same draft, RFC 5701 type 0x000c.
+message FlowSpecRedirectToIPv6Extended {
+  string address = 1;
+  bool copy = 2;
+}
+
 message RedirectFourOctetAsSpecificExtended {
   uint32 asn = 1;
   uint32 local_admin = 2;
@@ -176,6 +188,8 @@ message ExtendedCommunity {
     MUPTwoOctetAsSpecificExtended mup_two_octet_as_specific = 25;
     MUPIPv4AddressSpecificExtended mup_ipv4_address_specific = 26;
     MUPFourOctetAsSpecificExtended mup_four_octet_as_specific = 27;
+    FlowSpecRedirectToIPv4Extended flow_spec_redirect_to_ipv4 = 28;
+    // The IPv6 form lives in IP6ExtendedCommunitiesAttribute.
   }
 }
 


### PR DESCRIPTION
## Why
Implements the "Flow-spec Redirect to IP" action from [draft-ietf-idr-flowspec-redirect-ip-16]( https://datatracker.ietf.org/doc/html/draft-ietf-idr-flowspec-redirect-ip-16), requested in #2810, in both forms the draft defines: IPv4 (type 0x01, sub-type 0x0c) and IPv6 (type 0x000c, RFC 5701). 
The code points are IANA-assigned and the draft is in the RFC Editor queue. 

### Why not the existing `Redirect` types

Those implement redirect-to-VRF (RFC 8955 section 7.4), where the value is a **route target** naming a VRF. Here the value is the **address traffic is forwarded toward**. GoBGP previously decoded such communities into the generic `IPv4AddressSpecificExtended`, losing the action, and could only originate one by hand-crafting bytes.

The CLI gets its own verb for the same reason, `redirect` parses itsargument as a route target

```bash
$ gobgp global rib -a ipv4-flowspec add \
    match destination 192.0.2.1/32 destination-port '==61001' \
    then redirect-to-ip 198.51.100.11 [copy]
```

Trailing `copy` sets the C bit. `docs/sources/flowspec.md` documents the action with transcripts from a running `gobgpd`.