### PR TITLE
packet/bgp: reject VPLS NLRI with a length other than 17

### DIFF
--- a/pkg/packet/bgp/vpls.go
+++ b/pkg/packet/bgp/vpls.go
@@ -54,12 +54,14 @@ func (n *VPLSNLRI) decodeFromBytes(data []byte, options ...*MarshallingOption) e
 	if len(data) < length+2 {
 		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all VPLS NLRI bytes available")
 	}
-	if length == 12 { // BGP-AD
-		// BGP-AD is not supported yet
-		return nil
-	}
-	if len(data) < 19 {
-		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "Not all VPLS NLRI bytes available")
+	// RFC 4761 VPLS-BGP NLRI is a fixed 17 bytes, which is the size Len()
+	// reports to the MP_(UN)REACH framing loop. A different length desyncs
+	// Len() from the on-wire size and mis-frames the following NLRIs; the
+	// 12-byte RFC 6074 BGP-AD NLRI in particular was decoded into a route with
+	// a nil RD that panics when re-serialized. gobgp does not support BGP-AD,
+	// so reject anything that is not a 17-byte VPLS-BGP NLRI.
+	if length != 17 {
+		return NewMessageError(BGP_ERROR_UPDATE_MESSAGE_ERROR, BGP_ERROR_SUB_MALFORMED_ATTRIBUTE_LIST, nil, "unsupported VPLS NLRI length")
 	}
 	// VPLS-BGP
 	n.rd = GetRouteDistinguisher(data[2:10])

--- a/pkg/packet/bgp/vpls_test.go
+++ b/pkg/packet/bgp/vpls_test.go
@@ -58,6 +58,25 @@ func Test_VPLSNLRI(t *testing.T) {
 	assert.Equal(n1, n1)
 }
 
+func Test_VPLSNLRI_decodeRejectsUnsupportedLength(t *testing.T) {
+	// Len() reports a fixed 19 bytes to the MP_(UN)REACH framing loop, so a
+	// VPLS NLRI whose length field is not 17 must be rejected. Before the fix
+	// the 12-byte BGP-AD form decoded successfully into a VPLSNLRI with a nil
+	// RD, which both mis-framed the following NLRI and panicked on re-serialize.
+	adNLRI := &VPLSNLRI{}
+	// length = 12 (BGP-AD) followed by a 12-byte body.
+	err := adNLRI.decodeFromBytes([]byte{0x00, 0x0c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+	require.Error(t, err)
+	assert.Nil(t, adNLRI.rd)
+
+	// length = 32 (oversized) with enough trailing bytes to satisfy Len()==19.
+	longNLRI := &VPLSNLRI{}
+	buf := make([]byte, 2+32)
+	buf[1] = 0x20
+	err = longNLRI.decodeFromBytes(buf)
+	require.Error(t, err)
+}
+
 func Test_VPLSNLRI_decoding(t *testing.T) {
 	assert := assert.New(t)
 	buf := []byte{


### PR DESCRIPTION
reject a VPLS NLRI whose length field is not 17, since VPLSNLRI.Len() reports a fixed 19 bytes to the MP_(UN)REACH framing loop and any other length mis-frames the following NLRIs, with the 12-byte BGP-AD form additionally decoding into a route with a nil RD that panics on re-serialization.