### PR TITLE
mrt: bound element counts read from the input before preallocating

### DIFF
--- a/pkg/packet/mrt/mrt.go
+++ b/pkg/packet/mrt/mrt.go
@@ -227,6 +227,14 @@ type Peer struct {
 
 var errNotAllPeerBytesAvailable = errors.New("not all Peer bytes are available")
 
+// Minimum encoded length of one element, used to bound preallocation hints that
+// are read from the input. Each is the smallest length its own decoder accepts.
+const (
+	minPeerLen     = 5 + 4 // type, BGP id, then at least an IPv4 address
+	minRibEntryLen = 8     // peer index, originated time, attribute length
+	minGeoPeerLen  = 13    // type, BGP id, latitude, longitude
+)
+
 func (p *Peer) decodeFromBytes(data []byte) ([]byte, error) {
 	if len(data) < 5 {
 		return nil, errNotAllPeerBytesAvailable
@@ -340,7 +348,11 @@ func parsePeerIndexTable(data []byte) (*PeerIndexTable, error) {
 	}
 	peerNum := binary.BigEndian.Uint16(data[:2])
 	data = data[2:]
-	t.Peers = make([]*Peer, 0, peerNum)
+	// peerNum comes from the input, so it must not size an allocation on its own:
+	// decodeFromBytes below rejects the first peer that is short, and a peer needs
+	// at least minPeerLen bytes. Capacity is only a hint to append, so bounding it
+	// cannot change the result.
+	t.Peers = make([]*Peer, 0, min(int(peerNum), len(data)/minPeerLen+1))
 	var err error
 	for range peerNum {
 		p := &Peer{}
@@ -543,7 +555,8 @@ func parseRib(data []byte, family bgp.Family, isAddPath bool) (*Rib, error) {
 	data = data[prefix.Len():]
 	entryNum := binary.BigEndian.Uint16(data[:2])
 	data = data[2:]
-	u.Entries = make([]*RibEntry, 0, entryNum)
+	// See the note in parsePeerIndexTable: bound a hint taken from the input.
+	u.Entries = make([]*RibEntry, 0, min(int(entryNum), len(data)/minRibEntryLen+1))
 	for range entryNum {
 		var e *RibEntry
 		e, data, err = parseRibEntry(data, family, u.isAddPath, prefix)
@@ -668,7 +681,8 @@ func parseGeoPeerTable(data []byte) (*GeoPeerTable, error) {
 	t.CollectorLongitude = math.Float32frombits(binary.BigEndian.Uint32(data[8:12]))
 	peerCount := binary.BigEndian.Uint16(data[12:14])
 	data = data[14:]
-	t.Peers = make([]*GeoPeer, 0, peerCount)
+	// See the note in parsePeerIndexTable: bound a hint taken from the input.
+	t.Peers = make([]*GeoPeer, 0, min(int(peerCount), len(data)/minGeoPeerLen+1))
 	var err error
 	for range peerCount {
 		p := &GeoPeer{}

--- a/pkg/packet/mrt/mrt_test.go
+++ b/pkg/packet/mrt/mrt_test.go
@@ -18,8 +18,10 @@ package mrt
 import (
 	"bufio"
 	"bytes"
+	"encoding/binary"
 	"net/netip"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -402,4 +404,42 @@ func FuzzDecodeFromBytes(f *testing.F) {
 			parseBGP4MPMessage(h, false, false, data[8:])
 		}
 	})
+}
+
+// TestPeerIndexTableCapHint checks that a count taken from the input does not size
+// an allocation before the elements behind it have arrived, and that a real table
+// still parses. The assertion is on allocation volume rather than on getting an
+// error, because a count with no data behind it already errors either way.
+func TestPeerIndexTableCapHint(t *testing.T) {
+	buildTable := func(nPeers int) []byte {
+		b := []byte{1, 2, 3, 4, 0, 0} // collector id, empty view name
+		b = binary.BigEndian.AppendUint16(b, uint16(nPeers))
+		for i := range nPeers {
+			// type 0: IPv4 address, 2 byte AS
+			b = append(b, 0, 10, 0, 0, byte(i), 10, 0, 0, byte(i), 0, 1)
+		}
+		return b
+	}
+	for _, n := range []int{0, 1, 2, 10, 100} {
+		tbl, err := parsePeerIndexTable(buildTable(n))
+		assert.NoError(t, err, "n=%d", n)
+		assert.Len(t, tbl.Peers, n, "n=%d", n)
+	}
+
+	// A count of 65535 with no peer bytes behind it must error, and must not have
+	// reserved room for 65535 peers on the way there.
+	hostile := []byte{1, 2, 3, 4, 0, 0}
+	hostile = binary.BigEndian.AppendUint16(hostile, 65535)
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	_, err := parsePeerIndexTable(hostile)
+	runtime.ReadMemStats(&after)
+
+	assert.Error(t, err)
+	allocated := after.TotalAlloc - before.TotalAlloc
+	// 65535 *Peer pointers is over 500KB; a bounded parse needs a tiny fraction.
+	assert.Less(t, allocated, uint64(64*1024),
+		"parsing a table that claims 65535 peers with no peer data allocated %d bytes", allocated)
 }


### PR DESCRIPTION
## Description

`parsePeerIndexTable`, `parseRib` and `parseGeoPeerTable` each read a `uint16` element count out of the MRT data and use it as a capacity hint straight away:

```go
peerNum := binary.BigEndian.Uint16(data[:2])
data = data[2:]
t.Peers = make([]*Peer, 0, peerNum)
```

The per-element decoder rejects the first element that is short — `Peer.decodeFromBytes` returns `errNotAllPeerBytesAvailable` when `len(data) < 5` — so a count with no element data behind it gets reserved and then thrown away. MRT files come from disk or from a peer, so the count is not trusted input.

This bounds each count by what the remaining bytes could hold, using the minimum length each element decoder already enforces (9, 8 and 13 bytes respectively). Capacity is only a hint to `append`, so it cannot change what is parsed, and a real table is unaffected because its elements are longer than the minimum.

## Measurement

An 8 byte `PeerIndexTable` claiming 65535 peers. Apple M3 Pro, `-benchtime 100x`:

| | B/op | allocs/op | ns/op |
|---|---|---|---|
| before | **524,521** | 3 | 64,782 |
| after | **136** | 3 | 185.8 |
| Δ | **−99.97%** | | **−99.7%** |

The count is a `uint16`, so each call is capped around 512 KB rather than unbounded — but it is 8 bytes of input per 512 KB, and nothing stops it repeating.

## Why a proportional bound rather than a constant

I tried constant clamps first on similar code elsewhere and they were a regression: when a valid input has one element per separator, the count is an exact estimate rather than an overestimate, and `append` then has to regrow from the constant. Bounding by `len(data)/minElementLen` avoids that — hostile input is cut down while legitimate tables keep the exact hint they had before.

## Testing

`TestPeerIndexTableCapHint` added to `mrt_test.go`, using the `assert` import it already has:

- parses tables of 0 / 1 / 2 / 10 / 100 real peers and asserts the parsed count is unchanged;
- asserts a count of 65535 with no peer bytes behind it is still an error, so the bound cannot turn invalid input into a silent success.

`go test ./pkg/packet/...` passes (bfd, bgp, bmp, mrt, rtr).

## Disclosure

The three sites were found by a static checker I wrote that looks for allocations sized by a count decoded from untrusted bytes with no bounds check in between, and this change was prepared with AI assistance. The numbers are from benchmark runs on this diff, and I will answer review questions myself.
