### PR TITLE
cmd/gobgp: require route targets before use

### DIFF
--- a/cmd/gobgp/global.go
+++ b/cmd/gobgp/global.go
@@ -1121,7 +1121,7 @@ func parseEvpnIPMSIArgs(args []string) (bgp.NLRI, []string, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	for _, f := range []string{"etag", "rd"} {
+	for _, f := range []string{"etag", "rd", "rt"} {
 		for len(m[f]) == 0 {
 			return nil, nil, fmt.Errorf("specify %s", f)
 		}
@@ -1139,10 +1139,8 @@ func parseEvpnIPMSIArgs(args []string) (bgp.NLRI, []string, error) {
 	etag := uint32(e)
 
 	extcomms := make([]string, 0)
-	if len(m["rt"]) > 0 {
-		extcomms = append(extcomms, "rt")
-		extcomms = append(extcomms, m["rt"]...)
-	}
+	extcomms = append(extcomms, "rt")
+	extcomms = append(extcomms, m["rt"]...)
 	ec, err := bgp.ParseExtendedCommunity(bgp.EC_SUBTYPE_SOURCE_AS, m["rt"][0])
 	if err != nil {
 		return nil, nil, fmt.Errorf("route target parse failed")

--- a/cmd/gobgp/global_test.go
+++ b/cmd/gobgp/global_test.go
@@ -67,6 +67,19 @@ func Test_ParseEvpnPath(t *testing.T) {
 	}
 }
 
+func Test_ParseEvpnIPMSIPathRequiresRouteTarget(t *testing.T) {
+	assert := assert.New(t)
+
+	path, err := parsePath(
+		bgp.RF_EVPN,
+		strings.Split("i-pmsi etag 100 rd 1.1.1.1:65000 encap vxlan pmsi ingress-repl 100 1.1.1.1", " "),
+	)
+
+	assert.Error(err)
+	assert.Nil(path)
+	assert.Contains(err.Error(), "specify rt")
+}
+
 func Test_ParseFlowSpecPath(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

EVPN IP Prefix and I-PMSI parsing did not validate that a route target was present, while I-PMSI later accessed m["rt"][0] and could panic when rt was omitted.

Fixes #3545.

## Root cause

`parseEvpnIPMSIArgs()` accessed `m["rt"][0]` without first checking
whether `rt` was provided. Input without a route target therefore caused
an index-out-of-range panic.

## Changes

- Require `rt` during EVPN I-PMSI argument validation.
- Add a regression test verifying that input without `rt` returns
  `specify rt` instead of panicking.

## Testing

- `go test ./cmd/gobgp -run 'Test_ParseEvpnIPMSIPathRequiresRouteTarget$' -count=1`
- `go test ./cmd/gobgp -count=1`
- `go test ./...`


Fixes #3545