### PR TITLE
config/oc: reject out-of-range integers in the config file

### DIFF
--- a/pkg/config/oc/decode_hook.go
+++ b/pkg/config/oc/decode_hook.go
@@ -1,0 +1,104 @@
+// Copyright (C) 2026 The GoBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oc
+
+import (
+	"errors"
+	"math"
+	"reflect"
+
+	"github.com/go-viper/mapstructure/v2"
+)
+
+// errValueOutOfRange matches the wording mapstructure uses when it parses a
+// string into an integer, so that both paths report the same problem the same
+// way.
+var errValueOutOfRange = errors.New("value out of range")
+
+// integerRangeHookFunc rejects a config value that does not fit the target
+// integer type.
+//
+// mapstructure stores an integer with reflect.Value.SetInt or SetUint, and both
+// truncate without an error. With viper's WeaklyTypedInput a negative value is
+// stored in an unsigned field as well. Without this hook "as = 4294967296"
+// becomes 0, "as = -1" becomes 4294967295 and "tcp-mss = 70000" becomes 4464.
+//
+// Only integer input is checked. mapstructure parses a string with
+// strconv.Parse{Int,Uint} and passes the target width, so that path already
+// reports an out of range value. Float and bool input are left alone; they go
+// through the same weak conversion but are not worth breaking existing configs
+// for.
+func integerRangeHookFunc() mapstructure.DecodeHookFuncValue {
+	return func(from, to reflect.Value) (any, error) {
+		if !from.IsValid() || !to.IsValid() {
+			return nil, nil
+		}
+		data := from.Interface()
+
+		var bits int
+		var signed bool
+		switch to.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			bits, signed = to.Type().Bits(), true
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			bits = to.Type().Bits()
+		default:
+			return data, nil
+		}
+
+		var fits bool
+		switch from.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			v := from.Int()
+			if signed {
+				fits = fitsInt(v, bits)
+			} else {
+				fits = v >= 0 && fitsUint(uint64(v), bits)
+			}
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			v := from.Uint()
+			if signed {
+				fits = v <= math.MaxInt64 && fitsInt(int64(v), bits)
+			} else {
+				fits = fitsUint(v, bits)
+			}
+		default:
+			return data, nil
+		}
+		if !fits {
+			return nil, &mapstructure.ParseError{
+				Expected: to,
+				Value:    data,
+				Err:      errValueOutOfRange,
+			}
+		}
+		return data, nil
+	}
+}
+
+func fitsInt(v int64, bits int) bool {
+	if bits >= 64 {
+		return true
+	}
+	limit := int64(1) << (bits - 1)
+	return v >= -limit && v < limit
+}
+
+func fitsUint(v uint64, bits int) bool {
+	if bits >= 64 {
+		return true
+	}
+	return v < uint64(1)<<bits
+}

