### PR TITLE
server: drop stale notifications queued while a peer session was down

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1799,6 +1799,12 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 		}
 
 		drainChannel(peer.fsm.outgoingCh.Out())
+		// Drop any queued notification. Either it raced with the end of the
+		// session it was meant for, or it was generated while no session was
+		// up, e.g. by BFD detecting a failure while the peer was down. Only
+		// the established loop reads this channel, so a leftover would kill
+		// the next session right after it establishes.
+		drainChannel(peer.fsm.notification)
 
 		if nextState == bgp.BGP_FSM_ESTABLISHED {
 			conf := peer.fsm.pConf.ReadOnly()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -4781,3 +4781,163 @@ func TestDeletePeerDropsPolicyAssignment(t *testing.T) {
 	assert.NoError(addPeer("not-defined"))
 	assert.Empty(assignedPolicies())
 }
+
+// startServerWithPassivePeer starts a BgpServer without a TCP listener and
+// adds one passive ipv4-unicast neighbor, so tests can drive sessions by
+// injecting MockConnections into the peer's FSM.
+func startServerWithPassivePeer(t *testing.T, asn uint32, peerAddr string) (*BgpServer, *peer) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	s := NewBgpServer()
+	go s.Serve()
+
+	err := s.StartBgp(ctx, &api.StartBgpRequest{
+		Global: &api.Global{
+			Asn:        asn,
+			RouterId:   "192.168.1.1",
+			ListenPort: -1,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { s.StopBgp(ctx, &api.StopBgpRequest{}) })
+
+	neighbor := &oc.Neighbor{
+		Config: oc.NeighborConfig{
+			NeighborAddress: netip.MustParseAddr(peerAddr),
+			PeerAs:          asn,
+		},
+		Transport: oc.Transport{
+			Config: oc.TransportConfig{
+				PassiveMode: true,
+			},
+		},
+		AfiSafis: []oc.AfiSafi{
+			{
+				Config: oc.AfiSafiConfig{
+					AfiSafiName: oc.AFI_SAFI_TYPE_IPV4_UNICAST,
+					Enabled:     true,
+				},
+			},
+		},
+	}
+
+	w := newPeerStateWaiter(s, api.PeerState_SESSION_STATE_ACTIVE)
+	err = s.AddPeer(ctx, &api.AddPeerRequest{
+		Peer: oc.NewPeerFromConfigStruct(neighbor),
+	})
+	require.NoError(t, err)
+	w.Wait(t, 10*time.Second)
+
+	peer := s.neighborMap[netip.MustParseAddr(peerAddr)]
+	require.NotNil(t, peer)
+
+	return s, peer
+}
+
+// establishSession drives the passive peer to ESTABLISHED over a new
+// MockConnection and returns it.
+func establishSession(t *testing.T, s *BgpServer, peer *peer, asn uint32, peerAddr string) *MockConnection {
+	t.Helper()
+
+	m := NewMockConnection()
+	m.SetRemoteAddr(peerAddr)
+	t.Cleanup(func() { m.Close() })
+
+	peer.fsm.connCh <- m
+	openMsg, err := bgp.NewBGPOpenMessage(uint16(asn), 90, netip.MustParseAddr(peerAddr),
+		[]bgp.OptionParameterInterface{
+			bgp.NewOptionParameterCapability([]bgp.ParameterCapabilityInterface{
+				bgp.NewCapMultiProtocol(bgp.RF_IPv4_UC),
+			}),
+		})
+	require.NoError(t, err)
+	m.PushBgpMessage(openMsg)
+	m.PushBgpMessage(bgp.NewBGPKeepAliveMessage())
+
+	waitPeerState(t, s, api.PeerState_SESSION_STATE_ESTABLISHED, 10*time.Second)
+
+	return m
+}
+
+func sentNotification(m *MockConnection) *bgp.BGPNotification {
+	for _, buf := range m.GetSentMessages() {
+		msg, err := bgp.ParseBGPMessage(buf)
+		if err != nil || msg.Header.Type != bgp.BGP_MSG_NOTIFICATION {
+			continue
+		}
+		return msg.Body.(*bgp.BGPNotification)
+	}
+	return nil
+}
+
+// A hard ResetPeer against a peer whose session is down must not affect the
+// session the peer establishes later. Before the fix, the queued NOTIFICATION
+// survived in fsm.notification until the next session reached ESTABLISHED and
+// tore it down moments later, which looped forever against peers that destroy
+// their BFD session when BGP goes down.
+// https://github.com/osrg/gobgp/issues/3561
+func TestResetPeerWhileDownDoesNotResetNextSession(t *testing.T) {
+	const (
+		asn      = 65001
+		peerAddr = "10.0.0.1"
+	)
+
+	s, peer := startServerWithPassivePeer(t, asn, peerAddr)
+	m1 := establishSession(t, s, peer, asn, peerAddr)
+
+	// Bring the session down and wait until the peer settles in ACTIVE.
+	// Passive mode and no listener: it cannot progress on its own.
+	m1.Close()
+	waitPeerState(t, s, api.PeerState_SESSION_STATE_ACTIVE, 10*time.Second)
+
+	// Reset the peer while it is down: exactly what the BFD code does when
+	// its detect timer expires after the BGP session already ended.
+	err := s.ResetPeer(context.Background(), &api.ResetPeerRequest{
+		Address:       peerAddr,
+		Communication: "BFD is down",
+		Soft:          false,
+	})
+	require.NoError(t, err)
+	require.Len(t, peer.fsm.notification, 1)
+
+	m2 := establishSession(t, s, peer, asn, peerAddr)
+
+	// The stale reset must not reach the new session: it must stay
+	// established, with no NOTIFICATION on its connection.
+	require.Never(t, func() bool {
+		return peer.State() != bgp.BGP_FSM_ESTABLISHED || sentNotification(m2) != nil
+	}, time.Second, 10*time.Millisecond)
+	require.Empty(t, peer.fsm.notification)
+}
+
+// A hard ResetPeer against an established peer must still tear the session
+// down promptly. This is the behavior BFD relies on when it detects a failure
+// on a live session, and the drain that fixes the stale-notification bug must
+// not suppress it.
+func TestResetPeerEstablishedSendsNotification(t *testing.T) {
+	const (
+		asn      = 65001
+		peerAddr = "10.0.0.1"
+	)
+
+	s, peer := startServerWithPassivePeer(t, asn, peerAddr)
+	m1 := establishSession(t, s, peer, asn, peerAddr)
+
+	w := newPeerStateWaiter(s, api.PeerState_SESSION_STATE_IDLE)
+	err := s.ResetPeer(context.Background(), &api.ResetPeerRequest{
+		Address:       peerAddr,
+		Communication: "BFD is down",
+		Soft:          false,
+	})
+	require.NoError(t, err)
+	w.Wait(t, 10*time.Second)
+
+	require.Eventually(t, func() bool {
+		n := sentNotification(m1)
+		return n != nil &&
+			n.ErrorCode == bgp.BGP_ERROR_CEASE &&
+			n.ErrorSubcode == bgp.BGP_ERROR_SUB_ADMINISTRATIVE_RESET
+	}, 10*time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
Fixes #3561.

### What was wrong

`newFSM` creates `fsm.notification` once per peer, and only the ESTABLISHED loop reads it, so the
channel outlives every session of the peer. `ResetPeer` and `ShutdownPeer` enqueue into it without
checking the session state. A NOTIFICATION queued while the session is down waits in the channel,
and the next session reads it the moment it reaches ESTABLISHED and tears itself down. BFD produces
exactly this sequence: its detect timer expires seconds after the BGP session already ended and
queues an administrative reset. Against a peer that destroys its BFD session when BGP goes down,
this repeats on every reconnect and the peering never recovers (#3561 has the full trace).

### What this changes

`handleFSMMessage` now drops whatever is still queued in `fsm.notification` on every state
transition, next to the existing `outgoingCh` drain.

This is the issue's Option 1 in spirit, with one correction to its wording. Draining when the FSM
*leaves* ESTABLISHED would not break the loop: in the reported cycle, BFD queues the reset about
three seconds *after* teardown, while the peer is IDLE. The drain has to run between that enqueue
and the next delivery point, so it runs on every transition instead.

Why this placement is race-free: the transition callback runs under the server's read lock, and the
producers (`ResetPeer`, `ShutdownPeer`, including BFD's calls) run under the write lock. An enqueue
therefore lands either before the transition into ESTABLISHED — and is dropped, correctly, because
the reset targeted a session that no longer exists — or after it, when the established loop is live
and delivers it. A BFD failure detected moments after Peer Up still resets the session.

Draining at the top of `established()` instead would race the producers: a legitimate reset issued
right after Peer Up could be destroyed, and BFD would not repeat it (`expiry()` stops itself once
its state is DOWN). That would suppress a real BFD failure, which is the one behavior the fix must
protect.

The drain also covers a rarer variant of the same bug: the receive goroutine queues NOTIFICATIONs
for parse errors, and one left behind when the session dies concurrently was likewise delivered to
the next session. The teardown joins that goroutine before the state function returns, so the next
transition's drain disposes of it deterministically.

Intended behavior change: a hard `ResetPeer` or `ShutdownPeer` against a peer whose session is down
is now a no-op, instead of a deferred kill of the next session.

### Checks from the issue

- The loop ends: `TestResetPeerWhileDownDoesNotResetNextSession` reproduces the exact BFD call
  (`ResetPeer` with `Soft: false` while the peer is down) and fails on master — the next session
  dies with a NOTIFICATION on its connection moments after establishing. With the fix it stays
  ESTABLISHED and the channel is empty.
- A real BFD failure on an established session still tears BGP down promptly:
  `TestResetPeerEstablishedSendsNotification` asserts the session leaves ESTABLISHED and a
  cease/administrative-reset NOTIFICATION reaches the wire. It passes with and without the fix.
- A BFD session that never comes up still leaves BGP alone: unchanged; the `expiry()` guard and the
  existing BFD tests cover it.

`go test -race ./pkg/server/` passes. Option 3 from the issue (reset only on a real Up → Down BFD
transition) is left for a follow-up PR as suggested there.

Assisted-by: Claude Fable 5 <noreply@anthropic.com>