### PR TITLE
zebra: reject a nexthop label count above the maximum

### DIFF
--- a/pkg/zebra/zapi.go
+++ b/pkg/zebra/zapi.go
@@ -2465,8 +2465,12 @@ func (n *Nexthop) decode(data []byte, version uint8, software Software, family u
 		}
 		n.LabelNum = data[offset] // frr: STREAM_GETC(s, api_nh->label_num);
 		offset++
+		// frr rejects label_num > MPLS_MAX_LABELS instead of decoding the
+		// nexthop. Clamping the count here left the extra label octets in the
+		// buffer, so the reader resumed (label_num-maxMplsLabel)*4 bytes early
+		// and framed the next nexthop from label data.
 		if n.LabelNum > maxMplsLabel {
-			n.LabelNum = maxMplsLabel
+			return 0, fmt.Errorf("invalid number of nexthop labels %d exceeds maximum %d", n.LabelNum, maxMplsLabel)
 		}
 		if n.LabelNum > 0 {
 			n.MplsLabels = make([]uint32, n.LabelNum)

--- a/pkg/zebra/zapi_test.go
+++ b/pkg/zebra/zapi_test.go
@@ -1084,6 +1084,54 @@ func Test_NexthopUpdateBody(t *testing.T) {
 	}
 }
 
+func Test_NexthopUpdateBodyRejectsOversizedLabelNum(t *testing.T) {
+	assert := assert.New(t)
+
+	// zapi6 / frr7.2: MessageLabel is set for the whole body, so each nexthop
+	// carries a label_num followed by that many labels.
+	version := uint8(6)
+	software := NewSoftware(version, "frr7.2")
+
+	appendNexthop := func(buf []byte, gate []byte, ifindex uint32, labelNum uint8, labels []uint32) []byte {
+		buf = append(buf, 0x00, 0x00, 0x00, 0x00) // vrf_id
+		buf = append(buf, byte(nexthopTypeIPv4IFIndex))
+		buf = append(buf, gate...)
+		idx := make([]byte, 4)
+		binary.BigEndian.PutUint32(idx, ifindex)
+		buf = append(buf, idx...)
+		buf = append(buf, labelNum)
+		for _, l := range labels {
+			lb := make([]byte, 4)
+			binary.LittleEndian.PutUint32(lb, l)
+			buf = append(buf, lb...)
+		}
+		return buf
+	}
+
+	// nexthop[0] declares 20 labels (> maxMplsLabel). A well-formed nexthop[1]
+	// follows at the position a conformant reader lands on.
+	labels := make([]uint32, maxMplsLabel+4)
+	for i := range labels {
+		labels[i] = uint32(1000 + i)
+	}
+
+	buf := []byte{0x00, 0x02, 0x20, 0xc0, 0xa8, 0x01, 0x01} // family, prefixlen, prefix
+	buf = append(buf, 0x00, 0x00, 0x00)                     // type, instance
+	buf = append(buf, 0x00)                                 // distance
+	metric := make([]byte, 4)
+	binary.BigEndian.PutUint32(metric, 1)
+	buf = append(buf, metric...)
+	buf = append(buf, 0x02) // number of nexthops
+	buf = appendNexthop(buf, []byte{0xc0, 0xa8, 0x00, 0x01}, 2, uint8(len(labels)), labels)
+	buf = appendNexthop(buf, []byte{0x0a, 0x00, 0x00, 0x09}, 9, 0, nil)
+
+	b := &NexthopUpdateBody{}
+	err := b.decodeFromBytes(buf, version, software)
+	// Before the fix the oversized count was clamped and decoding succeeded,
+	// framing nexthop[1] from nexthop[0]'s trailing label octets.
+	assert.Error(err)
+}
+
 func Test_GetLabelChunkBody(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
zapi6 / frr7.2 NEXTHOP_UPDATE, two nexthops, nexthop[0] declares label_num=20:

    nexthop[0]: gate=192.168.0.1 ifindex=2 labelnum=16   (clamped from 20)
    nexthop[1]: gate=0.0.0.0     ifindex=0  labelnum=3   (wire had gate=10.0.0.9 ifindex=9)
    err=<nil>

Nexthop.decode clamps label_num to maxMplsLabel (16) instead of rejecting the nexthop the way frr's zapi_nexthop_decode does, then the label loop consumes only 16*4 bytes while the sender wrote label_num*4. NexthopUpdateBody.decodeFromBytes ignores the length decodeNexthops consumed, so the cursor is left (label_num-16)*4 bytes short and the following nexthop is framed from the leftover label octets, with no error. The label branch is reachable on frr6-7.2 via the body MessageLabel flag and on frr7.3+/8.x via the per-nexthop label flag bit.

Reject label_num past the maximum in the decoder, matching frr.
