### PR TITLE
config: remove the collector configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 
@@ -305,12 +304,6 @@ func InitialConfig(ctx context.Context, bgpServer *server.BgpServer, newConfig *
 			bgpServer.Log().Error("failed to set zebra config",
 				slog.String("Topic", "config"), slog.Any("Error", err))
 		}
-	}
-
-	if len(newConfig.Collector.Config.Url) > 0 {
-		bgpServer.Log().Error("collector feature is not supported",
-			slog.String("Topic", "config"))
-		return nil, errors.New("collector feature is not supported")
 	}
 
 	for _, c := range newConfig.RpkiServers {

--- a/pkg/config/oc/bgp_configs.go
+++ b/pkg/config/oc/bgp_configs.go
@@ -1316,60 +1316,6 @@ func (lhs *DynamicNeighbor) Equal(rhs *DynamicNeighbor) bool {
 }
 
 // struct for container gobgp:state.
-type CollectorState struct {
-	// original -> gobgp:url
-	Url string `mapstructure:"url" json:"url,omitempty"`
-	// original -> gobgp:db-name
-	DbName string `mapstructure:"db-name" json:"db-name,omitempty"`
-	// original -> gobgp:table-dump-interval
-	TableDumpInterval uint64 `mapstructure:"table-dump-interval" json:"table-dump-interval,omitempty"`
-}
-
-// struct for container gobgp:config.
-type CollectorConfig struct {
-	// original -> gobgp:url
-	Url string `mapstructure:"url" json:"url,omitempty"`
-	// original -> gobgp:db-name
-	DbName string `mapstructure:"db-name" json:"db-name,omitempty"`
-	// original -> gobgp:table-dump-interval
-	TableDumpInterval uint64 `mapstructure:"table-dump-interval" json:"table-dump-interval,omitempty"`
-}
-
-func (lhs *CollectorConfig) Equal(rhs *CollectorConfig) bool {
-	if lhs == nil || rhs == nil {
-		return false
-	}
-	if lhs.Url != rhs.Url {
-		return false
-	}
-	if lhs.DbName != rhs.DbName {
-		return false
-	}
-	if lhs.TableDumpInterval != rhs.TableDumpInterval {
-		return false
-	}
-	return true
-}
-
-// struct for container gobgp:collector.
-type Collector struct {
-	// original -> gobgp:collector-config
-	Config CollectorConfig `mapstructure:"config" json:"config,omitempty"`
-	// original -> gobgp:collector-state
-	State CollectorState `mapstructure:"state" json:"state,omitempty"`
-}
-
-func (lhs *Collector) Equal(rhs *Collector) bool {
-	if lhs == nil || rhs == nil {
-		return false
-	}
-	if !lhs.Config.Equal(&(rhs.Config)) {
-		return false
-	}
-	return true
-}
-
-// struct for container gobgp:state.
 type ZebraState struct {
 	// original -> gobgp:enabled
 	// gobgp:enabled's original type is boolean.
@@ -5396,8 +5342,6 @@ type Bgp struct {
 	MrtDump []Mrt `mapstructure:"mrt-dump" json:"mrt-dump,omitempty"`
 	// original -> gobgp:zebra
 	Zebra Zebra `mapstructure:"zebra" json:"zebra,omitempty"`
-	// original -> gobgp:collector
-	Collector Collector `mapstructure:"collector" json:"collector,omitempty"`
 	// original -> gobgp:dynamic-neighbors
 	DynamicNeighbors []DynamicNeighbor `mapstructure:"dynamic-neighbors" json:"dynamic-neighbors,omitempty"`
 }
@@ -5458,9 +5402,6 @@ func (lhs *Bgp) Equal(rhs *Bgp) bool {
 		}
 	}
 	if !lhs.Zebra.Equal(&(rhs.Zebra)) {
-		return false
-	}
-	if !lhs.Collector.Equal(&(rhs.Collector)) {
 		return false
 	}
 	if len(lhs.DynamicNeighbors) != len(rhs.DynamicNeighbors) {

--- a/pkg/config/oc/serve.go
+++ b/pkg/config/oc/serve.go
@@ -19,7 +19,6 @@ type BgpConfigSet struct {
 	Vrfs              []Vrf              `mapstructure:"vrfs"`
 	MrtDump           []Mrt              `mapstructure:"mrt-dump"`
 	Zebra             Zebra              `mapstructure:"zebra"`
-	Collector         Collector          `mapstructure:"collector"`
 	DefinedSets       DefinedSets        `mapstructure:"defined-sets"`
 	PolicyDefinitions []PolicyDefinition `mapstructure:"policy-definitions"`
 	DynamicNeighbors  []DynamicNeighbor  `mapstructure:"dynamic-neighbors"`

--- a/tools/pyang_plugins/gobgp.yang
+++ b/tools/pyang_plugins/gobgp.yang
@@ -1308,33 +1308,6 @@ module gobgp {
     uses zebra-set;
   }
 
-  grouping collector-config {
-    leaf url {
-      type string;
-    }
-    leaf db-name {
-      type string;
-    }
-    leaf table-dump-interval {
-      type uint64;
-    }
-  }
-
-  grouping collector-set {
-    container collector {
-      container config {
-        uses collector-config;
-      }
-      container state {
-        uses collector-config;
-      }
-    }
-  }
-
-  augment "/bgp:bgp" {
-    uses collector-set;
-  }
-
   grouping listen-config {
     leaf port {
         type int32;


### PR DESCRIPTION
The collector feature was removed in d91fb3d3 ("server: remove collector support") in 2018. Only its configuration stayed behind. InitialConfig just logged that the feature is not supported.

Drop the collector groupings from gobgp.yang, regenerate bgp_configs.go, and remove the field from BgpConfigSet along with the check in InitialConfig.

ReadConfig uses viper's UnmarshalExact, so a config file that still has a [collector] section now fails to parse with "has invalid keys: collector". Such a section has had no effect since 2018 and must be deleted.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>