--- a/pkg/config/oc/decode_hook_test.go
+++ b/pkg/config/oc/decode_hook_test.go
@@ -1,0 +1,153 @@
+// Copyright (C) 2026 The GoBGP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const rangeTestGlobal = `
+[global.config]
+  as = 65000
+  router-id = "192.0.2.1"
+`
+
+func rangeTestNeighbor(extra string) string {
+	return rangeTestGlobal + `
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "192.0.2.2"
+    peer-as = 65001
+` + extra
+}
+
+func TestIntegerRangeHookRejectsOutOfRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name:   "uint32 max",
+			config: "[global.config]\n  router-id = \"192.0.2.1\"\n  as = 4294967295\n",
+		},
+		{
+			name:    "uint32 overflow",
+			config:  "[global.config]\n  router-id = \"192.0.2.1\"\n  as = 4294967296\n",
+			wantErr: "'global.config.as' cannot parse value as 'uint32': value out of range",
+		},
+		{
+			name:    "uint32 negative",
+			config:  "[global.config]\n  router-id = \"192.0.2.1\"\n  as = -1\n",
+			wantErr: "'global.config.as' cannot parse value as 'uint32': value out of range",
+		},
+		{
+			name:   "uint16 max",
+			config: rangeTestNeighbor("  [neighbors.transport.config]\n    tcp-mss = 65535\n"),
+		},
+		{
+			name:    "uint16 overflow",
+			config:  rangeTestNeighbor("  [neighbors.transport.config]\n    tcp-mss = 65536\n"),
+			wantErr: "cannot parse value as 'uint16': value out of range",
+		},
+		{
+			name:   "uint8 max",
+			config: rangeTestNeighbor("  [neighbors.ttl-security.config]\n    enabled = true\n    ttl-min = 255\n"),
+		},
+		{
+			name:    "uint8 overflow",
+			config:  rangeTestNeighbor("  [neighbors.ttl-security.config]\n    enabled = true\n    ttl-min = 256\n"),
+			wantErr: "cannot parse value as 'uint8': value out of range",
+		},
+		{
+			name:    "uint8 overflow wraps without the hook",
+			config:  rangeTestNeighbor("  [neighbors.ebgp-multihop.config]\n    enabled = true\n    multihop-ttl = 300\n"),
+			wantErr: "cannot parse value as 'uint8': value out of range",
+		},
+		{
+			// port is int32 and -1 means "do not listen", so a negative value
+			// must stay accepted.
+			name:   "int32 negative is accepted",
+			config: "[global.config]\n  as = 65000\n  router-id = \"192.0.2.1\"\n  port = -1\n",
+		},
+		{
+			name:    "int32 overflow",
+			config:  "[global.config]\n  as = 65000\n  router-id = \"192.0.2.1\"\n  port = 2147483648\n",
+			wantErr: "'global.config.port' cannot parse value as 'int32': value out of range",
+		},
+		{
+			name:    "int32 underflow",
+			config:  "[global.config]\n  as = 65000\n  router-id = \"192.0.2.1\"\n  port = -2147483649\n",
+			wantErr: "'global.config.port' cannot parse value as 'int32': value out of range",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ReadConfig(strings.NewReader(tt.config), "toml")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestIntegerRangeHookKeepsInRangeValues checks that the hook does not disturb
+// the values it lets through.
+func TestIntegerRangeHookKeepsInRangeValues(t *testing.T) {
+	config, err := ReadConfig(strings.NewReader(rangeTestNeighbor(
+		"  [neighbors.transport.config]\n    tcp-mss = 1400\n"+
+			"  [neighbors.ttl-security.config]\n    enabled = true\n    ttl-min = 254\n")), "toml")
+	require.NoError(t, err)
+
+	assert.Equal(t, uint32(65000), config.Global.Config.As)
+	require.Len(t, config.Neighbors, 1)
+	assert.Equal(t, uint32(65001), config.Neighbors[0].Config.PeerAs)
+	assert.Equal(t, uint16(1400), config.Neighbors[0].Transport.Config.TcpMss)
+	assert.Equal(t, uint8(254), config.Neighbors[0].TtlSecurity.Config.TtlMin)
+}
+
+// TestIntegerRangeHookLeavesOtherInputAlone checks the input kinds the hook
+// deliberately does not touch. A string is already range checked by
+// mapstructure itself; float and bool keep the weak conversion they had.
+func TestIntegerRangeHookLeavesOtherInputAlone(t *testing.T) {
+	t.Run("string in range", func(t *testing.T) {
+		config, err := ReadConfig(strings.NewReader(
+			"[global.config]\n  router-id = \"192.0.2.1\"\n  as = \"65000\"\n"), "toml")
+		require.NoError(t, err)
+		assert.Equal(t, uint32(65000), config.Global.Config.As)
+	})
+
+	t.Run("string out of range is still rejected by mapstructure", func(t *testing.T) {
+		_, err := ReadConfig(strings.NewReader(
+			"[global.config]\n  router-id = \"192.0.2.1\"\n  as = \"4294967296\"\n"), "toml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot parse value as 'uint32'")
+	})
+
+	t.Run("float", func(t *testing.T) {
+		config, err := ReadConfig(strings.NewReader(
+			"[global.config]\n  router-id = \"192.0.2.1\"\n  as = 6.5e4\n"), "toml")
+		require.NoError(t, err)
+		assert.Equal(t, uint32(65000), config.Global.Config.As)
+	})
+}

--- a/pkg/config/oc/serve.go
+++ b/pkg/config/oc/serve.go
@@ -43,7 +43,7 @@ func ReadConfig(r io.Reader, format string) (*BgpConfigSet, error) {
 	var err error
 
 	config := &BgpConfigSet{}
-	opts := viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(mapstructure.StringToNetIPAddrHookFunc(), mapstructure.StringToNetIPPrefixHookFunc()))
+	opts := viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(integerRangeHookFunc(), mapstructure.StringToNetIPAddrHookFunc(), mapstructure.StringToNetIPPrefixHookFunc()))
 
 	v := viper.New()
 	v.SetConfigType(format)


### PR DESCRIPTION
About 140 leaves in the config file map to a Go integer narrower than 64 bits. mapstructure stores them with reflect.Value.SetInt or SetUint, and both truncate without an error, so a value that does not fit is silently replaced by a different one. viper turns on WeaklyTypedInput, which also lets a negative value into an unsigned field. "as = -1" comes up as AS 4294967295, "tcp-mss = 70000" as 4464 and "multihop-ttl = 300" as 44. Nothing in the log says the running value is not the configured one.

Turning WeaklyTypedInput off does not fix this. The truncation is in SetInt and SetUint, not in the weak conversion, and dropping it would also reject forms that work today such as as = "65000". mapstructure has no option for a width check either, so the check goes in a decode hook, which is the only place that sees the source value and the target width together. Only integer input is checked, because mapstructure passes the target width to strconv on the string path and a quoted value is already rejected there. Float and bool input keep the conversion they had.

A config file that used to load with a truncated value now fails to load.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>