### PR TITLE
server: jitter BFD control packet transmission

### DIFF
--- a/pkg/server/bfd_peer.go
+++ b/pkg/server/bfd_peer.go
@@ -58,7 +58,7 @@ type bfdPeer struct {
 
 	eventStart    *time.Ticker
 	eventRxPacket chan *bfd.BFDHeader
-	eventTx       *time.Ticker
+	eventTx       *time.Timer
 	eventExpiry   *time.Ticker
 	eventShutdown chan struct{}
 	shutdownOnce  sync.Once
@@ -106,7 +106,7 @@ func NewBfdPeer(ps peerState, logger *slog.Logger, peerAddress netip.Addr, confi
 	}
 
 	p.expiryInterval = time.Duration(p.multiplier) * p.rxInterval
-	p.eventTx = time.NewTicker(p.txInterval)
+	p.eventTx = time.NewTimer(p.jitteredTxInterval())
 
 	p.eventExpiry = time.NewTicker(p.expiryInterval)
 	p.eventExpiry.Stop()
@@ -152,6 +152,7 @@ func (p *bfdPeer) loop() {
 		case bfdPacket := <-p.eventRxPacket:
 			p.rxPacket(bfdPacket)
 		case <-p.eventTx.C:
+			p.eventTx.Reset(p.jitteredTxInterval())
 			p.tx()
 		case <-p.eventExpiry.C:
 			p.expiry()
@@ -365,6 +366,21 @@ func (p *bfdPeer) rxPacket(h *bfd.BFDHeader) {
 		p.sessionState() == api.BfdSessionState_BFD_SESSION_STATE_UP {
 		p.eventExpiry.Reset(p.expiryInterval)
 	}
+}
+
+// jitteredTxInterval returns the interval to wait before sending the next
+// BFD Control packet, based on the configured desired minimum TX interval.
+//
+// RFC 5880 Section 6.8.7: the transmit interval MUST be reduced per packet
+// by a random value of 0 to 25%; when the detect multiplier is 1, the
+// interval MUST be no more than 90% and no less than 75% of the negotiated
+// interval.
+func (p *bfdPeer) jitteredTxInterval() time.Duration {
+	maxPct := 100
+	if p.multiplier == 1 {
+		maxPct = 90
+	}
+	return p.txInterval * time.Duration(randRange(75, maxPct)) / 100
 }
 
 func (p *bfdPeer) tx() {

--- a/pkg/server/bfd_peer_test.go
+++ b/pkg/server/bfd_peer_test.go
@@ -355,6 +355,55 @@ func Test_ExpiryDoesNotResetAlreadyDownPeer(t *testing.T) {
 	assert.Equal(int64(0), atomic.LoadInt64(&ps.resetPeerCount))
 }
 
+// Test_JitteredTxInterval pins RFC 5880 Section 6.8.7: the transmit interval
+// must be reduced per packet by a random value of 0 to 25%, and when the
+// detect multiplier is 1, the interval must fall within 75%-90% of the
+// negotiated interval rather than the full 75%-100% range. The observed
+// min/max across many draws must land exactly on those endpoints: hitting
+// both inclusive endpoints, including the narrowed 90% ceiling, is what
+// pins the bounds rather than merely containing them.
+func Test_JitteredTxInterval(t *testing.T) {
+	assert := assert.New(t)
+
+	// multiplier > 1: bounds are [75%, 100%] of txInterval.
+	p := &bfdPeer{multiplier: 3, txInterval: 200 * time.Millisecond}
+
+	minSeen, maxSeen := p.txInterval, time.Duration(0)
+	for range 1000 {
+		d := p.jitteredTxInterval()
+		if d < minSeen {
+			minSeen = d
+		}
+		if d > maxSeen {
+			maxSeen = d
+		}
+	}
+	// 26 integer percentages in [75, 100], ~38.5 expected hits each in 1000
+	// draws; the chance either endpoint is never drawn is about
+	// (25/26)^1000 =~ 1e-17, so exact equality here is not flaky.
+	assert.Equal(150*time.Millisecond, minSeen)
+	assert.Equal(200*time.Millisecond, maxSeen)
+
+	// multiplier == 1: bounds narrow to [75%, 90%] of txInterval.
+	p1 := &bfdPeer{multiplier: 1, txInterval: 200 * time.Millisecond}
+
+	minSeen1, maxSeen1 := p1.txInterval, time.Duration(0)
+	for range 1000 {
+		d := p1.jitteredTxInterval()
+		if d < minSeen1 {
+			minSeen1 = d
+		}
+		if d > maxSeen1 {
+			maxSeen1 = d
+		}
+	}
+	// 16 integer percentages in [75, 90], ~62.5 expected hits each; the
+	// chance either endpoint is missed across 1000 draws is about
+	// (15/16)^1000 =~ 1e-28.
+	assert.Equal(150*time.Millisecond, minSeen1)
+	assert.Equal(180*time.Millisecond, maxSeen1)
+}
+
 func Test_TxPacket(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
Fixes #3562.

### What was wrong

The BFD transmit path drove transmission with a fixed `time.Ticker`, so every control packet left
exactly on the configured period. RFC 5880 section 6.8.7 requires the interval to be reduced on
every packet by a random value of 0 to 25%, and to stay between 75% and 90% of the transmission
interval when the detect multiplier is 1. Without jitter, sessions that start at similar times stay
in lockstep, and a speaker with many BFD peers on the same interval transmits them as a repeating
burst instead of spreading them across the period.

### What this changes

`eventTx` becomes a `*time.Timer` that the peer loop re-arms before each transmission with a fresh
interval: a uniformly random 75% to 100% of the configured desired minimum TX interval, narrowed to
75% to 90% when the detect multiplier is 1. Re-arming before the packet is written keeps the time
spent sending out of the gap between packets, which matters against the 90% ceiling in the
multiplier-1 case.

The issue asked which random source to use: this uses `randRange`, which already picks the BFD
source port. It draws whole percentage points rather than a continuous value (as the FSM's idle
hold-time jitter does), because 26 discrete values are directly assertable in a test and the RFC
only requires a random reduction within the window.

Jitter only shortens intervals, so the remote system's detection margin widens; it never rises
above the configured interval. Event-driven packets — poll replies and the poll sent on reaching
Up — are not periodic transmissions and are unchanged.

Out of scope, as proposed in the issue: raising the transmit interval to the peer's Required Min RX
Interval (#3563) and slowing transmission to one second while the session is down (#3564). Both
only change what base interval feeds the jitter, which now lives in one method; this PR changes the
type of `eventTx` first so those can follow in sequence.

### Checks from the issue

- Intervals vary within the required window: `Test_JitteredTxInterval` draws the interval 1000
  times per case and asserts the observed minimum and maximum land exactly on 75% and 100% of the
  configured interval. Endpoint equality also bounds every sample in between. The chance either
  endpoint never appears is about 1e-17, so the test is not timing-dependent and cannot flake the
  way a wall-clock packet capture in CI would.
- Detect multiplier 1 stays within 75% to 90%: the second half of the same test asserts the
  narrowed endpoints (75% and 90%) for a multiplier-1 peer.
- Mean rate and session health: the mean interval is 87.5% of the configured value and never
  exceeds it, so the negotiated rate is still satisfied. `Test_TxPacket` fails if the timer ever
  stops re-arming, and the pre-existing state-transition and expiry tests all pass unchanged.

`go test -race ./pkg/server/` passes.

Assisted-by: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)