### PR TITLE
packet/bgp: keep the value of an unknown route distinguisher

### DIFF
--- a/pkg/packet/bgp/bgp.go
+++ b/pkg/packet/bgp/bgp.go
@@ -1821,6 +1821,7 @@ func GetRouteDistinguisher(data []byte) RouteDistinguisherInterface {
 		DefaultRouteDistinguisher: DefaultRouteDistinguisher{
 			Type: typ,
 		},
+		Value: data[2:8],
 	}
 	return rd
 }

--- a/pkg/packet/bgp/bgp_test.go
+++ b/pkg/packet/bgp/bgp_test.go
@@ -1284,6 +1284,23 @@ func Test_EVPNIPPrefixRouteRejectsOversizedPrefixLength(t *testing.T) {
 	assert.Error(err)
 }
 
+func Test_GetRouteDistinguisherUnknownPreservesValue(t *testing.T) {
+	assert := assert.New(t)
+	// 8-byte RD with an unrecognized type (0x0003) and a nonzero value.
+	wire := []byte{0x00, 0x03, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x01}
+	rd := GetRouteDistinguisher(wire)
+	buf, err := rd.Serialize()
+	assert.NoError(err)
+	assert.Equal(wire, buf)
+
+	// Two unknown RDs that differ only in their value must not collapse
+	// onto the same serialized form.
+	other := GetRouteDistinguisher([]byte{0x00, 0x03, 0xca, 0xfe, 0xba, 0xbe, 0x00, 0x02})
+	otherBuf, err := other.Serialize()
+	assert.NoError(err)
+	assert.NotEqual(buf, otherBuf)
+}
+
 func Test_EVPNMacIPAdvertisementRoute(t *testing.T) {
 	rd, err := ParseRouteDistinguisher("100:100")
 	require.NoError(t, err)


### PR DESCRIPTION
Decode then re-serialize of an 8-byte RD whose type is not one of the three known values drops the value:

    in : 0003deadbeef0001
    out: 0003000000000000

GetRouteDistinguisher constructs RouteDistinguisherUnknown with only Type set, so Value stays nil and Serialize emits six zero octets. Any VPN, EVPN, MUP or VPLS route carrying such an RD is re-advertised with a rewritten RD, and two RDs differing only in the value share one table key. RouteDistinguisherUnknown.DecodeFromBytes already copies the value but has no caller; set it in the factory instead.