### PR TITLE
server: hold fsm.lock when reading fsm.recvOpen

### DIFF
--- a/pkg/server/fsm_test.go
+++ b/pkg/server/fsm_test.go
@@ -1640,3 +1640,74 @@ func TestSendMessageloop_KillSignal(t *testing.T) {
 		t.Fatal("sendMessageloop did not exit after non-path message")
 	}
 }
+
+// TestRace_NewWatchEventPeerRecvOpen tests that newWatchEventPeer is race-free
+// when called concurrently with an FSM connection transition, which writes
+// fsm.recvOpen under fsm.lock.
+//
+// newWatchEventPeer reads fsm.recvOpen after releasing fsm.lock, so the read is
+// unsynchronised with respect to those writes. WatchEvent reaches it for every
+// peer in neighborMap when a watcher registers, and broadcastPeerState reaches
+// it on each state transition.
+//
+// Run with: go test -race -count=1 ./pkg/server/... -run TestRace_NewWatchEventPeerRecvOpen
+func TestRace_NewWatchEventPeerRecvOpen(t *testing.T) {
+	s, _, peerAddrIP := newTestBgpServerWithPeer(t)
+	defer s.StopBgp(context.Background(), &api.StopBgpRequest{})
+
+	var testPeer *peer
+	err := s.mgmtOperation(func() error {
+		testPeer = s.neighborMap[peerAddrIP]
+		return nil
+	}, true)
+	if err != nil {
+		t.Fatalf("mgmtOperation failed: %v", err)
+	}
+
+	if testPeer == nil {
+		t.Fatal("Could not get internal peer object")
+	}
+
+	open, err := bgp.NewBGPOpenMessage(65002, 90, netip.MustParseAddr("2.2.2.2"), nil)
+	if err != nil {
+		t.Fatalf("NewBGPOpenMessage failed: %v", err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writer goroutine: assign fsm.recvOpen under fsm.lock, as the FSM does when
+	// a connection reaches OPENCONFIRM.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				testPeer.fsm.lock.Lock()
+				testPeer.fsm.recvOpen = open
+				testPeer.fsm.lock.Unlock()
+			}
+		}
+	}()
+
+	// Reader goroutine: build watch events, which reads fsm.recvOpen.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = newWatchEventPeer(testPeer, nil, bgp.BGP_FSM_IDLE, bgp.BGP_FSM_IDLE, apiutil.PEER_EVENT_STATE)
+			}
+		}
+	}()
+
+	time.Sleep(2 * time.Second)
+	close(stop)
+	wg.Wait()
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -817,7 +817,9 @@ func (s *BgpServer) toConfig(peer *peer, getAdvertised bool) *oc.Neighbor {
 	conf.State.SessionState = oc.IntToSessionStateMap[int(state)]
 	conf.State.AdminState = oc.IntToAdminStateMap[int(peer.AdminState())]
 	if state == bgp.BGP_FSM_ESTABLISHED {
+		peer.fsm.lock.Lock()
 		buf, _ := peer.fsm.recvOpen.Serialize()
+		peer.fsm.lock.Unlock()
 		// need to copy all values here
 		conf.State.ReceivedOpenMessage, _ = bgp.ParseBGPMessage(buf)
 	}
@@ -984,9 +986,9 @@ func newWatchEventPeer(peer *peer, m *fsmMsg, newState, oldState bgp.FSMState, t
 	// Publish conf only after buildopen and capabilitiesFromConfig finish mutating it
 	// (capabilitiesFromConfig updates per-AFI GR advertised state).
 	peer.fsm.pConf.Update(&conf)
+	recvOpen := peer.fsm.recvOpen
 	peer.fsm.lock.Unlock()
 
-	recvOpen := peer.fsm.recvOpen
 	e := &watchEventPeer{
 		Type:          t,
 		PeerAS:        conf.State.PeerAs,


### PR DESCRIPTION
## Problem

`fsm.recvOpen` is written by the FSM goroutine under `fsm.lock` (`pkg/server/fsm.go:1018`, and four other sites), but two readers accessed it without that lock:

- `pkg/server/server.go:989` in `newWatchEventPeer` — the read sat two lines below `peer.fsm.lock.Unlock()`
- `pkg/server/server.go:820` in `toConfig` — the lock was not taken at all

`newWatchEventPeer` is reached for every peer in `neighborMap` when a watcher registers via `WatchEvent`, and on each state transition via `broadcastPeerState`. Registering a watcher while a peer's FSM is starting up therefore races the FSM goroutine.

CONTRIBUTING states that `peer.fsm.lock` protects individual peer state, so these reads violate the documented invariant.

## Root cause

The read in `newWatchEventPeer` was inside the critical section from #2714 until f416268a, which merged two lock sections while moving to `atomic.Value` and left the single `Unlock()` above the read.

## Fix

Move the read above the `Unlock()` in `newWatchEventPeer`, and take the lock around the read in `toConfig`.

`toConfig` uses its own short critical section rather than extending the block above it, because `fsm.lock` is a plain `sync.Mutex` and `capabilitiesFromConfig`, `peer.State()` and `peer.AdminState()` sit in between.

## Test

`TestRace_NewWatchEventPeerRecvOpen` follows the existing `TestRace_*` pattern and reuses `newTestBgpServerWithPeer`. It fails under `-race` without the fix and passes with it. The test only writes `recvOpen` under the lock; the racing read arrives through the real FSM goroutine:

```
WARNING: DATA RACE
Write at 0x00c0001057a0 by goroutine 28:
  server.TestRace_NewWatchEventPeerRecvOpen.func2()
      pkg/server/fsm_test.go:1690

Previous read at 0x00c0001057a0 by goroutine 27:
  server.newWatchEventPeer()
      pkg/server/server.go:989
  server.(*BgpServer).broadcastPeerState()
      pkg/server/server.go:1018
  server.(*BgpServer).handleFSMMessage()
      pkg/server/server.go:1926
  server.(*fsmHandler).loop()
      pkg/server/fsm.go:2180
```

Verified on `linux/amd64`: `go test -race -timeout 900s ./...` passes for all packages, and `golangci-lint run` reports 0 issues.

Possibly related, though a different field and code path: #2705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)