### PR TITLE
server: withdraw ADD-PATH route when export policy starts rejecting it

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1547,10 +1547,22 @@ func (s *BgpServer) propagateUpdateToNeighbors(rib *table.TableManager, source *
 					}()
 				} else {
 					alreadySent := targetPeer.hasPathAlreadyBeenSent(newPath)
+					unfilteredPath := newPath
 					newPath := s.filterpath(targetPeer, newPath, nil)
-					// if the path is not filtered and the path has already been sent or land in the limit, we can send it
+					// if the path is not filtered and the path has already been sent or lands in the limit, we can send it.
+					// if the path IS filtered but was previously advertised, we must withdraw it explicitly.
 					if newPath == nil {
-						bestList = []*table.Path{}
+						if alreadySent {
+							// The path was previously advertised to this peer and no
+							// longer passes export policy (e.g. an attribute change
+							// crossed a policy match condition). It must be withdrawn
+							// explicitly, or the peer keeps a stale route indefinitely.
+							withdraw := unfilteredPath.Clone(true)
+							bestList = []*table.Path{withdraw}
+							targetPeer.updateRoutes(withdraw)
+						} else {
+							bestList = []*table.Path{}
+						}
 					} else if alreadySent || targetPeer.getRoutesCount(f, newPath.GetPrefix()) < targetPeer.getAddPathSendMax(f) {
 						bestList = []*table.Path{newPath}
 						if !alreadySent {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -4656,3 +4656,183 @@ func TestRTCShouldNotAdvertiseVPNRouteWhenRTCIsNotPassImportPolicies(t *testing.
 	require.Never(t, vpnPresentAtS2AdjIn, 10*time.Second, 100*time.Millisecond,
 		"VPN route should not appear at s2 adj-in from s1 after second VPN prefix is added")
 }
+
+func TestAddPathWithdrawsPreviouslyAdvertisedPathOnPolicyFilter(t *testing.T) {
+	ctx := context.Background()
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(ctx, &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        65001,
+			RouterId:   "1.1.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, s.policy.SetPolicyAssignment(
+		table.GLOBAL_RIB_NAME,
+		table.POLICY_DIRECTION_IMPORT,
+		nil,
+		table.ROUTE_TYPE_ACCEPT,
+	))
+
+	peerAddr := netip.MustParseAddr("10.0.0.1")
+	p := newPeerandInfo(t, 65001, 65002, peerAddr.String(), s.globalRib)
+	p.policy = s.policy
+	p.fsm.state.Store(bgp.BGP_FSM_ESTABLISHED)
+	p.fsm.familyMap.Store(map[bgp.Family]bgp.BGPAddPathMode{
+		bgp.RF_IPv4_UC: bgp.BGP_ADD_PATH_SEND,
+	})
+	p.fsm.lock.Lock()
+	conf := p.fsm.pConf.ReadCopy()
+	foundFamily := false
+	for i := range conf.AfiSafis {
+		if conf.AfiSafis[i].State.Family != bgp.RF_IPv4_UC {
+			continue
+		}
+		conf.AfiSafis[i].AddPaths.Config.SendMax = 1
+		conf.AfiSafis[i].AddPaths.State.SendMax = 1
+		foundFamily = true
+	}
+	p.fsm.pConf.Update(&conf)
+	p.fsm.lock.Unlock()
+	require.True(t, foundFamily)
+
+	err = s.mgmtOperation(func() error {
+		s.neighborMap[peerAddr] = p
+		return nil
+	}, true)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := s.mgmtOperation(func() error {
+			delete(s.neighborMap, peerAddr)
+			return nil
+		}, false)
+		require.NoError(t, err)
+		cleanInfiniteChannel(p.fsm.outgoingCh)
+		require.NoError(t, s.StopBgp(ctx, &api.StopBgpRequest{}))
+	})
+
+	// Export policy: reject any path carrying community 100:100.
+	commSet, err := table.NewCommunitySet(oc.CommunitySet{
+		CommunitySetName: "reject-comm",
+		CommunityList:    []string{"100:100"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.policy.AddDefinedSet(commSet, false))
+
+	statement := oc.Statement{
+		Name: "reject-comm-stmt",
+		Conditions: oc.Conditions{
+			BgpConditions: oc.BgpConditions{
+				MatchCommunitySet: oc.MatchCommunitySet{
+					CommunitySet: "reject-comm",
+				},
+			},
+		},
+		Actions: oc.Actions{
+			RouteDisposition: oc.ROUTE_DISPOSITION_REJECT_ROUTE,
+		},
+	}
+	policyDef := oc.PolicyDefinition{
+		Name:       "reject-comm-policy",
+		Statements: []oc.Statement{statement},
+	}
+	pol, err := table.NewPolicy(policyDef)
+	require.NoError(t, err)
+	require.NoError(t, s.policy.AddPolicy(pol, false))
+	require.NoError(t, s.policy.AddPolicyAssignment(
+		table.GLOBAL_RIB_NAME,
+		table.POLICY_DIRECTION_EXPORT,
+		[]*oc.PolicyDefinition{{Name: "reject-comm-policy"}},
+		table.ROUTE_TYPE_ACCEPT,
+	))
+
+	source := &table.PeerInfo{
+		AS:           65010,
+		ID:           netip.MustParseAddr("10.0.0.2"),
+		Address:      netip.MustParseAddr("10.0.0.2"),
+		LocalAS:      65001,
+		LocalID:      netip.MustParseAddr("1.1.1.1"),
+		LocalAddress: netip.MustParseAddr("1.1.1.1"),
+	}
+	nlri, err := bgp.NewIPAddrPrefix(netip.MustParsePrefix("192.0.2.0/32"))
+	require.NoError(t, err)
+	nextHop, err := bgp.NewPathAttributeNextHop(netip.MustParseAddr("192.0.2.254"))
+	require.NoError(t, err)
+	asPath := bgp.NewPathAttributeAsPath([]bgp.AsPathParamInterface{
+		bgp.NewAs4PathParam(2, []uint32{65010}),
+	})
+
+	requireNoOutgoing := func() {
+		t.Helper()
+		select {
+		case o := <-p.fsm.outgoingCh.Out():
+			t.Fatalf("unexpected outbound paths: %#v", o)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	requireOutgoing := func() []*table.Path {
+		t.Helper()
+		select {
+		case o := <-p.fsm.outgoingCh.Out():
+			msg, ok := o.(*fsmOutgoingMsg)
+			require.True(t, ok)
+			paths := make([]*table.Path, 0, len(msg.Paths))
+			for _, path := range msg.Paths {
+				if path != nil && !path.IsEOR() {
+					paths = append(paths, path)
+				}
+			}
+			return paths
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for outbound paths")
+			return nil
+		}
+	}
+
+	// --- Control case: a path that fails export policy from the start
+	// must never be advertised, and therefore never withdrawn either.
+	neverAdvertisedNLRI, err := bgp.NewIPAddrPrefix(netip.MustParsePrefix("192.0.3.0/32"))
+	require.NoError(t, err)
+	neverAdvertised := table.NewPath(bgp.RF_IPv4_UC, source, bgp.PathNLRI{NLRI: neverAdvertisedNLRI}, false, []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		asPath,
+		nextHop,
+		bgp.NewPathAttributeCommunities([]uint32{100<<16 | 100}),
+	}, time.Now(), false)
+	s.propagateUpdate(nil, []*table.Path{neverAdvertised})
+	requireNoOutgoing()
+
+	// --- Step 1: advertise a path with no community. It passes export
+	// policy and must be sent.
+	initial := table.NewPath(bgp.RF_IPv4_UC, source, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		asPath,
+		nextHop,
+	}, time.Now(), false)
+	s.propagateUpdate(nil, []*table.Path{initial})
+	paths := requireOutgoing()
+	require.Len(t, paths, 1)
+	require.False(t, paths[0].IsWithdraw)
+	require.Equal(t, "192.0.2.0/32", paths[0].GetPrefix())
+
+	// --- Step 2: the SAME path, same source, now carries community
+	// 100:100. This is an ordinary attribute-change event (not a policy
+	// edit), and it now fails export policy. Because the path WAS
+	// previously advertised to this ADD-PATH peer, an explicit withdraw
+	// is mandatory.
+	updated := table.NewPath(bgp.RF_IPv4_UC, source, bgp.PathNLRI{NLRI: nlri}, false, []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(0),
+		asPath,
+		nextHop,
+		bgp.NewPathAttributeCommunities([]uint32{100<<16 | 100}),
+	}, time.Now(), false)
+	s.propagateUpdate(nil, []*table.Path{updated})
+	paths = requireOutgoing()
+	require.Len(t, paths, 1)
+	require.True(t, paths[0].IsWithdraw, "path that was previously advertised and now fails export policy must be withdrawn")
+	require.Equal(t, "192.0.2.0/32", paths[0].GetPrefix())
+}


### PR DESCRIPTION
### Problem

In `propagateUpdateToNeighbors`, the ADD-PATH send branch calls `filterpath` with `nil` as the `old` argument:

```go
newPath := s.filterpath(targetPeer, newPath, nil)
if newPath == nil {
    bestList = []*table.Path{}
}
```

Because `old` is always `nil`, a path that was previously advertised to a peer and then starts failing that peer's export policy is silently dropped instead of being withdrawn. This happens whenever an attribute change causes the path to cross a policy match condition (for example a community is added and a policy rejects that community).

The peer keeps a stale route indefinitely, with no further update to correct it.

The non-ADD-PATH sibling, `processOutgoingPaths`, threads a real `old` path into `filterpath` and handles this case correctly, so the bug is specific to peers with ADD-PATH send enabled.

Note that `filterpath` already contains the logic for exactly this case:

```go
// When 'path' is filtered (path == nil), check 'old' has been sent to this peer.
// If it has, send withdrawal to the peer.
if path == nil && old != nil {
```

but it is unreachable from this call site because `old` is hardcoded to `nil`. A correct per-path `old` is not available here: the `oldList` produced by `dstsToPaths` holds the old *best* path per destination, which is the right notion for the non-ADD-PATH branch but not for ADD-PATH, where a peer holds several paths per prefix and the path being replaced is usually not the old best.

### Fix

Use the `alreadySent` bookkeeping already computed on the preceding line to distinguish "never advertised" from "advertised, now filtered". In the latter case, clone the pre-filter path as a withdraw and send it.

An attribute-only replacement inherits the old path's local ADD-PATH ID, so the `alreadySent` bookkeeping is already accurate for this case, and `Clone(true)` preserves the local/remote path IDs the withdraw needs. No new struct field and no additional locking.

### Testing

- New regression test `TestAddPathWithdrawsPreviouslyAdvertisedPathOnPolicyFilter` in `pkg/server/server_test.go`. It fails without the fix (times out waiting for outbound paths) and passes with it.
- `go test -race ./...` — no data races; the only failures are two pre-existing environment-dependent tests (`TestEBGPRouteStuck`, `TestRTCDeferralTimerRaceCondition`) that need extra loopback address aliases and fail identically on master.
- `gofmt -l .` clean, `go vet` clean, `golangci-lint run` reports nothing attributable to these changes.
- `GOARCH=386 GOOS=linux go build ./...` passes.
- Scenario tests on an x86-64 Ubuntu 24.04 host: `addpath_test.py` (25 passed), `route_server_policy_test.py`, `global_policy_test.py` (18 passed) and `route_server_softreset_test.py` (3 passed) all pass.

### Known adjacent issue, not addressed here

When a path is withdrawn, its ADD-PATH send-max slot is freed, and a path previously suppressed by `send-max` should be promoted into it. The withdraw branch of this same function does that (its `toAdd` loop), but three other places that stop advertising a path do not: `softResetOut`, the RTC route-target-loss path, and the branch this PR touches.

This is pre-existing and independent of the change here — for example `softResetOut` withdraws export-policy-rejected routes with the same `hasPathAlreadyBeenSent`/`Clone(true)` pattern and has no `send-max` awareness at all. Fixing it consistently means extracting the promotion loop into a helper and calling it from every site that frees a slot, which is a separate change; I would rather not mix it into this bug fix. Happy to follow up with it if that is useful.
