### PR TITLE
packet/bgp: serialize the full SID in the SRv6 Binding SID sub-TLV

### DIFF
--- a/pkg/packet/bgp/sr_policy.go
+++ b/pkg/packet/bgp/sr_policy.go
@@ -500,7 +500,7 @@ func (t *TunnelEncapSubTLVSRv6BSID) DecodeFromBytes(data []byte) error {
 func (t *TunnelEncapSubTLVSRv6BSID) Serialize() ([]byte, error) {
 	buf := make([]byte, t.Length)
 	buf[0] = t.Flags
-	copy(buf[2:t.BSID.Len()], t.BSID.Serialize())
+	copy(buf[2:], t.BSID.Serialize())
 	return t.TunnelEncapSubTLV.Serialize(buf[:])
 }
 

--- a/pkg/packet/bgp/sr_policy_test.go
+++ b/pkg/packet/bgp/sr_policy_test.go
@@ -1,6 +1,7 @@
 package bgp
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"net"
@@ -87,6 +88,36 @@ func TestBindingSIDRoundTrip(t *testing.T) {
 				t.Fatalf("expected: %+v does not match result: %+v", tt.input, result)
 			}
 		})
+	}
+}
+
+func TestSRv6BindingSIDRoundTrip(t *testing.T) {
+	input := &TunnelEncapSubTLVSRv6BSID{
+		TunnelEncapSubTLV: TunnelEncapSubTLV{
+			Type:   ENCAP_SUBTLV_TYPE_SRBINDING_SID,
+			Length: 18,
+		},
+		Flags: 0,
+		BSID: &BSID{
+			Value: net.ParseIP("2001:db8::1").To16(),
+		},
+	}
+	b, err := input.Serialize()
+	if err != nil {
+		t.Fatalf("Serialize failed: %v", err)
+	}
+	// Type (13), Length (18), Flags, RESERVED, then the full 16-octet SID.
+	expected := append([]byte{0x0d, 0x12, 0x00, 0x00}, net.ParseIP("2001:db8::1").To16()...)
+	if !bytes.Equal(b, expected) {
+		t.Fatalf("wire mismatch:\ngot:  %x\nwant: %x", b, expected)
+	}
+	result := &TunnelEncapSubTLVSRv6BSID{}
+	if err := result.DecodeFromBytes(b); err != nil {
+		t.Fatalf("DecodeFromBytes failed: %v", err)
+	}
+	if !reflect.DeepEqual(input, result) {
+		t.Logf("Diffs: %+v", deep.Equal(input, result))
+		t.Fatalf("expected: %+v does not match result: %+v", input, result)
 	}
 }
 


### PR DESCRIPTION
`TunnelEncapSubTLVSRv6BSID.Serialize` writes the SID with

    copy(buf[2:t.BSID.Len()], t.BSID.Serialize())

The upper bound of the slice expression is the SID length (16), but a slice upper bound is an end index, not a length.
The destination is therefore `buf[2:16]`, which is only 14 bytes, so `copy` silently drops the last 2 bytes of the 16-byte SID and the sub-TLV goes out on the wire with those bytes zeroed.

RFC 9830 (Section 2.4.3) defines the field as "Contains a 16-octet SRv6 SID".
With this bug, an SR Policy injected through the gRPC API with an `srv6_binding_sid` is advertised with a corrupted binding SID: for example `2001:db8::1` reaches the peer as `2001:db8::`.
Because the resulting sub-TLV still has a valid length of 18, the receiver cannot detect the corruption; the wrong SID propagates silently.

The fix uses `buf[2:]` as the copy destination, matching the adjacent `TunnelEncapSubTLVSRBSID.Serialize`, which already does this correctly.

Note on impact: the wire decoder maps sub-TLV type 13 to `TunnelEncapSubTLVSRBSID`, so routes relayed by GoBGP were not affected.
Only paths originated through the gRPC API's `srv6_binding_sid` branch hit this code.
Existing API users that pass a 16-byte SID through the `binding_sid` branch (for example Calico-VPP) are also unaffected, so this change does not alter the wire output for any working configuration.

A unit test is included that serializes a sub-TLV with a 16-octet BSID and verifies the SID survives a serialize/decode round trip and that the wire bytes contain the full SID.
