### PR TITLE
table: skip rejected paths when building Drop withdrawals

### DIFF
--- a/internal/pkg/table/adj.go
+++ b/internal/pkg/table/adj.go
@@ -206,6 +206,11 @@ func (adj *AdjRib) Drop(rfList []bgp.Family) []*Path {
 	l := make([]*Path, 0, adj.Count(rfList))
 	adj.walk(rfList, func(d *destination) bool {
 		for _, p := range d.knownPathList {
+			// Rejected paths were never installed in the local RIB; do not
+			// emit withdrawals for them (avoids "No matching path for withdraw").
+			if p.IsRejected() {
+				continue
+			}
 			w := p.Clone(true)
 			w.SetDropped(true)
 			l = append(l, w)

--- a/internal/pkg/table/adj_test.go
+++ b/internal/pkg/table/adj_test.go
@@ -138,7 +138,6 @@ func TestStale(t *testing.T) {
 	assert.Equal(t, 1, len(adj.table[family].GetDestinations()))
 }
 
-
 func TestDropSkipsRejected(t *testing.T) {
 	pi := &PeerInfo{}
 	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}

--- a/internal/pkg/table/adj_test.go
+++ b/internal/pkg/table/adj_test.go
@@ -138,6 +138,33 @@ func TestStale(t *testing.T) {
 	assert.Equal(t, 1, len(adj.table[family].GetDestinations()))
 }
 
+
+func TestDropSkipsRejected(t *testing.T) {
+	pi := &PeerInfo{}
+	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}
+
+	nlri1, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.10.0/24"))
+	p1 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri1}, false, attrs, time.Now(), false)
+	nlri2, _ := bgp.NewIPAddrPrefix(netip.MustParsePrefix("20.20.20.0/24"))
+	p2 := NewPath(bgp.RF_IPv4_UC, pi, bgp.PathNLRI{NLRI: nlri2}, false, attrs, time.Now(), false)
+	p2.SetRejected(true)
+
+	family := p1.GetFamily()
+	families := []bgp.Family{family}
+
+	adj := NewAdjRib(slog.Default(), families)
+	adj.Update([]*Path{p1, p2})
+	assert.Equal(t, 2, adj.Count(families))
+	assert.Equal(t, 1, adj.Accepted(families))
+
+	// Drop must not emit withdrawals for rejected paths that never entered the RIB.
+	dropped := adj.Drop(families)
+	assert.Equal(t, 1, len(dropped))
+	assert.False(t, dropped[0].IsRejected())
+	assert.Equal(t, 0, adj.Count(families))
+	assert.Equal(t, 0, adj.Accepted(families))
+}
+
 func TestLLGRStale(t *testing.T) {
 	pi := &PeerInfo{}
 	attrs := []bgp.PathAttributeInterface{bgp.NewPathAttributeOrigin(0)}


### PR DESCRIPTION
When a peer flaps, `AdjRib.Drop()` was cloning every adj-RIB-In path into a withdrawal list, including ones marked `IsRejected` (e.g. AS-loop rejects that never made it into the local RIB). Downstream withdraw processing then logs "No matching path for withdraw" for each of those.

Skip rejected paths when building the withdrawal list. The adj table is still cleared for the families being dropped.

Fixes #3455