### PR TITLE
apiutil: round-trip the SR-MPLS Binding SID label through the API

### DIFF
--- a/pkg/apiutil/attribute.go
+++ b/pkg/apiutil/attribute.go
@@ -3365,6 +3365,13 @@ func MarshalSRBSID(bsid *bgp.TunnelEncapSubTLVSRBSID) (*api.SRBindingSID, error)
 		Sid: make([]byte, len(bsid.BSID.Value)),
 	}
 	copy(s.Sid, bsid.BSID.Value)
+	// An SR-MPLS BSID is a 4-octet label stack entry with the label in the
+	// high 20 bits (RFC 9830 Figure 6). NewBSID shifts the API label into
+	// that position on decode, so undo the shift here to round-trip the
+	// label value instead of the encoded stack entry.
+	if len(bsid.BSID.Value) == 4 {
+		binary.BigEndian.PutUint32(s.Sid, binary.BigEndian.Uint32(bsid.BSID.Value)>>12)
+	}
 	s.SFlag = bsid.Flags&0x80 == 0x80
 	s.IFlag = bsid.Flags&0x40 == 0x40
 	return s, nil

--- a/pkg/apiutil/attribute_test.go
+++ b/pkg/apiutil/attribute_test.go
@@ -17,6 +17,7 @@ package apiutil
 
 import (
 	"bytes"
+	"encoding/binary"
 	"net/netip"
 	"testing"
 
@@ -1486,6 +1487,45 @@ func Test_TunnelEncapAttribute(t *testing.T) {
 
 	output, _ := NewTunnelEncapAttributeFromNative(n.(*bgp.PathAttributeTunnelEncap))
 	assert.True(proto.Equal(input, output))
+}
+
+func Test_SRBSIDLabelRoundTrip(t *testing.T) {
+	// The API carries an SR-MPLS Binding SID as the plain label value.
+	// UnmarshalSRBSID shifts it into the high 20 bits of the 4-octet label
+	// stack entry (RFC 9830 Figure 6); MarshalSRBSID must undo that shift so
+	// the label survives an unmarshal/marshal round trip.
+	const label = 100
+	sid := make([]byte, 4)
+	binary.BigEndian.PutUint32(sid, label)
+
+	native, err := UnmarshalSRBSID(&api.TunnelEncapSubTLVSRBindingSID{
+		Bsid: &api.TunnelEncapSubTLVSRBindingSID_SrBindingSid{
+			SrBindingSid: &api.SRBindingSID{Sid: sid, SFlag: true},
+		},
+	})
+	require.NoError(t, err)
+
+	// The native wire value has the label in the high 20 bits.
+	srbsid := native.(*bgp.TunnelEncapSubTLVSRBSID)
+	require.Equal(t, uint32(label<<12), binary.BigEndian.Uint32(srbsid.BSID.Value))
+
+	out, err := MarshalSRBSID(srbsid)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(label), binary.BigEndian.Uint32(out.Sid))
+	assert.True(t, out.SFlag)
+}
+
+func Test_SRBSIDSRv6NotShifted(t *testing.T) {
+	// A 16-octet SRv6 SID carried in the Binding SID sub-TLV must be copied
+	// verbatim, without the SR-MPLS label shift.
+	sid := netip.MustParseAddr("2001:db8::1").AsSlice()
+	native := &bgp.TunnelEncapSubTLVSRBSID{
+		TunnelEncapSubTLV: bgp.TunnelEncapSubTLV{Type: bgp.ENCAP_SUBTLV_TYPE_SRBINDING_SID, Length: 18},
+		BSID:              &bgp.BSID{Value: sid},
+	}
+	out, err := MarshalSRBSID(native)
+	require.NoError(t, err)
+	assert.Equal(t, sid, out.Sid)
 }
 
 func Test_IP6ExtendedCommunitiesAttribute(t *testing.T) {


### PR DESCRIPTION
`MarshalSRBSID` copies the native Binding SID value into the API `Sid` field verbatim.

For an SR-MPLS Binding SID this value is a 4-octet MPLS label stack entry with the label in the high 20 bits (RFC 9830 Figure 6; the low 12 bits are reserved TC/S/TTL).
The API carries the plain label value, and `NewBSID` shifts it left by 12 into the label position when converting from the API.
The marshal direction never undoes that shift, so reading a route back through the API returns the encoded stack entry instead of the label: a label of 100 comes back as 409600.
Re-injecting that value shifts it again, so an API read/write round trip corrupts the label.

Undo the shift in `MarshalSRBSID` for the 4-octet SR-MPLS case, so the API round-trips the label value.
The 16-octet SRv6 case (an SRv6 SID carried in the Binding SID sub-TLV for backward compatibility) is copied verbatim as before.

Tests are included: an unmarshal/marshal round trip that checks the label survives, and a check that a 16-octet SRv6 SID is not shifted.
