### PR TITLE
zebra: drop dead pos increments in zapi tests

### DIFF
--- a/pkg/zebra/zapi_test.go
+++ b/pkg/zebra/zapi_test.go
@@ -190,7 +190,6 @@ func Test_interfaceAddressUpdateBody(t *testing.T) {
 
 		// af invalid
 		buf[5] = 0x4
-		pos++
 		b = &interfaceAddressUpdateBody{}
 		err = b.decodeFromBytes(buf, v, software)
 		assert.NotNil(err)
@@ -220,7 +219,6 @@ func Test_routerIDUpdateBody(t *testing.T) {
 
 		// af invalid
 		buf[0] = 0x4
-		pos++
 		b = &routerIDUpdateBody{}
 		err = b.decodeFromBytes(buf, v, software)
 		assert.NotNil(err)
@@ -1061,7 +1059,6 @@ func Test_NexthopUpdateBody(t *testing.T) {
 		pos += 8
 		if v == 5 { // frr7.3&7.4 (latest software of zapi v6) depends on nexthop flag
 			bufIn[pos] = byte(0) // label num
-			pos++
 		}
 
 		// Test decodeFromBytes()


### PR DESCRIPTION
golangci-lint reports SA4006 three times in zapi_test.go. Each flagged pos++ is the last write to pos in its scope, so the new value is never read. Two of them sit in the "af invalid" blocks, which patch a fixed buffer offset and do not track pos at all. The third follows the final byte written to the test buffer.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>